### PR TITLE
DAOS-17381 rebuild: refine rebuild IO scheduling and rebuild IV

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -1,5 +1,6 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -777,6 +778,7 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 	struct crt_opc_info	*opc_info;
 	struct crt_corpc_ops	*co_ops;
 	bool			 ver_match;
+	bool                     co_failout = false;
 	int			 i, rc = 0;
 
 	co_info = rpc_priv->crp_corpc_info;
@@ -906,18 +908,18 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 	}
 
 forward_done:
-	if (rc != 0 && rpc_priv->crp_flags & CRT_RPC_FLAG_CO_FAILOUT) {
-		crt_corpc_complete(rpc_priv);
-		goto out;
-	}
+	if (rc != 0 && rpc_priv->crp_flags & CRT_RPC_FLAG_CO_FAILOUT)
+		co_failout = true;
 
 	/* NOOP bcast (no child and root excluded) */
-	if (co_info->co_child_num == 0 && co_info->co_root_excluded)
+	if (co_info->co_child_num == 0 && (co_info->co_root_excluded || co_failout))
 		crt_corpc_complete(rpc_priv);
 
-	if (co_info->co_root_excluded == 1) {
+	if (co_info->co_root_excluded == 1 || co_failout) {
 		if (co_info->co_grp_priv->gp_self == co_info->co_root) {
-			/* don't return error for root */
+			/* don't return error for root to avoid RPC_DECREF in
+			 * fail case in crt_req_send.
+			 */
 			rc = 0;
 		}
 		D_GOTO(out, rc);

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1537,7 +1538,7 @@ out:
 			/* failure already reported through complete cb */
 			if (complete_cb != NULL)
 				rc = 0;
-		} else if (!crt_rpc_completed(rpc_priv)) {
+		} else {
 			RPC_DECREF(rpc_priv);
 		}
 	}

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -471,14 +472,20 @@ again:
 				rc = cont_iv_snap_ent_create(entry, key);
 				if (rc == 0)
 					goto again;
-				D_DEBUG(DB_MD, "create cont snap iv entry failed "
-					""DF_RC"\n", DP_RC(rc));
+				/* convert to more specific errno */
+				if (rc == -DER_NONEXIST)
+					rc = -DER_CONT_NONEXIST;
+				DL_ERROR(rc, DF_CONT " create IV_CONT_SNAP iv entry failed",
+					 DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
 			} else if (class_id == IV_CONT_PROP) {
 				rc = cont_iv_prop_ent_create(entry, key);
 				if (rc == 0)
 					goto again;
-				D_ERROR("create cont prop iv entry failed "
-					""DF_RC"\n", DP_RC(rc));
+				/* convert to more specific errno */
+				if (rc == -DER_NONEXIST)
+					rc = -DER_CONT_NONEXIST;
+				DL_ERROR(rc, DF_CONT " create IV_CONT_PROP iv entry failed",
+					 DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
 			} else if (class_id == IV_CONT_CAPA) {
 				struct container_hdl	chdl = { 0 };
 				int			rc1;
@@ -541,7 +548,8 @@ again:
 				}
 			}
 		}
-		D_DEBUG(DB_MGMT, "lookup cont: rc "DF_RC"\n", DP_RC(rc));
+		D_DEBUG(DB_MGMT, DF_CONT "lookup cont: rc " DF_RC "\n",
+			DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid), DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -682,8 +683,10 @@ ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 	rc = cont_svc_lookup_leader(pool_uuid, 0, &svc, NULL);
-	if (rc != 0)
+	if (rc != 0) {
+		DL_ERROR(rc, "pool " DF_UUID " cont_svc_lookup_leader failed", DP_UUID(pool_uuid));
 		return rc;
+	}
 
 	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
 	if (rc != 0)
@@ -691,13 +694,17 @@ ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 
 	ABT_rwlock_rdlock(svc->cs_lock);
 	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
