### PR TITLE
DAOS-16922 dfuse: Avoid assertion on shutdown (#15972)

### DIFF
--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -1,5 +1,7 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -750,10 +752,19 @@ out_daos:
 		rc = rc2;
 out_fini:
 	if (dfuse_info && rc == -DER_SUCCESS) {
-		D_ASSERT(atomic_load_relaxed(&dfuse_info->di_inode_count) == 0);
-		D_ASSERT(atomic_load_relaxed(&dfuse_info->di_fh_count) == 0);
-		D_ASSERT(atomic_load_relaxed(&dfuse_info->di_pool_count) == 0);
-		D_ASSERT(atomic_load_relaxed(&dfuse_info->di_container_count) == 0);
+		if (atomic_load_relaxed(&dfuse_info->di_inode_count) != 0 ||
+		    atomic_load_relaxed(&dfuse_info->di_fh_count) != 0 ||
+		    atomic_load_relaxed(&dfuse_info->di_pool_count) != 0 ||
+		    atomic_load_relaxed(&dfuse_info->di_container_count) != 0) {
+			DFUSE_TRA_WARNING(dfuse_info,
+					  "Not all resources were cleaned up, probably"
+					  " due to forced umount: inodes=" DF_U64 " handles=" DF_U64
+					  " pools= " DF_U64 " containers=" DF_U64,
+					  atomic_load_relaxed(&dfuse_info->di_inode_count),
+					  atomic_load_relaxed(&dfuse_info->di_fh_count),
+					  atomic_load_relaxed(&dfuse_info->di_pool_count),
+					  atomic_load_relaxed(&dfuse_info->di_container_count));
+		}
 	}
 
 	DFUSE_TRA_DOWN(dfuse_info);


### PR DESCRIPTION
When there are open file handles and dfuse is shutdown using umount -f, it would assert due to resources being used.  Rather than asserting, just print a warning that we are shutting down ungracefully.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
