### PR TITLE
DAOS-17343 control: Validate SPDK config on engine start

### DIFF
--- a/src/control/cmd/daos_server_helper/handler.go
+++ b/src/control/cmd/daos_server_helper/handler.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -328,6 +329,30 @@ func (h *bdevWriteConfigHandler) Handle(log logging.Logger, req *pbin.Request) *
 	h.setupProvider(log)
 
 	fRes, err := h.bdevProvider.WriteConfig(fReq)
+	if err != nil {
+		return pbin.NewResponseWithError(err)
+	}
+
+	return pbin.NewResponseWithPayload(fRes)
+}
+
+type bdevReadConfigHandler struct {
+	bdevHandler
+}
+
+func (h *bdevReadConfigHandler) Handle(log logging.Logger, req *pbin.Request) *pbin.Response {
+	if req == nil {
+		return getNilRequestResp()
+	}
+
+	var fReq storage.BdevReadConfigRequest
+	if err := json.Unmarshal(req.Payload, &fReq); err != nil {
+		return pbin.NewResponseWithError(err)
+	}
+
+	h.setupProvider(log)
+
+	fRes, err := h.bdevProvider.ReadConfig(fReq)
 	if err != nil {
 		return pbin.NewResponseWithError(err)
 	}

--- a/src/control/cmd/daos_server_helper/main.go
+++ b/src/control/cmd/daos_server_helper/main.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -46,4 +47,5 @@ func addMethodHandlers(app *pbin.App) {
 	app.AddHandler("BdevScan", &bdevScanHandler{})
 	app.AddHandler("BdevFormat", &bdevFormatHandler{})
 	app.AddHandler("BdevWriteConfig", &bdevWriteConfigHandler{})
+	app.AddHandler("BdevReadConfig", &bdevReadConfigHandler{})
 }

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -1,6 +1,7 @@
 //
 // (C) Copyright 2018-2024 Intel Corporation.
 // (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -206,6 +207,7 @@ const (
 	SpdkCtrlrNoHealth
 	SpdkBindingRetNull
 	SpdkBindingFailed
+	SpdkInvalidConfiguration
 )
 
 // security fault codes

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -1,6 +1,7 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
 // (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -927,6 +928,22 @@ type formatNvmeReq struct {
 	mdFormatted bool
 }
 