-	if (rc != 0)
+	if (rc != 0) {
+		DL_ERROR(rc, DF_CONT " cont_lookup failed", DP_CONT(pool_uuid, cont_uuid));
 		D_GOTO(out_lock, rc);
+	}
 
 	rc = read_snap_list(&tx, cont, snapshots, snap_count);
 	cont_put(cont);
-	if (rc != 0)
+	if (rc != 0) {
+		DL_ERROR(rc, DF_CONT " read_snap_list failed", DP_CONT(pool_uuid, cont_uuid));
 		D_GOTO(out_lock, rc);
+	}
 
 out_lock:
 	ABT_rwlock_unlock(svc->cs_lock);

--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -129,11 +130,11 @@ test_d_errstr(void **state)
 	assert_string_equal(value, "DER_UNKNOWN");
 
 	/* Check the end of the DAOS error numbers. */
-	value = d_errstr(-DER_NOT_RESUME);
-	assert_string_equal(value, "DER_NOT_RESUME");
-	value = d_errstr(-2049);
-	assert_string_equal(value, "DER_NOT_RESUME");
-	value = d_errstr(-(DER_NOT_RESUME + 1));
+	value = d_errstr(-DER_CONT_NONEXIST);
+	assert_string_equal(value, "DER_CONT_NONEXIST");
+	value = d_errstr(-2050);
+	assert_string_equal(value, "DER_CONT_NONEXIST");
+	value = d_errstr(-(DER_CONT_NONEXIST + 1));
 	assert_string_equal(value, "DER_UNKNOWN");
 }
 

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -212,7 +213,8 @@ extern "C" {
 	ACTION(DER_DIV_BY_ZERO,	Division by zero)						   \
 	/** Target is overload, retry RPC */							   \
 	ACTION(DER_OVERLOAD_RETRY, "retry later because of overloaded service")			   \
-	ACTION(DER_NOT_RESUME, Cannot resume former DAOS check instance)
+	ACTION(DER_NOT_RESUME, Cannot resume former DAOS check instance)			   \
+	ACTION(DER_CONT_NONEXIST, The specified container does not exist)
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2015-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -498,6 +499,12 @@ daos_obj_id2class(daos_obj_id_t oid)
 	nr_grps = (oid.hi & OID_FMT_META_MASK) >> OID_FMT_META_SHIFT;
 
 	return (ord << OC_REDUN_SHIFT) | nr_grps;
+}
+
+static inline uint32_t
+daos_obj_id2grp_nr(daos_obj_id_t oid)
+{
+	return (oid.hi & OID_FMT_META_MASK) >> OID_FMT_META_SHIFT;
 }
 
 static inline bool

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -55,6 +56,11 @@ typedef enum {
 	DP_UUID((rpt)->rt_pool_uuid), (rpt)->rt_rebuild_ver, (rpt)->rt_rebuild_gen,                \
 	    RB_OP_STR((rpt)->rt_rebuild_op)
 #define DP_RBF_RPT(rpt) DP_RB_RPT(rpt), (rpt)->rt_leader_rank, (rpt)->rt_leader_term
+
+/* arguments for log rebuild identifier given a struct migrate_pool_tls *mpt */
+#define DP_RB_MPT(mpt)                                                                             \
+	DP_UUID((mpt)->mpt_pool_uuid), (mpt)->mpt_version, (mpt)->mpt_generation,                  \
+	    RB_OP_STR((mpt)->mpt_opc)
 
 int ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 			daos_epoch_t stable_eph, uint32_t layout_version,

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2020-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2435,6 +2436,7 @@ ec_agg_object(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *ag
 	struct pl_map		*map;
 	struct daos_oclass_attr  oca;
 	struct cont_props	 props;
+	uint32_t                 shard_nr;
 	int			 rc = 0;
 
 	/** We should have filtered it if it isn't EC */
@@ -2456,6 +2458,8 @@ ec_agg_object(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *ag
 	md.omd_pda = props.dcp_ec_pda;
 	rc = pl_obj_place(map, agg_entry->ae_oid.id_layout_ver, &md, DAOS_OO_RO, NULL,
 			  &agg_entry->ae_obj_layout);
+	shard_nr        = daos_oclass_grp_size(&oca) * daos_obj_id2grp_nr(md.omd_id);
+	agg_param->ap_credits += roundup(shard_nr, 128) / 128;
 
 out:
 	return rc;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -753,6 +754,11 @@ retry:
 			   NULL, flags, NULL, csum_iov_fetch);
 	if (rc == -DER_TIMEDOUT &&
 	    tls->mpt_version + 1 >= tls->mpt_pool->spc_map_version) {
+		if (tls->mpt_fini) {
+			DL_ERROR(rc, DF_RB ": dsc_obj_fetch " DF_UOID "failed when mpt_fini",
+				 DP_RB_MPT(tls), DP_UOID(mrone->mo_oid));
+			return rc;
+		}
 		/* If pool map does not change, then let's retry for timeout, instead of
 		 * fail out.
 		 */
@@ -1494,13 +1500,10 @@ post:
 			 * the rebuild and retry.
 			 */
 			rc = -DER_DATA_LOSS;
-			D_DEBUG(DB_REBUILD,
-				DF_UOID" %p dkey "DF_KEY" "DF_KEY" nr %d/%d"
-				" eph "DF_U64" "DF_RC"\n",
-				DP_UOID(mrone->mo_oid),
-				mrone, DP_KEY(&mrone->mo_dkey),
-				DP_KEY(&iods[i].iod_name), iod_num, i, mrone->mo_epoch,
-				DP_RC(rc));
+			D_INFO(DF_UOID " %p dkey " DF_KEY " " DF_KEY " nr %d/%d"
+				       " eph " DF_U64 " " DF_RC "\n",
+			       DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
+			       DP_KEY(&iods[i].iod_name), iod_num, i, mrone->mo_epoch, DP_RC(rc));
 			D_GOTO(end, rc);
 		}
 	}

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7408,43 +7408,6 @@ out:
 	return rc;
 }
 
