### PR TITLE
DAOS-17161 rebuild: fix possible hang in rebuild_obj_send_cb

### DIFF
--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -130,6 +130,13 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 		    !daos_crt_network_error(rc)))
 			break;
 
+		if (rpt->rt_abort || rpt->rt_finishing) {
+			rc = -DER_SHUTDOWN;
+			DL_INFO(rc, DF_RB ": give up ds_object_migrate_send, shutdown rebuild",
+				DP_RB_RPT(rpt));
+			break;
+		}
+
 		/* otherwise let's retry */
 		D_DEBUG(DB_REBUILD, DF_RB " retry send object to tgt_id %d\n", DP_RB_RPT(rpt),
 			arg->tgt_id);


### PR DESCRIPTION
ds_object_migrate_send() possibly always get -DER_TIMEOUT when target server left, should check rt_abort and rt_finishing flag to avoid endless retry to avoid hang.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
