### PR TITLE
DAOS-17382 engine: Make GDB happy

### DIFF
--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -1165,12 +1165,20 @@ main(int argc, char **argv)
 	sigdelset(&set, SIGBUS);
 	sigdelset(&set, SIGSEGV);
 	sigdelset(&set, SIGTRAP);
+	sigdelset(&set, SIGINT);
 	/** also allow abort()/assert() to trigger */
 	sigdelset(&set, SIGABRT);
 
 	rc = pthread_sigmask(SIG_BLOCK, &set, NULL);
 	if (rc) {
 		perror("failed to mask signals");
+		exit(EXIT_FAILURE);
+	}
+
+	struct sigaction sa = {.sa_handler = SIG_IGN};
+	rc                  = sigaction(SIGINT, &sa, NULL);
+	if (rc) {
+		perror("Failed to set sigaction for SIGINT");
 		exit(EXIT_FAILURE);
 	}
 
@@ -1185,7 +1193,6 @@ main(int argc, char **argv)
 
 	/** wait for shutdown signal */
 	sigemptyset(&set);
-	sigaddset(&set, SIGINT);
 	sigaddset(&set, SIGTERM);
 	sigaddset(&set, SIGUSR1);
 	sigaddset(&set, SIGUSR2);


### PR DESCRIPTION
This PR makes daos_engine GDB debuggable by not intercepting SIGINT signal.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