-void
-ds_pool_extend_handler(crt_rpc_t *rpc)
-{
-	struct pool_extend_in	*in = crt_req_get(rpc);
-	struct pool_extend_out	*out = crt_reply_get(rpc);
-	struct pool_svc		*svc;
-	uuid_t			pool_uuid;
-	d_rank_list_t		rank_list;
-	uint32_t		ndomains;
-	uint32_t		*domains;
-	int			rc;
-
-	D_DEBUG(DB_MD, DF_UUID": processing rpc %p\n", DP_UUID(in->pei_op.pi_uuid), rpc);
-
-	uuid_copy(pool_uuid, in->pei_op.pi_uuid);
-	rank_list.rl_nr = in->pei_tgt_ranks->rl_nr;
-	rank_list.rl_ranks = in->pei_tgt_ranks->rl_ranks;
-	ndomains = in->pei_ndomains;
-	domains = in->pei_domains.ca_arrays;
-
-	rc = pool_svc_lookup_leader(in->pei_op.pi_uuid, &svc, &out->peo_op.po_hint);
-	if (rc != 0)
-		goto out;
-
-	rc =
-	    pool_svc_update_map(svc, pool_opc_2map_opc(opc_get(rpc->cr_opc)),
-				false /* exclude_rank */, &rank_list, domains, ndomains, NULL, NULL,
-				&out->peo_op.po_map_version, &out->peo_op.po_hint, MUS_DMG, true);
-
-	pool_svc_put_leader(svc);
-out:
-	out->peo_op.po_rc = rc;
-	D_DEBUG(DB_MD, DF_UUID ": replying rpc: %p " DF_RC "\n", DP_UUID(in->pei_op.pi_uuid), rpc,
-		DP_RC(rc));
-	crt_reply_send(rpc);
-}
-
 static int
 pool_discard(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr_list *list)
 {
@@ -7502,6 +7465,62 @@ out:
 	if (rank_list)
 		d_rank_list_free(rank_list);
 	return rc;
+}
+
+void
+ds_pool_extend_handler(crt_rpc_t *rpc)
+{
+	struct pool_extend_in       *in  = crt_req_get(rpc);
+	struct pool_extend_out      *out = crt_reply_get(rpc);
+	struct pool_svc             *svc;
+	struct pool_target_addr_list tgt_addr_list;
+	uuid_t                       pool_uuid;
+	d_rank_list_t                rank_list;
+	uint32_t                     ndomains;
+	uint32_t                    *domains;
+	int                          i;
+	int                          rc;
+
+	D_DEBUG(DB_MD, DF_UUID ": processing rpc %p\n", DP_UUID(in->pei_op.pi_uuid), rpc);
+
+	uuid_copy(pool_uuid, in->pei_op.pi_uuid);
+	rank_list.rl_nr          = in->pei_tgt_ranks->rl_nr;
+	rank_list.rl_ranks       = in->pei_tgt_ranks->rl_ranks;
+	ndomains                 = in->pei_ndomains;
+	domains                  = in->pei_domains.ca_arrays;
+	tgt_addr_list.pta_number = rank_list.rl_nr;
+	D_ALLOC_ARRAY(tgt_addr_list.pta_addrs, tgt_addr_list.pta_number);
+	if (tgt_addr_list.pta_addrs == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+	for (i = 0; i < tgt_addr_list.pta_number; i++) {
+		tgt_addr_list.pta_addrs[i].pta_rank   = rank_list.rl_ranks[i];
+		tgt_addr_list.pta_addrs[i].pta_target = -1;
+	}
+
+	rc = pool_svc_lookup_leader(in->pei_op.pi_uuid, &svc, &out->peo_op.po_hint);
+	if (rc != 0)
+		goto out;
+
+	rc = pool_discard(rpc->cr_ctx, svc, &tgt_addr_list);
+	if (rc) {
+		DL_ERROR(rc, DF_UUID ": pool_discard failed.", DP_UUID(in->pei_op.pi_uuid));
+		goto failed;
+	}
+
+	rc =
+	    pool_svc_update_map(svc, pool_opc_2map_opc(opc_get(rpc->cr_opc)),
+				false /* exclude_rank */, &rank_list, domains, ndomains, NULL, NULL,
+				&out->peo_op.po_map_version, &out->peo_op.po_hint, MUS_DMG, true);
+
+failed:
+	pool_svc_put_leader(svc);
+out:
+	if (tgt_addr_list.pta_addrs != NULL)
+		D_FREE(tgt_addr_list.pta_addrs);
+	out->peo_op.po_rc = rc;
+	D_DEBUG(DB_MD, DF_UUID ": replying rpc: %p " DF_RC "\n", DP_UUID(in->pei_op.pi_uuid), rpc,
+		DP_RC(rc));
+	crt_reply_send(rpc);
 }
 
 static void

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -2618,8 +2618,7 @@ ds_pool_tgt_discard_ult(void *data)
 		D_GOTO(free, rc = 0);
 	}
 
