### PR TITLE
DAOS-17152 pool: seek to avoid false ENOSPACE

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -471,8 +471,7 @@ cont_aggregate_interval(struct ds_cont_child *cont, cont_aggregate_cb_t cb,
 		/*
 		 * Sleep 2 seconds before next round when:
 		 * - Aggregation isn't runnable yet, or;
-		 * - Last round of aggregation failed, or;
-		 * - There is no space pressure;
+		 * - Last round of aggregation failed;
 		 */
 		uint64_t msecs = 2000;
 
@@ -499,8 +498,8 @@ cont_aggregate_interval(struct ds_cont_child *cont, cont_aggregate_cb_t cb,
 				  DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
 				  param->ap_vos_agg ? "VOS" : "EC");
 		} else if (sched_req_space_check(req) != SCHED_SPACE_PRESS_NONE) {
-			/* Don't sleep too long when there is space pressure */
-			msecs = 2ULL * 100;
+			/* Don't sleep when there is space pressure */
+			msecs = 0;
 		}
 
 		if (param->ap_vos_agg)
@@ -515,10 +514,13 @@ next:
 		/* sleep 18 seconds for EC aggregation ULT if the pool is in rebuilding,
 		 * if no space pressure.
 		 */
-		if (cont->sc_pool->spc_pool->sp_rebuilding && !param->ap_vos_agg && msecs != 200)
+		if (cont->sc_pool->spc_pool->sp_rebuilding && !param->ap_vos_agg && msecs != 0)
 			msecs = 18000;
 
-		sched_req_sleep(req, msecs);
+		if (msecs != 0)
+			sched_req_sleep(req, msecs);
+		else
+			sched_req_yield(req);
 	}
 out:
 	D_DEBUG(DB_EPC, DF_CONT "[%d]: %s Aggregation ULT stopped\n",

--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -206,42 +206,48 @@ struct pressure_ratio {
 };
 
 static struct pressure_ratio pressure_gauge[] = {
-	{	/* free space > 40%, no space pressure */
-		.pr_free	= 40,
-		.pr_gc_ratio	= 10,
-		.pr_delay	= 0,
-		.pr_pressure	= SCHED_SPACE_PRESS_NONE,
-	},
-	{	/* free space > 30% */
-		.pr_free	= 30,
-		.pr_gc_ratio	= 20,
-		.pr_delay	= 4000, /* msecs */
-		.pr_pressure	= 1,
-	},
-	{	/* free space > 20% */
-		.pr_free	= 20,
-		.pr_gc_ratio	= 30,
-		.pr_delay	= 6000, /* msecs */
-		.pr_pressure	= 2,
-	},
-	{	/* free space > 10% */
-		.pr_free	= 10,
-		.pr_gc_ratio	= 40,
-		.pr_delay	= 8000, /* msecs */
-		.pr_pressure	= 3,
-	},
-	{	/* free space > 5% */
-		.pr_free	= 5,
-		.pr_gc_ratio	= 50,
-		.pr_delay	= 10000, /* msecs */
-		.pr_pressure	= 4,
-	},
-	{	/* free space <= 5% */
-		.pr_free	= 0,
-		.pr_gc_ratio	= 60,
-		.pr_delay	= 12000, /* msecs */
-		.pr_pressure	= 5,
-	},
+    {
+	/* free space > 40%, no space pressure */
+	.pr_free     = 40,
+	.pr_gc_ratio = 10,
+	.pr_delay    = 0,
+	.pr_pressure = SCHED_SPACE_PRESS_NONE,
+    },
+    {
+	/* free space > 30% */
+	.pr_free     = 30,
+	.pr_gc_ratio = 30,
+	.pr_delay    = 4000, /* msecs */
+	.pr_pressure = 1,
+    },
+    {
+	/* free space > 20% */
+	.pr_free     = 20,
+	.pr_gc_ratio = 45,
+	.pr_delay    = 6000, /* msecs */
+	.pr_pressure = 2,
+    },
+    {
+	/* free space > 10% */
+	.pr_free     = 10,
+	.pr_gc_ratio = 60,
+	.pr_delay    = 8000, /* msecs */
+	.pr_pressure = 3,
+    },
+    {
+	/* free space > 5% */
+	.pr_free     = 5,
+	.pr_gc_ratio = 75,
+	.pr_delay    = 10000, /* msecs */
+	.pr_pressure = 4,
+    },
+    {
+	/* free space <= 5% */
+	.pr_free     = 0,
+	.pr_gc_ratio = 90,
+	.pr_delay    = 12000, /* msecs */
+	.pr_pressure = 5,
+    },
 };
 
 static inline unsigned int

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -240,9 +240,9 @@ flush_ult(void *arg)
 		} else if (rc) {	/* This pool doesn't have NVMe partition */
 			sleep_ms = 60000;
 		} else if (sched_req_space_check(child->spc_flush_req) == SCHED_SPACE_PRESS_NONE) {
-			sleep_ms = 5000;
+			sleep_ms = 500;
 		} else {
-			sleep_ms = (nr_flushed < nr_flush) ? 1000 : 0;
+			sleep_ms = (nr_flushed < nr_flush) ? 50 : 0;
 		}
 
 		if (dss_ult_exiting(child->spc_flush_req))

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -442,7 +442,6 @@ class EngineYamlParameters(YamlParameters):
             "D_LOG_FILE_APPEND_PID=1",
             "DAOS_POOL_RF=4",
             "CRT_EVENT_DELAY=1",
-            "DAOS_VOS_AGG_GAP=25",
             # pylint: disable-next=fixme
             # FIXME disable space cache since some tests need to verify instant pool space
             # changing, this global setting to individual test setting once in follow-on PR.

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -379,7 +380,7 @@ error:
 	return rc;
 }
 
-#define FLUSH_INTVL		5	/* seconds */
+#define FLUSH_INTVL 2 /* seconds */
 
 static inline bool
 need_aging_flush(struct vea_space_info *vsi, bool force)

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -766,7 +767,7 @@ aggregated_free(struct vea_space_info *vsi, struct vea_free_entry *vfe)
 	return 0;
 }
 
-#define EXPIRE_INTVL		10	/* seconds */
+#define EXPIRE_INTVL            3               /* seconds */
 #define UNMAP_SIZE_THRESH	(1UL << 20)	/* 1MB */
 
 static int

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -145,7 +145,7 @@ enum {
 extern uint32_t vos_agg_gap;
 
 #define VOS_AGG_GAP_MIN		20 /* seconds */
-#define VOS_AGG_GAP_DEF		60
+#define VOS_AGG_GAP_DEF         20
 #define VOS_AGG_GAP_MAX		180
 
 extern unsigned int vos_agg_nvme_thresh;


### PR DESCRIPTION
Seek to avoid false ENOSPACE by few adjustments:

- Revert the 60 seconds VOS_AGG_GAP_DEF back to 20 seconds.

- Aggregation ULTs don't voluntarily sleep when there is space pressure, otherwise, scheduler will think that there is nothing to be reclaimed and gives up on throttling I/O.

- Increase the reclaim ULTs CPU ratio for all pressure levels: bump the original [20, 30, 40, 50, 60] to [30, 45, 60, 75, 90].

- Shrink VEA flush/expire interval from 5/10 seconds to 2/3 seconds.

- Shrink the flush ULT sleep interval from 5/1 seconds to 500/50 milli-seconds.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
