### PR TITLE
DAOS-16111 rebuild: uniform identifier in logs

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -1,5 +1,6 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -777,6 +778,7 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 	struct crt_opc_info	*opc_info;
 	struct crt_corpc_ops	*co_ops;
 	bool			 ver_match;
+	bool                     co_failout = false;
 	int			 i, rc = 0;
 
 	co_info = rpc_priv->crp_corpc_info;
@@ -906,18 +908,18 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 	}
 
 forward_done:
-	if (rc != 0 && rpc_priv->crp_flags & CRT_RPC_FLAG_CO_FAILOUT) {
-		crt_corpc_complete(rpc_priv);
-		goto out;
-	}
+	if (rc != 0 && rpc_priv->crp_flags & CRT_RPC_FLAG_CO_FAILOUT)
+		co_failout = true;
 
 	/* NOOP bcast (no child and root excluded) */
-	if (co_info->co_child_num == 0 && co_info->co_root_excluded)
+	if (co_info->co_child_num == 0 && (co_info->co_root_excluded || co_failout))
 		crt_corpc_complete(rpc_priv);
 
-	if (co_info->co_root_excluded == 1) {
+	if (co_info->co_root_excluded == 1 || co_failout) {
 		if (co_info->co_grp_priv->gp_self == co_info->co_root) {
-			/* don't return error for root */
+			/* don't return error for root to avoid RPC_DECREF in
+			 * fail case in crt_req_send.
+			 */
 			rc = 0;
 		}
 		D_GOTO(out, rc);

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1537,7 +1538,7 @@ out:
 			/* failure already reported through complete cb */
 			if (complete_cb != NULL)
 				rc = 0;
-		} else if (!crt_rpc_completed(rpc_priv)) {
+		} else {
 			RPC_DECREF(rpc_priv);
 		}
 	}

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -471,14 +472,14 @@ again:
 				rc = cont_iv_snap_ent_create(entry, key);
 				if (rc == 0)
 					goto again;
-				D_DEBUG(DB_MD, "create cont snap iv entry failed "
-					""DF_RC"\n", DP_RC(rc));
+				DL_ERROR(rc, "cont " DF_UUID " create IV_CONT_SNAP iv entry failed",
+					 DP_UUID(civ_key->cont_uuid));
 			} else if (class_id == IV_CONT_PROP) {
 				rc = cont_iv_prop_ent_create(entry, key);
 				if (rc == 0)
 					goto again;
-				D_ERROR("create cont prop iv entry failed "
-					""DF_RC"\n", DP_RC(rc));
+				DL_ERROR(rc, "cont " DF_UUID " create IV_CONT_PROP iv entry failed",
+					 DP_UUID(civ_key->cont_uuid));
 			} else if (class_id == IV_CONT_CAPA) {
 				struct container_hdl	chdl = { 0 };
 				int			rc1;

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -682,8 +683,10 @@ ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 	rc = cont_svc_lookup_leader(pool_uuid, 0, &svc, NULL);
-	if (rc != 0)
+	if (rc != 0) {
+		DL_ERROR(rc, "pool " DF_UUID " cont_svc_lookup_leader failed", DP_UUID(pool_uuid));
 		return rc;
+	}
 
 	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
 	if (rc != 0)
@@ -691,8 +694,10 @@ ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 
 	ABT_rwlock_rdlock(svc->cs_lock);
 	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
-	if (rc != 0)
+	if (rc != 0) {
+		DL_ERROR(rc, DF_CONT " cont_lookup failed", DP_CONT(pool_uuid, cont_uuid));
 		D_GOTO(out_lock, rc);
+	}
 
 	rc = read_snap_list(&tx, cont, snapshots, snap_count);
 	cont_put(cont);

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -678,33 +678,6 @@ obj_tree_insert(daos_handle_t toh, uuid_t co_uuid, uint64_t tgt_id,
 int
 obj_tree_destroy(daos_handle_t btr_hdl);
 
-/* Per xstream migrate status */
-struct ds_migrate_status {
-	uint64_t dm_rec_count;	/* migrated record size */
-	uint64_t dm_obj_count;	/* migrated object count */
-	uint64_t dm_total_size;	/* migrated total size */
-	int	 dm_status;	/* migrate status */
-	uint32_t dm_migrating:1; /* if it is migrating */
-};
-
-int
-ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, uint32_t generation,
-			struct ds_migrate_status *dms);
-int
-ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_uuid,
-		       uuid_t cont_hdl_uuid, int tgt_id, uint32_t version, unsigned int generation,
-		       uint64_t max_eph, daos_unit_oid_t *oids, daos_epoch_t *ephs,
-		       daos_epoch_t *punched_ephs, unsigned int *shards, int cnt,
-		       uint32_t new_gl_ver, unsigned int migrate_opc, uint64_t *enqueue_id,
-		       uint32_t *max_delay);
-int
-ds_migrate_object(struct ds_pool *pool, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_uuid,
-		  uint32_t version, uint32_t generation, uint64_t max_eph, uint32_t opc,
-		  daos_unit_oid_t *oids, daos_epoch_t *epochs, daos_epoch_t *punched_epochs,
-		  unsigned int *shards, uint32_t count, unsigned int tgt_idx, uint32_t new_gl_ver);
-void
-ds_migrate_stop(struct ds_pool *pool, uint32_t ver, unsigned int generation);
-
 int
 obj_layout_diff(struct pl_map *map, daos_unit_oid_t oid, uint32_t new_ver, uint32_t old_ver,
 		struct daos_obj_md *md, uint32_t *tgts, uint32_t *shards, int array_size);

--- a/src/include/daos_srv/object.h
+++ b/src/include/daos_srv/object.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -64,5 +65,33 @@ typedef int (*enum_iterate_cb_t)(vos_iter_param_t *param, vos_iter_type_t type,
 int ds_obj_enum_pack(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 		     struct vos_iter_anchors *anchors, struct ds_obj_enum_arg *arg,
 		     enum_iterate_cb_t iter_cb, struct dtx_handle *dth);
+
+/* Per xstream migrate status */
+struct ds_migrate_status {
+	uint64_t dm_rec_count;     /* migrated record size */
+	uint64_t dm_obj_count;     /* migrated object count */
+	uint64_t dm_total_size;    /* migrated total size */
+	int      dm_status;        /* migrate status */
+	uint32_t dm_migrating : 1; /* if it is migrating */
+};
+
+int
+ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, unsigned int generation, int op,
+			struct ds_migrate_status *dms);
+
+int
+ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_uuid,
+		       uuid_t cont_hdl_uuid, int tgt_id, uint32_t version, unsigned int generation,
+		       uint64_t max_eph, daos_unit_oid_t *oids, daos_epoch_t *ephs,
+		       daos_epoch_t *punched_ephs, unsigned int *shards, int cnt,
+		       uint32_t new_gl_ver, unsigned int migrate_opc, uint64_t *enqueue_id,
+		       uint32_t *max_delay);
+int
+ds_migrate_object(struct ds_pool *pool, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_uuid,
+		  uint32_t version, uint32_t generation, uint64_t max_eph, uint32_t opc,
+		  daos_unit_oid_t *oids, daos_epoch_t *epochs, daos_epoch_t *punched_epochs,
+		  unsigned int *shards, uint32_t count, unsigned int tgt_idx, uint32_t new_gl_ver);
+void
+ds_migrate_stop(struct ds_pool *pool, uint32_t ver, unsigned int generation);
 
 #endif /* __DAOS_SRV_OBJ_H__ */

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -68,6 +68,21 @@ typedef enum {
 	DP_UUID((mqa)->pool_uuid), (mqa)->version, (mqa)->generation, RB_OP_STR((mqa)->rebuild_op)
 #define DP_RBF_MQA(mqa) DP_RB_MQA(mqa), (mqa)->leader_rank, (mqa)->leader_term
 
+/* arguments for log rebuild identifier given a struct obj_migrate_in *omi */
+#define DP_RB_OMI(omi)                                                                             \
+	DP_UUID((omi)->om_pool_uuid), (omi)->om_version, (omi)->om_generation,                     \
+	    RB_OP_STR((omi)->om_opc)
+
+/* arguments for log rebuild identifier given a struct migrate_pool_tls *mpt */
+#define DP_RB_MPT(mpt)                                                                             \
+	DP_UUID((mpt)->mpt_pool_uuid), (mpt)->mpt_version, (mpt)->mpt_generation,                  \
+	    RB_OP_STR((mpt)->mpt_opc)
+
+/* arguments for log rebuild identifier given a struct migrate_one *mro */
+#define DP_RB_MRO(mro)                                                                             \
+	DP_UUID((mro)->mo_pool_uuid), (mro)->mo_pool_tls_version, (mro)->mo_generation,            \
+	    RB_OP_STR((mro)->mo_opc)
+
 int ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 			daos_epoch_t stable_eph, uint32_t layout_version,
 			struct pool_target_id_list *tgts,

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -55,6 +56,17 @@ typedef enum {
 	DP_UUID((rpt)->rt_pool_uuid), (rpt)->rt_rebuild_ver, (rpt)->rt_rebuild_gen,                \
 	    RB_OP_STR((rpt)->rt_rebuild_op)
 #define DP_RBF_RPT(rpt) DP_RB_RPT(rpt), (rpt)->rt_leader_rank, (rpt)->rt_leader_term
+
+/* arguments for log rebuild identifier given a struct rebuild_scan_in *rsin */
+#define DP_RB_RSI(rsi)                                                                             \
+	DP_UUID((rsi)->rsi_pool_uuid), (rsi)->rsi_rebuild_ver, (rsi)->rsi_rebuild_gen,             \
+	    RB_OP_STR((rsi)->rsi_rebuild_op)
+#define DP_RBF_RSI(rsi) DP_RB_RSI(rsi), (rsi)->rsi_master_rank, (rsi)->rsi_leader_term
+
+/* arguments for log rebuild identifier given a struct migrate_query_arg * */
+#define DP_RB_MQA(mqa)                                                                             \
+	DP_UUID((mqa)->pool_uuid), (mqa)->version, (mqa)->generation, RB_OP_STR((mqa)->rebuild_op)
+#define DP_RBF_MQA(mqa) DP_RB_MQA(mqa), (mqa)->leader_rank, (mqa)->leader_term
 
 int ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 			daos_epoch_t stable_eph, uint32_t layout_version,

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -752,6 +752,11 @@ retry:
 			   NULL, flags, NULL, csum_iov_fetch);
 	if (rc == -DER_TIMEDOUT &&
 	    tls->mpt_version + 1 >= tls->mpt_pool->spc_map_version) {
+		if (tls->mpt_fini) {
+			DL_ERROR(rc, DF_RB ": dsc_obj_fetch " DF_UOID "failed when mpt_fini",
+				 DP_RB_MPT(tls), DP_UOID(mrone->mo_oid));
+			return rc;
+		}
 		/* If pool map does not change, then let's retry for timeout, instead of
 		 * fail out.
 		 */
@@ -1401,6 +1406,7 @@ __migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	struct daos_csummer	*csummer = NULL;
 	struct dcs_iod_csums	*iod_csums = NULL;
 	d_iov_t			*p_csum_iov = NULL;
+	bool                     stale      = false;
 
 	if (daos_oclass_is_ec(&mrone->mo_oca))
 		mrone_recx_daos2_vos(mrone, iods, iod_num);
@@ -1489,7 +1495,8 @@ post:
 			 * failure for this rebuild, then reschedule
 			 * the rebuild and retry.
 			 */
-			rc = -DER_DATA_LOSS;
+			rc    = -DER_STALE;
+			stale = true;
 			D_DEBUG(DB_REBUILD,
 				DF_RB ": " DF_UOID " %p dkey " DF_KEY " " DF_KEY
 				      " nr %d/%d eph " DF_U64 " " DF_RC "\n",
@@ -1508,8 +1515,8 @@ end:
 		rc = rc1;
 
 	if (rc)
-		DL_ERROR(rc, DF_RB ": " DF_UOID " migrate error", DP_RB_MRO(mrone),
-			 DP_UOID(mrone->mo_oid));
+		DL_CDEBUG(stale, DB_REBUILD, DLOG_ERR, rc, DF_RB ": " DF_UOID " migrate error",
+			  DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid));
 
 	return rc;
 }

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -3842,12 +3843,14 @@ out:
 }
 
 struct migrate_query_arg {
-	uuid_t	pool_uuid;
-	ABT_mutex status_lock;
+	uuid_t                   pool_uuid;
+	ABT_mutex                status_lock;
 	struct ds_migrate_status dms;
-	uint32_t version;
-	uint32_t total_ult_cnt;
-	uint32_t generation;
+	uint32_t                 version;
+	uint32_t                 total_ult_cnt;
+	uint32_t                 generation;
+	daos_rebuild_opc_t       rebuild_op;
+	uint32_t                 pad;
 };
 
 static int
