### PR TITLE
DAOS-17391 rebuild: use d_list_del_init for rgt delete

### DIFF
--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -998,7 +998,7 @@ static void
 rebuild_global_pool_tracker_destroy(struct rebuild_global_pool_tracker *rgt)
 {
 	D_ASSERT(rgt->rgt_refcount == 0);
-	d_list_del(&rgt->rgt_list);
+	d_list_del_init(&rgt->rgt_list);
 	if (rgt->rgt_servers)
 		D_FREE(rgt->rgt_servers);
 	if (rgt->rgt_servers_sorted)
@@ -2086,7 +2086,7 @@ rgt_leader_stop(struct rebuild_global_pool_tracker *rgt)
 	rgt->rgt_abort = 1;
 
 	/* Remove it from the rgt list to avoid stopping rgt duplicately */
-	d_list_del(&rgt->rgt_list);
+	d_list_del_init(&rgt->rgt_list);
 
 	ABT_mutex_lock(rgt->rgt_lock);
 	ABT_cond_wait(rgt->rgt_done_cond, rgt->rgt_lock);


### PR DESCRIPTION
in rgt_leader_stop it calls d_list_del() to delete rgt from list, but rgt_put() -> rebuild_global_pool_tracker_destroy() may call d_list_del() again for the same rgt.
In this sequence -
d_list_del(&rgt1->rgt_list);
d_list_del(&rgt2->rgt_list);
d_list_del(&rgt1->rgt_list);
it will cause rgt2 not deleted in list but point to invalid pointer and possibly cause following list/mem corruption.
Change to d_list_del_init() to avoid the problem.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
