### PR TITLE
DAOS-17138 dtx: batched commit DTX entries after closed container - b26

### DIFF
--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2015-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -66,21 +67,11 @@ struct ds_cont_child {
 	ABT_cond		 sc_scrub_cond;
 	ABT_cond		 sc_rebuild_cond;
 	ABT_cond		 sc_fini_cond;
-	uint32_t		 sc_dtx_resyncing:1,
-				 sc_dtx_reindex:1,
-				 sc_dtx_reindex_abort:1,
-				 sc_dtx_delay_reset:1,
-				 sc_dtx_registered:1,
-				 sc_props_fetched:1,
-				 sc_stopping:1,
-				 sc_destroying:1,
-				 sc_vos_agg_active:1,
-				 sc_ec_agg_active:1,
-				 /* flag of CONT_CAPA_READ_DATA/_WRITE_DATA disabled */
-				 sc_rw_disabled:1,
-				 sc_scrubbing:1,
-				 sc_rebuilding:1;
-	uint32_t		 sc_dtx_batched_gen;
+	uint32_t                 sc_dtx_resyncing : 1, sc_dtx_reindex : 1, sc_dtx_reindex_abort : 1,
+	    sc_dtx_delay_reset : 1, sc_dtx_registered : 1, sc_props_fetched : 1, sc_stopping : 1,
+	    sc_destroying : 1, sc_vos_agg_active : 1, sc_ec_agg_active : 1,
+	    /* flag of CONT_CAPA_READ_DATA/_WRITE_DATA disabled */
+	    sc_rw_disabled : 1, sc_scrubbing : 1, sc_rebuilding : 1;
 	/* Tracks the schedule request for aggregation ULT */
 	struct sched_request	*sc_agg_req;
 


### PR DESCRIPTION
Generally, when an application closes the container, related committable DTX entries will be flushed. But the flush process maybe fail because of some unexpected issues, such as network trouble. To avoid blocking close process, the logic will give the left committable DTX entries to batched commit ULT to retry asynchronously.

Remove useless code for cleanup.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
