### PR TITLE
DAOS-17131 dfs: Possible missing string termination after strncpy function call

### DIFF
--- a/src/client/dfs/cont.c
+++ b/src/client/dfs/cont.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -83,7 +84,7 @@ dfs_cont_create(daos_handle_t poh, uuid_t *cuuid, dfs_attr_t *attr, daos_handle_
 			dattr.da_chunk_size = DFS_DEFAULT_CHUNK_SIZE;
 
 		if (attr->da_hints[0] != 0) {
-			strncpy(dattr.da_hints, attr->da_hints, DAOS_CONT_HINT_MAX_LEN);
+			strncpy(dattr.da_hints, attr->da_hints, DAOS_CONT_HINT_MAX_LEN - 1);
 			dattr.da_hints[DAOS_CONT_HINT_MAX_LEN - 1] = '\0';
 		}
 	} else {

--- a/src/client/dfs/obj.c
+++ b/src/client/dfs/obj.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -505,7 +506,8 @@ dfs_dup(dfs_t *dfs, dfs_obj_t *obj, int flags, dfs_obj_t **_new_obj)
 		D_GOTO(err, rc = EINVAL);
 	}
 
-	strncpy(new_obj->name, obj->name, DFS_MAX_NAME + 1);
+	strncpy(new_obj->name, obj->name, DFS_MAX_NAME);
+	new_obj->name[DFS_MAX_NAME] = '\0';
 	new_obj->mode  = obj->mode;
 	new_obj->flags = flags;
 	oid_cp(&new_obj->parent_oid, obj->parent_oid);
@@ -610,8 +612,8 @@ dfs_obj_local2global(dfs_t *dfs, dfs_obj_t *obj, d_iov_t *glob)
 	oid_cp(&obj_glob->parent_oid, obj->parent_oid);
 	uuid_copy(obj_glob->coh_uuid, coh_uuid);
 	uuid_copy(obj_glob->cont_uuid, cont_uuid);
-	strncpy(obj_glob->name, obj->name, DFS_MAX_NAME + 1);
-	obj_glob->name[DFS_MAX_NAME] = 0;
+	strncpy(obj_glob->name, obj->name, DFS_MAX_NAME);
+	obj_glob->name[DFS_MAX_NAME] = '\0';
 	if (S_ISDIR(obj_glob->mode))
 		return 0;
 	rc = dfs_get_chunk_size(obj, &obj_glob->chunk_size);
@@ -668,7 +670,7 @@ dfs_obj_global2local(dfs_t *dfs, int flags, d_iov_t glob, dfs_obj_t **_obj)
 
 	oid_cp(&obj->oid, obj_glob->oid);
 	oid_cp(&obj->parent_oid, obj_glob->parent_oid);
-	strncpy(obj->name, obj_glob->name, DFS_MAX_NAME + 1);
+	strncpy(obj->name, obj_glob->name, DFS_MAX_NAME);
 	obj->name[DFS_MAX_NAME] = '\0';
 	obj->mode               = obj_glob->mode;
 	obj->flags              = flags ? flags : obj_glob->flags;

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -110,7 +111,8 @@ dfuse_reply_entry(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie,
 			wipe_name[NAME_MAX] = '\0';
 
 			inode->ie_parent = ie->ie_parent;
-			strncpy(inode->ie_name, ie->ie_name, NAME_MAX + 1);
+			strncpy(inode->ie_name, ie->ie_name, NAME_MAX);
+			inode->ie_name[NAME_MAX] = '\0';
 		}
 		atomic_fetch_sub_relaxed(&ie->ie_ref, 1);
 		dfuse_ie_close(dfuse_info, ie);
@@ -283,6 +285,7 @@ dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 		DFUSE_TRA_DEBUG(ie, "Attr len is %zi", attr_len);
 
 	strncpy(ie->ie_name, name, NAME_MAX);
+	ie->ie_name[NAME_MAX] = '\0';
 
 	dfs_obj2id(ie->ie_obj, &ie->ie_oid);
 

--- a/src/tests/obj_ctl.c
+++ b/src/tests/obj_ctl.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -198,7 +199,7 @@ ctl_cmd_run(char opc, char *args)
 	int			 rc;
 
 	if (args) {
-		strncpy(buf, args, CTL_BUF_LEN);
+		strncpy(buf, args, CTL_BUF_LEN - 1);
 		buf[CTL_BUF_LEN - 1] = '\0';
 		str = daos_str_trimwhite(buf);
 	} else {


### PR DESCRIPTION
There are several issues in strncpy usage that may cause memory
corruption. Target string may not be ended by `\0` character.

Ref: https://github.com/daos-stack/daos/pull/15920

Issues detected during sanitizer integration
Ref: https://github.com/daos-stack/daos/pull/15105

Signed-off-by: Tomasz Gromadzki <tomasz.gromadzki@hpe.com>
Co-authored-by: Cedric Koch-Hofer <cedric.koch.hofer@gmail.com>

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
