### PR TITLE
DAOS-17404 ci: Enable plugin for finding branches

### DIFF
--- a/utils/githooks/branches.default
+++ b/utils/githooks/branches.default
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eEuo pipefail
+echo feature/cat_recovery
+echo feature/multiprovider
+echo feature/firewall

--- a/utils/githooks/branches.google
+++ b/utils/githooks/branches.google
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eEuo pipefail
+git branch -r | grep " ${ORIGIN:-origin}/[0-9]\+\.[0-9]\+-ps-[0-9]\+" | sed 's/.*\///'
+echo upstream/google/2.6
+echo upstream/release/2.6
+echo main-2.6
+echo upstream/master

--- a/utils/githooks/find_base.sh
+++ b/utils/githooks/find_base.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # /*
 #  * (C) Copyright 2024 Intel Corporation.
+#  * (C) Copyright 2025 Google LLC
 #  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #  *
 #  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -33,13 +34,21 @@ if ${USE_GH:-true} && command -v gh > /dev/null 2>&1; then
     fi
 fi
 
+find_branches()
+{
+      for script in "utils/githooks/branches."*; do
+        "${script}"
+      done
+}
+
 if [ -z "$TARGET" ]; then
     # With no 'gh' command installed, or no PR open yet, use the "closest" branch
     # as the target, calculated as the sum of the commits this branch is ahead and
     # behind.
     # check master, then current release branches, then current feature branches.
     export ORIGIN
-    TARGET="$ORIGIN/$(utils/rpms/packaging/get_release_branch "feature/cat_recovery feature/multiprovider")"
+    readarray -t branches <<< "$(eval find_branches)"
+    TARGET="$ORIGIN/$(utils/rpms/packaging/get_release_branch "${branches[@]}")"
     echo "  Install gh command to auto-detect target branch, assuming $TARGET."
 fi
 

--- a/utils/rpms/packaging/get_release_branch
+++ b/utils/rpms/packaging/get_release_branch
@@ -8,17 +8,18 @@
 # base branches can be master, release/2.4+, release/3+
 # or optionally branches passed into $1
 set -eu -o pipefail
-IFS=' ' read -r -a add_bases <<< "${1:-}"
 origin="${ORIGIN:-origin}"
-all_bases=()
+builtin_bases=()
 while IFS= read -r base; do
-    all_bases+=("$base")
+    builtin_bases+=("$base")
 done < <(echo "master"
          git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[4-9]\|[3-9]\)/s/^  $origin\\///p")
+all_bases=("${builtin_bases[@]}" "$@")
 TARGET="master"
 min_diff=-1
 for base in "${all_bases[@]}"; do
     git rev-parse --verify "$origin/$base" &> /dev/null || continue
+
     commits_ahead=$(git log --oneline "$origin/$base..HEAD" | wc -l)
     if [ "$min_diff" -eq -1 ] || [ "$min_diff" -gt "$commits_ahead" ]; then
         TARGET="$base"


### PR DESCRIPTION
When we are using a repo for other than GitHub, things may not be in proper places for the defaults to work. This enables running plugin scripts to get extra
branch names

Change-Id: I07a1e952b0873ec95a9c2c7b5d9a093e3274255a

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
