### PR TITLE
DAOS-16686 dfuse: fix list corruption

### DIFF
--- a/src/client/dfuse/ops/read.c
+++ b/src/client/dfuse/ops/read.c
@@ -586,6 +586,7 @@ dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position, struct
 	ev->de_oh           = oh;
 	ev->de_req_len      = len;
 	ev->de_req_position = position;
+	D_INIT_LIST_HEAD(&ev->de_read_list);
 
 	if (mock_read) {
 		ev->de_len = len;


### PR DESCRIPTION
Initialize the list, otherwise it might be corrupted if multiple threads read the same file.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
