### PR TITLE
DAOS-16845 test: update tests to use check_free_space (#15553)

### DIFF
--- a/src/tests/ftest/aggregation/dfuse_space_check.py
+++ b/src/tests/ftest/aggregation/dfuse_space_check.py
@@ -1,11 +1,10 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-
 import os
-import time
 
 from dfuse_utils import get_dfuse, start_dfuse
 from ior_test_base import IorTestBase
@@ -21,8 +20,8 @@ class DfuseSpaceCheck(IorTestBase):
     def __init__(self, *args, **kwargs):
         """Initialize a DfuseSpaceCheck object."""
         super().__init__(*args, **kwargs)
-        self.initial_space = None
-        self.block_size = None
+        self.__initial_space = None
+        self.__block_size = None
 
     def get_nvme_free_space(self, display=True):
         """Display pool free space.
@@ -40,24 +39,11 @@ class DfuseSpaceCheck(IorTestBase):
 
         return free_space_nvme
 
-    def wait_for_aggregation(self, retries=4, interval=60):
-        """Wait for aggregation to finish.
-
-        Args:
-            retries (int, optional): number of times to retry.
-                Default is 4.
-            interval (int, optional): seconds to wait before retrying.
-                Default is 60.
-
-        """
-        for _ in range(retries):
-            current_space = self.get_nvme_free_space()
-            if current_space == self.initial_space:
-                return
-            time.sleep(interval)
-
-        self.log.info("Free space when test terminated: %s", current_space)
-        self.fail("Aggregation did not complete within {} seconds".format(retries * interval))
+    def wait_for_aggregation(self):
+        """Wait for aggregation to finish."""
+        if not self.pool.check_free_space(
+                expected_nvme=self.__initial_space, timeout=240, interval=30):
+            self.fail("Aggregation did not complete within 240 seconds")
 
     def write_multiple_files(self, dfuse):
         """Write multiple files.
@@ -70,9 +56,9 @@ class DfuseSpaceCheck(IorTestBase):
 
         """
         file_count = 0
-        while self.get_nvme_free_space(False) >= self.block_size:
+        while self.get_nvme_free_space(False) >= self.__block_size:
             file_path = os.path.join(dfuse.mount_dir.value, "file{}.txt".format(file_count))
-            write_dd_cmd = "dd if=/dev/zero of={} bs={} count=1".format(file_path, self.block_size)
+            write_dd_cmd = f"dd if=/dev/zero of={file_path} bs={self.__block_size} count=1"
             result = run_remote(
                 self.log, self.hostlist_clients, write_dd_cmd, verbose=False, timeout=300)
             if not result.passed:
@@ -81,13 +67,12 @@ class DfuseSpaceCheck(IorTestBase):
 
         return file_count
 
-    def test_dfusespacecheck(self):
+    def test_dfuse_space_check(self):
         """Jira ID: DAOS-3777.
 
         Test Description:
-            Purpose of this test is to mount dfuse and verify aggregation
-            to return space when pool is filled with once large file and
-            once with small files.
+            Purpose of this test is to mount dfuse and verify aggregation to return space when pool
+            is filled with once large file and once with small files.
 
         Use cases:
             Create a pool.
@@ -106,10 +91,10 @@ class DfuseSpaceCheck(IorTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
         :avocado: tags=aggregation,daosio,dfuse
-        :avocado: tags=DfuseSpaceCheck,test_dfusespacecheck
+        :avocado: tags=DfuseSpaceCheck,test_dfuse_space_check
         """
-        # get test params for cont and pool count
-        self.block_size = self.params.get('block_size', '/run/dfusespacecheck/*')
+        # Get test params for cont and pool count
+        self.__block_size = self.params.get('block_size', '/run/dfuse_space_check/*')
 
         # Create a pool, container, and start dfuse
         self.create_pool()
@@ -117,16 +102,16 @@ class DfuseSpaceCheck(IorTestBase):
         dfuse = get_dfuse(self, self.hostlist_clients)
         start_dfuse(self, dfuse, self.pool, self.container)
 
-        # get nvme space before write
-        self.initial_space = self.get_nvme_free_space()
+        # Get nvme space before write
+        self.__initial_space = self.get_nvme_free_space()
 
         # Create a file as large as we can
         large_file = os.path.join(dfuse.mount_dir.value, 'largefile.txt')
         if not run_remote(self.log, self.hostlist_clients, f'touch {large_file}').passed:
             self.fail(f"Error creating {large_file}")
-        dd_count = (self.initial_space // self.block_size) + 1
+        dd_count = (self.__initial_space // self.__block_size) + 1
         write_dd_cmd = "dd if=/dev/zero of={} bs={} count={}".format(
-            large_file, self.block_size, dd_count)
+            large_file, self.__block_size, dd_count)
         run_remote(self.log, self.hostlist_clients, write_dd_cmd)
 
         # Remove the file

--- a/src/tests/ftest/aggregation/dfuse_space_check.yaml
+++ b/src/tests/ftest/aggregation/dfuse_space_check.yaml
@@ -1,7 +1,9 @@
 hosts:
   test_servers: 1
   test_clients: 1
+
 timeout: 1500
+
 server_config:
   name: daos_server
   engines_per_host: 1
@@ -9,11 +11,14 @@ server_config:
     0:
       targets: 1
       storage: auto
+
 pool:
   scm_size: 200MB
   nvme_size: 1GiB  # Minimum for 1 target
+
 container:
   type: POSIX
   control_method: daos
-dfusespacecheck:
+
+dfuse_space_check:
   block_size: 2097152  # 2M

--- a/src/tests/ftest/container/multiple_delete.py
+++ b/src/tests/ftest/container/multiple_delete.py
@@ -1,11 +1,11 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import time
 
-from general_utils import DaosTestError
 from ior_test_base import IorTestBase
 
 
@@ -60,11 +60,8 @@ class MultipleContainerDelete(IorTestBase):
         self.log.info("SCM = %d, NVMe = %d", final_scm_fs, final_ssd_fs)
 
         self.log.info("Verifying NVMe space is recovered")
-        try:
-            self.pool.check_free_space(expected_nvme=initial_ssd_fs)
-        except DaosTestError as error:
-            self.fail("NVMe space is not recovered after 50 "
-                      "create-write-destroy iterations {}".format(error))
+        if not self.pool.check_free_space(expected_nvme=initial_ssd_fs):
+            self.fail("NVMe space is not recovered after 50 create-write-destroy iterations")
 
         # Verify SCM space recovery. About 198KB of the SCM free space isn't recovered
         # even after waiting for 180 sec, so apply the threshold. Considered not a bug.

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -401,18 +402,28 @@ class NvmeEnospace(ServerFillUp, TestWithTelemetry):
         :avocado: tags=nvme,der_enospace,enospc_lazy,enospc_lazy_fg
         :avocado: tags=NvmeEnospace,test_enospace_lazy_with_fg
         """
-        self.log.info(self.pool.pool_percentage_used())
+        scm_threshold_percent = self.params.get("scm_threshold_percent", "/run/aggregation/*")
+
+        self.log_step("Get initial pool free space")
+        pool_space = self.pool.get_tier_stats(True)
+        initial_free_scm = pool_space["scm"]["free"]
+        initial_free_nvme = pool_space["nvme"]["free"]
+        self.log.info("initial_free_scm  = %s", initial_free_scm)
+        self.log.info("initial_free_nvme = %s", initial_free_nvme)
 
         # Repeat the test in loop.
         for _loop in range(10):
-            self.log.info("-------enospc_lazy_fg Loop--------- %d", _loop)
-            # Run IOR to fill the pool.
+            self.log_step(f"Run IOR to fill the pool - enospc_lazy_fg loop {_loop}")
             log_file = f"-loop_{_loop}".join(os.path.splitext(self.client_log))
             self.run_enospace_foreground(log_file)
-            # Delete all the containers
+            self.log_step(f"Delete all containers - enospc_lazy_fg loop {_loop}")
             self.delete_all_containers()
-            # Delete container will take some time to release the space
-            time.sleep(60)
+            self.log_step(f"Wait for aggregation to complete - enospc_lazy_fg loop {_loop}")
+            if not self.pool.check_free_space(
+                    expected_scm=f">={int(initial_free_scm * scm_threshold_percent / 100)}",
+                    expected_nvme=initial_free_nvme,
+                    timeout=240, interval=15):
+                self.fail("Pool space not reclaimed after deleting all containers")
 
         # Run last IO
         self.start_ior_load(storage='SCM', operation="Auto_Write", percent=1)
@@ -459,24 +470,36 @@ class NvmeEnospace(ServerFillUp, TestWithTelemetry):
         :avocado: tags=nvme,der_enospace,enospc_time,enospc_time_fg
         :avocado: tags=NvmeEnospace,test_enospace_time_with_fg
         """
+        scm_threshold_percent = self.params.get("scm_threshold_percent", "/run/aggregation/*")
         self.log.info(self.pool.pool_percentage_used())
 
-        # Enabled TIme mode for Aggregation.
+        self.log_step("Enable pool aggregation")
         self.pool.set_property("reclaim", "time")
+
+        self.log_step("Get initial pool free space")
+        pool_space = self.pool.get_tier_stats(True)
+        initial_free_scm = pool_space["scm"]["free"]
+        initial_free_nvme = pool_space["nvme"]["free"]
+        self.log.info("initial_free_scm  = %s", initial_free_scm)
+        self.log.info("initial_free_nvme = %s", initial_free_nvme)
 
         # Repeat the test in loop.
         for _loop in range(10):
-            self.log.info("-------enospc_time_fg Loop--------- %d", _loop)
+            self.log_step(f"Run IOR to fill the pool - enospace_time_with_fg loop {_loop}")
             self.log.info(self.pool.pool_percentage_used())
             # Run IOR to fill the pool.
             log_file = f"-loop_{_loop}".join(os.path.splitext(self.client_log))
             self.run_enospace_with_bg_job(log_file)
-            # Delete all the containers
+            self.log_step(f"Delete all containers - enospace_time_with_fg loop {_loop}")
             self.delete_all_containers()
-            # Delete container will take some time to release the space
-            time.sleep(60)
+            self.log_step(f"Wait for aggregation to complete - enospace_time_with_fg loop {_loop}")
+            if not self.pool.check_free_space(
+                    expected_scm=f">={int(initial_free_scm * scm_threshold_percent / 100)}",
+                    expected_nvme=initial_free_nvme,
+                    timeout=240, interval=15):
+                self.fail("Pool space not reclaimed after deleting all containers")
 
-        # Run last IO
+        self.log_step("Run one more sanity IOR to fill 1%")
         self.start_ior_load(storage='SCM', operation="Auto_Write", percent=1)
 
     @skipForTicket("DAOS-8896")

--- a/src/tests/ftest/nvme/enospace.yaml
+++ b/src/tests/ftest/nvme/enospace.yaml
@@ -59,3 +59,6 @@ ior:
       transfer_size: 2048  # 2K
     16M:
       nvme_transfer_size: 16777216  # 16M
+
+aggregation:
+  scm_threshold_percent: 99  # percent of scm expected to be reclaimed after aggregation

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -906,14 +907,15 @@ class TestPool(TestDaosApiBase):
             for index, item in enumerate(val)]
         return self._check_info(checks)
 
-    def check_free_space(self, expected_scm=None, expected_nvme=None, timeout=30):
+    def check_free_space(self, expected_scm=None, expected_nvme=None, timeout=30, interval=1):
         """Check pool free space with expected value.
 
         Args:
             expected_scm (int, optional): pool expected SCM free space.
             expected_nvme (int, optional): pool expected NVME free space.
-            timeout(int, optional): time to fail test if it could not match
+            timeout (int, optional): time to fail test if it could not match
                 expected values.
+            interval (int, optional): time to sleep between retries
 
         Note:
             Arguments may also be provided as a string with a number preceded
@@ -921,25 +923,21 @@ class TestPool(TestDaosApiBase):
             default '=='.
 
         Raises:
-            DaosTestError: if scm or nvme free space doesn't match expected
-            values within timeout.
+            ValueError: if no space arguments are given
 
         Returns:
-            bool: True if expected value is specified and all the
-                specified values match; False if no space parameters specified.
+            bool: whether the space matched expected values
 
         """
         if not expected_scm and not expected_nvme:
-            self.log.error("at least one space parameter must be specified")
-            return False
+            raise ValueError("at least one space parameter must be specified")
 
-        done = False
         scm_fs = 0
         nvme_fs = 0
         start = time()
         scm_index, nvme_index = 0, 1
-        while time() - start < timeout and not done:
-            sleep(1)
+        while time() - start < timeout:
+            sleep(interval)
             checks = []
             self.get_info()
             scm_fs = self.info.pi_space.ps_space.s_free[scm_index]
@@ -948,14 +946,10 @@ class TestPool(TestDaosApiBase):
                 checks.append(("scm", scm_fs, expected_scm))
             if expected_nvme is not None:
                 checks.append(("nvme", nvme_fs, expected_nvme))
-            done = self._check_info(checks)
+            if self._check_info(checks):
+                return True
 
-        if not done:
-            raise DaosTestError(
-                "Pool Free space did not match: actual={},{} expected={},{}".format(
-                    scm_fs, nvme_fs, expected_scm, expected_nvme))
-
-        return done
+        return False
 
     def check_rebuild_status(self, rs_version=None, rs_seconds=None,
                              rs_errno=None, rs_state=None, rs_padding32=None,


### PR DESCRIPTION
Update tests to use pool.check_free_space to dynamicall wait for pool aggregation.

Test-tag: test_enospace_time_with_fg DfuseSpaceCheck MultipleContainerDelete test_enospace_lazy_with_fg
Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
