### PR TITLE
SRE-2928 build: Fix artifactory url variable (16123)

### DIFF
--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -60,7 +60,7 @@ install_mofed() {
     : "${ARTIFACTORY_URL:=https://artifactory.dc.hpdd.intel.com/artifactory/}"
     # Temporary fix
     if  [[ ${ARTIFACTORY_URL} != *"/artifactory" ]]; then
-        ARTIFACTORY_URL="${ARTIFACTORY}artifactory"
+        ARTIFACTORY_URL="${ARTIFACTORY_URL}artifactory"
     fi
     mellanox_proxy="${ARTIFACTORY_URL}/mellanox-proxy/mlnx_ofed/"
     mellanox_key_url="${ARTIFACTORY_URL}/mlnx_ofed/RPM-GPG-KEY-Mellanox"


### PR DESCRIPTION
Fix typo that's failing HW stages.

Skip-unit-test: true
Skip-fault-injection-test: true
Test-tag: test_always_passes_hw

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
