### PR TITLE
DAOS-17254 rebuild: fix a case of akey punch

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1554,6 +1554,17 @@ end:
 	if (rc == 0)
 		rc = rc1;
 
+	if (stale && iod_num == 1 && fetch_eph < mrone->mo_akey_punch_ephs[0]) {
+		/* XXX got record rebuild epoch lower than akey punch epoch, maybe should fix
+		 * pack/unpack part, ignore it now to avoid rebuild stuck.
+		 */
+		D_INFO(DF_RB ": " DF_UOID " %p dkey " DF_KEY " " DF_KEY " fetch_eph " DF_U64
+			     "akey_punch_eph " DF_U64 "\n",
+		       DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
+		       DP_KEY(&iods[0].iod_name), fetch_eph, mrone->mo_akey_punch_ephs[0]);
+		rc = 0;
+	}
+
 	if (rc)
 		DL_CDEBUG(stale, DB_REBUILD, DLOG_ERR, rc, DF_RB ": " DF_UOID " migrate error",
 			  DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid));


### PR DESCRIPTION
Possibly got record rebuild epoch lower than akey punch epoch, ignore that case now to avoid rebuild stuck.

Test-tag: EcodRunIoConf
Test-repeat: 8

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
