### PR TITLE
Fix an issues with internal githooks

### DIFF
--- a/utils/githooks/branches.google
+++ b/utils/githooks/branches.google
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -eEuo pipefail
-git branch -r | grep " ${ORIGIN:-origin}/[0-9]\+\.[0-9]\+-ps-[0-9]\+" | sed 's/.*\///'
+git branch -r | grep " ${ORIGIN:-origin}/[0-9]\+\.[0-9]\+-ps-[0-9]\+" | sed 's/.*\///' || true
 echo upstream/google/2.6
 echo upstream/release/2.6
 echo main-2.6
 echo upstream/master
+echo google/2.6

--- a/utils/githooks/get_branch
+++ b/utils/githooks/get_branch
@@ -30,7 +30,8 @@ for origin in $(git remote); do
     done < <(echo "master"
              git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[4-9]\|[3-9]\)/s/^  $origin\\///p")
     export ORIGIN="${origin}"
-    readarray -t branches <<< find_branches
+    export find_branches
+    readarray -t branches <<< "$(find_branches)"
     all_bases=("${builtin_bases[@]}" "${branches[@]}")
   fi
   for base in "${all_bases[@]}"; do


### PR DESCRIPTION
Branch resolution was broken
1. In trying to address shellcheck, it actually broke the checks
2. Add google/2.6 as a branch
3. Don't fail branches.google script if grep fails

Change-Id: Ibec7319d44fc533325207d39145b99de52cb9651

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