@@ -3869,18 +3872,18 @@ migrate_check_one(void *data)
 	arg->total_ult_cnt += atomic_load(tls->mpt_tgt_obj_ult_cnt) +
 			      atomic_load(tls->mpt_tgt_dkey_ult_cnt);
 	ABT_mutex_unlock(arg->status_lock);
-	D_DEBUG(DB_REBUILD, "status %d/%d/ ult %u/%u  rec/obj/size "
-		DF_U64"/"DF_U64"/"DF_U64"\n", tls->mpt_status,
-		arg->dms.dm_status, atomic_load(tls->mpt_tgt_obj_ult_cnt),
-		atomic_load(tls->mpt_tgt_dkey_ult_cnt), tls->mpt_rec_count,
-		tls->mpt_obj_count, tls->mpt_size);
+	D_DEBUG(DB_REBUILD,
+		DF_RB " status %d/%d/ ult %u/%u  rec/obj/size " DF_U64 "/" DF_U64 "/" DF_U64 "\n",
+		DP_RB_MQA(arg), tls->mpt_status, arg->dms.dm_status,
+		atomic_load(tls->mpt_tgt_obj_ult_cnt), atomic_load(tls->mpt_tgt_dkey_ult_cnt),
+		tls->mpt_rec_count, tls->mpt_obj_count, tls->mpt_size);
 
 	migrate_pool_tls_put(tls);
 	return 0;
 }
 
 int
-ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, unsigned int generation,
+ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, unsigned int generation, int op,
 			struct ds_migrate_status *dms)
 {
 	struct migrate_query_arg	arg = { 0 };
@@ -3894,6 +3897,7 @@ ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, unsigned int generation,
 	uuid_copy(arg.pool_uuid, pool_uuid);
 	arg.version = ver;
 	arg.generation = generation;
+	arg.rebuild_op = op;
 	rc = ABT_mutex_create(&arg.status_lock);
 	if (rc != ABT_SUCCESS)
 		D_GOTO(out, rc);
@@ -3912,12 +3916,12 @@ ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, unsigned int generation,
 		*dms = arg.dms;
 
 	migrate_system_try_wakeup(tls);
-	D_DEBUG(DB_REBUILD, "pool "DF_UUID" ver %u migrating=%s,"
-		" obj_count="DF_U64", rec_count="DF_U64
-		" size="DF_U64" ult cnt %u status %d\n",
-		DP_UUID(pool_uuid), ver, arg.dms.dm_migrating ? "yes" : "no",
-		arg.dms.dm_obj_count, arg.dms.dm_rec_count, arg.dms.dm_total_size,
-		arg.total_ult_cnt, arg.dms.dm_status);
+	D_DEBUG(DB_REBUILD,
+		DF_RB " migrating=%s, obj_count=" DF_U64 ", rec_count=" DF_U64 ", size=" DF_U64
+		      " ult_cnt %u status %d\n",
+		DP_RB_MQA(&arg), arg.dms.dm_migrating ? "yes" : "no", arg.dms.dm_obj_count,
+		arg.dms.dm_rec_count, arg.dms.dm_total_size, arg.total_ult_cnt, arg.dms.dm_status);
+
 out:
 	ABT_mutex_free(&arg.status_lock);
 	migrate_pool_tls_put(tls);
@@ -4037,8 +4041,8 @@ ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_h
 		*max_delay = rpc_timeout;
 	}
 out:
-	D_DEBUG(DB_REBUILD, DF_UUID" migrate object: %d\n",
-		DP_UUID(pool->sp_uuid), rc);
+	D_DEBUG(DB_REBUILD, DF_RB ": rc=%d\n", DP_UUID(pool->sp_uuid), version, generation,
+		RB_OP_STR(migrate_opc), rc);
 	if (rpc)
 		crt_req_decref(rpc);
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -34,6 +34,7 @@
 #include <daos/pool.h>
 #include <daos_srv/container.h>
 #include <daos_srv/daos_mgmt_srv.h>
+#include <daos_srv/object.h>
 #include <daos_srv/vos.h>
 #include <daos_srv/rebuild.h>
 #include <daos_srv/srv_csum.h>

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -122,6 +122,11 @@ struct rebuild_global_pool_tracker {
 
 	/** rebuild status for each server */
 	struct rebuild_server_status *rgt_servers;
+	double                         *rgt_servers_last_update;
+	double                          rgt_last_warn;
+
+	/** indirect indices for binary search by rank */
+	struct rebuild_server_status  **rgt_servers_sorted;
 
 	/** the current version being rebuilt */
 	uint32_t	rgt_rebuild_ver;

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -1072,6 +1072,7 @@ rebuild_scan_leader(void *data)
 			if (rpt->rt_global_dtx_resync_version < rpt->rt_rebuild_ver) {
 				D_INFO(DF_RB " wait for global dtx %u\n", DP_RB_RPT(rpt),
 				       rpt->rt_global_dtx_resync_version);
+				wait = true;
 				ABT_cond_wait(rpt->rt_global_dtx_wait_cond, rpt->rt_lock);
 			}
 			ABT_mutex_unlock(rpt->rt_lock);
@@ -1082,7 +1083,10 @@ rebuild_scan_leader(void *data)
 		}
 	}
 
-	D_DEBUG(DB_REBUILD, DF_RB " scan collective begin\n", DP_RB_RPT(rpt));
+	if (wait)
+		D_INFO(DF_RB " scan collective begin\n", DP_RB_RPT(rpt));
+	else
+		D_DEBUG(DB_REBUILD, DF_RB " scan collective begin\n", DP_RB_RPT(rpt));
 
 	rc = ds_pool_thread_collective(rpt->rt_pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN |
 				       PO_COMP_ST_DOWNOUT, rebuild_scanner, rpt,
@@ -1090,7 +1094,10 @@ rebuild_scan_leader(void *data)
 	if (rc)
 		D_GOTO(out, rc);
 
-	D_DEBUG(DB_REBUILD, DF_RB "rebuild scan collective done\n", DP_RB_RPT(rpt));
+	if (wait)
+		D_INFO(DF_RB "rebuild scan collective done\n", DP_RB_RPT(rpt));
+	else
+		D_DEBUG(DB_REBUILD, DF_RB "rebuild scan collective done\n", DP_RB_RPT(rpt));
 
 	ABT_mutex_lock(rpt->rt_lock);
 	rc = ds_pool_task_collective(rpt->rt_pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN |

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -634,8 +634,8 @@ rebuild_object(struct rebuild_tgt_pool_tracker *rpt, uuid_t co_uuid, daos_unit_o
 
 	if (myrank == target->ta_comp.co_rank && mytarget == target->ta_comp.co_index &&
 	    (shard == oid.id_shard) && rpt->rt_rebuild_op != RB_OP_UPGRADE) {
-		D_DEBUG(DB_REBUILD, DF_UOID" %u/%u already on the target shard\n",
-			DP_UOID(oid), myrank, mytarget);
+		D_DEBUG(DB_REBUILD, DF_RB ": " DF_UOID " %u/%u already on the target shard\n",
+			DP_RB_RPT(rpt), DP_UOID(oid), myrank, mytarget);
 		return 0;
 	}
 

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -22,6 +23,7 @@
 #include <daos_srv/daos_mgmt_srv.h>
 #include <daos_srv/daos_engine.h>
 #include <daos_srv/rebuild.h>
+#include <daos_srv/object.h>
 #include <daos_srv/vos.h>
 #include <daos_srv/dtx_srv.h>
 #include "rpc.h"
@@ -101,7 +103,7 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 	rc = dbtree_iterate(root->root_hdl, DAOS_INTENT_MIGRATION, false,
 			    rebuild_obj_fill_buf, arg);
 	if (rc < 0 || arg->count == 0) {
-		D_DEBUG(DB_REBUILD, "Can not get objects: "DF_RC"\n",
+		D_DEBUG(DB_REBUILD, DF_RB " cannot get objects: " DF_RC "\n", DP_RB_RPT(rpt),
 			DP_RC(rc));
 		D_GOTO(out, rc);
 	}
@@ -109,9 +111,9 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 	if (daos_fail_check(DAOS_REBUILD_TGT_SEND_OBJS_FAIL))
 		D_GOTO(out, rc = -DER_IO);
 
-	D_DEBUG(DB_REBUILD, "send rebuild objects "DF_UUID" to tgt %d"
-		" cnt %d stable epoch "DF_U64"\n", DP_UUID(rpt->rt_pool_uuid), arg->tgt_id,
-		arg->count, rpt->rt_stable_epoch);
+	D_DEBUG(DB_REBUILD,
+		DF_RB " send rebuild objects to tgt %d cnt %d stable epoch " DF_U64 "\n",
+		DP_RB_RPT(rpt), arg->tgt_id, arg->count, rpt->rt_stable_epoch);
 	while (1) {
 		enqueue_id = 0;
 		max_delay = 0;
@@ -129,8 +131,8 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 			break;
 
 		/* otherwise let's retry */
-		D_DEBUG(DB_REBUILD, DF_UUID" retry send object to tgt_id %d\n",
-			DP_UUID(rpt->rt_pool_uuid), arg->tgt_id);
+		D_DEBUG(DB_REBUILD, DF_RB " retry send object to tgt_id %d\n", DP_RB_RPT(rpt),
+			arg->tgt_id);
 		dss_sleep(daos_rpc_rand_delay(max_delay) << 10);
 	}
 out:
@@ -213,8 +215,7 @@ rebuild_tgt_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov, void *
 	while (!dbtree_is_empty(root->root_hdl)) {
 		rc = rebuild_obj_send_cb(root, arg);
 		if (rc < 0) {
-			D_ERROR("rebuild_obj_send_cb failed: "DF_RC"\n",
-				DP_RC(rc));
+			DL_ERROR(rc, DF_RB " rebuild_obj_send_cb failed", DP_RB_RPT(arg->rpt));
 			break;
 		}
 	}
@@ -242,8 +243,7 @@ rebuild_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 		rc = dbtree_iterate(root->root_hdl, DAOS_INTENT_MIGRATION, false,
 				    rebuild_tgt_iter_cb, arg);
 		if (rc < 0) {
-			D_ERROR("rebuild_tgt_send_cb failed: "DF_RC"\n",
-				DP_RC(rc));
+			DL_ERROR(rc, DF_RB " rebuild_tgt_send_cb failed", DP_RB_RPT(arg->rpt));
 			break;
 		}
 	}
@@ -308,14 +308,13 @@ rebuild_objects_send_ult(void *data)
 		rc = dbtree_iterate(tls->rebuild_tree_hdl, DAOS_INTENT_MIGRATION,
 				    false, rebuild_cont_iter_cb, &arg);
 		if (rc < 0) {
-			D_ERROR("dbtree iterate failed: "DF_RC"\n", DP_RC(rc));
+			DL_ERROR(rc, DF_RB " dbtree iterate failed", DP_RB_RPT(rpt));
 			break;
 		}
 		dss_sleep(0);
 	}
 
-	D_DEBUG(DB_REBUILD, DF_UUID"/%d objects send finish\n",
-		DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver);
+	D_DEBUG(DB_REBUILD, DF_RB " objects send finished\n", DP_RB_RPT(rpt));
 out:
 	if (oids != NULL)
 		D_FREE(oids);
@@ -325,8 +324,10 @@ out:
 		D_FREE(ephs);
 	if (punched_ephs != NULL)
 		D_FREE(punched_ephs);
-	if (rc != 0 && tls->rebuild_pool_status == 0)
+	if (rc != 0 && tls->rebuild_pool_status == 0) {
+		DL_ERROR(rc, DF_RB " objects send error", DP_RB_RPT(rpt));
 		tls->rebuild_pool_status = rc;
+	}
 
 	rpt_put(rpt);
 }
@@ -527,8 +528,8 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 		return 0;
 	}
 
