### PR TITLE
DAOS-17347 dtx: retry DTX resync for recoverable network failure - b26

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -57,12 +57,16 @@ enum dtx_operation {
 #undef X
 
 /* DTX RPC input fields */
+/* clang-format off */
 #define DAOS_ISEQ_DTX							\
 	((uuid_t)		(di_po_uuid)		CRT_VAR)	\
 	((uuid_t)		(di_co_uuid)		CRT_VAR)	\
 	((uint64_t)		(di_epoch)		CRT_VAR)	\
+	((uint32_t)		(di_version)		CRT_VAR)	\
+	((uint32_t)		(di_padding)		CRT_VAR)	\
 	((struct dtx_id)	(di_dtx_array)		CRT_ARRAY)	\
 	((uint32_t)		(di_flags)		CRT_ARRAY)
+/* clang-format on */
 
 /* DTX RPC output fields */
 #define DAOS_OSEQ_DTX							\

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -245,6 +245,13 @@ dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte, daos_un
 		 * let's commit the DTX globally.
 		 */
 		D_GOTO(out, rc = DSHR_NEED_COMMIT);
+	case -DER_OOG:
+	case -DER_HG:
+		D_WARN("Need retry resync for DTX " DF_DTI " because of " DF_RC "\n",
+		       DP_DTI(&dte->dte_xid), DP_RC(rc));
+		/* Yield to give more chance for network recovery. */
+		ABT_thread_yield();
+		D_GOTO(out, rc = DSHR_NEED_RETRY);
 	case -DER_INPROGRESS:
 	case -DER_TIMEDOUT:
 		D_WARN("Other participants not sure about whether the "
@@ -433,6 +440,10 @@ dtx_status_handle(struct dtx_resync_args *dra)
 
 		rc = dtx_status_handle_one(cont, &dre->dre_dte, dre->dre_oid, dre->dre_dkey_hash,
 					   dre->dre_epoch, tgt_array, &err);
+
+		if (unlikely(cont->sc_stopping))
+			D_GOTO(out, rc = -DER_CANCELED);
+
 		switch (rc) {
 		case DSHR_NEED_COMMIT:
 			goto commit;
@@ -684,6 +695,9 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, b
 
 	if (rc >= 0)
 		rc = rc1;
+
+	if (rc >= 0)
+		vos_set_dtx_resync_version(cont->sc_hdl, ver);
 
 	D_DEBUG(DB_MD, "Stop DTX resync (%s) scan for "DF_UUID"/"DF_UUID" with ver %u: rc = %d\n",
 		block ? "block" : "non-block", DP_UUID(po_uuid), DP_UUID(co_uuid), ver, rc);

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -56,6 +56,7 @@ struct dtx_req_args {
 	uuid_t				 dra_po_uuid;
 	/* container UUID */
 	uuid_t				 dra_co_uuid;
+	uint32_t                         dra_version;
 	/* The count of sub requests. */
 	int				 dra_length;
 	/* The collective RPC result. */
@@ -261,8 +262,9 @@ dtx_req_send(struct dtx_req_rec *drr, daos_epoch_t epoch)
 		din = crt_req_get(req);
 		uuid_copy(din->di_po_uuid, dra->dra_po_uuid);
 		uuid_copy(din->di_co_uuid, dra->dra_co_uuid);
-		din->di_epoch = epoch;
-		din->di_dtx_array.ca_count = drr->drr_count;
+		din->di_epoch               = epoch;
+		din->di_version             = dra->dra_version;
+		din->di_dtx_array.ca_count  = drr->drr_count;
 		din->di_dtx_array.ca_arrays = drr->drr_dti;
 		if (drr->drr_flags != NULL) {
 			din->di_flags.ca_count = drr->drr_count;
@@ -666,7 +668,8 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 	dra->dra_cmt_list = cmt_list;
 	dra->dra_abt_list = abt_list;
 	dra->dra_act_list = act_list;
-	dra->dra_opc = opc;
+	dra->dra_version  = pool->sp_map_version;
+	dra->dra_opc      = opc;
 	uuid_copy(dra->dra_po_uuid, pool->sp_uuid);
 	uuid_copy(dra->dra_co_uuid, cont->sc_uuid);
 

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -164,8 +164,7 @@ dtx_handler(crt_rpc_t *rpc)
 	struct dtx_out		*dout = crt_reply_get(rpc);
 	struct ds_cont_child	*cont = NULL;
 	struct dtx_id		*dtis;
-	struct dtx_cos_key	 dcks[DTX_REFRESH_MAX] = { 0 };
-	uint32_t		 vers[DTX_REFRESH_MAX] = { 0 };
+	struct dtx_cos_key       dcks[DTX_REFRESH_MAX] = {0};
 	uint32_t		 opc = opc_get(rpc->cr_opc);
 	uint32_t		 committed = 0;
 	uint32_t		*flags = NULL;
@@ -299,7 +298,8 @@ dtx_handler(crt_rpc_t *rpc)
 		for (i = 0, rc1 = 0; i < count; i++) {
 			ptr = (int *)dout->do_sub_rets.ca_arrays + i;
 			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
-			*ptr = vos_dtx_check(cont->sc_hdl, dtis, NULL, &vers[i], &dcks[i], true);
+			*ptr = vos_dtx_check(cont->sc_hdl, dtis, NULL, &din->di_version, &dcks[i],
+					     true);
 			if (*ptr == -DER_NONEXIST && !(flags[i] & DRF_INITIAL_LEADER)) {
 				struct dtx_stat		stat = { 0 };
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2015-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -221,6 +222,15 @@ vos_dtx_aggregate(daos_handle_t coh);
  */
 void
 vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat, uint32_t flags);
+
+/**
+ * Notify lower layer that DTX resync has been done.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param ver	[IN]	The version that DTX resync has been done.
+ */
+void
+vos_set_dtx_resync_version(daos_handle_t coh, uint32_t ver);
 
 /**
  * Set the DTX committable as committable.

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -2953,8 +2954,8 @@ again:
 			e = orw->orw_epoch;
 		else
 			e = 0;
-		rc = dtx_handle_resend(ioc.ioc_vos_coh, &orw->orw_dti,
-				       &e, &version);
+		version = orw->orw_map_ver;
+		rc      = dtx_handle_resend(ioc.ioc_vos_coh, &orw->orw_dti, &e, &version);
 		switch (rc) {
 		case -DER_ALREADY:
 			D_GOTO(out, rc = 0);
@@ -3879,8 +3880,8 @@ again:
 			e = opi->opi_epoch;
 		else
 			e = 0;
-		rc = dtx_handle_resend(ioc.ioc_vos_coh, &opi->opi_dti,
-				       &e, &version);
+		version = opi->opi_map_ver;
+		rc      = dtx_handle_resend(ioc.ioc_vos_coh, &opi->opi_dti, &e, &version);
 		switch (rc) {
 		case -DER_ALREADY:
 			D_GOTO(out, rc = 0);
@@ -5668,7 +5669,8 @@ again:
 			tmp = ocpi->ocpi_epoch;
 		else
 			tmp = 0;
-		rc = dtx_handle_resend(ioc.ioc_vos_coh, &ocpi->ocpi_xid, &tmp, &version);
+		version = ocpi->ocpi_map_ver;
+		rc      = dtx_handle_resend(ioc.ioc_vos_coh, &ocpi->ocpi_xid, &tmp, &version);
 		switch (rc) {
 		case -DER_ALREADY:
 			D_GOTO(out, rc = 0);

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1360,6 +1360,12 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 		d_list_for_each_entry(dsp, &dth->dth_share_act_list, dsp_link) {
 			if (memcmp(&dsp->dsp_xid, &DAE_XID(dae),
 				   sizeof(struct dtx_id)) == 0) {
+				if (dsp->dsp_status == -DER_INPROGRESS)
+					return dtx_inprogress(dae, dth, true, true, 9);
+
+				if (unlikely(dsp->dsp_status != 0))
+					return dsp->dsp_status;
+
 				if (!dtx_is_valid_handle(dth) ||
 				    intent == DAOS_INTENT_IGNORE_NONCOMMITTED)
 					return ALB_UNAVAILABLE;
@@ -1939,9 +1945,6 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 		if (DAE_FLAGS(dae) & DTE_ORPHAN)
 			return -DER_TX_UNCERTAIN;
 
-		if (pm_ver != NULL)
-			*pm_ver = DAE_VER(dae);
-
 		if (dck != NULL) {
 			dck->oid = DAE_OID(dae);
 			dck->dkey_hash = DAE_DKEY_HASH(dae);
@@ -1981,28 +1984,42 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 			 */
 			if (!(DAE_FLAGS(dae) & DTE_LEADER))
 				return -DER_INPROGRESS;
+		} else {
+			/* Not committable yet, related RPC handler ULT is still running. */
+			if (dae->dae_dth != NULL)
+				return -DER_INPROGRESS;
 
-			return vos_dae_is_prepare(dae) ? DTX_ST_PREPARED : DTX_ST_INITED;
-		}
+			if (epoch != NULL) {
+				daos_epoch_t e = *epoch;
 
-		/* Not committable yet, related RPC handler ULT is still running. */
-		if (dae->dae_dth != NULL)
-			return -DER_INPROGRESS;
+				*epoch = DAE_EPOCH(dae);
+				if (e != 0) {
+					if (e > DAE_EPOCH(dae))
+						return -DER_MISMATCH;
 
-		if (epoch != NULL) {
-			daos_epoch_t	e = *epoch;
-
-			*epoch = DAE_EPOCH(dae);
-			if (e != 0) {
-				if (e > DAE_EPOCH(dae))
-					return -DER_MISMATCH;
-
-				if (e < DAE_EPOCH(dae))
-					return -DER_TX_RESTART;
+					if (e < DAE_EPOCH(dae))
+						return -DER_TX_RESTART;
+				}
 			}
 		}
 
-		return vos_dae_is_prepare(dae) ? DTX_ST_PREPARED : DTX_ST_INITED;
+		if (!vos_dae_is_prepare(dae))
+			return DTX_ST_INITED;
+
+		if (pm_ver == NULL)
+			return DTX_ST_PREPARED;
+
+		if (*pm_ver <= cont->vc_dtx_resync_ver) {
+			if (!for_refresh)
+				*pm_ver = DAE_VER(dae);
+			return DTX_ST_PREPARED;
+		}
+
+		/*
+		 * Before DTX resync completed, it is not sure whether related DTX is
+		 * committable or not, then have to ask DTX refresh sponsor to retry.
+		 */
+		return -DER_INPROGRESS;
 	}
 
 	if (rc == -DER_NONEXIST) {
@@ -2767,6 +2784,20 @@ cmt:
 				break;
 			}
 		}
+	}
+}
+
+void
+vos_set_dtx_resync_version(daos_handle_t coh, uint32_t ver)
+{
+	struct vos_container *cont = vos_hdl2cont(coh);
+
+	D_ASSERT(cont != NULL);
+
+	if (likely(cont->vc_dtx_resync_ver < ver)) {
+		D_INFO("Update resync version %u => %u for container " DF_UUID "\n",
+		       cont->vc_dtx_resync_ver, ver, DP_UUID(cont->vc_id));
+		cont->vc_dtx_resync_ver = ver;
 	}
 }
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -375,6 +375,8 @@ struct vos_container {
 				vc_cmt_dtx_indexed:1;
 	unsigned int		vc_obj_discard_count;
 	unsigned int		vc_open_count;
+	/* The latest pool map version that DTX resync has been done. */
+	uint32_t                vc_dtx_resync_ver;
 };
 
 struct vos_dtx_act_ent {


### PR DESCRIPTION
If the engine on which some DTX leader reside restart, then former in-DRAM committable DTX status will be lost. When (re)open related container, DTX resync will be triggered to resync and commit those former committable DTX entries. But during DTX resync, it may hit recoverable netwrok failure, such as "-DER_OOG" since lower layer network membership may be not ready yet. Under such case, wen need to retry resync for related DTX; otherwise related DTX will become non-committable status globally as to misguide subsequent IO logic to give wrong visibility decision.

On the other hand, if some non-leader triggers DTX refresh before DTX resync completed on the leader, it will get "-DER_INPROGRESS" and needs to retry.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
