### PR TITLE
DAOS-17180 ddb: replace device offline

### DIFF
--- a/src/bio/bio_device.c
+++ b/src/bio/bio_device.c
@@ -576,15 +576,8 @@ bio_dev_list(struct bio_xs_context *xs_ctxt, d_list_t *dev_list, int *dev_cnt)
 
 	/*
 	 * Scan remaining SMD devices not present bio_bdev list.
-	 *
-	 * As for current implementation, there won't be any device
-	 * present in SMD but not in bio_bdev list, here we just do
-	 * it for sanity check.
 	 */
 	d_list_for_each_entry(s_info, &s_dev_list, sdi_link) {
-		D_ERROR("Found unexpected device "DF_UUID" in SMD\n",
-			DP_UUID(s_info->sdi_id));
-
 		b_info = alloc_dev_info(s_info->sdi_id, NULL, s_info);
 		if (b_info == NULL) {
 			D_ERROR("Failed to allocate device info\n");

--- a/src/control/cmd/ddb/commands_wrapper.go
+++ b/src/control/cmd/ddb/commands_wrapper.go
@@ -268,3 +268,25 @@ func ddbDtxActDiscardInvalid(ctx *DdbContext, path string, dtx_id string) error 
 	/* Run the c code command */
 	return daosError(C.ddb_run_dtx_act_discard_invalid(&ctx.ctx, &options))
 }
+
+func ddbDevList(ctx *DdbContext, db_path string) error {
+	/* Set up the options */
+	options := C.struct_dev_list_options{}
+	options.db_path = C.CString(db_path)
+	defer freeString(options.db_path)
+	/* Run the c code command */
+	return daosError(C.ddb_run_dev_list(&ctx.ctx, &options))
+}
+
+func ddbDevReplace(ctx *DdbContext, db_path string, old_devid string, new_devid string) error {
+	/* Set up the options */
+	options := C.struct_dev_replace_options{}
+	options.db_path = C.CString(db_path)
+	defer freeString(options.db_path)
+	options.old_devid = C.CString(old_devid)
+	defer freeString(options.old_devid)
+	options.new_devid = C.CString(new_devid)
+	defer freeString(options.new_devid)
+	/* Run the c code command */
+	return daosError(C.ddb_run_dev_replace(&ctx.ctx, &options))
+}

--- a/src/control/cmd/ddb/ddb_commands.go
+++ b/src/control/cmd/ddb/ddb_commands.go
@@ -349,4 +349,36 @@ the path must include the extent, otherwise, it must not.`,
 		},
 		Completer: nil,
 	})
+	// Command: dev_list
+	app.AddCommand(&grumble.Command{
+		Name:      "dev_list",
+		Aliases:   nil,
+		Help:      "List all devices",
+		LongHelp:  "",
+		HelpGroup: "vos",
+		Args: func(a *grumble.Args) {
+			a.String("db_path", "Path to the vos db.")
+		},
+		Run: func(c *grumble.Context) error {
+			return ddbDevList(ctx, c.Args.String("db_path"))
+		},
+		Completer: nil,
+	})
+	// Command dev_replace
+	app.AddCommand(&grumble.Command{
+		Name:      "dev_replace",
+		Aliases:   nil,
+		Help:      "Replace an old device with a new unused device",
+		LongHelp:  "",
+		HelpGroup: "vos",
+		Args: func(a *grumble.Args) {
+			a.String("db_path", "Path to the vos db.")
+			a.String("old_dev", "Old device UUID.")
+			a.String("new_dev", "New device UUID.")
+		},
+		Run: func(c *grumble.Context) error {
+			return ddbDevReplace(ctx, c.Args.String("db_path"), c.Args.String("old_dev"), c.Args.String("new_dev"))
+		},
+		Completer: nil,
+	})
 }

--- a/src/control/cmd/ddb/main.go
+++ b/src/control/cmd/ddb/main.go
@@ -183,7 +183,10 @@ Example Paths:
 	app := createGrumbleApp(ctx)
 
 	if opts.Args.VosPath != "" {
-		if !strings.HasPrefix(string(opts.Args.RunCmd), "feature") && !strings.HasPrefix(string(opts.Args.RunCmd), "rm_pool") {
+		if !strings.HasPrefix(string(opts.Args.RunCmd), "feature") &&
+			!strings.HasPrefix(string(opts.Args.RunCmd), "rm_pool") &&
+			!strings.HasPrefix(string(opts.Args.RunCmd), "dev_list") &&
+			!strings.HasPrefix(string(opts.Args.RunCmd), "dev_replace") {
 			log.Debugf("Connect to path: %s\n", opts.Args.VosPath)
 			if err := ddbOpen(ctx, string(opts.Args.VosPath), opts.WriteMode); err != nil {
 				return errors.Wrapf(err, "Error opening path: %s", opts.Args.VosPath)

--- a/src/utils/ddb/ddb.c
+++ b/src/utils/ddb/ddb.c
@@ -39,6 +39,8 @@
 #define COMMAND_NAME_FEATURE         "feature"
 #define COMMAND_NAME_RM_POOL         "rm_pool"
 #define COMMAND_NAME_DTX_ACT_DISCARD_INVALID "dtx_act_discard_invalid"
+#define COMMAND_NAME_DEV_LIST                "dev_list"
+#define COMMAND_NAME_DEV_REPLACE             "dev_replace"
 
 /* Parse command line options for the 'ls' command */
 static int
@@ -723,6 +725,95 @@ rm_pool_option_parse(struct ddb_ctx *ctx, struct rm_pool_options *cmd_args, uint
 	return 0;
 }
 
+/* Parse command line options for the 'dev_list' command */
+static int
+dev_list_option_parse(struct ddb_ctx *ctx, struct dev_list_options *cmd_args, uint32_t argc,
+		      char **argv)
+{
+	char         *options_short  = "";
+	int           index          = 0;
+	struct option options_long[] = {{NULL}};
+
+	memset(cmd_args, 0, sizeof(*cmd_args));
+
+	/* Restart getopt */
+	optind = 1;
+	opterr = 0;
+	if (getopt_long(argc, argv, options_short, options_long, &index) != -1) {
+		ddb_printf(ctx, "Unknown option: '%c'\n", optopt);
+		return -DER_INVAL;
+	}
+
+	index = optind;
+	if (argc - index > 0) {
+		cmd_args->db_path = argv[index];
+		index++;
+	}
+
+	if (argc - index > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\n", argv[index]);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+
+/* Parse command line options for the 'dev_replace' command */
+static int
+dev_replace_option_parse(struct ddb_ctx *ctx, struct dev_replace_options *cmd_args, uint32_t argc,
+			 char **argv)
+{
+	uuid_t        dev_uuid;
+	char         *options_short  = "o:n:";
+	int           index          = 0, opt, rc;
+	struct option options_long[] = {{"old_dev", required_argument, NULL, 'o'},
+					{"new_dev", required_argument, NULL, 'n'},
+					{NULL}};
+
+	memset(cmd_args, 0, sizeof(*cmd_args));
+	/* Restart getopt */
+	optind = 1;
+	opterr = 0;
+	while ((opt = getopt_long(argc, argv, options_short, options_long, &index)) != -1) {
+		switch (opt) {
+		case 'o':
+			rc = uuid_parse(optarg, dev_uuid);
+			if (rc) {
+				ddb_printf(ctx, "Invalid UUID string %s for old device\n", optarg);
+				return rc;
+			}
+			cmd_args->old_devid = optarg;
+			break;
+		case 'n':
+			rc = uuid_parse(optarg, dev_uuid);
+			if (rc) {
+				ddb_printf(ctx, "Invalid UUID string %s for new device\n", optarg);
+				return rc;
+			}
+			cmd_args->new_devid = optarg;
+			break;
+		case '?':
+			ddb_printf(ctx, "Unknown option: '%c'\n", optopt);
+			break;
+		default:
+			return -DER_INVAL;
+		}
+	}
+
+	index = optind;
+	if (argc - index > 0) {
+		cmd_args->db_path = argv[index];
+		index++;
+	}
+
+	if (argc - index > 0) {
+		ddb_printf(ctx, "Unexpected argument: %s\n", argv[index]);
+		return -DER_INVAL;
+	}
+
+	return 0;
+}
+
 int
 ddb_parse_cmd_args(struct ddb_ctx *ctx, uint32_t argc, char **argv, struct ddb_cmd_info *info)
 {
@@ -833,6 +924,17 @@ ddb_parse_cmd_args(struct ddb_ctx *ctx, uint32_t argc, char **argv, struct ddb_c
 		return feature_option_parse(ctx, &info->dci_cmd_option.dci_feature, argc, argv);
 	}
 
+	if (same(cmd, COMMAND_NAME_DEV_LIST)) {
+		info->dci_cmd = DDB_CMD_DEV_LIST;
+		return dev_list_option_parse(ctx, &info->dci_cmd_option.dci_dev_list, argc, argv);
+	}
+
+	if (same(cmd, COMMAND_NAME_DEV_REPLACE)) {
+		info->dci_cmd = DDB_CMD_DEV_REPLACE;
+		return dev_replace_option_parse(ctx, &info->dci_cmd_option.dci_dev_replace, argc,
+						argv);
+	}
+
 	ddb_errorf(ctx,
 		   "'%s' is not a valid command. Available commands are:"
 		   "'help', "
@@ -856,7 +958,9 @@ ddb_parse_cmd_args(struct ddb_ctx *ctx, uint32_t argc, char **argv, struct ddb_c
 		   "'dtx_act_commit', "
 		   "'dtx_act_abort', "
 		   "'feature', "
-		   "'rm_pool'\n",
+		   "'rm_pool', "
+		   "'dev_list', "
+		   "'dev_replace'\n",
 		   cmd);
 
 	return -DER_INVAL;
@@ -1022,6 +1126,14 @@ ddb_run_cmd(struct ddb_ctx *ctx, const char *cmd_str)
 
 	case DDB_CMD_RM_POOL:
 		rc = ddb_run_rm_pool(ctx, &info.dci_cmd_option.dci_rm_pool);
+		break;
+
+	case DDB_CMD_DEV_LIST:
+		rc = ddb_run_dev_list(ctx, &info.dci_cmd_option.dci_dev_list);
+		break;
+
+	case DDB_CMD_DEV_REPLACE:
+		rc = ddb_run_dev_replace(ctx, &info.dci_cmd_option.dci_dev_replace);
 		break;
 
 	case DDB_CMD_UNKNOWN:
@@ -1210,6 +1322,25 @@ ddb_commands_help(struct ddb_ctx *ctx)
 	ddb_print(ctx, "    -s, --show\n");
 	ddb_print(ctx, "\tShow current features\n");
 	ddb_print(ctx, "\n");
+
+	/* Command: dev_list */
+	ddb_print(ctx, "dev_list [db_path]\n");
+	ddb_print(ctx, "\tList all devices\n");
+	ddb_print(ctx, "    [db_path]\n");
+	ddb_print(ctx, "\tPath to the vos db. (default /mnt/daos)\n");
+	ddb_print(ctx, "\n");
+
+	/* Command: dev_replace */
+	ddb_print(ctx, "dev_replace [db_path]\n");
+	ddb_print(ctx, "\tReplaced an old device with a new unused device\n");
+	ddb_print(ctx, "    [db_path]\n");
+	ddb_print(ctx, "\tPath to the vos db. (default /mnt/daos)\n");
+	ddb_print(ctx, "Options:\n");
+	ddb_print(ctx, "    -o, --old_dev\n");
+	ddb_print(ctx, "\tSpecify the old device UUID\n");
+	ddb_print(ctx, "    -n, --new_dev\n");
+	ddb_print(ctx, "\tSpecify the new device UUID\n");
+	ddb_print(ctx, "\n");
 }
 
 void
@@ -1275,4 +1406,6 @@ ddb_program_help(struct ddb_ctx *ctx)
 	ddb_print(ctx, "   dtx_act_abort     Mark the active dtx entry as aborted\n");
 	ddb_print(ctx, "   feature	     Manage vos pool features\n");
 	ddb_print(ctx, "   rm_pool	     Remove pool shard\n");
+	ddb_print(ctx, "   dev_list	     List all devices\n");
+	ddb_print(ctx, "   dev_replace	     Replace an old device with a new unused device\n");
 }

--- a/src/utils/ddb/ddb.h
+++ b/src/utils/ddb/ddb.h
@@ -119,6 +119,8 @@ enum ddb_cmd {
 	DDB_CMD_FEATURE                 = 21,
 	DDB_CMD_RM_POOL                 = 22,
 	DDB_CMD_DTX_ACT_DISCARD_INVALID = 23,
+	DDB_CMD_DEV_LIST                = 24,
+	DDB_CMD_DEV_REPLACE             = 25,
 };
 
 /* option and argument structures for commands that need them */
@@ -197,6 +199,16 @@ struct rm_pool_options {
 	const char *path;
 };
 
+struct dev_list_options {
+	char *db_path;
+};
+
+struct dev_replace_options {
+	char *db_path;
+	char *old_devid;
+	char *new_devid;
+};
+
 struct ddb_cmd_info {
 	enum ddb_cmd dci_cmd;
 	union {
@@ -215,6 +227,8 @@ struct ddb_cmd_info {
 		struct feature_options        dci_feature;
 		struct rm_pool_options        dci_rm_pool;
 		struct dtx_act_options        dci_dtx_act;
+		struct dev_list_options       dci_dev_list;
+		struct dev_replace_options    dci_dev_replace;
 	} dci_cmd_option;
 };
 
@@ -256,6 +270,10 @@ int
 ddb_run_rm_pool(struct ddb_ctx *ctx, struct rm_pool_options *opt);
 int
      ddb_run_dtx_act_discard_invalid(struct ddb_ctx *ctx, struct dtx_act_options *opt);
+int
+ddb_run_dev_list(struct ddb_ctx *ctx, struct dev_list_options *opt);
+int
+     ddb_run_dev_replace(struct ddb_ctx *ctx, struct dev_replace_options *opt);
 
 void ddb_program_help(struct ddb_ctx *ctx);
 void ddb_commands_help(struct ddb_ctx *ctx);

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -1954,3 +1954,89 @@ dv_pool_get_flags(daos_handle_t poh, uint64_t *compat_flags, uint64_t *incompat_
 
 	return 0;
 }
+
+int
+dv_dev_list(const char *db_path, d_list_t *dev_list, int *dev_cnt)
+{
+	int rc;
+
+	rc = vos_self_init(db_path, true, 0);
+	if (rc) {
+		DL_ERROR(rc, "Initialize standalone VOS failed.");
+		return rc;
+	}
+
+	D_ASSERT(d_list_empty(dev_list));
+	rc = bio_dev_list(vos_xsctxt_get(), dev_list, dev_cnt);
+	if (rc)
+		DL_ERROR(rc, "Failed to list devices.");
+
+	vos_self_fini();
+	return rc;
+}
+
+static inline struct bio_dev_info *
+find_dev_info(d_list_t *dev_list, uuid_t dev_id)
+{
+	struct bio_dev_info *dev_info;
+
+	d_list_for_each_entry(dev_info, dev_list, bdi_link) {
+		if (uuid_compare(dev_id, dev_info->bdi_dev_id) == 0)
+			return dev_info;
+	}
+
+	return NULL;
+}
+
+int
+dv_dev_replace(const char *db_path, uuid_t old_devid, uuid_t new_devid)
+{
+	struct bio_dev_info *old_dev_info, *new_dev_info, *dev_info, *tmp;
+	d_list_t             dev_list;
+	int                  rc, dev_cnt = 0;
+
+	rc = vos_self_init(db_path, true, 0);
+	if (rc) {
+		DL_ERROR(rc, "Initialize standalone VOS failed.");
+		return rc;
+	}
+
+	D_INIT_LIST_HEAD(&dev_list);
+	rc = bio_dev_list(vos_xsctxt_get(), &dev_list, &dev_cnt);
+	if (rc) {
+		DL_ERROR(rc, "Failed to list devices.");
+		goto out;
+	}
+
+	rc           = -DER_INVAL;
+	old_dev_info = find_dev_info(&dev_list, old_devid);
+	if (old_dev_info == NULL) {
+		D_ERROR("Old dev " DF_UUID " isn't found\n", DP_UUID(old_devid));
+		goto out;
+	} else if (!(old_dev_info->bdi_flags & NVME_DEV_FL_INUSE)) {
+		D_ERROR("Old dev " DF_UUID " isn't inuse\n", DP_UUID(old_devid));
+		goto out;
+	}
+
+	new_dev_info = find_dev_info(&dev_list, new_devid);
+	if (new_dev_info == NULL) {
+		D_ERROR("New dev " DF_UUID " isn't found\n", DP_UUID(new_devid));
+		goto out;
+	} else if (new_dev_info->bdi_flags & NVME_DEV_FL_INUSE) {
+		D_ERROR("New dev " DF_UUID " is inuse\n", DP_UUID(new_devid));
+		goto out;
+	}
+
+	/* Specify 'roles' as 0 */
+	rc = smd_dev_replace(old_devid, new_devid, 0);
+	if (rc)
+		DL_ERROR(rc, "Failed to replace device in SMD");
+out:
+	d_list_for_each_entry_safe(dev_info, tmp, &dev_list, bdi_link) {
+		d_list_del_init(&dev_info->bdi_link);
+		bio_free_dev_info(dev_info);
+	}
+
+	vos_self_fini();
+	return rc;
+}

--- a/src/utils/ddb/ddb_vos.h
+++ b/src/utils/ddb/ddb_vos.h
@@ -210,4 +210,9 @@ void dv_oid_to_obj(daos_obj_id_t oid, struct ddb_obj *obj);
 
 int ddb_vtp_verify(daos_handle_t poh, struct dv_tree_path *vtp);
 
+int
+dv_dev_list(const char *db_path, d_list_t *dev_list, int *dev_cnt);
+int
+dv_dev_replace(const char *db_path, uuid_t old_devid, uuid_t new_devid);
+
 #endif /* DAOS_DDB_VOS_H */


### PR DESCRIPTION
If a NVMe SSD namespace is failed to be discovered by SPDK, the engine will fail to start due to missing device, so there is no way to do the online device replacing.

To fix above missing SSD namespace issue, offline device replacing could be used in following steps:

- Run 'ddb dev_list' to show all devices;
- Run 'ddb dev_replace' to replace the old broken SSD with an unused new SSD;
- Start engine;
- Run 'dmg storage replace' with same old and new device UUID to revive the replaced SSD (blobs will be auto created and reintegration will be triggered);

Limitation:
Offline device replacing can't handle the missing sys SSD in md-on-ssd mode (RDB is located on sys SSD in md-on-ssd mode) so far.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