-	D_DEBUG(DB_REBUILD, "deleting stale object "DF_UOID" rank %u tgt %u oid layout %u/%u",
-		DP_UOID(oid), myrank, mytarget, oid.id_layout_ver, new_layout_ver);
+	D_DEBUG(DB_REBUILD, DF_RB " deleting stale object " DF_UOID " oid layout %u/%u",
+		DP_RB_RPT(rpt), DP_UOID(oid), oid.id_layout_ver, new_layout_ver);
 	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
 	D_ASSERT(tls != NULL);
 	tls->rebuild_pool_reclaim_obj_count++;
@@ -547,7 +548,7 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 		if (rc != -DER_BUSY && rc != -DER_INPROGRESS)
 			break;
 
-		D_DEBUG(DB_REBUILD, "retry by "DF_RC"/"DF_UOID"\n",
+		D_DEBUG(DB_REBUILD, DF_RB " retry by " DF_RC "/" DF_UOID "\n", DP_RB_RPT(rpt),
 			DP_RC(rc), DP_UOID(oid));
 		/* Busy - inform iterator and yield */
 		*acts |= VOS_ITER_CB_YIELD;
@@ -555,7 +556,8 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 	} while (1);
 
 	if (rc != 0)
-		D_ERROR("Failed to delete object "DF_UOID" :"DF_RC"\n", DP_UOID(oid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB " Failed to delete object " DF_UOID, DP_RB_RPT(rpt),
+			 DP_UOID(oid));
 
 	return rc;
 }
@@ -685,15 +687,14 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 		  "flags %x snapshot_cnt %d\n", ent->ie_vis_flags, arg->snapshot_cnt);
 	map = pl_map_find(rpt->rt_pool_uuid, oid.id_pub);
 	if (map == NULL) {
-		D_ERROR(DF_UOID ": Cannot find valid placement map" DF_UUID "\n", DP_UOID(oid),
-			DP_UUID(rpt->rt_pool_uuid));
+		D_ERROR(DF_RB " " DF_UOID ": Cannot find valid placement map\n", DP_RB_RPT(rpt),
+			DP_UOID(oid));
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
 	oc_attr = daos_oclass_attr_find(oid.id_pub, NULL);
 	if (oc_attr == NULL) {
-		D_INFO(DF_UUID" skip invalid "DF_UOID"\n", DP_UUID(rpt->rt_pool_uuid),
-		       DP_UOID(oid));
+		D_INFO(DF_RB " skip invalid " DF_UOID "\n", DP_RB_RPT(rpt), DP_UOID(oid));
 		D_GOTO(out, rc = 0);
 	}
 
@@ -738,25 +739,28 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 	}
 
 	if (rc <= 0) {
-		DL_CDEBUG(rc == 0, DB_REBUILD, DLOG_ERR, rc, DF_UOID " rebuild shards",
-			  DP_UOID(oid));
+		DL_CDEBUG(rc == 0, DB_REBUILD, DLOG_ERR, rc, DF_RB " " DF_UOID " rebuild shards",
+			  DP_RB_RPT(rpt), DP_UOID(oid));
 		D_GOTO(out, rc);
 	}
 
