### PR TITLE
DAOS-17404 ci: Enable plugin for finding branches

### DIFF
--- a/utils/githooks/branches.default
+++ b/utils/githooks/branches.default
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eEuo pipefail
+echo feature/cat_recovery
+echo feature/multiprovider
+echo feature/firewall

--- a/utils/githooks/find_base.sh
+++ b/utils/githooks/find_base.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # /*
 #  * (C) Copyright 2024 Intel Corporation.
+#  * (C) Copyright 2025 Google LLC
 #  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #  *
 #  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -33,13 +34,21 @@ if ${USE_GH:-true} && command -v gh > /dev/null 2>&1; then
     fi
 fi
 
+find_branches()
+{
+      for script in "utils/githooks/branches."*; do
+        "${script}"
+      done
+}
+
 if [ -z "$TARGET" ]; then
     # With no 'gh' command installed, or no PR open yet, use the "closest" branch
     # as the target, calculated as the sum of the commits this branch is ahead and
     # behind.
     # check master, then current release branches, then current feature branches.
     export ORIGIN
-    TARGET="$ORIGIN/$(utils/rpms/packaging/get_release_branch "feature/cat_recovery feature/multiprovider")"
+    readarray -t branches <<< "$(eval find_branches)"
+    TARGET="$ORIGIN/$(utils/rpms/packaging/get_release_branch "${branches[@]}")"
     echo "  Install gh command to auto-detect target branch, assuming $TARGET."
 fi
 

--- a/utils/githooks/find_base.sh
+++ b/utils/githooks/find_base.sh
@@ -29,20 +29,11 @@ if ${USE_GH:-true} && command -v gh > /dev/null 2>&1; then
     fi
 fi
 
-find_branches()
-{
-      for script in "utils/githooks/branches."*; do
-        "${script}"
-      done
-}
-
 if [ -z "$TARGET_BRANCH" ]; then
     # With no 'gh' command installed, or no PR open yet, use the "closest" branch
     # as the target, calculated as the sum of the commits this branch is ahead and
-    # behind.
-    # check master, then current release branches, then current feature branches.
-    readarray -t branches <<< "$(eval find_branches)"
-    TARGET="$(utils/githooks/get_branch "${branches[@]}")"
+    # behind. This will check any branches configured by a branches.* script
+    TARGET="$(utils/githooks/get_branch)"
 else
     # We don't know the remote for sure so let's run the checks anyway which
     # should come to the same answer but uses gh to get a better one

--- a/utils/githooks/get_branch
+++ b/utils/githooks/get_branch
@@ -30,7 +30,7 @@ for origin in $(git remote); do
     done < <(echo "master"
              git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[4-9]\|[3-9]\)/s/^  $origin\\///p")
     export ORIGIN="${origin}"
-    readarray -t branches <<< "$(eval find_branches)"
+    readarray -t branches <<< find_branches
     all_bases=("${builtin_bases[@]}" "${branches[@]}")
   fi
   for base in "${all_bases[@]}"; do

--- a/utils/githooks/get_branch
+++ b/utils/githooks/get_branch
@@ -12,13 +12,27 @@ set -eu -o pipefail
 TARGET="origin/master"
 min_diff=-1
 
+find_branches()
+{
+      for script in "utils/githooks/branches."*; do
+        "${script}"
+      done
+}
+
 for origin in $(git remote); do
