### PR TITLE
DAOS-17376 tests: enable local flock in dfuse for io_sys_admin

### DIFF
--- a/src/tests/ftest/deployment/io_sys_admin.yaml
+++ b/src/tests/ftest/deployment/io_sys_admin.yaml
@@ -84,6 +84,7 @@ ior:
   block_size: '1Mib'
 dfuse:
   disable_caching: True
+  enable_local_flock: true
 
 mdtest:
   client_processes:


### PR DESCRIPTION
Local flock support is needed to create hdf5 file by daos-serialize in test io_sys_admin.

Test-tag: test_io_sys_admin

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
