### PR TITLE
DAOS-17350 build: Search in user environment for Go binary (#16176)

### DIFF
--- a/site_scons/site_tools/go_builder.py
+++ b/site_scons/site_tools/go_builder.py
@@ -118,7 +118,7 @@ def generate(env):
         context.Result(go_version)
         return 1
 
-    env.d_go_bin = env.get("GO_BIN", env.WhereIs(GO_COMPILER))
+    env.d_go_bin = env.get("GO_BIN", env.WhereIs(GO_COMPILER, os.environ['PATH']))
 
     if GetOption('help') or GetOption('clean'):
         return


### PR DESCRIPTION
By default scons only searches the execution environment PATH, not the external user environment PATH. We must request the user's PATH explicitly.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