+func getEngineBdevCtrlrs(ctx context.Context, engine Engine) (storage.NvmeControllers, error) {
+	respBdevs, err := scanEngineBdevs(ctx, engine, new(ctlpb.ScanNvmeReq))
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert proto ctrlr scan results to native when calling into storage provider.
+	pbCtrlrs := proto.NvmeControllers(respBdevs.Ctrlrs)
+	ctrlrs, err := pbCtrlrs.ToNative()
+	if err != nil {
+		return nil, errors.Wrapf(err, "convert %T to %T", pbCtrlrs, ctrlrs)
+	}
+
+	return ctrlrs, nil
+}
+
 func formatNvme(ctx context.Context, req formatNvmeReq, resp *ctlpb.StorageFormatResp) error {
 	// Allow format to complete on one instance even if another fails
 	for idx, engine := range req.instances {
@@ -947,7 +964,7 @@ func formatNvme(ctx context.Context, req formatNvmeReq, resp *ctlpb.StorageForma
 			continue
 		}
 
-		respBdevs, err := scanEngineBdevs(ctx, engine, new(ctlpb.ScanNvmeReq))
+		ctrlrs, err := getEngineBdevCtrlrs(ctx, engine)
 		if err != nil {
 			if errors.Is(err, errEngineBdevScanEmptyDevList) {
 				// No controllers assigned in config, continue.
@@ -956,13 +973,6 @@ func formatNvme(ctx context.Context, req formatNvmeReq, resp *ctlpb.StorageForma
 			req.errored[idx] = err.Error()
 			resp.Crets = append(resp.Crets, engine.newCret("", err))
 			continue
-		}
-
-		// Convert proto ctrlr scan results to native when calling into storage provider.
-		pbCtrlrs := proto.NvmeControllers(respBdevs.Ctrlrs)
-		ctrlrs, err := pbCtrlrs.ToNative()
-		if err != nil {
-			return errors.Wrapf(err, "convert %T to %T", pbCtrlrs, ctrlrs)
 		}
 
 		ei, ok := engine.(*EngineInstance)

--- a/src/control/server/instance_storage.go
+++ b/src/control/server/instance_storage.go
@@ -157,7 +157,7 @@ func (ei *EngineInstance) awaitStorageReady(ctx context.Context) error {
 				if err != nil {
 					return err
 				}
-				return ei.storage.ValidateBdevConfig(ctx, ctrlrs)
+				return ei.storage.UpgradeBdevConfig(ctx, ctrlrs)
 			}
 			return nil
 		}

--- a/src/control/server/instance_storage.go
+++ b/src/control/server/instance_storage.go
@@ -1,6 +1,7 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
 // (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -148,6 +149,16 @@ func (ei *EngineInstance) awaitStorageReady(ctx context.Context) error {
 		}
 		if !needsSuperblock {
 			ei.log.Debugf("%s: superblock not needed", msgIdx)
+
+			if ei.storage.HasBlockDevices() {
+				ei.log.Debugf("%s: checking bdev config", msgIdx)
+
+				ctrlrs, err := getEngineBdevCtrlrs(ctx, ei)
+				if err != nil {
+					return err
+				}
+				return ei.storage.ValidateBdevConfig(ctx, ctrlrs)
+			}
 			return nil
 		}
 		ei.log.Debugf("%s: superblock needed", msgIdx)

--- a/src/control/server/storage/bdev.go
+++ b/src/control/server/storage/bdev.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -539,6 +540,7 @@ type (
 		Scan(BdevScanRequest) (*BdevScanResponse, error)
 		Format(BdevFormatRequest) (*BdevFormatResponse, error)
 		WriteConfig(BdevWriteConfigRequest) (*BdevWriteConfigResponse, error)
+		ReadConfig(BdevReadConfigRequest) (*BdevReadConfigResponse, error)
 		QueryFirmware(NVMeFirmwareQueryRequest) (*NVMeFirmwareQueryResponse, error)
 		UpdateFirmware(NVMeFirmwareUpdateRequest) (*NVMeFirmwareUpdateResponse, error)
 	}
@@ -616,6 +618,15 @@ type (
 
 	// BdevWriteConfigResponse contains the result of a WriteConfig operation.
 	BdevWriteConfigResponse struct{}
+
+	// BdevReadConfigRequest defines the parameters for a ReadConfig operation.
+	BdevReadConfigRequest struct {
+		pbin.ForwardableRequest
+		ConfigPath string
+	}
+
+	// BdevReadConfigResponse contains the result of a ReadConfig operation.
+	BdevReadConfigResponse struct{}
 
 	// BdevDeviceFormatRequest designs the parameters for a device-specific format.
 	BdevDeviceFormatRequest struct {
@@ -819,6 +830,17 @@ func (f *BdevAdminForwarder) WriteConfig(req BdevWriteConfigRequest) (*BdevWrite
 
 	res := new(BdevWriteConfigResponse)
 	if err := f.SendReq("BdevWriteConfig", req, res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (f *BdevAdminForwarder) ReadConfig(req BdevReadConfigRequest) (*BdevReadConfigResponse, error) {
+	req.Forwarded = true
+
+	res := new(BdevReadConfigResponse)
+	if err := f.SendReq("BdevReadConfig", req, res); err != nil {
 		return nil, err
 	}
 

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -543,6 +544,29 @@ func (sb *spdkBackend) writeNvmeConfig(req storage.BdevWriteConfigRequest, confW
 
 func (sb *spdkBackend) WriteConfig(req storage.BdevWriteConfigRequest) (*storage.BdevWriteConfigResponse, error) {
 	return &storage.BdevWriteConfigResponse{}, sb.writeNvmeConfig(req, writeJsonConfig)
+}
+
+func (sb *spdkBackend) ReadConfig(req storage.BdevReadConfigRequest) (*storage.BdevReadConfigResponse, error) {
+	if req.ConfigPath == "" {
+		return nil, errors.New("empty SPDK config path")
+	}
+
+	r, err := os.Open(req.ConfigPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open SPDK config at %q", req.ConfigPath)
+	}
+	defer r.Close()
+
+	_, err = readSpdkConfig(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Reconstruct the WriteConfig request params? At the moment, all we care about is
+	// that we can read and parse the config file, but in the future it might be useful to
+	// be able to inspect its contents.
+	resp := &storage.BdevReadConfigResponse{}
+	return resp, nil
 }
 
 // UpdateFirmware uses the SPDK bindings to update an NVMe controller's firmware.

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -542,10 +542,15 @@ func (sb *spdkBackend) writeNvmeConfig(req storage.BdevWriteConfigRequest, confW
 	return errors.Wrap(confWriter(sb.log, &req), "write spdk nvme config")
 }
 
+// WriteConfig writes the SPDK configuration file.
 func (sb *spdkBackend) WriteConfig(req storage.BdevWriteConfigRequest) (*storage.BdevWriteConfigResponse, error) {
 	return &storage.BdevWriteConfigResponse{}, sb.writeNvmeConfig(req, writeJsonConfig)
 }
 
+// ReadConfig reads the SPDK configuration file.
+// NB: Currently returns an empty response struct if the file is read
+// and parsed successfully, but may be extended to return the
+// parsed configuration.
 func (sb *spdkBackend) ReadConfig(req storage.BdevReadConfigRequest) (*storage.BdevReadConfigResponse, error) {
 	if req.ConfigPath == "" {
 		return nil, errors.New("empty SPDK config path")

--- a/src/control/server/storage/bdev/backend_class_test.go
+++ b/src/control/server/storage/bdev/backend_class_test.go
@@ -10,7 +10,6 @@ package bdev
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/dustin/go-humanize"
@@ -104,13 +103,39 @@ func TestBackend_createAioFile(t *testing.T) {
 
 func TestBackend_writeJSONFile(t *testing.T) {
 	tierID := 84
-	host, _ := os.Hostname()
+	hostName := "testHost"
+
+	genSpdkCfg := func(in *SpdkConfig, mut func(in *SpdkConfig) *SpdkConfig) *SpdkConfig {
+		if mut != nil {
+			return mut(in)
+		}
+		return in
+	}
+	defaultTestCfg := func() *SpdkConfig {
+		return genSpdkCfg(defaultSpdkConfig(), func(in *SpdkConfig) *SpdkConfig {
+			in.Subsystems[0].Configs = append(in.Subsystems[0].Configs,
+				&SpdkSubsystemConfig{
+					Method: "bdev_nvme_attach_controller",
+					Params: &NvmeAttachControllerParams{
+						TransportType:    "PCIe",
+						DeviceName:       "Nvme_testHost_0_84_0",
+						TransportAddress: "0000:01:00.0",
+					},
+				},
+				&SpdkSubsystemConfig{
+					Method: "bdev_nvme_set_hotplug",
+					Params: &NvmeSetHotplugParams{},
+				},
+			)
+			return in
+		})
+	}
 
 	tests := map[string]struct {
 		confIn    *engine.Config
 		enableVmd bool
+		expCfg    *SpdkConfig
 		expErr    error
-		expOut    string
 	}{
 		"nvme; single ssds; hotplug enabled": {
 			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
@@ -120,60 +145,35 @@ func TestBackend_writeJSONFile(t *testing.T) {
 					DeviceList: storage.MustNewBdevDeviceList(test.MockPCIAddrs(1)...),
 				},
 			}).WithStorageEnableHotplug(true),
-			expOut: `
-{
-  "daos_data": {
-    "config": [
-      {
-        "params": {
-          "begin": 0,
-          "end": 7
-        },
-        "method": "hotplug_busid_range"
-      }
-    ]
-  },
-  "subsystems": [
-    {
-      "subsystem": "bdev",
-      "config": [
-        {
-          "params": {
-            "bdev_io_pool_size": 65536,
-            "bdev_io_cache_size": 256
-          },
-          "method": "bdev_set_options"
-        },
-        {
-          "params": {
-            "transport_retry_count": 4,
-            "timeout_us": 0,
-            "nvme_adminq_poll_period_us": 100000,
-            "action_on_timeout": "none",
-            "nvme_ioq_poll_period_us": 0
-          },
-          "method": "bdev_nvme_set_options"
-        },
-        {
-          "params": {
-            "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84_0",
-            "traddr": "0000:01:00.0"
-          },
-          "method": "bdev_nvme_attach_controller"
-        },
-        {
-          "params": {
-            "enable": true,
-            "period_us": 5000000
-          },
-          "method": "bdev_nvme_set_hotplug"
-        }
-      ]
-    }
-  ]
-}
-`,
+			expCfg: genSpdkCfg(defaultSpdkConfig(), func(in *SpdkConfig) *SpdkConfig {
+				in.DaosData.Configs = []*DaosConfig{
+					{
+						Method: "hotplug_busid_range",
+						Params: &HotplugBusidRangeParams{
+							Begin: 0,
+							End:   7,
+						},
+					},
+				}
+				in.Subsystems[0].Configs = append(in.Subsystems[0].Configs,
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_attach_controller",
+						Params: &NvmeAttachControllerParams{
+							TransportType:    "PCIe",
+							DeviceName:       "Nvme_testHost_0_84_0",
+							TransportAddress: "0000:01:00.0",
+						},
+					},
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_set_hotplug",
+						Params: &NvmeSetHotplugParams{
+							Enable:     true,
+							PeriodUsec: 5000000,
+						},
+					},
+				)
+				return in
+			}),
 		},
 		"nvme; multiple ssds": {
 			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
@@ -184,60 +184,31 @@ func TestBackend_writeJSONFile(t *testing.T) {
 					DeviceRoles: storage.BdevRolesFromBits(storage.BdevRoleAll),
 				},
 			}),
-			expOut: `
-{
-  "daos_data": {
-    "config": []
-  },
-  "subsystems": [
-    {
-      "subsystem": "bdev",
-      "config": [
-        {
-          "params": {
-            "bdev_io_pool_size": 65536,
-            "bdev_io_cache_size": 256
-          },
-          "method": "bdev_set_options"
-        },
-        {
-          "params": {
-            "transport_retry_count": 4,
-            "timeout_us": 0,
-            "nvme_adminq_poll_period_us": 100000,
-            "action_on_timeout": "none",
-            "nvme_ioq_poll_period_us": 0
-          },
-          "method": "bdev_nvme_set_options"
-        },
-        {
-          "params": {
-            "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84_7",
-            "traddr": "0000:01:00.0"
-          },
-          "method": "bdev_nvme_attach_controller"
-        },
-        {
-          "params": {
-            "trtype": "PCIe",
-            "name": "Nvme_hostfoo_1_84_7",
-            "traddr": "0000:02:00.0"
-          },
-          "method": "bdev_nvme_attach_controller"
-        },
-        {
-          "params": {
-            "enable": false,
-            "period_us": 0
-          },
-          "method": "bdev_nvme_set_hotplug"
-        }
-      ]
-    }
-  ]
-}
-`,
+			expCfg: genSpdkCfg(defaultSpdkConfig(), func(in *SpdkConfig) *SpdkConfig {
+				in.Subsystems[0].Configs = append(in.Subsystems[0].Configs,
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_attach_controller",
+						Params: &NvmeAttachControllerParams{
+							TransportType:    "PCIe",
+							DeviceName:       "Nvme_testHost_0_84_7",
+							TransportAddress: "0000:01:00.0",
+						},
+					},
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_attach_controller",
+						Params: &NvmeAttachControllerParams{
+							TransportType:    "PCIe",
+							DeviceName:       "Nvme_testHost_1_84_7",
+							TransportAddress: "0000:02:00.0",
+						},
+					},
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_set_hotplug",
+						Params: &NvmeSetHotplugParams{},
+					},
+				)
+				return in
+			}),
 		},
 		"nvme; multiple ssds; vmd enabled; bus-id range": {
 			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
@@ -249,69 +220,40 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				},
 			}),
 			enableVmd: true,
-			expOut: `
-{
-  "daos_data": {
-    "config": []
-  },
-  "subsystems": [
-    {
-      "subsystem": "bdev",
-      "config": [
-        {
-          "params": {
-            "bdev_io_pool_size": 65536,
-            "bdev_io_cache_size": 256
-          },
-          "method": "bdev_set_options"
-        },
-        {
-          "params": {
-            "transport_retry_count": 4,
-            "timeout_us": 0,
-            "nvme_adminq_poll_period_us": 100000,
-            "action_on_timeout": "none",
-            "nvme_ioq_poll_period_us": 0
-          },
-          "method": "bdev_nvme_set_options"
-        },
-        {
-          "params": {
-            "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84_0",
-            "traddr": "0000:01:00.0"
-          },
-          "method": "bdev_nvme_attach_controller"
-        },
-        {
-          "params": {
-            "trtype": "PCIe",
-            "name": "Nvme_hostfoo_1_84_0",
-            "traddr": "0000:02:00.0"
-          },
-          "method": "bdev_nvme_attach_controller"
-        },
-        {
-          "params": {
-            "enable": false,
-            "period_us": 0
-          },
-          "method": "bdev_nvme_set_hotplug"
-        }
-      ]
-    },
-    {
-      "subsystem": "vmd",
-      "config": [
-        {
-          "params": {},
-          "method": "enable_vmd"
-        }
-      ]
-    }
-  ]
-}
-`,
+			expCfg: genSpdkCfg(defaultSpdkConfig(), func(in *SpdkConfig) *SpdkConfig {
+				in.Subsystems[0].Configs = append(in.Subsystems[0].Configs,
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_attach_controller",
+						Params: &NvmeAttachControllerParams{
+							TransportType:    "PCIe",
+							DeviceName:       "Nvme_testHost_0_84_0",
+							TransportAddress: "0000:01:00.0",
+						},
+					},
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_attach_controller",
+						Params: &NvmeAttachControllerParams{
+							TransportType:    "PCIe",
+							DeviceName:       "Nvme_testHost_1_84_0",
+							TransportAddress: "0000:02:00.0",
+						},
+					},
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_set_hotplug",
+						Params: &NvmeSetHotplugParams{},
+					},
+				)
+				in.Subsystems = append(in.Subsystems, &SpdkSubsystem{
+					Name: "vmd",
+					Configs: []*SpdkSubsystemConfig{
+						{
+							Method: "enable_vmd",
+							Params: &VmdEnableParams{},
+						},
+					},
+				})
+				return in
+			}),
 		},
 		"nvme; multiple ssds; hotplug enabled; bus-id range": {
 			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
@@ -322,68 +264,43 @@ func TestBackend_writeJSONFile(t *testing.T) {
 					BusidRange: storage.MustNewBdevBusRange("0x80-0x8f"),
 				},
 			}).WithStorageEnableHotplug(true),