-	ex_status = PO_COMP_ST_UP | PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN |
-		    PO_COMP_ST_DOWN | PO_COMP_ST_NEW;
+	ex_status = PO_COMP_ST_UP | PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN | PO_COMP_ST_NEW;
 	ds_pool_thread_collective(arg->pool_uuid, ex_status, pool_child_discard, arg,
 				  DSS_ULT_DEEP_STACK);
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -2618,7 +2618,7 @@ ds_pool_tgt_discard_ult(void *data)
 		D_GOTO(free, rc = 0);
 	}
 
-	ex_status = PO_COMP_ST_UP | PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN | PO_COMP_ST_NEW;
+	ex_status = PO_COMP_ST_UP | PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN;
 	ds_pool_thread_collective(arg->pool_uuid, ex_status, pool_child_discard, arg,
 				  DSS_ULT_DEEP_STACK);
 

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -299,9 +300,6 @@ struct rebuild_iv {
 	int		riv_status;
 
 };
-
-#define SCAN_YIELD_FREQ		4096
-#define SCAN_OBJ_YIELD_CNT	128
 
 extern struct dss_module_key rebuild_module_key;
 static inline struct rebuild_tls *

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -109,7 +110,14 @@ rebuild_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	if (rc)
 		return rc;
 
-	if (rank != src_iv->riv_master_rank)
+	/* possibly the iv_master_rank changed due to PS leader switch */
+	if (entry->ns->iv_master_rank != src_iv->riv_master_rank)
+		D_WARN(DF_UUID ":ns->iv_master_rank %d mismatch with src_iv->riv_master_rank %d, "
+			       "on rank %d\n",
+		       DP_UUID(entry->ns->iv_pool_uuid), entry->ns->iv_master_rank,
+		       src_iv->riv_master_rank, rank);
+
+	if (rank != entry->ns->iv_master_rank)
 		return -DER_IVCB_FORWARD;
 
 	if (src_iv->riv_sync)

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -46,6 +46,44 @@ rebuild_pool_map_put(struct pool_map *map)
 	pool_map_decref(map);
 }
 
