### PR TITLE
DAOS_623 Build: skip dependabot-related build in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
           - "*"
     assignees:
       - daos-stack/actions-watchers
+    commit-message:
+      prefix: "Doc-only: true \n"
 
   - package-ecosystem: github-actions
     target-branch: release/2.6


### PR DESCRIPTION
To avoid unnecessary load on the Jenkins,
PR related to github actions should not trigger automatically the CI.

Such solution has already been added to release/2.6 scan.


### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
