### PR TITLE
DAOS-17052 test: update expected msg for critical_integration (#15855)

### DIFF
--- a/src/tests/ftest/deployment/critical_integration.py
+++ b/src/tests/ftest/deployment/critical_integration.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -174,7 +175,7 @@ class CriticalIntegrationWithServers(TestWithServers):
         # gather journalctl logs for each server host, verify system stop event was sent to logs
         results = get_journalctl(hosts=self.hostlist_servers, since=since,
                                  until=until, journalctl_type="daos_server")
-        str_to_match = "daos_engine exited: process exited with 0"
+        str_to_match = "daos_engine exited: signal: killed"
         for count, host in enumerate(self.hostlist_servers):
             occurrence = results[count]["data"].count(str_to_match)
             if occurrence != 2:


### PR DESCRIPTION
Updated the expected journalctl message from "exited with 0" to "killed", since #15811 changed the default dmg system stop to use --force.

Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