+/**
+ * Check whether the RPT is stale (new rebuild started).
+ * Only used in rebuild_tgt_status_check_ult(), the ULT only can exit when rebuild abort
+ * or globally done. When rebuild done, the leader notifies each target server by IV LAZY SYNC
+ * (see rebuild_leader_status_notify), so possibly the rebuild globally done but the async IV
+ * notification lost due to some network issue and lead to dangling rebuild_tgt_status_check_ult().
+ */
+bool
+rpt_stale(struct rebuild_tgt_pool_tracker *rpt)
+{
+	struct rebuild_tls      *tls = rebuild_tls_get();
+	struct rebuild_pool_tls *pool_tls;
+	bool                     found = false;
+
+	D_ASSERT(tls != NULL);
+	/* Only 1 thread will access the list, no need lock */
+	d_list_for_each_entry(pool_tls, &tls->rebuild_pool_list, rebuild_pool_list) {
+		if (uuid_compare(pool_tls->rebuild_pool_uuid, rpt->rt_pool_uuid) != 0)
+			continue;
+
+		if (rpt->rt_rebuild_ver == pool_tls->rebuild_pool_ver &&
+		    rpt->rt_rebuild_gen == pool_tls->rebuild_pool_gen)
+			found = true;
+
+		if ((rpt->rt_rebuild_ver < pool_tls->rebuild_pool_ver) ||
+		    (rpt->rt_rebuild_ver == pool_tls->rebuild_pool_ver &&
+		     rpt->rt_rebuild_gen < pool_tls->rebuild_pool_gen)) {
+			D_ERROR(DF_RB ": found new rebuild ver %d, gen %d\n", DP_RB_RPT(rpt),
+				pool_tls->rebuild_pool_ver, pool_tls->rebuild_pool_gen);
+			return true;
+		}
+	}
+
+	if (!found)
+		D_ERROR(DF_RB ": rebuild_tls not found\n", DP_RB_RPT(rpt));
+	return !found;
+}
+
 struct rebuild_pool_tls *
 rebuild_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver, uint32_t gen)
 {
@@ -788,7 +826,7 @@ static void
 rebuild_global_pool_tracker_destroy(struct rebuild_global_pool_tracker *rgt)
 {
 	D_ASSERT(rgt->rgt_refcount == 0);
-	d_list_del(&rgt->rgt_list);
+	d_list_del_init(&rgt->rgt_list);
 	if (rgt->rgt_servers)
 		D_FREE(rgt->rgt_servers);
 
@@ -1867,7 +1905,7 @@ rgt_leader_stop(struct rebuild_global_pool_tracker *rgt)
 	rgt->rgt_abort = 1;
 
 	/* Remove it from the rgt list to avoid stopping rgt duplicately */
-	d_list_del(&rgt->rgt_list);
+	d_list_del_init(&rgt->rgt_list);
 
 	ABT_mutex_lock(rgt->rgt_lock);
 	ABT_cond_wait(rgt->rgt_done_cond, rgt->rgt_lock);
@@ -2372,7 +2410,7 @@ rebuild_tgt_status_check_ult(void *arg)
 		if (!rpt->rt_global_done) {
 			struct ds_iv_ns *ns = rpt->rt_pool->sp_iv_ns;
 
-			iv.riv_master_rank = rpt->rt_leader_rank;
+			iv.riv_master_rank       = ns->iv_master_rank;
 			iv.riv_rank = rpt->rt_rank;
 			iv.riv_ver = rpt->rt_rebuild_ver;
 			iv.riv_rebuild_gen = rpt->rt_rebuild_gen;
@@ -2430,6 +2468,10 @@ rebuild_tgt_status_check_ult(void *arg)
 			break;
 
 		sched_req_sleep(rpt->rt_ult, RBLD_CHECK_INTV);
+		if (iv.riv_pull_done && rpt_stale(rpt)) {
+			D_ERROR(DF_RB " is stale, exit the ULT.\n", DP_RB_RPT(rpt));
+			break;
+		}
 	}
 
 	sched_req_put(rpt->rt_ult);
@@ -2725,6 +2767,22 @@ rebuild_cleanup(void)
 	return 0;
 }
 
+static int
+rebuild_get_req_attr(crt_rpc_t *rpc, struct sched_req_attr *attr)
+{
+	if (opc_get(rpc->cr_opc) == REBUILD_OBJECTS_SCAN) {
+		struct rebuild_scan_in *rsi = crt_req_get(rpc);
+
+		sched_req_attr_init(attr, SCHED_REQ_MIGRATE, &rsi->rsi_pool_uuid);
+	}
+
+	return 0;
+}
+
+static struct dss_module_ops rebuild_mod_ops = {
+    .dms_get_req_attr = rebuild_get_req_attr,
+};
+
 struct dss_module rebuild_module = {
     .sm_name        = "rebuild",
     .sm_mod_id      = DAOS_REBUILD_MODULE,
@@ -2737,4 +2795,5 @@ struct dss_module rebuild_module = {
     .sm_cli_count   = {0},
     .sm_handlers    = {rebuild_handlers},
     .sm_key         = &rebuild_module_key,
+    .sm_mod_ops     = &rebuild_mod_ops,
 };

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2025 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -666,7 +667,7 @@ void
 dv_oid_to_obj(daos_obj_id_t oid, struct ddb_obj *obj)
 {
 	obj->ddbo_oid = oid;
-	obj->ddbo_nr_grps = (oid.hi & OID_FMT_META_MASK) >> OID_FMT_META_SHIFT;
+	obj->ddbo_nr_grps = daos_obj_id2grp_nr(oid);
 
 	/*
 	 * It would be nice to get the object class name, but currently that is client


### PR DESCRIPTION
1. refine rebuild IV detailed handling
2. for rebuild IO, apply SCHED_REQ_MIGRATE for scheduler throttling
3. refine yield for rebuild scanner
4. use d_list_del_init for rgt delete
5. skip orphan container for rebuild scanner

Several patches backport -
2a74db871 - rebuild: fix possible hang in rebuild_obj_send_cb (#16146) 
61dcef126 - rebuild: cannot retry infinitely for dsc_obj_fetch timeout (#16083) 
caf1a2524 - rebuild: exit rebuild_tgt_status_check_ult when RPT stale (#15994) 
c86aa7bcc - cart: refine corpc fail handling for CRT_RPC_FLAG_CO_FAILOUT (#15572)

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
