### PR TITLE
DAOS-17343 control: Rename retry_count in SPDK config

### DIFF
--- a/src/control/server/storage/bdev/backend_class_test.go
+++ b/src/control/server/storage/bdev/backend_class_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -145,7 +146,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "retry_count": 4,
+            "transport_retry_count": 4,
             "timeout_us": 0,
             "nvme_adminq_poll_period_us": 100000,
             "action_on_timeout": "none",
@@ -203,7 +204,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "retry_count": 4,
+            "transport_retry_count": 4,
             "timeout_us": 0,
             "nvme_adminq_poll_period_us": 100000,
             "action_on_timeout": "none",
@@ -268,7 +269,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "retry_count": 4,
+            "transport_retry_count": 4,
             "timeout_us": 0,
             "nvme_adminq_poll_period_us": 100000,
             "action_on_timeout": "none",
@@ -349,7 +350,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "retry_count": 4,
+            "transport_retry_count": 4,
             "timeout_us": 0,
             "nvme_adminq_poll_period_us": 100000,
             "action_on_timeout": "none",
@@ -421,7 +422,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "retry_count": 4,
+            "transport_retry_count": 4,
             "timeout_us": 0,
             "nvme_adminq_poll_period_us": 100000,
             "action_on_timeout": "none",
@@ -495,7 +496,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "retry_count": 4,
+            "transport_retry_count": 4,
             "timeout_us": 0,
             "nvme_adminq_poll_period_us": 100000,
             "action_on_timeout": "none",
@@ -551,7 +552,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "retry_count": 4,
+            "transport_retry_count": 4,
             "timeout_us": 0,
             "nvme_adminq_poll_period_us": 100000,
             "action_on_timeout": "none",
@@ -607,7 +608,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "retry_count": 4,
+            "transport_retry_count": 4,
             "timeout_us": 0,
             "nvme_adminq_poll_period_us": 100000,
             "action_on_timeout": "none",
@@ -689,7 +690,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "retry_count": 4,
+            "transport_retry_count": 4,
             "timeout_us": 0,
             "nvme_adminq_poll_period_us": 100000,
             "action_on_timeout": "none",

--- a/src/control/server/storage/bdev/backend_json.go
+++ b/src/control/server/storage/bdev/backend_json.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -45,7 +46,7 @@ func (_ SetOptionsParams) isSpdkSubsystemConfigParams() {}
 
 // NvmeSetOptionsParams specifies details for a storage.ConfBdevNvmeSetOptions method.
 type NvmeSetOptionsParams struct {
-	RetryCount               uint32 `json:"retry_count"`
+	TransportRetryCount      uint32 `json:"transport_retry_count"`
 	TimeoutUsec              uint64 `json:"timeout_us"`
 	NvmeAdminqPollPeriodUsec uint32 `json:"nvme_adminq_poll_period_us"`
 	ActionOnTimeout          string `json:"action_on_timeout"`
@@ -152,7 +153,7 @@ func defaultSpdkConfig() *SpdkConfig {
 		{
 			Method: storage.ConfBdevNvmeSetOptions,
 			Params: NvmeSetOptionsParams{
-				RetryCount:               4,
+				TransportRetryCount:      4,
 				NvmeAdminqPollPeriodUsec: 100 * 1000,
 				ActionOnTimeout:          "none",
 			},

--- a/src/vos/tests/daos_nvme.conf
+++ b/src/vos/tests/daos_nvme.conf
@@ -15,7 +15,7 @@
         },
         {
           "params": {
-            "retry_count": 4,
+            "transport_retry_count": 4,
             "timeout_us": 0,
             "nvme_adminq_poll_period_us": 100000,
             "action_on_timeout": "none",


### PR DESCRIPTION
The retry_count parameter in the SPDK bdev configuration was
deprecated in v22 and renamed to transport_retry_count. As
of v24, retry_count is not accepted and will cause a parsing
error on engine startup. Using transport_retry_count will
work for both v22 and v24.

Signed-off-by: Michael MacDonald <mjmac@google.com>
