### PR TITLE
b/406041958 control: Add configurable engine delay

### DIFF
--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -64,6 +65,7 @@ type Server struct {
 	CoreDumpFilter    uint8                     `yaml:"core_dump_filter,omitempty"`
 	ClientEnvVars     []string                  `yaml:"client_env_vars,omitempty"`
 	SupportConfig     SupportConfig             `yaml:"support_config,omitempty"`
+	EngineStartDelay  int                       `yaml:"engine_start_delay,omitempty"`
 
 	// duplicated in engine.Config
 	SystemName string              `yaml:"name"`
@@ -188,6 +190,7 @@ func (cfg *Server) updateServerConfig(cfgPtr **engine.Config) {
 	engineCfg.SocketDir = cfg.SocketDir
 	engineCfg.Modules = cfg.Modules
 	engineCfg.Storage.EnableHotplug = cfg.EnableHotplug
+	engineCfg.StartDelay = cfg.EngineStartDelay
 }
 
 // WithEngines sets the list of engine configurations.

--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -260,6 +261,7 @@ type Config struct {
 	MemSize           int            `yaml:"-" cmdLongFlag:"--mem_size" cmdShortFlag:"-r"`
 	HugepageSz        int            `yaml:"-" cmdLongFlag:"--hugepage_size" cmdShortFlag:"-H"`
 	CheckerEnabled    bool           `yaml:"-" cmdLongFlag:"--checker" cmdShortFlag:"-C"`
+	StartDelay        int            `yaml:"-"`
 }
 
 // NewConfig returns an I/O Engine config.

--- a/src/control/server/engine/exec.go
+++ b/src/control/server/engine/exec.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -12,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -74,6 +76,12 @@ func (r *Runner) run(parent context.Context, args, env []string, exitCh RunnerEx
 			Gid:         uint32(os.Getgid()),
 			NoSetGroups: true,
 		},
+	}
+
+	if r.Config.StartDelay > 0 {
+		delay := time.Duration(r.Config.StartDelay) * time.Second
+		r.log.Noticef("Delaying I/O Engine start for %s", delay)
+		time.Sleep(delay)
 	}
 
 	r.log.Debugf("%s:%d args: %s", engineBin, r.Config.Index, args)


### PR DESCRIPTION
When engine_start_delay is set to a non-zero value in
the daos_server yaml, delay engine start by that value
in seconds. Potentially useful in preventing use of PD
devices before they are ready.

Change-Id: I998aaf814114d6cb7383f936df6fa56a9cb33c34
Signed-off-by: Michael MacDonald <mjmac@google.com>
