### PR TITLE
DAOS-623 common: Add thread_private fail_loc

### DIFF
--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2015-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -699,6 +700,8 @@ daos_quiet_error(int err)
 
 void
 daos_fail_loc_set(uint64_t id);
+void
+daos_fail_loc_set_private(uint64_t id);
 void
 daos_fail_loc_reset(void);
 void


### PR DESCRIPTION
Sometimes it may be useful to use a thread private fail loc.  For now, keep the attributes global and just change where the value is stored.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
