### PR TITLE
DAOS-xxxxx nlt: Add debug for failing dfuse command

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1419,16 +1419,16 @@ class DFuse():
 
         print(f"Running {' '.join(cmd)}")
         # pylint: disable-next=consider-using-with
-        self._sp = subprocess.Popen(cmd, env=my_env)
+        self._sp = subprocess.Popen(cmd, env=my_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         print(f'Started dfuse at {self.dir}')
         print(f'Log file is {self.log_file}')
 
         total_time = 0
         while os.stat(self.dir).st_ino == pre_inode:
-            print('Dfuse not started, waiting...')
+            print('Dfuse not started, waiting...', flush=True)
             try:
                 ret = self._sp.wait(timeout=1)
-                print(f'dfuse command exited with {ret}')
+                print(f'dfuse command exited with {ret}', flush=True)
                 self._sp = None
                 if os.path.exists(self.log_file):
                     log_test(self.conf, self.log_file)


### PR DESCRIPTION
Get the out put for the dfuse command to aid in determining failure.

Skip-func-tests: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
