### PR TITLE
DAOS-17257 object: bypass CSUM for data consistency verification - b26

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -648,6 +649,8 @@ enum daos_io_flags {
 	DIOF_FOR_FORCE_DEGRADE = 0x400,
 	/* reverse enumeration for recx */
 	DIOF_RECX_REVERSE = 0x800,
+	/* For data consistency verification. */
+	DIOF_FOR_DATA_VERIFICATION = 0x1000,
 };
 
 /**

--- a/src/object/cli_mod.c
+++ b/src/object/cli_mod.c
@@ -187,7 +187,8 @@ dc_obj_init(void)
 	if (rc != 0)
 		goto out_class;
 
-	obj_coll_thd = OBJ_COLL_THD_MIN;
+	/* Temporarily disable collective punch by default to trigger DAOS-17258, for debug. */
+	obj_coll_thd = 0;
 	d_getenv_uint("DAOS_OBJ_COLL_THD", &obj_coll_thd);
 	if (obj_coll_thd == 0) {
 		D_INFO("Disable collective operation.\n");

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -878,22 +878,11 @@ crt_proc_struct_daos_cpd_bulk(crt_proc_t proc, crt_proc_op_t proc_op,
 	if (unlikely(rc))
 		return rc;
 
-	if (DECODING(proc_op)) {
-		D_ALLOC_PTR(dcb->dcb_bulk);
-		if (dcb->dcb_bulk == NULL)
-			return -DER_NOMEM;
-	}
-
-	rc = crt_proc_crt_bulk_t(proc, proc_op, dcb->dcb_bulk);
-	if (unlikely(rc))
-		return rc;
-
-	if (FREEING(proc_op))
-		D_FREE(dcb->dcb_bulk);
+	rc = crt_proc_crt_bulk_t(proc, proc_op, &dcb->dcb_bulk);
 
 	/* The other fields will not be packed on-wire. */
 
-	return 0;
+	return rc;
 }
 
 static int

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -640,7 +641,7 @@ struct daos_cpd_bulk {
 	struct daos_cpd_sub_head	 dcb_head;
 	uint32_t			 dcb_size;
 	uint32_t			 dcb_padding;
-	crt_bulk_t			*dcb_bulk;
+	crt_bulk_t                       dcb_bulk;
 	/*
 	 * The following are only used to handle the bulk for CPD RPC body temporarily,
 	 * do not pack on-wire.

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2020-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -393,6 +394,15 @@ out:
 	return rc;
 }
 
+static inline void
+dc_tx_bulk_free(crt_bulk_t *hdl)
+{
+	if (hdl != NULL && *hdl != CRT_BULK_NULL) {
+		crt_bulk_free(*hdl);
+		*hdl = CRT_BULK_NULL;
+	}
+}
+
 static void
 dc_tx_cleanup_one(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr)
 {
@@ -407,11 +417,8 @@ dc_tx_cleanup_one(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr)
 
 		csummer = tx->tx_co->dc_csummer;
 		if (dcu->dcu_flags & ORF_CPD_BULK) {
-			for (i = 0; i < dcsr->dcsr_nr; i++) {
-				if (dcu->dcu_bulks[i] != CRT_BULK_NULL)
-					crt_bulk_free(dcu->dcu_bulks[i]);
-			}
-
+			for (i = 0; i < dcsr->dcsr_nr; i++)
+				dc_tx_bulk_free(&dcu->dcu_bulks[i]);
 			D_FREE(dcu->dcu_bulks);
 		}
 
@@ -522,12 +529,7 @@ dc_tx_cleanup(struct dc_tx *tx)
 	/* Keep 'tx_set_resend'. */
 
 	if (tx->tx_reqs.dcs_type == DCST_BULK_REQ) {
-		if (tx->tx_reqs_bulk.dcb_bulk != NULL) {
-			if (tx->tx_reqs_bulk.dcb_bulk[0] != CRT_BULK_NULL)
-				crt_bulk_free(tx->tx_reqs_bulk.dcb_bulk[0]);
-			D_FREE(tx->tx_reqs_bulk.dcb_bulk);
-		}
-
+		dc_tx_bulk_free(&tx->tx_reqs_bulk.dcb_bulk);
 		D_FREE(tx->tx_reqs_bulk.dcb_iov.iov_buf);
 	}
 
@@ -539,11 +541,7 @@ dc_tx_cleanup(struct dc_tx *tx)
 	}
 
 	if (tx->tx_head.dcs_type == DCST_BULK_HEAD) {
-		if (tx->tx_head_bulk.dcb_bulk != NULL) {
-			if (tx->tx_head_bulk.dcb_bulk[0] != CRT_BULK_NULL)
-				crt_bulk_free(tx->tx_head_bulk.dcb_bulk[0]);
-			D_FREE(tx->tx_head_bulk.dcb_bulk);
-		}
+		dc_tx_bulk_free(&tx->tx_head_bulk.dcb_bulk);
 		/* Free MBS buffer. */
 		D_FREE(tx->tx_head_bulk.dcb_iov.iov_buf);
 	} else {
@@ -556,11 +554,7 @@ dc_tx_cleanup(struct dc_tx *tx)
 	tx->tx_head.dcs_buf = NULL;
 
 	if (tx->tx_disp.dcs_type == DCST_BULK_ENT) {
-		if (tx->tx_disp_bulk.dcb_bulk != NULL) {
-			if (tx->tx_disp_bulk.dcb_bulk[0] != CRT_BULK_NULL)
-				crt_bulk_free(tx->tx_disp_bulk.dcb_bulk[0]);
-			D_FREE(tx->tx_disp_bulk.dcb_bulk);
-		}
+		dc_tx_bulk_free(&tx->tx_disp_bulk.dcb_bulk);
 		dcde = tx->tx_disp_bulk.dcb_iov.iov_buf;
 	} else {
 		dcde = tx->tx_disp.dcs_buf;
@@ -576,11 +570,7 @@ dc_tx_cleanup(struct dc_tx *tx)
 	}
 
 	if (tx->tx_tgts.dcs_type == DCST_BULK_TGT) {
-		if (tx->tx_tgts_bulk.dcb_bulk != NULL) {
-			if (tx->tx_tgts_bulk.dcb_bulk[0] != CRT_BULK_NULL)
-				crt_bulk_free(tx->tx_tgts_bulk.dcb_bulk[0]);
-			D_FREE(tx->tx_tgts_bulk.dcb_bulk);
-		}
+		dc_tx_bulk_free(&tx->tx_tgts_bulk.dcb_bulk);
 		D_FREE(tx->tx_tgts_bulk.dcb_iov.iov_buf);
 		tx->tx_tgts.dcs_buf = NULL;
 	} else {
@@ -1767,15 +1757,23 @@ dc_tx_cpd_body_bulk(struct daos_cpd_sg *dcs, struct daos_cpd_bulk *dcb,
 	dcb->dcb_sgl.sg_nr_out = 1;
 	dcb->dcb_sgl.sg_iovs = &dcb->dcb_iov;
 
-	rc = obj_bulk_prep(&dcb->dcb_sgl, 1, true, CRT_BULK_RO, task, &dcb->dcb_bulk);
-	if (rc == 0) {
-		dcs->dcs_type = type;
-		dcs->dcs_nr = nr;
-		dcs->dcs_buf = dcb;
-	} else {
+	rc = crt_bulk_create(daos_task2ctx(task), &dcb->dcb_sgl, CRT_BULK_RO, &dcb->dcb_bulk);
+	if (rc != 0)
+		goto out;
+
+	rc = crt_bulk_bind(dcb->dcb_bulk, daos_task2ctx(task));
+	if (rc != 0)
+		goto out;
+
+	dcs->dcs_type = type;
+	dcs->dcs_nr   = nr;
+	dcs->dcs_buf  = dcb;
+
+out:
+	if (rc != 0) {
+		dc_tx_bulk_free(&dcb->dcb_bulk);
 		dcb->dcb_iov.iov_buf = NULL;
 	}
-
 	return rc;
 }
 

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -119,8 +120,8 @@ dc_obj_verify_fetch(struct dc_obj_verify_args *dova)
 
 	shard = dc_obj_anchor2shard(&dova->dkey_anchor);
 	rc = dc_obj_fetch_task_create(dova->oh, dova->th, 0, &cursor->dkey, 1,
-				      DIOF_TO_SPEC_SHARD, iod, &dova->fetch_sgl,
-				      NULL, &shard, NULL, NULL, NULL, &task);
+				      DIOF_TO_SPEC_SHARD | DIOF_FOR_DATA_VERIFICATION, iod,
+				      &dova->fetch_sgl, NULL, &shard, NULL, NULL, NULL, &task);
 	if (rc == 0)
 		rc = dc_task_schedule(task, true);
 
@@ -707,8 +708,8 @@ dc_obj_verify_ec_cb(struct dc_obj_enum_unpack_io *io, void *arg)
 
 	/* Fetch by specific shard */
 	rc = dc_obj_fetch_task_create(dova->oh, dova->th, 0, &io->ui_dkey, idx,
-				      0, iods, sgls, NULL, &shard, NULL, NULL, NULL,
-				      &task);
+				      DIOF_FOR_DATA_VERIFICATION, iods, sgls, NULL, &shard, NULL,
+				      NULL, NULL, &task);
 	if (rc != 0) {
 		D_ERROR(DF_OID" sgl num %u shard "DF_U64"\n",
 			DP_OID(obj->cob_md.omd_id), idx, shard);
@@ -733,8 +734,8 @@ dc_obj_verify_ec_cb(struct dc_obj_enum_unpack_io *io, void *arg)
 
 	daos_fail_loc_set(DAOS_OBJ_FORCE_DEGRADE | DAOS_FAIL_ONCE);
 	rc = dc_obj_fetch_task_create(dova->oh, dova->th, 0, &io->ui_dkey, idx,
-				      0, iods, sgls_verify, NULL, &shard, NULL, NULL,
-				      NULL, &verify_task);
+				      DIOF_FOR_DATA_VERIFICATION, iods, sgls_verify, NULL, &shard,
+				      NULL, NULL, NULL, &verify_task);
 	if (rc != 0) {
 		D_ERROR(DF_OID" sgl num %u shard "DF_U64"\n",
 			DP_OID(obj->cob_md.omd_id), idx, shard);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -5331,20 +5332,27 @@ ds_obj_cpd_body_bulk(crt_rpc_t *rpc, struct obj_io_context *ioc, bool leader,
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	for (i = 0; i < count; i++) {
-		bulks[i] = *dcbs[i]->dcb_bulk;
+		bulks[i] = dcbs[i]->dcb_bulk;
 		sgls[i] = &dcbs[i]->dcb_sgl;
 	}
 
-	rc = obj_bulk_transfer(rpc, CRT_BULK_GET, ORF_BULK_BIND, bulks, NULL, NULL,
-			       DAOS_HDL_INVAL, sgls, count, count, NULL, ioc->ioc_coh);
+	rc = obj_bulk_transfer(rpc, CRT_BULK_GET, true, bulks, NULL, NULL, DAOS_HDL_INVAL, sgls,
+			       count, count, NULL, ioc->ioc_coh);
 	if (rc != 0)
 		goto out;
 
 	for (i = 0; i < count; i++) {
+		D_ASSERTF(dcbs[i]->dcb_size == dcbs[i]->dcb_iov.iov_len, "Bad bulk: %u vs %u\n",
+			  dcbs[i]->dcb_size, (uint32_t)dcbs[i]->dcb_iov.iov_len);
+
 		switch (dcbs[i]->dcb_type) {
 		case DCST_BULK_HEAD:
 			dcsh = &dcbs[i]->dcb_head;
 			dcsh->dcsh_mbs = dcbs[i]->dcb_iov.iov_buf;
+			D_ASSERTF(dcsh->dcsh_mbs->dm_data_size ==
+				      dcbs[i]->dcb_iov.iov_len - sizeof(*dcsh->dcsh_mbs),
+				  "Invalid MBS data: %u vs %u\n", dcsh->dcsh_mbs->dm_data_size,
+				  (uint32_t)(dcbs[i]->dcb_iov.iov_len - sizeof(*dcsh->dcsh_mbs)));
 			break;
 		case DCST_BULK_REQ:
 			rc = crt_proc_create(dss_get_module_info()->dmi_ctx,
@@ -5373,7 +5381,11 @@ ds_obj_cpd_body_bulk(crt_rpc_t *rpc, struct obj_io_context *ioc, bool leader,
 			for (j = 0; j < dcbs[i]->dcb_item_nr; j++) {
 				dcde[j].dcde_reqs = dcri;
 				dcri += dcde[j].dcde_read_cnt + dcde[j].dcde_write_cnt;
-				D_ASSERT((void *)dcri <= end);
+				D_ASSERTF((void *)dcri <= end,
+					  "Hit invalid CPD bulk data: pos %u, "
+					  "rd %u, wr %u, nr %u, size %u, base %p, cur %p, end %p\n",
+					  j, dcde[j].dcde_read_cnt, dcde[j].dcde_write_cnt,
+					  dcbs[i]->dcb_item_nr, dcbs[i]->dcb_size, dcde, dcri, end);
 			}
 			break;
 		default:


### PR DESCRIPTION
Since data consistency verification logic will check whether data is valid or not. That will be helpful to detect some CSUM itself issue.

The patch also cleanup CPD RPC bulk logic and add more check for CPD RPC bulk transfer to detect potential CPD RPC bulk body corruption.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
