### PR TITLE
DAOS-16767 doc: improve documentation for daos cont set-prop

### DIFF
--- a/docs/user/container.md
+++ b/docs/user/container.md
@@ -400,7 +400,7 @@ accessed again.
 
 If the user is willing to access an unhealthy container (e.g., to recover data),
 the force flag can be passed on container open or the container state can be
-forced to healthy via `daos cont set-prop tank mycont1 --properties health:healthy`.
+forced to healthy via `daos cont set-prop tank mycont1 --properties status:healthy`.
 
 The redundancy level (rd\_lvl) is another property that was introduced to
 specify the fault domain level to use for placement.


### PR DESCRIPTION
Doc-only:true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
