### PR TITLE
DAOS-17296 pool: distinguish local pool stop for maintenance - b26

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1448,7 +1448,8 @@ ds_cont_local_close(uuid_t cont_hdl_uuid)
 	if (hdl == NULL)
 		return 0;
 
-	hdl->sch_closed = 1;
+	if (hdl->sch_cont != NULL && hdl->sch_cont->sc_pool->spc_stop_for_maintain == 0)
+		hdl->sch_closed = 1;
 	cont_hdl_delete(&tls->dt_cont_hdl_hash, hdl);
 
 	ds_cont_hdl_put(hdl);

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -186,8 +187,8 @@ struct ds_pool_child {
 	int		spc_ref;
 	ABT_eventual	spc_ref_eventual;
 
-	uint64_t	spc_discard_done:1,
-			spc_no_storage:1; /* The pool shard has no storage. */
+	uint32_t spc_discard_done : 1, spc_no_storage : 1, /* The pool shard has no storage. */
+	    spc_stop_for_maintain : 1; /* Stop the pool_child for local maintenance. */
 
 	uint32_t	spc_reint_mode;
 	uint32_t	*spc_state;	/* Pointer to ds_pool->sp_states[i] */

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -551,6 +551,7 @@ pool_child_start(struct ds_pool_child *child, bool recreate)
 		goto out_cont;
 
 done:
+	child->spc_stop_for_maintain = 0;
 	*child->spc_state = POOL_CHILD_STARTED;
 	return 0;
 
@@ -675,6 +676,8 @@ ds_pool_child_stop(uuid_t pool_uuid, bool free)
 		return -DER_NONEXIST;
 	}
 
+	if (!free)
+		child->spc_stop_for_maintain = 1;
 	rc = pool_child_stop(child);
 	if (rc == 0 && free)
 		pool_child_free(child);
@@ -735,6 +738,8 @@ pool_child_delete_one(void *uuid)
 	child = pool_child_lookup_noref(uuid);
 	if (child == NULL)
 		return 0;
+
+	child->spc_stop_for_maintain = 0;
 retry:
 	rc = pool_child_stop(child);
 	if (rc) {


### PR DESCRIPTION
Under some cases, such as NVMe faulty cause local pool stop, we will mark related pool_child as stop_for_maintain, then the subsequent IO logic can distinguish it from regular global pool stop case to avoid returning non-retriable errno.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