-			expOut: `
-{
-  "daos_data": {
-    "config": [
-      {
-        "params": {
-          "begin": 128,
-          "end": 143
-        },
-        "method": "hotplug_busid_range"
-      }
-    ]
-  },
-  "subsystems": [
-    {
-      "subsystem": "bdev",
-      "config": [
-        {
-          "params": {
-            "bdev_io_pool_size": 65536,
-            "bdev_io_cache_size": 256
-          },
-          "method": "bdev_set_options"
-        },
-        {
-          "params": {
-            "transport_retry_count": 4,
-            "timeout_us": 0,
-            "nvme_adminq_poll_period_us": 100000,
-            "action_on_timeout": "none",
-            "nvme_ioq_poll_period_us": 0
-          },
-          "method": "bdev_nvme_set_options"
-        },
-        {
-          "params": {
-            "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84_0",
-            "traddr": "0000:01:00.0"
-          },
-          "method": "bdev_nvme_attach_controller"
-        },
-        {
-          "params": {
-            "trtype": "PCIe",
-            "name": "Nvme_hostfoo_1_84_0",
-            "traddr": "0000:02:00.0"
-          },
-          "method": "bdev_nvme_attach_controller"
-        },
-        {
-          "params": {
-            "enable": true,
-            "period_us": 5000000
-          },
-          "method": "bdev_nvme_set_hotplug"
-        }
-      ]
-    }
-  ]
-}
-`,
+			expCfg: genSpdkCfg(defaultSpdkConfig(), func(in *SpdkConfig) *SpdkConfig {
+				in.DaosData.Configs = []*DaosConfig{
+					{
+						Method: "hotplug_busid_range",
+						Params: &HotplugBusidRangeParams{
+							Begin: 128,
+							End:   143,
+						},
+					},
+				}
+				in.Subsystems[0].Configs = append(in.Subsystems[0].Configs,
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_attach_controller",
+						Params: &NvmeAttachControllerParams{
+							TransportType:    "PCIe",
+							DeviceName:       "Nvme_testHost_0_84_0",
+							TransportAddress: "0000:01:00.0",
+						},
+					},
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_attach_controller",
+						Params: &NvmeAttachControllerParams{
+							TransportType:    "PCIe",
+							DeviceName:       "Nvme_testHost_1_84_0",
+							TransportAddress: "0000:02:00.0",
+						},
+					},
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_set_hotplug",
+						Params: &NvmeSetHotplugParams{
+							Enable:     true,
+							PeriodUsec: 5000000,
+						},
+					},
+				)
+				return in
+			}),
 		},
 		"nvme; multiple ssds; vmd and hotplug enabled": {
 			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
@@ -394,77 +311,52 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				},
 			}).WithStorageEnableHotplug(true),
 			enableVmd: true,