-	D_DEBUG(DB_REBUILD, "rebuild obj "DF_UOID" rebuild_nr %d\n", DP_UOID(oid), rc);
+	D_DEBUG(DB_REBUILD, DF_RB " rebuild obj " DF_UOID " rebuild_nr %d\n", DP_RB_RPT(rpt),
+		DP_UOID(oid), rc);
 	rebuild_nr = rc;
 	rc = 0;
 	for (i = 0; i < rebuild_nr; i++) {
-		D_DEBUG(DB_REBUILD, "rebuild obj "DF_UOID"/"DF_UUID"/"DF_UUID
-			"on %d for shard %d eph "DF_U64" visible %s\n", DP_UOID(oid),
-			DP_UUID(rpt->rt_pool_uuid), DP_UUID(arg->co_uuid),
-			tgts[i], shards[i], ent->ie_epoch,
-			ent->ie_vis_flags & VOS_VIS_FLAG_COVERED ? "no" : "yes");
+		D_DEBUG(DB_REBUILD,
+			DF_RB " cont " DF_UUID " rebuild obj " DF_UOID " on %d for shard %d"
+			      " eph " DF_U64 " visible %s\n",
+			DP_RB_RPT(rpt), DP_UUID(arg->co_uuid), DP_UOID(oid), tgts[i], shards[i],
+			ent->ie_epoch, ent->ie_vis_flags & VOS_VIS_FLAG_COVERED ? "no" : "yes");
 
 		/* Ignore the shard if it is not in the same group of failure shard */
 		if ((int)tgts[i] == -1 || oid.id_shard / grp_size != shards[i] / grp_size) {
-			D_DEBUG(DB_REBUILD, "i %d stale object "DF_UOID" shards %u grp_size %u tgt %d\n",
-				i, DP_UOID(oid), shards[i], grp_size, (int)tgts[i]);
+			D_DEBUG(DB_REBUILD,
+				DF_RB " i %d stale object " DF_UOID " shards %u "
+				      "grp_size %u tgt %d\n",
+				DP_RB_RPT(rpt), i, DP_UOID(oid), shards[i], grp_size, (int)tgts[i]);
 			continue;
 		}
 
@@ -778,8 +782,7 @@ out:
 		pl_map_decref(map);
 
 	if (--arg->yield_freq == 0 || arg->obj_yield_cnt <= 0) {
-		D_DEBUG(DB_REBUILD, DF_UUID" rebuild yield: %d\n",
-			DP_UUID(rpt->rt_pool_uuid), rc);
+		D_DEBUG(DB_REBUILD, DF_RB " rebuild yield: %d\n", DP_RB_RPT(rpt), rc);
 		arg->yield_freq = SCAN_YIELD_FREQ;
 		arg->obj_yield_cnt = SCAN_OBJ_YIELD_CNT;
 		if (rc == 0)
@@ -809,34 +812,35 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	int				rc;
 
 	if (uuid_compare(arg->co_uuid, entry->ie_couuid) == 0) {
-		D_DEBUG(DB_REBUILD, DF_UUID" already scan\n",
+		D_DEBUG(DB_REBUILD, DF_RB " co_uuid " DF_UUID " already scanned\n", DP_RB_RPT(rpt),
 			DP_UUID(arg->co_uuid));
 		return 0;
 	}
 
 	rc = vos_cont_open(iter_param->ip_hdl, entry->ie_couuid, &coh);
 	if (rc == -DER_NONEXIST) {
-		D_DEBUG(DB_REBUILD, DF_UUID" already destroyed\n", DP_UUID(arg->co_uuid));
+		D_DEBUG(DB_REBUILD, DF_RB " co_uuid " DF_UUID " already destroyed\n",
+			DP_RB_RPT(rpt), DP_UUID(arg->co_uuid));
 		return 0;
 	}
 
 	if (rc != 0) {
-		D_ERROR("Open container "DF_UUID" failed: "DF_RC"\n",
-			DP_UUID(entry->ie_couuid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB " Open container " DF_UUID " failed", DP_RB_RPT(rpt),
+			 DP_UUID(entry->ie_couuid));
 		return rc;
 	}
 
 	rc = ds_cont_child_lookup(rpt->rt_pool_uuid, entry->ie_couuid, &cont_child);
 	if (rc == -DER_NONEXIST || rc == -DER_SHUTDOWN) {
-		D_DEBUG(DB_REBUILD, DF_UUID" already destroyed or destroying\n",
-			DP_UUID(arg->co_uuid));
+		D_DEBUG(DB_REBUILD, DF_RB " co_uuid " DF_UUID " already destroyed or destroying\n",
+			DP_RB_RPT(rpt), DP_UUID(arg->co_uuid));
 		rc = 0;
 		D_GOTO(close, rc);
 	}
 
 	if (rc != 0) {
-		D_ERROR("Container "DF_UUID", ds_cont_child_lookup failed: "DF_RC"\n",
-			DP_UUID(entry->ie_couuid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB " Container " DF_UUID ", ds_cont_child_lookup failed",
+			 DP_RB_RPT(rpt), DP_UUID(entry->ie_couuid));
 		D_GOTO(close, rc);
 	}
 
@@ -855,15 +859,15 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	rc = ds_cont_fetch_snaps(rpt->rt_pool->sp_iv_ns, entry->ie_couuid, NULL,
 				 &snapshot_cnt);
 	if (rc) {
-		D_ERROR("Container "DF_UUID", ds_cont_fetch_snaps failed: "DF_RC"\n",
-			DP_UUID(entry->ie_couuid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB " Container " DF_UUID ", ds_cont_fetch_snaps failed",
+			 DP_RB_RPT(rpt), DP_UUID(entry->ie_couuid));
 		D_GOTO(close, rc);
 	}
 
 	rc = ds_cont_get_props(&arg->co_props, rpt->rt_pool->sp_uuid, entry->ie_couuid);
 	if (rc) {
-		D_ERROR("Container "DF_UUID", ds_cont_get_props failed: "DF_RC"\n",
-			DP_UUID(entry->ie_couuid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB " Container " DF_UUID ", ds_cont_get_props failed",
+			 DP_RB_RPT(rpt), DP_UUID(entry->ie_couuid));
 		D_GOTO(close, rc);
 	}
 
@@ -874,14 +878,13 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		D_ASSERTF(rpt->rt_pool->sp_rebuilding >= 0, DF_UUID" rebuilding %d\n",
 			  DP_UUID(rpt->rt_pool_uuid), rpt->rt_pool->sp_rebuilding);
 		/* Wait for EC aggregation to abort before discard the object */
-		D_INFO(DF_UUID" wait for ec agg abort, rebuilding %d.\n",
+		D_INFO(DF_RB " " DF_UUID " wait for ec agg abort, rebuilding %d\n", DP_RB_RPT(rpt),
 		       DP_UUID(entry->ie_couuid), rpt->rt_pool->sp_rebuilding);
 		dss_sleep(1000);
 		if (rpt->rt_abort || rpt->rt_finishing) {
-			D_DEBUG(DB_REBUILD, DF_CONT" rebuild op %s ver %u abort %u/%u.\n",
-				DP_CONT(rpt->rt_pool_uuid, entry->ie_couuid),
-				RB_OP_STR(rpt->rt_rebuild_op), rpt->rt_rebuild_ver,
-				rpt->rt_abort, rpt->rt_finishing);
+			D_DEBUG(DB_REBUILD, DF_RB " " DF_UUID " rebuild abort %u/%u.\n",
+				DP_RB_RPT(rpt), DP_UUID(entry->ie_couuid), rpt->rt_abort,
+				rpt->rt_finishing);
 			*acts |= VOS_ITER_CB_ABORT;
 			D_GOTO(close, rc);
 		}
@@ -920,9 +923,8 @@ close:
 		ds_cont_child_put(cont_child);
 	}
 
-	D_DEBUG(DB_REBUILD, DF_UUID"/"DF_UUID" iterate cont done: "DF_RC"\n",
-		DP_UUID(rpt->rt_pool_uuid), DP_UUID(entry->ie_couuid),
-		DP_RC(rc));
+	D_DEBUG(DB_REBUILD, DF_RB " " DF_UUID " iterate cont done: " DF_RC "\n", DP_RB_RPT(rpt),
+		DP_UUID(entry->ie_couuid), DP_RC(rc));
 
 	return rc;
 }
@@ -978,7 +980,7 @@ rebuild_scanner(void *data)
 		return 0;
 
 	if (!is_rebuild_scanning_tgt(rpt)) {
-		D_DEBUG(DB_REBUILD, DF_UUID" skip scan\n", DP_UUID(rpt->rt_pool_uuid));
+		D_DEBUG(DB_REBUILD, DF_RB " skip scan\n", DP_RB_RPT(rpt));
 		D_GOTO(out, rc = 0);
 	}
 
@@ -988,7 +990,7 @@ rebuild_scanner(void *data)
 		    rpt->rt_rebuild_op == RB_OP_FAIL_RECLAIM)
 			break;
 
-		D_DEBUG(DB_REBUILD, "sleep 2 seconds then retry\n");
+		D_DEBUG(DB_REBUILD, DF_RB " sleep 2 seconds then retry\n", DP_RB_RPT(rpt));
 		dss_sleep(2 * 1000);
 	}
 	D_ASSERT(daos_handle_is_inval(tls->rebuild_tree_hdl));
@@ -998,7 +1000,7 @@ rebuild_scanner(void *data)
 	rc = dbtree_create(DBTREE_CLASS_UV, 0, 4, &uma, NULL,
 			   &tls->rebuild_tree_hdl);
 	if (rc != 0) {
-		D_ERROR("failed to create rebuild tree: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB " failed to create rebuild tree", DP_RB_RPT(rpt));
 		D_GOTO(out, rc);
 	}
 
@@ -1036,8 +1038,7 @@ out:
 	if (tls->rebuild_pool_status == 0 && rc != 0)
 		tls->rebuild_pool_status = rc;
 
-	D_DEBUG(DB_REBUILD, DF_UUID" iterate pool done: "DF_RC"\n",
-		DP_UUID(rpt->rt_pool_uuid), DP_RC(rc));
+	D_DEBUG(DB_REBUILD, DF_RB " iterate pool done: " DF_RC "\n", DP_RB_RPT(rpt), DP_RC(rc));
 	return rc;
 }
 
@@ -1053,35 +1054,28 @@ rebuild_scan_leader(void *data)
 	int			   rc;
 	bool			   wait = false;
 
-	D_DEBUG(DB_REBUILD, DF_UUID "check resync %u/%u < %u\n",
-		DP_UUID(rpt->rt_pool_uuid), rpt->rt_pool->sp_dtx_resync_version,
-		rpt->rt_global_dtx_resync_version, rpt->rt_rebuild_ver);
+	D_DEBUG(DB_REBUILD, DF_RB " check resync %u/%u < %u\n", DP_RB_RPT(rpt),
+		rpt->rt_pool->sp_dtx_resync_version, rpt->rt_global_dtx_resync_version,
+		rpt->rt_rebuild_ver);
 
 	/* Wait for dtx resync to finish */
 	while (rpt->rt_global_dtx_resync_version < rpt->rt_rebuild_ver) {
 		if (!rpt->rt_abort && !rpt->rt_finishing) {
 			ABT_mutex_lock(rpt->rt_lock);
 			if (rpt->rt_global_dtx_resync_version < rpt->rt_rebuild_ver) {
-				D_INFO(DF_UUID "wait for global dtx %u rebuild ver %u\n",
-				       DP_UUID(rpt->rt_pool_uuid),
-				       rpt->rt_global_dtx_resync_version, rpt->rt_rebuild_ver);
-				wait = true;
+				D_INFO(DF_RB " wait for global dtx %u\n", DP_RB_RPT(rpt),
+				       rpt->rt_global_dtx_resync_version);
 				ABT_cond_wait(rpt->rt_global_dtx_wait_cond, rpt->rt_lock);
 			}
 			ABT_mutex_unlock(rpt->rt_lock);
 		}
 		if (rpt->rt_abort || rpt->rt_finishing) {
-			D_INFO("shutdown rebuild "DF_UUID": "DF_RC"\n",
-			       DP_UUID(rpt->rt_pool_uuid), DP_RC(-DER_SHUTDOWN));
+			DL_INFO(-DER_SHUTDOWN, DF_RB ": shutdown rebuild", DP_RB_RPT(rpt));
 			D_GOTO(out, rc = -DER_SHUTDOWN);
 		}
 	}
 
-	if (wait)
-		D_INFO("rebuild scan collective "DF_UUID" begin.\n", DP_UUID(rpt->rt_pool_uuid));
-	else
-		D_DEBUG(DB_REBUILD, "rebuild scan collective "DF_UUID" begin.\n",
-			DP_UUID(rpt->rt_pool_uuid));
+	D_DEBUG(DB_REBUILD, DF_RB " scan collective begin\n", DP_RB_RPT(rpt));
 
 	rc = ds_pool_thread_collective(rpt->rt_pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN |
 				       PO_COMP_ST_DOWNOUT, rebuild_scanner, rpt,
@@ -1089,31 +1083,26 @@ rebuild_scan_leader(void *data)
 	if (rc)
 		D_GOTO(out, rc);
 
-	if (wait)
-		D_INFO("rebuild scan collective "DF_UUID" done.\n", DP_UUID(rpt->rt_pool_uuid));
-	else
-		D_DEBUG(DB_REBUILD, "rebuild scan collective "DF_UUID" done.\n",
-			DP_UUID(rpt->rt_pool_uuid));
+	D_DEBUG(DB_REBUILD, DF_RB "rebuild scan collective done\n", DP_RB_RPT(rpt));
 
 	ABT_mutex_lock(rpt->rt_lock);
 	rc = ds_pool_task_collective(rpt->rt_pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN |
 				     PO_COMP_ST_DOWNOUT, rebuild_scan_done, rpt, 0);
 	ABT_mutex_unlock(rpt->rt_lock);
 	if (rc) {
-		D_ERROR(DF_UUID" send rebuild object list failed:%d\n",
-			DP_UUID(rpt->rt_pool_uuid), rc);
+		DL_ERROR(rc, DF_RB " send rebuild object list failed", DP_RB_RPT(rpt));
 		D_GOTO(out, rc);
 	}
 
-	D_DEBUG(DB_REBUILD, DF_UUID" sent objects to initiator: "DF_RC"\n",
-		DP_UUID(rpt->rt_pool_uuid), DP_RC(rc));
+	D_DEBUG(DB_REBUILD, DF_RB " sent objects to initiator: " DF_RC "\n", DP_RB_RPT(rpt),
+		DP_RC(rc));
 out:
 	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
 				      rpt->rt_rebuild_gen);
 	D_ASSERT(tls != NULL);
 	if (tls->rebuild_pool_status == 0 && rc != 0)
 		tls->rebuild_pool_status = rc;
-	D_INFO(DF_UUID"scan leader done: "DF_RC"\n", DP_UUID(rpt->rt_pool_uuid), DP_RC(rc));
+	DL_INFO(rc, DF_RB " scan leader done", DP_RB_RPT(rpt));
 	rpt_put(rpt);
 }
 
@@ -1130,10 +1119,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	rsi = crt_req_get(rpc);
 	D_ASSERT(rsi != NULL);
 
-	D_INFO("%d/"DF_UUID" scan ver %d gen %u leader %u term "DF_U64" op:%s\n",
-	       dss_get_module_info()->dmi_tgt_id, DP_UUID(rsi->rsi_pool_uuid),
-	       rsi->rsi_rebuild_ver, rsi->rsi_rebuild_gen, rsi->rsi_master_rank,
-	       rsi->rsi_leader_term, RB_OP_STR(rsi->rsi_rebuild_op));
+	D_INFO(DF_RB "\n", DP_RB_RSI(rsi));
 
 	/* If PS leader has been changed, and rebuild version is also increased
 	 * due to adding new failure targets for rebuild, let's abort previous
@@ -1143,17 +1129,13 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 		if (uuid_compare(rpt->rt_pool_uuid, rsi->rsi_pool_uuid) == 0 &&
 		    rpt->rt_rebuild_ver < rsi->rsi_rebuild_ver &&
 		    rpt->rt_rebuild_op == rsi->rsi_rebuild_op) {
-			D_INFO(DF_UUID" %p %s %u/"DF_U64"/%u < incoming rebuild %u/"DF_U64"/%u\n",
-			       DP_UUID(rpt->rt_pool_uuid), rpt, RB_OP_STR(rpt->rt_rebuild_op),
-			       rpt->rt_rebuild_ver, rpt->rt_leader_term, rpt->rt_rebuild_gen,
-			       rsi->rsi_rebuild_ver, rsi->rsi_leader_term, rsi->rsi_rebuild_gen);
+			D_INFO("existing " DF_RB " < incoming " DF_RB "\n", DP_RB_RPT(rpt),
+			       DP_RB_RSI(rsi));
 			rpt->rt_abort = 1;
 			if (rpt->rt_leader_rank != rsi->rsi_master_rank) {
-				D_DEBUG(DB_REBUILD, DF_UUID" master rank"
-					" %d -> %d term "DF_U64" -> "DF_U64"\n",
-					DP_UUID(rpt->rt_pool_uuid),
-					rpt->rt_leader_rank, rsi->rsi_master_rank,
-					rpt->rt_leader_term, rsi->rsi_leader_term);
+				D_DEBUG(DB_REBUILD,
+					"leader change existing " DF_RBF " incoming " DF_RBF "\n",
+					DP_RBF_RPT(rpt), DP_RBF_RSI(rsi));
 				/* If this is the old leader, then also stop the rebuild
 				 * tracking ULT.
 				 */
@@ -1167,9 +1149,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	rpt = rpt_lookup(rsi->rsi_pool_uuid, -1, rsi->rsi_rebuild_ver, -1);
 	if (rpt != NULL && rpt->rt_rebuild_op == rsi->rsi_rebuild_op) {
 		if (rpt->rt_global_done) {
-			D_WARN("the previous rebuild "DF_UUID"/%d/"DF_U64"/%p is not cleanup yet\n",
-			       DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_rebuild_ver,
-			       rsi->rsi_leader_term, rpt);
+			D_WARN("previous not cleaned up yet " DF_RBF "\n", DP_RBF_RPT(rpt));
 			D_GOTO(out, rc = -DER_BUSY);
 		}
 
@@ -1196,9 +1176,8 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 			goto tls_lookup;
 		}
 
-		D_DEBUG(DB_REBUILD, DF_UUID" already started, req "DF_U64" master %u/"DF_U64"\n",
-			DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_leader_term, rsi->rsi_master_rank,
-			rpt->rt_leader_term);
+		D_DEBUG(DB_REBUILD, "already started, existing " DF_RBF ", req " DF_RBF "\n",
+			DP_RBF_RPT(rpt), DP_RBF_RSI(rsi));
 
 		/* Ignore the rebuild trigger request if it comes from
 		 * an old or same leader.
@@ -1207,11 +1186,8 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 			D_GOTO(out, rc = 0);
 
 		if (rpt->rt_leader_rank != rsi->rsi_master_rank) {
-			D_DEBUG(DB_REBUILD, DF_UUID" master rank"
-				" %d -> %d term "DF_U64" -> "DF_U64"\n",
-				DP_UUID(rpt->rt_pool_uuid),
-				rpt->rt_leader_rank, rsi->rsi_master_rank,
-				rpt->rt_leader_term, rsi->rsi_leader_term);
+			D_DEBUG(DB_REBUILD, "new leader existing " DF_RBF "-> req " DF_RBF "\n",
+				DP_RBF_RPT(rpt), DP_RBF_RSI(rsi));
 			/* re-report the #rebuilt cnt next time */
 			rpt->rt_re_report = 1;
 
@@ -1234,8 +1210,7 @@ tls_lookup:
 	tls = rebuild_pool_tls_lookup(rsi->rsi_pool_uuid, rsi->rsi_rebuild_ver,
 				      rsi->rsi_rebuild_gen);
 	if (tls != NULL) {
-		D_WARN("the previous rebuild "DF_UUID"/%d is not cleanup yet\n",
-		       DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_rebuild_ver);
+		D_WARN("previous not cleaned up yet " DF_RBF, DP_RBF_RSI(rsi));
 		D_GOTO(out, rc = -DER_BUSY);
 	}
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -14,6 +14,7 @@
 #include <daos/rpc.h>
 #include <daos/pool.h>
 #include <daos_srv/daos_engine.h>
+#include <daos_srv/object.h>
 #include <daos_srv/pool.h>
 #include <daos_srv/container.h>
 #include <daos_srv/iv.h>
@@ -69,22 +70,22 @@ rebuild_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver, uint32_t gen)
 }
 
 static struct rebuild_pool_tls *
-rebuild_pool_tls_create(uuid_t pool_uuid, uuid_t poh_uuid, uuid_t coh_uuid,
-			unsigned int ver, uint32_t gen)
+rebuild_pool_tls_create(struct rebuild_tgt_pool_tracker *rpt)
 {
 	struct rebuild_pool_tls *rebuild_pool_tls;
 	struct rebuild_tls *tls = rebuild_tls_get();
 
-	rebuild_pool_tls = rebuild_pool_tls_lookup(pool_uuid, ver, gen);
+	rebuild_pool_tls =
+	    rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
 	D_ASSERT(rebuild_pool_tls == NULL);
 
 	D_ALLOC_PTR(rebuild_pool_tls);
 	if (rebuild_pool_tls == NULL)
 		return NULL;
 
-	rebuild_pool_tls->rebuild_pool_ver = ver;
-	rebuild_pool_tls->rebuild_pool_gen = gen;
-	uuid_copy(rebuild_pool_tls->rebuild_pool_uuid, pool_uuid);
+	rebuild_pool_tls->rebuild_pool_ver = rpt->rt_rebuild_ver;
+	rebuild_pool_tls->rebuild_pool_gen = rpt->rt_rebuild_gen;
+	uuid_copy(rebuild_pool_tls->rebuild_pool_uuid, rpt->rt_pool_uuid);
 	rebuild_pool_tls->rebuild_pool_scanning = 1;
 	rebuild_pool_tls->rebuild_pool_scan_done = 0;
 	rebuild_pool_tls->rebuild_pool_obj_count = 0;
@@ -94,16 +95,16 @@ rebuild_pool_tls_create(uuid_t pool_uuid, uuid_t poh_uuid, uuid_t coh_uuid,
 	d_list_add(&rebuild_pool_tls->rebuild_pool_list,
 		   &tls->rebuild_pool_list);
 
-	D_DEBUG(DB_REBUILD, "TLS create for "DF_UUID" ver %d\n",
-		DP_UUID(pool_uuid), ver);
+	D_DEBUG(DB_REBUILD, DF_RB " TLS create\n", DP_RB_RPT(rpt));
 	return rebuild_pool_tls;
 }
 
 static void
 rebuild_pool_tls_destroy(struct rebuild_pool_tls *tls)
 {
-	D_DEBUG(DB_REBUILD, "TLS destroy for "DF_UUID" ver %d\n",
-		DP_UUID(tls->rebuild_pool_uuid), tls->rebuild_pool_ver);
+	/* log format derived from DF_RB format definition (don't have leader rank, opcode here) */
+	D_DEBUG(DB_REBUILD, DF_UUID "/%u/%u/op=? TLS destroy\n", DP_UUID(tls->rebuild_pool_uuid),
+		tls->rebuild_pool_ver, tls->rebuild_pool_gen);
 	if (daos_handle_is_valid(tls->rebuild_tree_hdl))
 		rebuild_obj_tree_destroy(tls->rebuild_tree_hdl);
 	d_list_del(&tls->rebuild_pool_list);
@@ -378,8 +379,7 @@ dss_rebuild_check_one(void *data)
 	struct rebuild_tgt_query_arg	*arg = data;
 	struct rebuild_pool_tls		*pool_tls;
 	struct rebuild_tgt_query_info	*status = arg->status;
-	struct rebuild_tgt_pool_tracker	*rpt = arg->rpt;
-	unsigned int			idx = dss_get_module_info()->dmi_tgt_id;
+	struct rebuild_tgt_pool_tracker *rpt    = arg->rpt;
 
 	if (!is_rebuild_scanning_tgt(rpt))
 		return 0;
@@ -389,9 +389,8 @@ dss_rebuild_check_one(void *data)
 	if (pool_tls == NULL)
 		return 0;
 
-	D_DEBUG(DB_REBUILD, "%d scanning %d status: "DF_RC"\n", idx,
-		pool_tls->rebuild_pool_scanning,
-		DP_RC(pool_tls->rebuild_pool_status));
+	D_DEBUG(DB_REBUILD, DF_RB " scanning %d status: " DF_RC "\n", DP_RB_RPT(rpt),
+		pool_tls->rebuild_pool_scanning, DP_RC(pool_tls->rebuild_pool_status));
 
 	ABT_mutex_lock(status->lock);
 	if (pool_tls->rebuild_pool_scanning)
@@ -420,7 +419,7 @@ rebuild_tgt_query(struct rebuild_tgt_pool_tracker *rpt,
 
 	if (rpt->rt_rebuild_op != RB_OP_RECLAIM && rpt->rt_rebuild_op != RB_OP_FAIL_RECLAIM) {
 		rc = ds_migrate_query_status(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
-					     rpt->rt_rebuild_gen, &dms);
+					     rpt->rt_rebuild_gen, rpt->rt_rebuild_op, &dms);
 		if (rc)
 			D_GOTO(out, rc);
 	}
@@ -452,13 +451,11 @@ rebuild_tgt_query(struct rebuild_tgt_pool_tracker *rpt,
 
 	ABT_mutex_unlock(rpt->rt_lock);
 
-	D_DEBUG(DB_REBUILD, "pool "DF_UUID" scanning %d/%d rebuilding=%s, "
-		"obj_count="DF_U64", tobe_obj="DF_U64" rec_count="DF_U64
-		" size= "DF_U64"\n",
-		DP_UUID(rpt->rt_pool_uuid), status->scanning,
-		status->status, status->rebuilding ? "yes" : "no",
-		status->obj_count, status->tobe_obj_count, status->rec_count,
-		status->size);
+	D_DEBUG(DB_REBUILD,
+		DF_RB " scanning %d/%d rebuilding=%s, obj_count=" DF_U64 ", "
+		      "tobe_obj=" DF_U64 " rec_count=" DF_U64 " size= " DF_U64 "\n",
+		DP_RB_RPT(rpt), status->scanning, status->status, status->rebuilding ? "yes" : "no",
+		status->obj_count, status->tobe_obj_count, status->rec_count, status->size);
 out:
 	return rc;
 }
@@ -477,9 +474,8 @@ ds_rebuild_running_query(uuid_t pool_uuid, uint32_t opc, uint32_t *upper_ver,
 		*generation = -1;
 	rpt = rpt_lookup(pool_uuid, opc, -1, -1);
 	if (rpt != NULL && !rpt->rt_global_done && !rpt->rt_abort) {
-		D_DEBUG(DB_REBUILD, DF_UUID" rebuild %p running eph/ver/gen "DF_X64"/%u/%u\n",
-			DP_UUID(pool_uuid), rpt, rpt->rt_stable_epoch, rpt->rt_rebuild_ver,
-			rpt->rt_rebuild_gen);
+		D_DEBUG(DB_REBUILD, DF_RB " rebuild %p running eph " DF_X64 "\n", DP_RB_RPT(rpt),
+			rpt, rpt->rt_stable_epoch);
 		if (stable_eph)
 			*stable_eph = rpt->rt_stable_epoch;
 		if (upper_ver)
@@ -623,11 +619,9 @@ rebuild_leader_status_notify(struct rebuild_global_pool_tracker *rgt, struct ds_
 				rebuild_get_global_dtx_resync_ver(rgt);
 	iv.riv_dtx_resyc_version = pool->sp_dtx_resync_version;
 
-
-	D_DEBUG(DB_REBUILD, DF_UUID "/%u/%u op: %s dtx %u scan_gd/gd/abort %u/%u/%u: %d\n",
-		DP_UUID(rgt->rgt_pool_uuid), rgt->rgt_rebuild_ver, rgt->rgt_rebuild_gen,
-		RB_OP_STR(op), iv.riv_global_dtx_resyc_version, iv.riv_global_scan_done,
-		iv.riv_global_done, rgt->rgt_abort, rgt->rgt_status.rs_errno);
+	D_DEBUG(DB_REBUILD, DF_RB " dtx %u scan_gd/gd/abort %u/%u/%u: %d\n", DP_RB_RGT(rgt),
+		iv.riv_global_dtx_resyc_version, iv.riv_global_scan_done, iv.riv_global_done,
+		rgt->rgt_abort, rgt->rgt_status.rs_errno);
 
 	rc = rebuild_iv_update(pool->sp_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
 			       CRT_IV_SYNC_LAZY, true);
@@ -686,7 +680,7 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 				    PO_COMP_ST_DOWNOUT | PO_COMP_ST_NEW,
 				    &excluded);
 		if (rc != 0) {
-			D_INFO(DF_UUID": get rank list: %d\n", DP_UUID(pool->sp_uuid), rc);
+			D_INFO(DF_RB ": get rank list: %d\n", DP_RB_RGT(rgt), rc);
 			ABT_rwlock_unlock(pool->sp_lock);
 			goto sleep;
 		}
@@ -700,9 +694,8 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 			if (rgt->rgt_opc == RB_OP_REBUILD) {
 				if (dom->do_comp.co_status == PO_COMP_ST_UP) {
 					if (dom->do_comp.co_in_ver > rgt->rgt_rebuild_ver) {
-						D_INFO(DF_UUID": cancel rebuild %u/%u\n",
-				       		       DP_UUID(pool->sp_uuid), rgt->rgt_rebuild_ver,
-						       dom->do_comp.co_in_ver);
+						D_INFO(DF_RB ": cancel rebuild co_in_ver=%u\n",
+						       DP_RB_RGT(rgt), dom->do_comp.co_in_ver);
 						rebuild_abort = true;
 						break;
 					} else {
@@ -710,16 +703,15 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 					}
 				} else if (dom->do_comp.co_status == PO_COMP_ST_DOWN) {
 					if (dom->do_comp.co_fseq > rgt->rgt_rebuild_ver) {
-						D_INFO(DF_UUID": cancel rebuild %u/%u\n",
-				       		       DP_UUID(pool->sp_uuid), rgt->rgt_rebuild_ver,
-						       dom->do_comp.co_fseq);
+						D_INFO(DF_RB ": cancel rebuild co_fseq=%u\n",
+						       DP_RB_RGT(rgt), dom->do_comp.co_fseq);
 						rebuild_abort = true;
 						break;
 					}
 				}
 			}
-			D_INFO(DF_UUID" exclude rank %d/%x.\n", DP_UUID(pool->sp_uuid),
-			       dom->do_comp.co_rank, dom->do_comp.co_status);
+			D_INFO(DF_RB " exclude rank %d/%x.\n", DP_RB_RGT(rgt), dom->do_comp.co_rank,
+			       dom->do_comp.co_status);
 			rebuild_leader_set_status(rgt, dom->do_comp.co_rank,
 						  -1, SCAN_DONE | PULL_DONE);
 		}
@@ -753,15 +745,13 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 		rs->rs_seconds =
 			(d_timeus_secdiff(0) - rgt->rgt_time_start) / 1e6;
 		snprintf(sbuf, RBLD_SBUF_LEN,
-			 "%s [%s] (pool "DF_UUID" leader %u term "DF_U64" dtx gl %u ver=%u,"
-			 "gen %u toberb_obj=" DF_U64", rb_obj="DF_U64", rec="DF_U64", size="DF_U64
-			 " done %d status %d/%d  stable "DF_X64" reclaim "DF_X64
-			 " duration=%d secs)\n",
-			 RB_OP_STR(op), str, DP_UUID(pool->sp_uuid), myrank,
-			 rgt->rgt_leader_term, rgt->rgt_dtx_resync_version, rgt->rgt_rebuild_ver,
-			 rgt->rgt_rebuild_gen, rs->rs_toberb_obj_nr, rs->rs_obj_nr, rs->rs_rec_nr,
-			 rs->rs_size, rs->rs_state, rs->rs_errno, rs->rs_fail_rank,
-			 rgt->rgt_stable_epoch, rgt->rgt_reclaim_epoch, rs->rs_seconds);
+			 DF_RB " [%s] (leader %u dtx_gl %u toberb_obj=" DF_U64 ", rb_obj=" DF_U64
+			       ", rec=" DF_U64 ", size=" DF_U64 " done %d status %d/%d "
+			       "stable " DF_X64 " reclaim " DF_X64 " duration=%d secs)\n",
+			 DP_RB_RGT(rgt), str, myrank, rgt->rgt_dtx_resync_version,
+			 rs->rs_toberb_obj_nr, rs->rs_obj_nr, rs->rs_rec_nr, rs->rs_size,
+			 rs->rs_state, rs->rs_errno, rs->rs_fail_rank, rgt->rgt_stable_epoch,
+			 rgt->rgt_reclaim_epoch, rs->rs_seconds);
 
 		D_INFO("%s", sbuf);
 		if (rs->rs_state == DRS_COMPLETED || rebuild_gst.rg_abort ||
@@ -903,8 +893,8 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 {
 	int	rc = 0;
 
-	D_DEBUG(DB_REBUILD, "pool "DF_UUID" create rebuild iv, op=%s\n",
-		DP_UUID(pool->sp_uuid), RB_OP_STR(rebuild_op));
+	D_DEBUG(DB_REBUILD, DF_RB " create rebuild iv\n", DP_UUID(pool->sp_uuid), rebuild_ver,
+		rebuild_gen, RB_OP_STR(rebuild_op));
 
 	if (rebuild_op == RB_OP_UPGRADE || rebuild_op == RB_OP_RECLAIM ||
 	    rebuild_op == RB_OP_FAIL_RECLAIM) {
@@ -948,8 +938,9 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 		ret = rebuild_global_pool_tracker_create(pool, rebuild_ver, rebuild_gen,
 							leader_term, reclaim_eph, rebuild_op, rgt);
 		if (ret) {
-			D_ERROR("rebuild_global_pool_tracker create failed: "DF_RC"\n",
-				DP_RC(ret));
+			DL_ERROR(rc, DF_RB " rebuild_global_pool_tracker create failed",
+				 DP_UUID(pool->sp_uuid), rebuild_ver, rebuild_gen,
+				 RB_OP_STR(rebuild_op));
 			rc = ret;
 		}
 	}
@@ -975,7 +966,7 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 	 * but not included in this reintegration, so let's exclude those
 	 * ranks from this reintegration.
 	 */
-	D_DEBUG(DB_REBUILD, "rebuild op %d\n", rebuild_op);
+	D_DEBUG(DB_REBUILD, DF_RB "\n", DP_RB_RGT(rgt));
 	if (rebuild_op == RB_OP_REBUILD || rebuild_op == RB_OP_RECLAIM ||
 	    rebuild_op == RB_OP_FAIL_RECLAIM) {
 		d_rank_list_t	up_ranks = { 0 };
@@ -986,12 +977,11 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 		rc = map_ranks_init(pool->sp_map, PO_COMP_ST_UP, &up_ranks);
 		ABT_rwlock_unlock(pool->sp_lock);
 		if (rc != 0) {
-			D_ERROR(DF_UUID": failed to create rank list: %d\n",
-				DP_UUID(pool->sp_uuid), rc);
+			DL_ERROR(rc, DF_RB ": failed to create rank list", DP_RB_RGT(rgt));
 			return rc;
 		}
 
-		D_DEBUG(DB_REBUILD, "up_ranks %d\n", up_ranks.rl_nr);
+		D_DEBUG(DB_REBUILD, DF_RB ": up_ranks %d\n", DP_RB_RGT(rgt), up_ranks.rl_nr);
 		excluded = d_rank_list_alloc(up_ranks.rl_nr);
 		/* exclude ranks which is scheduled after the current
 		 * reintegraion started.
@@ -1006,8 +996,8 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 
 			dom = pool_map_find_dom_by_rank(pool->sp_map, up_ranks.rl_ranks[i]);
 			D_ASSERT(dom != NULL);
-			D_DEBUG(DB_REBUILD, "rank %u ver %u rebuild %u\n",
-				up_ranks.rl_ranks[i], dom->do_comp.co_in_ver, rgt->rgt_rebuild_ver);
+			D_DEBUG(DB_REBUILD, DF_RB " rank %u co_in_ver %u\n", DP_RB_RGT(rgt),
+				up_ranks.rl_ranks[i], dom->do_comp.co_in_ver);
 			if (dom->do_comp.co_in_ver < rgt->rgt_rebuild_ver)
 				continue;
 
@@ -1022,13 +1012,12 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 				  REBUILD_OBJECTS_SCAN, DAOS_REBUILD_VERSION,
 				  &rpc, NULL, excluded, NULL);
 	if (rc != 0) {
-		D_ERROR("pool map broad cast failed: rc "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB " pool map broadcast failed", DP_RB_RGT(rgt));
 		D_GOTO(out, rc);
 	}
 
 	rsi = crt_req_get(rpc);
-	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID" scan broadcast, op=%s\n",
-		DP_UUID(pool->sp_uuid), RB_OP_STR(rebuild_op));
+	D_DEBUG(DB_REBUILD, DF_RB " scan broadcast\n", DP_RB_RGT(rgt));
 
 	uuid_copy(rsi->rsi_pool_uuid, pool->sp_uuid);
 	rsi->rsi_ns_id = pool->sp_iv_ns->iv_ns_id;
@@ -1051,9 +1040,8 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 
 	rgt->rgt_init_scan = 1;
 	rgt->rgt_stable_epoch = rso->rso_stable_epoch;
-	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID": "DF_RC" got stable/reclaim epoch "
-		DF_X64"/"DF_X64"\n", DP_UUID(rsi->rsi_pool_uuid), DP_RC(rc),
-		rgt->rgt_stable_epoch, rgt->rgt_reclaim_epoch);
+	D_DEBUG(DB_REBUILD, DF_RB " " DF_RC " got stable/reclaim epoch " DF_X64 "/" DF_X64 "\n",
+		DP_RB_RGT(rgt), DP_RC(rc), rgt->rgt_stable_epoch, rgt->rgt_reclaim_epoch);
 	crt_req_decref(rpc);
 out:
 	if (excluded)
@@ -1365,15 +1353,13 @@ rebuild_leader_start(struct ds_pool *pool, struct rebuild_task *task,
 		return rc;
 
 	D_ASSERT(*p_rgt != NULL);
-	D_INFO("rebuild "DF_UUID", version=%u/%u, op=%s\n",
-	       DP_UUID(pool->sp_uuid), task->dst_map_ver, pool->sp_rebuild_gen,
-	       RB_OP_STR(task->dst_rebuild_op));
+	D_INFO(DF_RB "\n", DP_RB_RGT(*p_rgt));
 
 	/* broadcast scan RPC to all targets */
 	rc = rebuild_scan_broadcast(pool, *p_rgt, &task->dst_tgts,
 				    task->dst_new_layout_version, task->dst_rebuild_op);
 	if (rc)
-		D_ERROR("object scan failed: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": object scan failed", DP_RB_RGT(*p_rgt));
 	else
 		rc = 1;
 
@@ -1476,7 +1462,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 
 		if (task->dst_rebuild_op == RB_OP_RECLAIM ||
 		    task->dst_rebuild_op == RB_OP_FAIL_RECLAIM) {
-			DL_INFO(ret, DF_UUID" retry opc %u/%u", DP_UUID(task->dst_pool_uuid),
+			DL_INFO(ret, DF_UUID " retry opc %u/%u", DP_UUID(task->dst_pool_uuid),
 				task->dst_rebuild_op, task->dst_map_ver);
 			rc = ds_rebuild_schedule(pool, task->dst_map_ver, rgt->rgt_stable_epoch,
 						 task->dst_new_layout_version, &task->dst_tgts,
@@ -1493,7 +1479,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 			 * (reclaim - 1 see obj_reclaim()), but keep the in-flight I/O data.
 			 */
 			DL_INFO(rgt->rgt_status.rs_errno,
-				DF_UUID" opc %u/%u, schedule RB_OP_FAIL_RECLAIM.",
+				DF_UUID " opc %u/%u, schedule RB_OP_FAIL_RECLAIM.",
 				DP_UUID(task->dst_pool_uuid), task->dst_rebuild_op,
 				task->dst_map_ver);
 			rc = ds_rebuild_schedule(pool, task->dst_reclaim_ver - 1,
@@ -1501,8 +1487,8 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 						 task->dst_new_layout_version,
 						 &task->dst_tgts, RB_OP_FAIL_RECLAIM, 5);
 			if (rc)
-				D_ERROR(DF_UUID "schedule reclaim fail: "DF_RC"\n",
-					DP_UUID(task->dst_pool_uuid), DP_RC(rc));
+				DL_ERROR(rc, DF_UUID " schedule reclaim fail",
+					 DP_UUID(task->dst_pool_uuid));
 		}
 
 		/* Then check if it needs to retry */
@@ -1614,9 +1600,12 @@ rebuild_task_ult(void *arg)
 		D_GOTO(output, rc);
 	}
 
-	D_PRINT("%s [started] (pool "DF_UUID" ver=%u/%u)\n",
-		RB_OP_STR(task->dst_rebuild_op), DP_UUID(task->dst_pool_uuid),
-		task->dst_map_ver, task->dst_reclaim_ver);
+	if (rgt)
+		D_PRINT(DF_RB " [started] reclaim_ver=%u\n", DP_RB_RGT(rgt), task->dst_reclaim_ver);
+	else
+		D_PRINT("%s [started] (pool " DF_UUID " ver=%u/%u)\n",
+			RB_OP_STR(task->dst_rebuild_op), DP_UUID(task->dst_pool_uuid),
+			task->dst_map_ver, task->dst_reclaim_ver);
 
 	if (rc < 0) {
 		if (rc == -DER_NOTLEADER &&
@@ -1660,8 +1649,7 @@ rebuild_task_ult(void *arg)
 done:
 	D_ASSERT(rgt != NULL);
 	if (!is_rebuild_global_done(rgt)) {
-		D_DEBUG(DB_REBUILD, DF_UUID" rebuild is not done: "DF_RC"\n",
-			DP_UUID(task->dst_pool_uuid),
+		D_DEBUG(DB_REBUILD, DF_RB " rebuild is not done: " DF_RC "\n", DP_RB_RGT(rgt),
 			DP_RC(rgt->rgt_status.rs_errno));
 
 		if (rgt->rgt_abort && rgt->rgt_status.rs_errno == 0) {
@@ -1671,8 +1659,7 @@ done:
 			 * scan requests, which will then become the new
 			 * leader to track the rebuild.
 			 */
-			D_DEBUG(DB_REBUILD, DF_UUID" Only stop the leader\n",
-				DP_UUID(task->dst_pool_uuid));
+			D_DEBUG(DB_REBUILD, DF_RB " Only stop the leader\n", DP_RB_RGT(rgt));
 			D_GOTO(out_pool, rc);
 		}
 	} else if (rgt->rgt_status.rs_errno == 0) {
@@ -1681,8 +1668,8 @@ done:
 
 		if (task->dst_rebuild_op == RB_OP_REBUILD)
 			rc = ds_pool_tgt_finish_rebuild(pool->sp_uuid, &task->dst_tgts);
-		D_INFO("finish rebuild %d of " DF_UUID " "DF_RC"\n",
-		       task->dst_tgts.pti_ids[0].pti_id, DP_UUID(task->dst_pool_uuid), DP_RC(rc));
+		DL_INFO(rc, DF_RB " finish rebuild %d", DP_RB_RGT(rgt),
+			task->dst_tgts.pti_ids[0].pti_id);
 	}
 iv_stop:
 	/* NB: even if there are some failures, the leader should
@@ -1695,8 +1682,8 @@ iv_stop:
 			 * iv sync, and the new leader will take over
 			 * the rebuild process anyway.
 			 */
-			D_DEBUG(DB_REBUILD, "rank %u != master %u\n",
-				myrank, pool->sp_iv_ns->iv_master_rank);
+			D_DEBUG(DB_REBUILD, DF_RB " rank %u != master %u\n", DP_RB_RGT(rgt), myrank,
+				pool->sp_iv_ns->iv_master_rank);
 			D_GOTO(try_reschedule, rc);
 		}
 
@@ -1841,9 +1828,7 @@ ds_rebuild_abort(uuid_t pool_uuid, unsigned int ver, unsigned int gen, uint64_t 
 			    (ver == (unsigned int)(-1) || rpt->rt_rebuild_ver == ver) &&
 			    (gen == (unsigned int)(-1) || rpt->rt_rebuild_gen == gen) &&
 			    (term == (uint64_t)(-1) || rpt->rt_leader_term == term)) {
-				D_INFO(DF_UUID" try abort the rpt %p op %s ver %u gen %u\n",
-				       DP_UUID(rpt->rt_pool_uuid), rpt, RB_OP_STR(rpt->rt_rebuild_op),
-				       rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
+				D_INFO(DF_RB " try abort rpt %p\n", DP_RB_RPT(rpt), rpt);
 				rpt->rt_abort = 1;
 				aborted = false;
 			}
@@ -2226,14 +2211,13 @@ rebuild_fini_one(void *arg)
 	if (rpt->rt_rebuild_fence == dpc->spc_rebuild_fence) {
 		dpc->spc_rebuild_fence = 0;
 		dpc->spc_rebuild_end_hlc = d_hlc_get();
-		D_DEBUG(DB_REBUILD, DF_UUID": Reset aggregation end hlc "
-			DF_U64"\n", DP_UUID(rpt->rt_pool_uuid),
-			dpc->spc_rebuild_end_hlc);
+		D_DEBUG(DB_REBUILD, DF_RB ": Reset aggregation end hlc " DF_U64 "\n",
+			DP_RB_RPT(rpt), dpc->spc_rebuild_end_hlc);
 	} else {
-		D_DEBUG(DB_REBUILD, DF_UUID": pool is still being rebuilt"
-			" rt_rebuild_fence "DF_U64" spc_rebuild_fence "
-			DF_U64"\n", DP_UUID(rpt->rt_pool_uuid),
-			rpt->rt_rebuild_fence, dpc->spc_rebuild_fence);
+		D_DEBUG(DB_REBUILD,
+			DF_RB ": pool is still being rebuilt rt_rebuild_fence " DF_U64
+			      " spc_rebuild_fence " DF_U64 "\n",
+			DP_RB_RPT(rpt), rpt->rt_rebuild_fence, dpc->spc_rebuild_fence);
 	}
 
 	ds_pool_child_put(dpc);
@@ -2247,8 +2231,7 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 	struct rebuild_pool_tls	*pool_tls;
 	int			 rc;
 
-	D_INFO("finishing rebuild for "DF_UUID", map_ver=%u refcount %u\n",
-	       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver, rpt->rt_refcount);
+	D_INFO(DF_RB " finishing rebuild refcount %u\n", DP_RB_RPT(rpt), rpt->rt_refcount);
 
 	D_ASSERT(rpt->rt_pool->sp_rebuilding > 0);
 	rpt->rt_pool->sp_rebuilding--;
@@ -2278,13 +2261,11 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 	/* close the rebuild pool/container on all main XS */
 	rc = dss_task_collective(rebuild_fini_one, rpt, 0);
 	if (rc != 0)
-		D_WARN(DF_UUID" rebuild fini one failed: "DF_RC"\n",
-		       DP_UUID(rpt->rt_pool_uuid), DP_RC(rc));
+		DL_WARN(rc, DF_RB " rebuild fini one failed", DP_RB_RPT(rpt));
 	/* destroy the migrate_tls of 0-xstream */
 	ds_migrate_stop(rpt->rt_pool, rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
 	/* No one should access rpt after rebuild_fini_one. */
-	D_INFO("Finalized rebuild for "DF_UUID", map_ver=%u.\n",
-	       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver);
+	D_INFO(DF_RB " Finalized rebuild\n", DP_RB_RPT(rpt));
 	rpt_delete(rpt);
 	rpt_put(rpt);
 }
@@ -2315,9 +2296,7 @@ rebuild_tgt_status_check_ult(void *arg)
 		rc = rebuild_tgt_query(rpt, &status);
 		ABT_mutex_free(&status.lock);
 		if (rc || status.status != 0) {
-			D_ERROR(DF_UUID" rebuild failed: "DF_RC"\n",
-				DP_UUID(rpt->rt_pool_uuid),
-				DP_RC(rc == 0 ? status.status : rc));
+			DL_ERROR(rc == 0 ? status.status : rc, DF_RB " failed", DP_RB_RPT(rpt));
 			if (status.status == 0)
 				status.status = rc;
 			if (rpt->rt_errno == 0)
@@ -2400,7 +2379,7 @@ rebuild_tgt_status_check_ult(void *arg)
 				rpt->rt_reported_rec_cnt = status.rec_count;
 				rpt->rt_reported_size = status.size;
 			} else {
-				D_WARN("rebuild iv update failed: %d\n", rc);
+				DL_WARN(rc, DF_RB " rebuild iv update failed", DP_RB_RPT(rpt));
 				/* Already finish rebuilt, but it can not
 				 * its rebuild status on the leader, i.e.
 				 * it can not find the IV see crt_iv_hdlr_xx().
@@ -2410,21 +2389,17 @@ rebuild_tgt_status_check_ult(void *arg)
 					rpt->rt_global_done = 1;
 
 				if (ns->iv_stop) {
-					D_DEBUG(DB_REBUILD, "abort rebuild "
-						DF_UUID"\n",
-						DP_UUID(rpt->rt_pool_uuid));
+					D_DEBUG(DB_REBUILD, "abort rebuild " DF_RB "\n",
+						DP_RB_RPT(rpt));
 					rpt->rt_abort = 1;
 				}
 			}
 		}
 
-		D_INFO(DF_UUID" ver %d gen %u obj "DF_U64" rec "DF_U64" size "
-		       DF_U64" scan done %d pull done %d scan gl done %d"
-		       " gl done %d status %d abort %s\n",
-		       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver,
-		       rpt->rt_pool->sp_rebuild_gen,
-		       iv.riv_obj_count, iv.riv_rec_count, iv.riv_size, rpt->rt_scan_done,
-		       iv.riv_pull_done, rpt->rt_global_scan_done,
+		D_INFO(DF_RB " obj " DF_U64 " rec " DF_U64 " size " DF_U64 " scan done %d "
+			     "pull done %d scan gl done %d gl done %d status %d abort %s\n",
+		       DP_RB_RPT(rpt), iv.riv_obj_count, iv.riv_rec_count, iv.riv_size,
+		       rpt->rt_scan_done, iv.riv_pull_done, rpt->rt_global_scan_done,
 		       rpt->rt_global_done, iv.riv_status, rpt->rt_abort ? "yes" : "no");
 		if (rpt->rt_global_done || rpt->rt_abort)
 			break;
@@ -2462,9 +2437,7 @@ rebuild_prepare_one(void *data)
 	if (unlikely(dpc->spc_no_storage))
 		D_GOTO(put, rc = 0);
 
-	pool_tls = rebuild_pool_tls_create(rpt->rt_pool_uuid, rpt->rt_poh_uuid,
-					   rpt->rt_coh_uuid, rpt->rt_rebuild_ver,
-					   rpt->rt_rebuild_gen);
+	pool_tls = rebuild_pool_tls_create(rpt);
 	if (pool_tls == NULL)
 		D_GOTO(put, rc = -DER_NOMEM);
 
@@ -2475,9 +2448,8 @@ rebuild_prepare_one(void *data)
 	 */
 	D_ASSERT(rpt->rt_rebuild_fence != 0);
 	dpc->spc_rebuild_fence = rpt->rt_rebuild_fence;
-	D_DEBUG(DB_REBUILD, "open local container "DF_UUID"/"DF_UUID
-		" rebuild eph "DF_X64" "DF_RC"\n", DP_UUID(rpt->rt_pool_uuid),
-		DP_UUID(rpt->rt_coh_uuid), rpt->rt_rebuild_fence, DP_RC(rc));
+	D_DEBUG(DB_REBUILD, DF_RB " open local container " DF_UUID " rebuild eph " DF_X64 "\n",
+		DP_RB_RPT(rpt), DP_UUID(rpt->rt_coh_uuid), rpt->rt_rebuild_fence);
 
 put:
 	ds_pool_child_put(dpc);
@@ -2550,19 +2522,17 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 	uuid_t				cont_uuid;
 	int				rc;
 
-	D_DEBUG(DB_REBUILD, "prepare rebuild for "DF_UUID"/%d\n",
-		DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_rebuild_ver);
+	D_DEBUG(DB_REBUILD, DF_RB " prepare rebuild\n", DP_RB_RSI(rsi));
 
 	rc = ds_pool_lookup(rsi->rsi_pool_uuid, &pool);
 	if (rc) {
-		D_ERROR("Can not find pool "DF_UUID": %d\n", DP_UUID(rsi->rsi_pool_uuid), rc);
+		DL_ERROR(rc, DF_RB " cannot find pool", DP_RB_RSI(rsi));
 		return rc;
 	}
 
 	if (ds_pool_get_version(pool) < rsi->rsi_rebuild_ver) {
-		D_INFO(DF_UUID" map %u < rsi_rebuild_ver %u\n",
-		       DP_UUID(rsi->rsi_pool_uuid), ds_pool_get_version(pool),
-		       rsi->rsi_rebuild_ver);
+		D_INFO(DF_RB " map %u < rsi_rebuild_ver %u\n", DP_RB_RSI(rsi),
+		       ds_pool_get_version(pool), rsi->rsi_rebuild_ver);
 		D_GOTO(out, rc = -DER_BUSY);
 	}
 
@@ -2601,7 +2571,7 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 	if (rc)
 		D_GOTO(out, rc);
 
-	D_DEBUG(DB_REBUILD, "rebuild coh/poh "DF_UUID"/"DF_UUID"\n",
+	D_DEBUG(DB_REBUILD, DF_RB " coh/poh " DF_UUID "/" DF_UUID "\n", DP_RB_RPT(rpt),
 		DP_UUID(rpt->rt_coh_uuid), DP_UUID(rpt->rt_poh_uuid));
 
 	ds_pool_iv_ns_update(pool, rsi->rsi_master_rank, rsi->rsi_leader_term);
@@ -2617,9 +2587,7 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 	if (rc)
 		D_GOTO(out, rc);
 
-	pool_tls = rebuild_pool_tls_create(rpt->rt_pool_uuid, rpt->rt_poh_uuid,
-					   rpt->rt_coh_uuid, rpt->rt_rebuild_ver,
-					   rpt->rt_rebuild_gen);
+	pool_tls = rebuild_pool_tls_create(rpt);
 	if (pool_tls == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -162,22 +162,70 @@ is_rebuild_global_done(struct rebuild_global_pool_tracker *rgt)
 
 #define SCAN_DONE	0x1
 #define PULL_DONE	0x2
+
+static void
+servers_sop_swap(void *array, int a, int b)
+{
+	struct rebuild_server_status **servers = (struct rebuild_server_status **)array;
+	struct rebuild_server_status  *tmp;
+
+	tmp        = servers[a];
+	servers[a] = servers[b];
+	servers[b] = tmp;
+}
+
+static int
+servers_sop_cmp(void *array, int a, int b)
+{
+	struct rebuild_server_status **servers = (struct rebuild_server_status **)array;
+
+	if (servers[a]->rank > servers[b]->rank)
+		return 1;
+	if (servers[a]->rank < servers[b]->rank)
+		return -1;
+	return 0;
+}
+
+static int
+servers_sop_cmp_key(void *array, int i, uint64_t key)
+{
+	struct rebuild_server_status **servers = (struct rebuild_server_status **)array;
+	d_rank_t                       rank    = (d_rank_t)key;
+
+	if (servers[i]->rank > rank)
+		return 1;
+	if (servers[i]->rank < rank)
+		return -1;
+	return 0;
+}
+
+static daos_sort_ops_t servers_sort_ops = {
+    .so_swap    = servers_sop_swap,
+    .so_cmp     = servers_sop_cmp,
+    .so_cmp_key = servers_sop_cmp_key,
+};
+
+static struct rebuild_server_status *
+rebuild_server_get_status(struct rebuild_global_pool_tracker *rgt, d_rank_t rank)
+{
+	int idx;
+
+	idx = daos_array_find(rgt->rgt_servers_sorted, rgt->rgt_servers_number, rank,
+			      &servers_sort_ops);
+	if (idx < 0)
+		return NULL;
+	return rgt->rgt_servers_sorted[idx];
+}
+
 static void
 rebuild_leader_set_status(struct rebuild_global_pool_tracker *rgt,
 			  d_rank_t rank, uint32_t resync_ver, unsigned flags)
 {
-	struct rebuild_server_status	*status = NULL;
-	int				i;
+	struct rebuild_server_status *status = NULL;
 
 	D_ASSERT(rgt->rgt_servers_number > 0);
 	D_ASSERT(rgt->rgt_servers != NULL);
-	for (i = 0; i < rgt->rgt_servers_number; i++) {
-		if (rgt->rgt_servers[i].rank == rank) {
-			status = &rgt->rgt_servers[i];
-			break;
-		}
-	}
-
+	status = rebuild_server_get_status(rgt, rank);
 	if (status == NULL) {
 		D_INFO("rank %u is not included in this rebuild.\n", rank);
 		return;
@@ -188,6 +236,20 @@ rebuild_leader_set_status(struct rebuild_global_pool_tracker *rgt,
 		status->scan_done = 1;
 	if (flags & PULL_DONE)
 		status->pull_done = 1;
+}
+
+static void
+rebuild_leader_set_update_time(struct rebuild_global_pool_tracker *rgt, d_rank_t rank)
+{
+	int i;
+
+	i = daos_array_find(rgt->rgt_servers_sorted, rgt->rgt_servers_number, rank,
+			    &servers_sort_ops);
+	if (i >= 0) {
+		rgt->rgt_servers_last_update[i] = ABT_get_wtime();
+		return;
+	}
+	D_INFO("rank %u is not included in this rebuild.\n", rank);
 }
 
 static uint32_t
@@ -262,6 +324,8 @@ int
 rebuild_global_status_update(struct rebuild_global_pool_tracker *rgt,
 			     struct rebuild_iv *iv)
 {
+	rebuild_leader_set_update_time(rgt, iv->riv_rank);
+
 	D_DEBUG(DB_REBUILD, "iv rank %d scan_done %d pull_done %d resync dtx %u\n",
 		iv->riv_rank, iv->riv_scan_done, iv->riv_pull_done,
 		iv->riv_dtx_resyc_version);
@@ -638,6 +702,39 @@ enum {
 	RB_BCAST_QUERY,
 };
 
+static void
+warn_for_slow_engine_updates(struct rebuild_global_pool_tracker *rgt)
+{
+	int    i;
+	double now    = ABT_get_wtime();
+	double tw     = now - rgt->rgt_last_warn; /* time since last warning logged */
+	bool   warned = false;
+
+	/* Throttle warnings to not more often than once per 2 minutes */
+	if (tw < 120)
+		return;
+
+	/* Warn for ranks not done and that haven't provided updates in a while (> 30 sec) */
+	for (i = 0; i < rgt->rgt_servers_number; i++) {
+		double   tu = now - rgt->rgt_servers_last_update[i];
+		d_rank_t r  = rgt->rgt_servers[i].rank;
+
+		if (rgt->rgt_servers[i].scan_done && rgt->rgt_servers[i].pull_done)
+			continue;
+
+		if (tu > 30) {
+			D_WARN(DF_RB ": no updates from rank %u in %8.3f seconds. "
+				     "scan_done=%d pull_done=%d\n",
+			       DP_RB_RGT(rgt), r, tu, rgt->rgt_servers[i].scan_done,
+			       rgt->rgt_servers[i].pull_done);
+			warned = true;
+		}
+	}
+
+	if (warned)
+		rgt->rgt_last_warn = now;
+}
+
 /*
  * Check rebuild status on the leader. Every other target sends
  * its own rebuild status by IV.
@@ -767,6 +864,7 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 			D_PRINT("%s", sbuf);
 		}
 sleep:
+		warn_for_slow_engine_updates(rgt);
 		sched_req_sleep(rgt->rgt_ult, RBLD_CHECK_INTV);
 	}
 
@@ -781,6 +879,10 @@ rebuild_global_pool_tracker_destroy(struct rebuild_global_pool_tracker *rgt)
 	d_list_del(&rgt->rgt_list);
 	if (rgt->rgt_servers)
 		D_FREE(rgt->rgt_servers);
+	if (rgt->rgt_servers_sorted)
+		D_FREE(rgt->rgt_servers_sorted);
+	if (rgt->rgt_servers_last_update)
+		D_FREE(rgt->rgt_servers_last_update);
 
 	if (rgt->rgt_lock)
 		ABT_mutex_free(&rgt->rgt_lock);
@@ -799,6 +901,7 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver, uint32_t 
 	struct rebuild_global_pool_tracker *rgt;
 	int rank_nr;
 	struct pool_domain *doms;
+	double                              now;
 	int i;
 	int rc = 0;
 
@@ -814,6 +917,24 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver, uint32_t 
 	D_ALLOC_ARRAY(rgt->rgt_servers, rank_nr);
 	if (rgt->rgt_servers == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
+	D_ALLOC_ARRAY(rgt->rgt_servers_sorted, rank_nr);
+	if (rgt->rgt_servers_sorted == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+	D_ALLOC_ARRAY(rgt->rgt_servers_last_update, rank_nr);
+	if (rgt->rgt_servers_last_update == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	now                = ABT_get_wtime();
+	rgt->rgt_last_warn = now;
+	for (i = 0; i < rank_nr; i++) {
+		rgt->rgt_servers_sorted[i]      = &rgt->rgt_servers[i];
+		rgt->rgt_servers[i].rank        = doms[i].do_comp.co_rank;
+		rgt->rgt_servers_last_update[i] = now;
+	}
+	rgt->rgt_servers_number = rank_nr;
+
+	rc = daos_array_sort(rgt->rgt_servers_sorted, rank_nr, true, &servers_sort_ops);
+	D_ASSERT(rc == 0);
 
 	rc = ABT_mutex_create(&rgt->rgt_lock);
 	if (rc != ABT_SUCCESS)
@@ -822,10 +943,6 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver, uint32_t 
 	rc = ABT_cond_create(&rgt->rgt_done_cond);
 	if (rc != ABT_SUCCESS)
 		D_GOTO(out, rc = dss_abterr2der(rc));
-
-	for (i = 0; i < rank_nr; i++)
-		rgt->rgt_servers[i].rank = doms[i].do_comp.co_rank;
-	rgt->rgt_servers_number = rank_nr;
 
 	uuid_copy(rgt->rgt_pool_uuid, pool->sp_uuid);
 	rgt->rgt_rebuild_ver = ver;
@@ -938,10 +1055,10 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 		ret = rebuild_global_pool_tracker_create(pool, rebuild_ver, rebuild_gen,
 							leader_term, reclaim_eph, rebuild_op, rgt);
 		if (ret) {
+			rc = ret;
 			DL_ERROR(rc, DF_RB " rebuild_global_pool_tracker create failed",
 				 DP_UUID(pool->sp_uuid), rebuild_ver, rebuild_gen,
 				 RB_OP_STR(rebuild_op));
-			rc = ret;
 		}
 	}
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -47,6 +47,44 @@ rebuild_pool_map_put(struct pool_map *map)
 	pool_map_decref(map);
 }
 
+/**
+ * Check whether the RPT is stale (new rebuild started).
+ * Only used in rebuild_tgt_status_check_ult(), the ULT only can exit when rebuild abort
+ * or globally done. When rebuild done, the leader notifies each target server by IV LAZY SYNC
+ * (see rebuild_leader_status_notify), so possibly the rebuild globally done but the async IV
+ * notification lost due to some network issue and lead to dangling rebuild_tgt_status_check_ult().
+ */
+bool
+rpt_stale(struct rebuild_tgt_pool_tracker *rpt)
+{
+	struct rebuild_tls      *tls = rebuild_tls_get();
+	struct rebuild_pool_tls *pool_tls;
+	bool                     found = false;
+
+	D_ASSERT(tls != NULL);
+	/* Only 1 thread will access the list, no need lock */
+	d_list_for_each_entry(pool_tls, &tls->rebuild_pool_list, rebuild_pool_list) {
+		if (uuid_compare(pool_tls->rebuild_pool_uuid, rpt->rt_pool_uuid) != 0)
+			continue;
+
+		if (rpt->rt_rebuild_ver == pool_tls->rebuild_pool_ver &&
+		    rpt->rt_rebuild_gen == pool_tls->rebuild_pool_gen)
+			found = true;
+
+		if ((rpt->rt_rebuild_ver < pool_tls->rebuild_pool_ver) ||
+		    (rpt->rt_rebuild_ver == pool_tls->rebuild_pool_ver &&
+		     rpt->rt_rebuild_gen < pool_tls->rebuild_pool_gen)) {
+			D_ERROR(DF_RB ": found new rebuild ver %d, gen %d\n", DP_RB_RPT(rpt),
+				pool_tls->rebuild_pool_ver, pool_tls->rebuild_pool_gen);
+			return true;
+		}
+	}
+
+	if (!found)
+		D_ERROR(DF_RB ": rebuild_tls not found\n", DP_RB_RPT(rpt));
+	return !found;
+}
+
 struct rebuild_pool_tls *
 rebuild_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver, uint32_t gen)
 {
@@ -876,7 +914,7 @@ static void
 rebuild_global_pool_tracker_destroy(struct rebuild_global_pool_tracker *rgt)
 {
 	D_ASSERT(rgt->rgt_refcount == 0);
-	d_list_del(&rgt->rgt_list);
+	d_list_del_init(&rgt->rgt_list);
 	if (rgt->rgt_servers)
 		D_FREE(rgt->rgt_servers);
 	if (rgt->rgt_servers_sorted)
@@ -1969,7 +2007,7 @@ rgt_leader_stop(struct rebuild_global_pool_tracker *rgt)
 	rgt->rgt_abort = 1;
 
 	/* Remove it from the rgt list to avoid stopping rgt duplicately */
-	d_list_del(&rgt->rgt_list);
+	d_list_del_init(&rgt->rgt_list);
 
 	ABT_mutex_lock(rgt->rgt_lock);
 	ABT_cond_wait(rgt->rgt_done_cond, rgt->rgt_lock);
@@ -2468,7 +2506,15 @@ rebuild_tgt_status_check_ult(void *arg)
 		if (!rpt->rt_global_done) {
 			struct ds_iv_ns *ns = rpt->rt_pool->sp_iv_ns;
 
-			iv.riv_master_rank = rpt->rt_leader_rank;
+			if (ns->iv_master_rank != rpt->rt_leader_rank)
+				D_WARN(DF_RB ":iv_master_rank %d mismatch with rt_leader_rank %d\n",
+				       DP_RB_RPT(rpt), ns->iv_master_rank, rpt->rt_leader_rank);
+			/* master rank set as ns->iv_master_rank rather than rpt->rt_leader_rank,
+			 * same as usage in rebuild_leader_status_notify() and iv_op_internal().
+			 * also see rebuild_iv_ent_update(), ivc_on_hash().
+			 * It is safer in case of PS leader switch.
+			 */
+			iv.riv_master_rank       = ns->iv_master_rank;
 			iv.riv_rank = rpt->rt_rank;
 			iv.riv_ver = rpt->rt_rebuild_ver;
 			iv.riv_rebuild_gen = rpt->rt_rebuild_gen;
@@ -2522,6 +2568,10 @@ rebuild_tgt_status_check_ult(void *arg)
 			break;
 
 		sched_req_sleep(rpt->rt_ult, RBLD_CHECK_INTV);
+		if (iv.riv_pull_done && rpt_stale(rpt)) {
+			D_ERROR(DF_RB " is stale, exit the ULT.\n", DP_RB_RPT(rpt));
+			break;
+		}
 	}
 
 	sched_req_put(rpt->rt_ult);
@@ -2810,6 +2860,22 @@ rebuild_cleanup(void)
 	return 0;
 }
 
+static int
+rebuild_get_req_attr(crt_rpc_t *rpc, struct sched_req_attr *attr)
+{
+	if (opc_get(rpc->cr_opc) == REBUILD_OBJECTS_SCAN) {
+		struct rebuild_scan_in *rsi = crt_req_get(rpc);
+
+		sched_req_attr_init(attr, SCHED_REQ_MIGRATE, &rsi->rsi_pool_uuid);
+	}
+
+	return 0;
+}
+
+static struct dss_module_ops rebuild_mod_ops = {
+    .dms_get_req_attr = rebuild_get_req_attr,
+};
+
 struct dss_module rebuild_module = {
     .sm_name        = "rebuild",
     .sm_mod_id      = DAOS_REBUILD_MODULE,
@@ -2822,4 +2888,5 @@ struct dss_module rebuild_module = {
     .sm_cli_count   = {0},
     .sm_handlers    = {rebuild_handlers},
     .sm_key         = &rebuild_module_key,
+    .sm_mod_ops     = &rebuild_mod_ops,
 };

--- a/src/tests/ftest/erasurecode/offline_rebuild_single.yaml
+++ b/src/tests/ftest/erasurecode/offline_rebuild_single.yaml
@@ -10,6 +10,9 @@ hosts:
 setup:
   start_servers_once: False
 timeout: 900
+agent_config:
+  #cache_expiration: 1
+  disable_caching: true
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/erasurecode/online_rebuild.yaml
+++ b/src/tests/ftest/erasurecode/online_rebuild.yaml
@@ -11,6 +11,9 @@ timeout: 1000
 setup:
   start_agents_once: False
   start_servers_once: False
+agent_config:
+  #cache_expiration: 1
+  disable_caching: true
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/rebuild/cascading_failures.yaml
+++ b/src/tests/ftest/rebuild/cascading_failures.yaml
@@ -2,6 +2,9 @@ hosts:
   test_servers: 6
   test_clients: 1
 timeout: 420
+agent_config:
+  #cache_expiration: 1
+  disable_caching: true
 server_config:
   name: daos_server
   engines_per_host: 1


### PR DESCRIPTION
Multiple backports
5f46808 - rebuild: uniform identifier in logs part 1 (#14383)
32345e2 - rebuild:  uniform identifier in logs part 2 (migrate)  (#14547)

Features: rebuild
Allow-unstable-test: true

Signed-off-by: Kenneth Cain <kenneth.cain@hpe.com>

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