-  builtin_bases=()
-  while IFS= read -r base; do
-      builtin_bases+=("$base")
-  done < <(echo "master"
-           git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[4-9]\|[3-9]\)/s/^  $origin\\///p")
-  all_bases=("${builtin_bases[@]}" "$@")
+  if [ $# -eq 1 ]; then
+    # Assume the branch was found and we just want to find the remote
+    all_bases=("$1")
+  else
+    builtin_bases=()
+    while IFS= read -r base; do
+        builtin_bases+=("$base")
+    done < <(echo "master"
+             git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[4-9]\|[3-9]\)/s/^  $origin\\///p")
+    export ORIGIN="${origin}"
+    readarray -t branches <<< "$(eval find_branches)"
+    all_bases=("${builtin_bases[@]}" "${branches[@]}")
+  fi
   for base in "${all_bases[@]}"; do
       git rev-parse --verify "${origin}/${base}" &> /dev/null || continue
 

--- a/utils/githooks/get_branch
+++ b/utils/githooks/get_branch
@@ -30,7 +30,8 @@ for origin in $(git remote); do
     done < <(echo "master"
              git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[4-9]\|[3-9]\)/s/^  $origin\\///p")
     export ORIGIN="${origin}"
-    readarray -t branches <<< find_branches
+    export find_branches
+    readarray -t branches <<< "$(find_branches)"
     all_bases=("${builtin_bases[@]}" "${branches[@]}")
   fi
   for base in "${all_bases[@]}"; do

--- a/utils/githooks/get_branch
+++ b/utils/githooks/get_branch
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# find the base branch of the current branch
+# base branches can be master, release/2.4+, release/3+
+# or optionally branches passed into $1
+set -eu -o pipefail
+
+TARGET="origin/master"
+min_diff=-1
+
+for origin in $(git remote); do
+  builtin_bases=()
+  while IFS= read -r base; do
+      builtin_bases+=("$base")
+  done < <(echo "master"
+           git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[4-9]\|[3-9]\)/s/^  $origin\\///p")
+  all_bases=("${builtin_bases[@]}" "$@")
+  for base in "${all_bases[@]}"; do
+      git rev-parse --verify "${origin}/${base}" &> /dev/null || continue
+
+      commits_ahead=$(git log --oneline "${origin}/${base}..HEAD" | wc -l)
+      if [ "${min_diff}" -eq -1 ] || [ "${min_diff}" -gt "${commits_ahead}" ]; then
+          TARGET="${origin}/${base}"
+          min_diff="${commits_ahead}"
+      fi
+  done
+done
+echo "$TARGET"
+exit 0

--- a/utils/rpms/packaging/get_release_branch
+++ b/utils/rpms/packaging/get_release_branch
@@ -8,17 +8,18 @@
 # base branches can be master, release/2.4+, release/3+
 # or optionally branches passed into $1
 set -eu -o pipefail
-IFS=' ' read -r -a add_bases <<< "${1:-}"
 origin="${ORIGIN:-origin}"
-all_bases=()
+builtin_bases=()
 while IFS= read -r base; do
-    all_bases+=("$base")
+    builtin_bases+=("$base")
 done < <(echo "master"
          git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[4-9]\|[3-9]\)/s/^  $origin\\///p")
+all_bases=("${builtin_bases[@]}" "$@")
 TARGET="master"
 min_diff=-1
 for base in "${all_bases[@]}"; do
     git rev-parse --verify "$origin/$base" &> /dev/null || continue
+
     commits_ahead=$(git log --oneline "$origin/$base..HEAD" | wc -l)
     if [ "$min_diff" -eq -1 ] || [ "$min_diff" -gt "$commits_ahead" ]; then
         TARGET="$base"

--- a/utils/rpms/packaging/get_release_branch
+++ b/utils/rpms/packaging/get_release_branch
@@ -8,18 +8,17 @@
 # base branches can be master, release/2.4+, release/3+
 # or optionally branches passed into $1
 set -eu -o pipefail
+IFS=' ' read -r -a add_bases <<< "${1:-}"
 origin="${ORIGIN:-origin}"
-builtin_bases=()
+all_bases=()
 while IFS= read -r base; do
-    builtin_bases+=("$base")
+    all_bases+=("$base")
 done < <(echo "master"
          git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[4-9]\|[3-9]\)/s/^  $origin\\///p")
-all_bases=("${builtin_bases[@]}" "$@")
 TARGET="master"
 min_diff=-1
 for base in "${all_bases[@]}"; do
     git rev-parse --verify "$origin/$base" &> /dev/null || continue
-
     commits_ahead=$(git log --oneline "$origin/$base..HEAD" | wc -l)
     if [ "$min_diff" -eq -1 ] || [ "$min_diff" -gt "$commits_ahead" ]; then
         TARGET="$base"


### PR DESCRIPTION
Fixes a few issues

1. For folks that have other multiple remotes and branches with different names they want 
to check, this enables them to add those branches as a plugin.
2. Auto-detect the origin of the closest branch or of the branch returned by gh
3. Works whether or not the remote is a gh branch when gh is installed.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