-			expOut: `
-{
-  "daos_data": {
-    "config": [
-      {
-        "params": {
-          "begin": 0,
-          "end": 255
-        },
-        "method": "hotplug_busid_range"
-      }
-    ]
-  },
-  "subsystems": [
-    {
-      "subsystem": "bdev",
-      "config": [
-        {
-          "params": {
-            "bdev_io_pool_size": 65536,
-            "bdev_io_cache_size": 256
-          },
-          "method": "bdev_set_options"
-        },
-        {
-          "params": {
-            "transport_retry_count": 4,
-            "timeout_us": 0,
-            "nvme_adminq_poll_period_us": 100000,
-            "action_on_timeout": "none",
-            "nvme_ioq_poll_period_us": 0
-          },
-          "method": "bdev_nvme_set_options"
-        },
-        {
-          "params": {
-            "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84_0",
-            "traddr": "0000:01:00.0"
-          },
-          "method": "bdev_nvme_attach_controller"
-        },
-        {
-          "params": {
-            "trtype": "PCIe",
-            "name": "Nvme_hostfoo_1_84_0",
-            "traddr": "0000:02:00.0"
-          },
-          "method": "bdev_nvme_attach_controller"
-        },
-        {
-          "params": {
-            "enable": true,
-            "period_us": 5000000
-          },
-          "method": "bdev_nvme_set_hotplug"
-        }
-      ]
-    },
-    {
-      "subsystem": "vmd",
-      "config": [
-        {
-          "params": {},
-          "method": "enable_vmd"
-        }
-      ]
-    }
-  ]
-}
-`,
+			expCfg: genSpdkCfg(defaultSpdkConfig(), func(in *SpdkConfig) *SpdkConfig {
+				in.DaosData.Configs = []*DaosConfig{
+					{
+						Method: "hotplug_busid_range",
+						Params: &HotplugBusidRangeParams{
+							Begin: 0,
+							End:   255,
+						},
+					},
+				}
+				in.Subsystems[0].Configs = append(in.Subsystems[0].Configs,
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_attach_controller",
+						Params: &NvmeAttachControllerParams{
+							TransportType:    "PCIe",
+							DeviceName:       "Nvme_testHost_0_84_0",
+							TransportAddress: "0000:01:00.0",
+						},
+					},
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_attach_controller",
+						Params: &NvmeAttachControllerParams{
+							TransportType:    "PCIe",
+							DeviceName:       "Nvme_testHost_1_84_0",
+							TransportAddress: "0000:02:00.0",
+						},
+					},
+					&SpdkSubsystemConfig{
+						Method: "bdev_nvme_set_hotplug",
+						Params: &NvmeSetHotplugParams{
+							Enable:     true,
+							PeriodUsec: 5000000,
+						},
+					},
+				)
+				in.Subsystems = append(in.Subsystems, &SpdkSubsystem{
+					Name: "vmd",
+					Configs: []*SpdkSubsystemConfig{
+						{
+							Method: "enable_vmd",
+							Params: &VmdEnableParams{},
+						},
+					},
+				})
+				return in
+			}),
 		},
 		"nvme; single controller; acceleration set to none; move and crc opts specified": {
 			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
@@ -476,52 +368,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				// Verify default "none" acceleration setting is ignored.
 			}).WithStorageAccelProps(storage.AccelEngineNone,
 				storage.AccelOptCRCFlag|storage.AccelOptMoveFlag),
-			expOut: `
-{
-  "daos_data": {
-    "config": []
-  },
-  "subsystems": [
-    {
-      "subsystem": "bdev",
-      "config": [
-        {
-          "params": {
-            "bdev_io_pool_size": 65536,
-            "bdev_io_cache_size": 256
-          },
-          "method": "bdev_set_options"
-        },
-        {
-          "params": {
-            "transport_retry_count": 4,
-            "timeout_us": 0,
-            "nvme_adminq_poll_period_us": 100000,
-            "action_on_timeout": "none",
-            "nvme_ioq_poll_period_us": 0
-          },
-          "method": "bdev_nvme_set_options"
-        },
-        {
-          "params": {
-            "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84_0",
-            "traddr": "0000:01:00.0"
-          },
-          "method": "bdev_nvme_attach_controller"
-        },
-        {
-          "params": {
-            "enable": false,
-            "period_us": 0
-          },
-          "method": "bdev_nvme_set_hotplug"
-        }
-      ]
-    }
-  ]
-}
-`,
+			expCfg: defaultTestCfg(),
 		},
 		"nvme; single controller; acceleration set to spdk; no opts specified": {
 			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
@@ -532,52 +379,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				},
 				// Verify default "spdk" acceleration setting with no enable options is ignored.
 			}).WithStorageAccelProps(storage.AccelEngineSPDK, 0),
