### PR TITLE
DAOS-17404 ci: Enable plugin for finding branches

### DIFF
--- a/utils/githooks/find_base.sh
+++ b/utils/githooks/find_base.sh
@@ -14,43 +14,33 @@ if ! BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); then
     exit 1
 fi
 
-ORIGIN="${DAOS_ORIGIN:=origin}"
-if [ "$ORIGIN" = "origin" ]; then
-    echo "  Using origin as remote repo.  If this is incorrect, set DAOS_ORIGIN in environment"
-fi
-
+TARGET_BRANCH=""
 # Try and use the gh command to work out the target branch, or if not installed
 # then assume origin/master.
-TARGET=""
 if ${USE_GH:-true} && command -v gh > /dev/null 2>&1; then
     # If there is no PR created yet then do not check anything.
-    if ! TARGET="$ORIGIN"/$(gh pr view "$BRANCH" --json baseRefName -t "{{.baseRefName}}"); then
-        TARGET=""
+    if ! TARGET_BRANCH="$(gh pr view "$BRANCH" --json baseRefName -t "{{.baseRefName}}")"; then
+        TARGET_BRANCH=""
     else
         state=$(gh pr view "$BRANCH" --json state -t "{{.state}}")
         if [ ! "$state" = "OPEN" ]; then
-            TARGET=""
+          TARGET_BRANCH=""
         fi
     fi
 fi
 
-find_branches()
-{
-      for script in "utils/githooks/branches."*; do
-        "${script}"
-      done
-}
-
-if [ -z "$TARGET" ]; then
+if [ -z "$TARGET_BRANCH" ]; then
     # With no 'gh' command installed, or no PR open yet, use the "closest" branch
     # as the target, calculated as the sum of the commits this branch is ahead and
-    # behind.
-    # check master, then current release branches, then current feature branches.
-    export ORIGIN
-    readarray -t branches <<< "$(eval find_branches)"
-    TARGET="$ORIGIN/$(utils/rpms/packaging/get_release_branch "${branches[@]}")"
-    echo "  Install gh command to auto-detect target branch, assuming $TARGET."
+    # behind. This will check any branches configured by a branches.* script
+    TARGET="$(utils/githooks/get_branch)"
+else
+    # We don't know the remote for sure so let's run the checks anyway which
+    # should come to the same answer but uses gh to get a better one
+    TARGET="$(utils/githooks/get_branch "${TARGET_BRANCH}")"
 fi
+
+echo "Using ${TARGET} as base branch"
 
 # get the actual commit in $TARGET that is our base, if we are working on a commit in the history
 # of $TARGET and not it's HEAD

--- a/utils/githooks/get_branch
+++ b/utils/githooks/get_branch
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# find the base branch of the current branch
+# base branches can be master, release/2.4+, release/3+
+# or optionally branches passed into $1
+set -eu -o pipefail
+
+TARGET="origin/master"
+min_diff=-1
+
+find_branches()
+{
+      for script in "utils/githooks/branches."*; do
+        "${script}"
+      done
+}
+
+for origin in $(git remote); do
+  if [ $# -eq 1 ]; then
+    # Assume the branch was found and we just want to find the remote
+    all_bases=("$1")
+  else
+    builtin_bases=()
+    while IFS= read -r base; do
+        builtin_bases+=("$base")
+    done < <(echo "master"
+             git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[4-9]\|[3-9]\)/s/^  $origin\\///p")
+    export ORIGIN="${origin}"
+    readarray -t branches <<< find_branches
+    all_bases=("${builtin_bases[@]}" "${branches[@]}")
+  fi
+  for base in "${all_bases[@]}"; do
+      git rev-parse --verify "${origin}/${base}" &> /dev/null || continue
+
+      commits_ahead=$(git log --oneline "${origin}/${base}..HEAD" | wc -l)
+      if [ "${min_diff}" -eq -1 ] || [ "${min_diff}" -gt "${commits_ahead}" ]; then
+          TARGET="${origin}/${base}"
+          min_diff="${commits_ahead}"
+      fi
+  done
+done
+echo "$TARGET"
+exit 0

--- a/utils/rpms/packaging/get_release_branch
+++ b/utils/rpms/packaging/get_release_branch
@@ -8,18 +8,17 @@
 # base branches can be master, release/2.4+, release/3+
 # or optionally branches passed into $1
 set -eu -o pipefail
+IFS=' ' read -r -a add_bases <<< "${1:-}"
 origin="${ORIGIN:-origin}"
-builtin_bases=()
+all_bases=()
 while IFS= read -r base; do
-    builtin_bases+=("$base")
+    all_bases+=("$base")
 done < <(echo "master"
          git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[4-9]\|[3-9]\)/s/^  $origin\\///p")
-all_bases=("${builtin_bases[@]}" "$@")
 TARGET="master"
 min_diff=-1
 for base in "${all_bases[@]}"; do
     git rev-parse --verify "$origin/$base" &> /dev/null || continue
-
     commits_ahead=$(git log --oneline "$origin/$base..HEAD" | wc -l)
     if [ "$min_diff" -eq -1 ] || [ "$min_diff" -gt "$commits_ahead" ]; then
         TARGET="$base"


### PR DESCRIPTION
Accidentlly landed the prior patch before a subsequent change to the patch on master branch

Change-Id: I43ad8078255fd8c2b48e79d98bb2080d5b37a983

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
