### PR TITLE
DAOS-17344 build: Remove path elements from tar

### DIFF
--- a/utils/rpms/archive.sh
+++ b/utils/rpms/archive.sh
@@ -30,7 +30,7 @@ tmp=$(mktemp -d)
 
 file_extless="${name}-${version}"
 file="${file_extless}.${ext}"
-sm_file_prefix="${file_extless}-submodule"
+sm_file_prefix="${file_extless//\/_}-submodule"
 
 # Create an archive, which doesn't include any submodule.
 git archive --prefix "${name}-${version}/" -o "${tmp}/${file}" HEAD


### PR DESCRIPTION
For submodules with names that include path elements, remove those elements from the name.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