-			expOut: `
-{
-  "daos_data": {
-    "config": []
-  },
-  "subsystems": [
-    {
-      "subsystem": "bdev",
-      "config": [
-        {
-          "params": {
-            "bdev_io_pool_size": 65536,
-            "bdev_io_cache_size": 256
-          },
-          "method": "bdev_set_options"
-        },
-        {
-          "params": {
-            "transport_retry_count": 4,
-            "timeout_us": 0,
-            "nvme_adminq_poll_period_us": 100000,
-            "action_on_timeout": "none",
-            "nvme_ioq_poll_period_us": 0
-          },
-          "method": "bdev_nvme_set_options"
-        },
-        {
-          "params": {
-            "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84_0",
-            "traddr": "0000:01:00.0"
-          },
-          "method": "bdev_nvme_attach_controller"
-        },
-        {
-          "params": {
-            "enable": false,
-            "period_us": 0
-          },
-          "method": "bdev_nvme_set_hotplug"
-        }
-      ]
-    }
-  ]
-}
-`,
+			expCfg: defaultTestCfg(),
 		},
 		"nvme; single controller; auto faulty disabled but criteria set": {
 			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
@@ -588,52 +390,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				},
 				// Verify "false" auto faulty setting is ignored.
 			}).WithStorageAutoFaultyCriteria(false, 100, 200),
-			expOut: `
-{
-  "daos_data": {
-    "config": []
-  },
-  "subsystems": [
-    {
-      "subsystem": "bdev",
-      "config": [
-        {
-          "params": {
-            "bdev_io_pool_size": 65536,
-            "bdev_io_cache_size": 256
-          },
-          "method": "bdev_set_options"
-        },
-        {
-          "params": {
-            "transport_retry_count": 4,
-            "timeout_us": 0,
-            "nvme_adminq_poll_period_us": 100000,
-            "action_on_timeout": "none",
-            "nvme_ioq_poll_period_us": 0
-          },
-          "method": "bdev_nvme_set_options"
-        },
-        {
-          "params": {
-            "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84_0",
-            "traddr": "0000:01:00.0"
-          },
-          "method": "bdev_nvme_attach_controller"
-        },
-        {
-          "params": {
-            "enable": false,
-            "period_us": 0
-          },
-          "method": "bdev_nvme_set_hotplug"
-        }
-      ]
-    }
-  ]
-}
-`,
+			expCfg: defaultTestCfg(),
 		},
 		"nvme; single controller; accel set with opts; rpc srv set; auto faulty criteria": {
 			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
@@ -647,78 +404,35 @@ func TestBackend_writeJSONFile(t *testing.T) {
 					storage.AccelOptCRCFlag|storage.AccelOptMoveFlag).
 				WithStorageSpdkRpcSrvProps(true, "/tmp/spdk.sock").
 				WithStorageAutoFaultyCriteria(true, 100, 200),
-			expOut: `
-{
-  "daos_data": {
-    "config": [
-      {
-        "params": {
-          "accel_engine": "spdk",
-          "accel_opts": 3
-        },
-        "method": "accel_props"
-      },
-      {
-        "params": {
-          "enable": true,
-          "sock_addr": "/tmp/spdk.sock"
-        },
-        "method": "spdk_rpc_srv"
-      },
-      {
-        "params": {
-          "enable": true,
-          "max_io_errs": 100,
-          "max_csum_errs": 200
-        },
-        "method": "auto_faulty"
-      }
-    ]
-  },
-  "subsystems": [
-    {
-      "subsystem": "bdev",
-      "config": [
-        {
-          "params": {
-            "bdev_io_pool_size": 65536,
-            "bdev_io_cache_size": 256
-          },
-          "method": "bdev_set_options"
-        },
-        {
-          "params": {
-            "transport_retry_count": 4,
-            "timeout_us": 0,
-            "nvme_adminq_poll_period_us": 100000,
-            "action_on_timeout": "none",
-            "nvme_ioq_poll_period_us": 0
-          },
-          "method": "bdev_nvme_set_options"
-        },
-        {
-          "params": {
-            "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84_0",
-            "traddr": "0000:01:00.0"
-          },
-          "method": "bdev_nvme_attach_controller"
-        },
-        {
-          "params": {
-            "enable": false,
-            "period_us": 0
-          },
-          "method": "bdev_nvme_set_hotplug"
-        }
-      ]
-    }
-  ]
-}
-`,
+			expCfg: genSpdkCfg(defaultTestCfg(), func(in *SpdkConfig) *SpdkConfig {
+				in.DaosData.Configs = []*DaosConfig{
+					{
+						Method: "accel_props",
+						Params: &AccelPropsParams{
+							Engine:  "spdk",
+							Options: 3,
+						},
+					},
+					{
+						Method: "spdk_rpc_srv",
+						Params: &SpdkRpcServerParams{
+							Enable:   true,
+							SockAddr: "/tmp/spdk.sock",
+						},
+					},
+					{
+						Method: "auto_faulty",
+						Params: &AutoFaultyParams{
+							Enable:      true,
+							MaxIoErrs:   100,
+							MaxCsumErrs: 200,
+						},
+					},
+				}
+				return in
+			}),
 		},
 	}
-
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
@@ -735,6 +449,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			req.Hostname = hostName
 
 			gotErr := writeJsonConfig(log, req)
 			test.CmpErr(t, tc.expErr, gotErr)
@@ -742,17 +457,17 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				return
 			}
 
