### PR TITLE
DAOS-16136 common: unnecessary sgl warning

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -612,18 +613,10 @@ calc_csum_recx_with_map(struct daos_csummer *obj, size_t *csum_nr,
 		}
 	}
 
-	if (consumed_bytes < recx->rx_nr * rec_len) {
-		/** Nothing mapped for recx or tail unmapped */
-		bytes_to_skip = (recx->rx_nr * rec_len) - consumed_bytes;
-		daos_sgl_processor(sgl, false, idx, bytes_to_skip,
-				   sgl_process_nop_cb, NULL);
-		consumed_bytes += bytes_to_skip;
-	}
-
 	*csum_nr = csums_calculated;
-	D_ASSERTF(consumed_bytes == recx->rx_nr * rec_len,
-		"consumed_bytes(%lu) == recx->rx_nr * rec_len(%lu)",
-		  consumed_bytes, recx->rx_nr * rec_len);
+	D_ASSERTF(consumed_bytes <= recx->rx_nr * rec_len,
+		  "consumed_bytes(%lu) <= recx->rx_nr * rec_len(%lu)", consumed_bytes,
+		  recx->rx_nr * rec_len);
 	return 0;
 }
 

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -361,6 +362,7 @@ daos_sgl_processor(d_sg_list_t *sgl, bool check_buf, struct daos_sgl_idx *idx,
 	size_t		 len = 0;
 	bool		 end = false;
 	int		 rc  = 0;
+	size_t           original_bytes = requested_bytes;
 
 	/*
 	 * loop until all bytes are consumed, the end of the sgl is reached, or
@@ -376,7 +378,8 @@ daos_sgl_processor(d_sg_list_t *sgl, bool check_buf, struct daos_sgl_idx *idx,
 	}
 
 	if (requested_bytes)
-		D_INFO("Requested more bytes than what's available in sgl\n");
+		D_INFO("Requested more bytes %zd than what's available in sgl %zd\n",
+		       original_bytes, original_bytes - requested_bytes);
 
 	return rc;
 }


### PR DESCRIPTION
client side checksum calculation is based on the request iod recxs, though the checksum is calculated by real IOM, so the input request bytes might be larger than the real fetched bytes in sgl, so let's ignore the size after the real fetched bytes.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
