### PR TITLE
DAOS-17241 test: reset timeout in dmg command util

### DIFF
--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -247,10 +247,12 @@ class DmgCommand(DmgCommandBase):
 
         """
         saved_timeout = self.timeout
-        self.timeout = timeout
-        self._get_result(
-            ("storage", "format"), force=force, verbose=verbose)
-        self.timeout = saved_timeout
+        try:
+            self.timeout = timeout
+            self._get_result(
+                ("storage", "format"), force=force, verbose=verbose)
+        finally:
+            self.timeout = saved_timeout
         return self.result
 
     def storage_set_faulty(self, host, uuid, force=True):


### PR DESCRIPTION
Always reset the timeout in DmgCommand in dmg
utilities no matter the outcome of storage format.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