-			gotOut, err := os.ReadFile(cfgOutputPath)
+			r, err := os.Open(cfgOutputPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotCfg, err := readSpdkConfig(r)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			// replace hostname in wantOut
-			tc.expOut = strings.ReplaceAll(tc.expOut, "hostfoo", host)
-			tc.expOut = strings.TrimSpace(tc.expOut)
-
-			if diff := cmp.Diff(tc.expOut, string(gotOut)); diff != "" {
-				t.Fatalf("(-want, +got):\n%s", diff)
+			if diff := cmp.Diff(tc.expCfg, gotCfg); diff != "" {
+				t.Fatalf("unexpected config after write (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/src/control/server/storage/bdev/backend_json.go
+++ b/src/control/server/storage/bdev/backend_json.go
@@ -8,6 +8,7 @@
 package bdev
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -116,6 +117,36 @@ type SpdkSubsystemConfig struct {
 	Method string                    `json:"method"`
 }
 
+func (ssc *SpdkSubsystemConfig) UnmarshalJSON(data []byte) error {
+	var tmp struct {
+		Params json.RawMessage `json:"params"`
+		Method string          `json:"method"`
+	}
+	if err := strictJsonUnmarshalBuf(data, &tmp); err != nil {
+		return err
+	}
+	ssc.Method = tmp.Method
+
+	switch ssc.Method {
+	case storage.ConfBdevSetOptions:
+		ssc.Params = &SetOptionsParams{}
+	case storage.ConfBdevNvmeSetOptions:
+		ssc.Params = &NvmeSetOptionsParams{}
+	case storage.ConfBdevNvmeAttachController:
+		ssc.Params = &NvmeAttachControllerParams{}
+	case storage.ConfBdevNvmeSetHotplug:
+		ssc.Params = &NvmeSetHotplugParams{}
+	case storage.ConfVmdEnable:
+		ssc.Params = &VmdEnableParams{}
+	case storage.ConfBdevAioCreate:
+		ssc.Params = &AioCreateParams{}
+	default:
+		return errors.Errorf("unknown SPDK subsystem config method %q", ssc.Method)
+	}
+
+	return strictJsonUnmarshalBuf(tmp.Params, ssc.Params)
+}
+
 // SpdkSubsystem entries make up the Subsystems field of a SpdkConfig.
 type SpdkSubsystem struct {
 	Name    string                 `json:"subsystem"`
@@ -126,6 +157,32 @@ type SpdkSubsystem struct {
 type DaosConfig struct {
 	Params DaosConfigParams `json:"params"`
 	Method string           `json:"method"`
+}
+
+func (dc *DaosConfig) UnmarshalJSON(data []byte) error {
+	var tmp struct {
+		Params json.RawMessage `json:"params"`
+		Method string          `json:"method"`
+	}
+	if err := strictJsonUnmarshalBuf(data, &tmp); err != nil {
+		return err
+	}
+	dc.Method = tmp.Method
+
+	switch dc.Method {
+	case storage.ConfSetHotplugBusidRange:
+		dc.Params = &HotplugBusidRangeParams{}
+	case storage.ConfSetAccelProps:
+		dc.Params = &AccelPropsParams{}
+	case storage.ConfSetSpdkRpcServer:
+		dc.Params = &SpdkRpcServerParams{}
+	case storage.ConfSetAutoFaultyProps:
+		dc.Params = &AutoFaultyParams{}
+	default:
+		return errors.Errorf("unknown DAOS config method %q", dc.Method)
+	}
+
+	return strictJsonUnmarshalBuf(tmp.Params, dc.Params)
 }
 
 // DaosData entries contain a number of DaosConfig entries and make up
@@ -145,14 +202,14 @@ func defaultSpdkConfig() *SpdkConfig {
 	bdevSubsystemConfigs := []*SpdkSubsystemConfig{
 		{
 			Method: storage.ConfBdevSetOptions,
-			Params: SetOptionsParams{
+			Params: &SetOptionsParams{
 				BdevIoPoolSize:  humanize.KiByte * 64,
 				BdevIoCacheSize: 256,
 			},
 		},
 		{
 			Method: storage.ConfBdevNvmeSetOptions,
-			Params: NvmeSetOptionsParams{
+			Params: &NvmeSetOptionsParams{
 				TransportRetryCount:      4,
 				NvmeAdminqPollPeriodUsec: 100 * 1000,
 				ActionOnTimeout:          "none",
@@ -182,7 +239,7 @@ type configMethodGetter func(string, string) *SpdkSubsystemConfig
 func getNvmeAttachMethod(name, pci string) *SpdkSubsystemConfig {
 	return &SpdkSubsystemConfig{
 		Method: storage.ConfBdevNvmeAttachController,
-		Params: NvmeAttachControllerParams{
+		Params: &NvmeAttachControllerParams{
 			TransportType:    "PCIe",
 			DeviceName:       fmt.Sprintf("Nvme_%s", name),
 			TransportAddress: pci,
@@ -193,7 +250,7 @@ func getNvmeAttachMethod(name, pci string) *SpdkSubsystemConfig {
 func getAioFileCreateMethod(name, path string) *SpdkSubsystemConfig {
 	return &SpdkSubsystemConfig{
 		Method: storage.ConfBdevAioCreate,
-		Params: AioCreateParams{
+		Params: &AioCreateParams{
 			DeviceName: fmt.Sprintf("AIO_%s", name),
 			Filename:   path,
 			BlockSize:  aioBlockSize,
@@ -204,7 +261,7 @@ func getAioFileCreateMethod(name, path string) *SpdkSubsystemConfig {
 func getAioKdevCreateMethod(name, path string) *SpdkSubsystemConfig {
 	return &SpdkSubsystemConfig{
 		Method: storage.ConfBdevAioCreate,
-		Params: AioCreateParams{
+		Params: &AioCreateParams{
 			DeviceName: fmt.Sprintf("AIO_%s", name),
 			Filename:   path,
 		},
@@ -242,7 +299,7 @@ func (sc *SpdkConfig) WithVMDEnabled() *SpdkConfig {
 		Configs: []*SpdkSubsystemConfig{
 			{
 				Method: storage.ConfVmdEnable,
-				Params: VmdEnableParams{},
+				Params: &VmdEnableParams{},
 			},
 		},
 	})
@@ -272,7 +329,7 @@ func (sc *SpdkConfig) WithBdevConfigs(log logging.Logger, req *storage.BdevWrite
 func hotplugPropSet(req *storage.BdevWriteConfigRequest, data *DaosData) {
 	data.Configs = append(data.Configs, &DaosConfig{
 		Method: storage.ConfSetHotplugBusidRange,
-		Params: HotplugBusidRangeParams{
+		Params: &HotplugBusidRangeParams{
 			Begin: req.HotplugBusidBegin,
 			End:   req.HotplugBusidEnd,
 		},
@@ -287,7 +344,7 @@ func accelPropSet(req *storage.BdevWriteConfigRequest, data *DaosData) {
 	if props.Engine != storage.AccelEngineNone && !props.Options.IsEmpty() {
 		data.Configs = append(data.Configs, &DaosConfig{
 			Method: storage.ConfSetAccelProps,
-			Params: AccelPropsParams(props),
+			Params: (*AccelPropsParams)(&props),
 		})
 	}
 }
@@ -299,7 +356,7 @@ func rpcSrvSet(req *storage.BdevWriteConfigRequest, data *DaosData) {
 	if props.Enable {
 		data.Configs = append(data.Configs, &DaosConfig{
 			Method: storage.ConfSetSpdkRpcServer,
-			Params: SpdkRpcServerParams(props),
+			Params: (*SpdkRpcServerParams)(&props),
 		})
 	}
 }
@@ -310,7 +367,7 @@ func autoFaultySet(req *storage.BdevWriteConfigRequest, data *DaosData) {
 	if props.Enable {
 		data.Configs = append(data.Configs, &DaosConfig{
 			Method: storage.ConfSetAutoFaultyProps,
-			Params: AutoFaultyParams(props),
+			Params: (*AutoFaultyParams)(&props),
 		})
 	}
 }
@@ -334,7 +391,7 @@ func newSpdkConfig(log logging.Logger, req *storage.BdevWriteConfigRequest) (*Sp
 
 	// SPDK-3370: Ensure hotplug config appears after attach directives to avoid race when VMD
 	// with hotplug is enabled with multiple domains.
-	hpParams := NvmeSetHotplugParams{}
+	hpParams := &NvmeSetHotplugParams{}
 	if req.HotplugEnabled {
 		hpParams.Enable = true
 		hpParams.PeriodUsec = uint64(hotplugPeriod.Microseconds())

--- a/src/control/server/storage/bdev/mocks.go
+++ b/src/control/server/storage/bdev/mocks.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -126,6 +127,10 @@ func (mb *MockBackend) WriteConfig(req storage.BdevWriteConfigRequest) (*storage
 	default:
 		return mb.cfg.WriteConfRes, nil
 	}
+}
+
+func (mb *MockBackend) ReadConfig(_ storage.BdevReadConfigRequest) (*storage.BdevReadConfigResponse, error) {
+	return &storage.BdevReadConfigResponse{}, nil
 }
 
 func NewMockProvider(log logging.Logger, mbc *MockBackendConfig) *Provider {

--- a/src/control/server/storage/bdev/provider.go
+++ b/src/control/server/storage/bdev/provider.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -24,6 +25,7 @@ type (
 		Format(storage.BdevFormatRequest) (*storage.BdevFormatResponse, error)
 		UpdateFirmware(pciAddr string, path string, slot int32) error
 		WriteConfig(storage.BdevWriteConfigRequest) (*storage.BdevWriteConfigResponse, error)
+		ReadConfig(storage.BdevReadConfigRequest) (*storage.BdevReadConfigResponse, error)
 	}
 
 	// Provider encapsulates configuration and logic for interacting with a Block
@@ -81,4 +83,9 @@ func (p *Provider) Format(req storage.BdevFormatRequest) (*storage.BdevFormatRes
 // WriteConfig calls into the bdev backend to create an nvme config file.
 func (p *Provider) WriteConfig(req storage.BdevWriteConfigRequest) (*storage.BdevWriteConfigResponse, error) {
 	return p.backend.WriteConfig(req)
+}
+
+// ReadConfig calls into the bdev backend to read an nvme config file.
+func (p *Provider) ReadConfig(req storage.BdevReadConfigRequest) (*storage.BdevReadConfigResponse, error) {
+	return p.backend.ReadConfig(req)
 }

--- a/src/control/server/storage/faults.go
+++ b/src/control/server/storage/faults.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2022-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -262,6 +263,15 @@ func FaultPathAccessDenied(path string) *fault.Fault {
 		code.StoragePathAccessDenied,
 		fmt.Sprintf("path %q has incompatible access permissions", path),
 		"verify the path is accessible by the user running daos_server and try again",
+	)
+}
+
+// FaultInvalidSPDKConfig creates a Fault for the case where SPDK configuration is invalid.
+func FaultInvalidSPDKConfig(err error) *fault.Fault {
+	return storageFault(
+		code.SpdkInvalidConfiguration,
+		fmt.Sprintf("unable to parse SPDK configuration: %s", err),
+		"regenerate the configuration and restart daos_server",
 	)
 }
 

--- a/src/control/server/storage/mocks.go
+++ b/src/control/server/storage/mocks.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -453,4 +454,64 @@ func (m *MockScmProvider) QueryFirmware(ScmFirmwareQueryRequest) (*ScmFirmwareQu
 
 func (m *MockScmProvider) UpdateFirmware(ScmFirmwareUpdateRequest) (*ScmFirmwareUpdateResponse, error) {
 	return m.FirmwareUpdateRes, m.FirmwareUpdateErr
+}
+
+type mockBdevProvider struct {
+	callCounts         map[string]int
+	PrepareErr         error
+	PrepareResp        *BdevPrepareResponse
+	ScanErr            error
+	ScanResp           *BdevScanResponse
+	FormatErr          error
+	FormatResp         *BdevFormatResponse
+	WriteConfigErr     error
+	WriteConfigResp    *BdevWriteConfigResponse
+	ReadConfigErr      error
+	ReadConfigResp     *BdevReadConfigResponse
+	QueryFirmwareErr   error
+	QueryFirmwareResp  *NVMeFirmwareQueryResponse
+	UpdateFirmwareErr  error
+	UpdateFirmwareResp *NVMeFirmwareUpdateResponse
+}
+
+func (m *mockBdevProvider) addCall(name string) {
+	if m.callCounts == nil {
+		m.callCounts = make(map[string]int)
+	}
+	m.callCounts[name]++
+}
+
+func (m *mockBdevProvider) Prepare(BdevPrepareRequest) (*BdevPrepareResponse, error) {
+	m.addCall("Prepare")
+	return m.PrepareResp, m.PrepareErr
+}
+
+func (m *mockBdevProvider) Scan(BdevScanRequest) (*BdevScanResponse, error) {
+	m.addCall("Scan")
+	return m.ScanResp, m.ScanErr
+}
+
+func (m *mockBdevProvider) Format(BdevFormatRequest) (*BdevFormatResponse, error) {
+	m.addCall("Format")
+	return m.FormatResp, m.FormatErr
+}
+
+func (m *mockBdevProvider) WriteConfig(BdevWriteConfigRequest) (*BdevWriteConfigResponse, error) {
+	m.addCall("WriteConfig")
+	return m.WriteConfigResp, m.WriteConfigErr
+}
+
+func (m *mockBdevProvider) ReadConfig(BdevReadConfigRequest) (*BdevReadConfigResponse, error) {
+	m.addCall("ReadConfig")
+	return m.ReadConfigResp, m.ReadConfigErr
+}
+
+func (m *mockBdevProvider) QueryFirmware(NVMeFirmwareQueryRequest) (*NVMeFirmwareQueryResponse, error) {
+	m.addCall("QueryFirmware")
+	return m.QueryFirmwareResp, m.QueryFirmwareErr
+}
+
+func (m *mockBdevProvider) UpdateFirmware(NVMeFirmwareUpdateRequest) (*NVMeFirmwareUpdateResponse, error) {
+	m.addCall("UpdateFirmware")
+	return m.UpdateFirmwareResp, m.UpdateFirmwareErr
 }

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -15,6 +16,8 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/fault/code"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/lib/hardware/hwloc"
 	"github.com/daos-stack/daos/src/control/logging"
@@ -618,6 +621,15 @@ func (p *Provider) WriteNvmeConfig(ctx context.Context, log logging.Logger, ctrl
 	return err
 }
 
+// ReadNvmeConfig calls into the bdev storage provider to read an NVMe config file.
+func (p *Provider) ReadNvmeConfig(ctx context.Context) (*BdevReadConfigResponse, error) {
+	req := BdevReadConfigRequest{
+		ConfigPath: p.engineStorage.ConfigOutputPath,
+	}
+
+	return p.bdev.ReadConfig(req)
+}
+
 // BdevTierScanResult contains details of a scan operation result.
 type BdevTierScanResult struct {
 	Tier   int
@@ -664,6 +676,33 @@ func (p *Provider) QueryBdevFirmware(req NVMeFirmwareQueryRequest) (*NVMeFirmwar
 // UpdateBdevFirmware queries NVMe SSD firmware.
 func (p *Provider) UpdateBdevFirmware(req NVMeFirmwareUpdateRequest) (*NVMeFirmwareUpdateResponse, error) {
 	return p.bdev.UpdateFirmware(req)
+}
+
+// ValidateBdevConfig updates an existing SPDK bdev config, if necessary.
+func (p *Provider) ValidateBdevConfig(ctx context.Context, ctrlrs NvmeControllers) error {
+	if !p.HasBlockDevices() {
+		return nil
+	}
+
+	_, err := p.ReadNvmeConfig(ctx)
+	if err == nil {
+		// For now, we'll just assume that if we can read the config file, then
+		// we don't need to do anything else.
+		return nil
+	}
+
+	// Take the conservative approach that if we expect there to have been a config
+	// file and it's not there, then we need the admin to investigate.
+	if !fault.IsFaultCode(err, code.SpdkInvalidConfiguration) {
+		p.log.Errorf("Failed to read bdev config file: %s", p.engineStorage.ConfigOutputPath)
+		return err
+	}
+
+	// Otherwise, if the config file is there but we can't understand it, then
+	// it's probably from a different version of DAOS and we should just regenerate
+	// it based on our version of the configuration.
+	p.log.Notice("The bdev config file was unparsable; regenerating it.")
+	return p.WriteNvmeConfig(ctx, p.log, ctrlrs)
 }
 
 // NewProvider returns an initialized storage provider.

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -678,8 +678,8 @@ func (p *Provider) UpdateBdevFirmware(req NVMeFirmwareUpdateRequest) (*NVMeFirmw
 	return p.bdev.UpdateFirmware(req)
 }
 
-// ValidateBdevConfig updates an existing SPDK bdev config, if necessary.
-func (p *Provider) ValidateBdevConfig(ctx context.Context, ctrlrs NvmeControllers) error {
+// UpgradeBdevConfig updates an existing SPDK bdev config, if necessary.
+func (p *Provider) UpgradeBdevConfig(ctx context.Context, ctrlrs NvmeControllers) error {
 	if !p.HasBlockDevices() {
 		return nil
 	}

--- a/src/control/server/storage/provider_test.go
+++ b/src/control/server/storage/provider_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2023 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -263,6 +264,92 @@ func Test_BdevWriteRequestFromConfig(t *testing.T) {
 
 			if diff := cmp.Diff(tc.expReq, gotReq, defBdevCmpOpts()...); diff != "" {
 				t.Fatalf("\nunexpected generated request (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestStorage_ProviderValidateBdevConfig(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cfg      *Config
+		ctrlrs   NvmeControllers
+		bdevProv *mockBdevProvider
+		expCalls map[string]int
+		expErr   error
+	}{
+		"one bdev: read fails, write fails": {
+			cfg: &Config{
+				Tiers: TierConfigs{
+					NewTierConfig().WithStorageClass(ClassNvme.String()).WithBdevDeviceList("/dev/loop0"),
+				},
+			},
+			ctrlrs: MockNvmeControllers(1),
+			bdevProv: &mockBdevProvider{
+				ReadConfigErr:  FaultInvalidSPDKConfig(errors.New("whoops")),
+				WriteConfigErr: errors.New("write config failed"),
+			},
+			expErr: errors.New("write config failed"),
+		},
+		"one bdev: read fails for something other than invalid spdk config": {
+			cfg: &Config{
+				Tiers: TierConfigs{
+					NewTierConfig().WithStorageClass(ClassNvme.String()).WithBdevDeviceList("/dev/loop0"),
+				},
+			},
+			ctrlrs: MockNvmeControllers(1),
+			bdevProv: &mockBdevProvider{
+				ReadConfigErr:  errors.New("read config failed"),
+				WriteConfigErr: errors.New("write config failed"),
+			},
+			expErr: errors.New("read config failed"),
+		},
+		"one bdev: read fails, successful write": {
+			cfg: &Config{
+				Tiers: TierConfigs{
+					NewTierConfig().WithStorageClass(ClassNvme.String()).WithBdevDeviceList("/dev/loop0"),
+				},
+			},
+			ctrlrs: MockNvmeControllers(1),
+			bdevProv: &mockBdevProvider{
+				ReadConfigErr: FaultInvalidSPDKConfig(errors.New("whoops")),
+			},
+			expCalls: map[string]int{
+				"ReadConfig":  1,
+				"WriteConfig": 1,
+			},
+		},
+		"one bdev: no update needed": {
+			cfg: &Config{
+				Tiers: TierConfigs{
+					NewTierConfig().WithStorageClass(ClassNvme.String()).WithBdevDeviceList("/dev/loop0"),
+				},
+			},
+			ctrlrs:   MockNvmeControllers(1),
+			bdevProv: &mockBdevProvider{},
+			expCalls: map[string]int{
+				"ReadConfig": 1,
+			},
+		},
+		"no bdevs: success": {
+			cfg: &Config{
+				Tiers: TierConfigs{},
+			},
+			ctrlrs:   NvmeControllers{},
+			bdevProv: &mockBdevProvider{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := test.MustLogContext(t, test.Context(t))
+
+			p := NewProvider(logging.FromContext(ctx), 0, tc.cfg, nil, nil, tc.bdevProv, nil)
+			gotErr := p.ValidateBdevConfig(ctx, tc.ctrlrs)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expCalls, tc.bdevProv.callCounts); diff != "" {
+				t.Fatalf("\nunexpected calls (-want, +got):\n%s\n", diff)
 			}
 		})
 	}

--- a/src/control/server/storage/provider_test.go
+++ b/src/control/server/storage/provider_test.go
@@ -269,7 +269,7 @@ func Test_BdevWriteRequestFromConfig(t *testing.T) {
 	}
 }
 
-func TestStorage_ProviderValidateBdevConfig(t *testing.T) {
+func TestStorage_ProviderUpgradeBdevConfig(t *testing.T) {
 	for name, tc := range map[string]struct {
 		cfg      *Config
 		ctrlrs   NvmeControllers
@@ -342,7 +342,7 @@ func TestStorage_ProviderValidateBdevConfig(t *testing.T) {
 			ctx := test.MustLogContext(t, test.Context(t))
 
 			p := NewProvider(logging.FromContext(ctx), 0, tc.cfg, nil, nil, tc.bdevProv, nil)
-			gotErr := p.ValidateBdevConfig(ctx, tc.ctrlrs)
+			gotErr := p.UpgradeBdevConfig(ctx, tc.ctrlrs)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return


### PR DESCRIPTION
Before starting an engine, first check to see if the on-disk
SPDK configuration file can be read and parsed by this
version of DAOS. If it's not found or can't be parsed, take
it as a signal to regenerate the file.

Change-Id: I3ccbd4c5ce036435c45f185f902f0aa6a679beb3
Signed-off-by: Michael MacDonald <mjmac@google.com>
