### PR TITLE
DAOS-16918 vos: suppress two log messages (#15679)

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -3513,8 +3514,8 @@ crt_iv_update_internal(crt_iv_namespace_t ivns, uint32_t class_id,
 
 		D_GOTO(exit, rc);
 	} else {
-		DL_CDEBUG(rc == -DER_NONEXIST || rc == -DER_NOTLEADER || rc == -DER_BUSY,
-			  DLOG_INFO, DLOG_ERR, rc, "ivo_on_update failed");
+		DL_CDEBUG(rc == -DER_NONEXIST || rc == -DER_NOTLEADER || rc == -DER_BUSY, DB_TRACE,
+			  DLOG_ERR, rc, "ivo_on_update failed");
 
 		update_comp_cb(ivns, class_id, iv_key, NULL,
 			       iv_value, rc, cb_arg);

--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1060,10 +1061,13 @@ static int
 _iv_op(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,
        crt_iv_sync_t *sync, unsigned int shortcut, bool retry, int opc)
 {
-	int rc;
+	int sleep_ms, total_ms = 0, rc;
 
 	if (ns->iv_stop)
 		return -DER_SHUTDOWN;
+
+	/* Sleep 1 ms before retry for IV_OID, sleep 1 sec before retry for other IV */
+	sleep_ms = key->class_id == IV_OID ? 1 : 1000;
 retry:
 	rc = iv_op_internal(ns, key, value, sync, shortcut, opc);
 	if (retry && !ns->iv_stop &&
@@ -1094,15 +1098,13 @@ retry:
 		 * but in-flight fetch request return IVCB_FORWARD, then queued RPC will
 		 * reply IVCB_FORWARD.
 		 */
-		D_INFO("ns %u retry for class %d opc %d rank %u/%u: " DF_RC "\n", ns->iv_ns_id,
-		       key->class_id, opc, key->rank, ns->iv_master_rank, DP_RC(rc));
-		if (key->class_id == IV_OID) {
-			/* sleep 1msec and retry */
-			dss_sleep(1);
-		} else {
-			/* sleep 1sec and retry */
-			dss_sleep(1000);
-		}
+		if (total_ms % 10000 == 0)
+			D_DEBUG(DB_TRACE, "ns %u retry for class %d opc %d rank %u/%u: " DF_RC "\n",
+				ns->iv_ns_id, key->class_id, opc, key->rank, ns->iv_master_rank,
+				DP_RC(rc));
+
+		dss_sleep(sleep_ms);
+		total_ms += sleep_ms;
 		goto retry;
 	}
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1254,21 +1254,26 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 		  DF_U64 ", boundary " DF_U64 "\n", entry, epoch, cont->vc_solo_dtx_epoch);
 
 	if (intent == DAOS_INTENT_PURGE) {
-		uint64_t	now = daos_gettime_coarse();
+		uint32_t age = d_hlc_age2sec(DAE_XID(dae).dti_hlc);
+		uint64_t now;
 
 		/*
-		 * The DTX entry still references related data record,
-		 * then we cannot (vos) aggregate related data record.
-		 * Report warning per each 10 seconds to avoid log flood.
+		 * Don't print warning message for fresh record, since INTENT_PURGE could
+		 * be used for fresh record in normal cases. (see vos_ilog_is_punched()).
 		 */
-		if (now - cont->vc_agg_busy_ts > 10) {
-			D_WARN("DTX "DF_DTI" (state:%u, flags:%x, age:%u) still references "
-			       "the modification, cannot be (VOS) aggregated\n",
-			       DP_DTI(&DAE_XID(dae)), vos_dtx_status(dae), DAE_FLAGS(dae),
-			       (unsigned int)d_hlc_age2sec(DAE_XID(dae).dti_hlc));
-			cont->vc_agg_busy_ts = now;
-		}
+		if (age <= 10)
+			return ALB_AVAILABLE_DIRTY;
 
+		/* Rate limit on such warning messages */
+		now = daos_gettime_coarse();
+		if (now <= cont->vc_agg_busy_ts + 10)
+			return ALB_AVAILABLE_DIRTY;
+
+		/* VOS aggregation is trying to reclaim data record being referenced by DTX */
+		D_WARN("DTX " DF_DTI " (state:%u, flags:%x, age:%u, type:%u) is still inuse!\n",
+		       DP_DTI(&DAE_XID(dae)), vos_dtx_status(dae), DAE_FLAGS(dae), age, type);
+
+		cont->vc_agg_busy_ts = now;
 		return ALB_AVAILABLE_DIRTY;
 	}
 


### PR DESCRIPTION
- Rate limit on IV_OID busy message, change the debug level of two IV log messages from INFO to DEBUG.
- Don't print warning message in vos_dtx_check_availability() for fresh record.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
