### PR TITLE
DAOS-15947 docs: Update admin guide dmg system command syntax

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -1036,6 +1036,16 @@ storage for that rank will need to be formatted and rank metadata regenerated. I
 the storage server has not changed the old rank can be "reused" by formatting using the
 `dmg storage format --replace` option.
 
+An examples workflow would be:
+- `daos_server` is running and PMem NVDIMM fails causing an engine to enter excluded state.
+- `daos_server` is stopped, storage server powered down, faulty PMem NVDIMM is replaced.
+- After powering up storage server, `daos_server scm prepare` command is used to repair PMem.
+- Storage server is rebooted after running `daos_server scm prepare` and command is run again.
+- Now PMem is intact, clear with `wipefs -a /dev/pmemX` where "X" refers to the repaired PMem ID.
+- `daos_server` can be started again. On start-up repaired engine prompts for "SCM format required".
+- Running `dmg storage format` now will create new "Joined" rank, instead run with `--replace` flag.
+- Formatted engine will join using the existing (old) rank which is mapped to the engine's hardware.
+
 ### System Erase
 
 To erase the DAOS sorage configuration, the `dmg system erase`

--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -1031,8 +1031,8 @@ DAOS I/O Engines will be started, and all DAOS pools will have been removed.
 
 ### Storage Format Replace
 
-If storage metadata for a rank is lost, for example after losing PMem contents after NVDIMM failure.
-Storage for that rank will need to be formatted and rank metadata regenerated. If other hardware on
+If storage metadata for a rank is lost, for example after losing PMem contents after NVDIMM failure,
+storage for that rank will need to be formatted and rank metadata regenerated. If other hardware on
 the storage server has not changed the old rank can be "reused" by formatting using the
 `dmg storage format --replace` option.
 

--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -1029,6 +1029,13 @@ DAOS I/O Engines will be started, and all DAOS pools will have been removed.
     Then restart DAOS Servers and format.
 
 
+### Storage Format Replace
+
+If storage metadata for a rank is lost, for example after losing PMem contents after NVDIMM failure.
+Storage for that rank will need to be formatted and rank metadata regenerated. If other hardware on
+the storage server has not changed the old rank can be "reused" by formatting using the
+`dmg storage format --replace` option.
+
 ### System Erase
 
 To erase the DAOS sorage configuration, the `dmg system erase`

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -1278,6 +1278,12 @@ unusable in pools until `dmg system clear-exclude --ranks=${rank_range_list}` is
 ranks to the previous (normally `Excluded`) state. Then the engine can be restarted to rejoin the
 system and will enter the `Joined` state and ready to be reintegrated into pools.
 
+Engine state can be queryed via the system membership using:
+
+```bash
+$ dmg system query
+```
+
 ### Drain
 
 Alternatively, when an operator would like to remove one or more engines or

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -1237,7 +1237,7 @@ $ dmg pool exclude --ranks=${rank_range_list} --target-idx=${idx1},${idx2},${idx
 
 The pool target exclude command accepts 4 parameters:
 
-* The label or UUID of the pool that the targets will be reintegrated into.
+* The label or UUID of the pool that the targets will be excluded.
 * The engine rank(s) of the target(s) to be excluded. This can be a single integer or a list of
   comma-separated ranges e.g. "1" or "1-9,10,12-19".
 * The target indices of the targets to be excluded from each specified engine rank (optional).

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -1219,20 +1219,30 @@ surviving engine.
 
 ### Manual Exclusion
 
-An operator can exclude one or more engines or targets from a specific DAOS pool
-using the rank the target resides, as well as the target idx on that rank.
-If a target idx list is not provided, all targets on the engine rank will be excluded.
+An operator can exclude one or more engines or targets from a specific DAOS pool using the rank(s)
+where the target(s) reside, as well as the target index(es) on the rank(s). If a target idx list is
+not provided, all selected targets on the engine rank(s) will be excluded.
 
-To exclude a target from a pool:
+To exclude multiple targets on a single rank from a pool:
 
 ```bash
-$ dmg pool exclude --rank=${rank} --target-idx=${idx1},${idx2},${idx3} <pool_label>
+$ dmg pool exclude --ranks=${rank} --target-idx=${idx1},${idx2},${idx3} <pool_label>
 ```
 
-The pool target exclude command accepts 2 parameters:
+To exclude multiple targets on multiple ranks from a pool:
 
-* The engine rank of the target(s) to be excluded.
-* The target indices of the targets to be excluded from that engine rank (optional).
+```bash
+$ dmg pool exclude --ranks=${rank_range_list} --target-idx=${idx1},${idx2},${idx3} <pool_label>
+```
+
+The pool target reintegrate command accepts 4 parameters:
+
+* The label or UUID of the pool that the targets will be reintegrated into.
+* The engine rank(s) of the target(s) to be excluded. This can be a single integer or a list of
+  comma-separated ranges e.g. "1" or "1-9,10,12-19".
+* The target indices of the targets to be excluded from each specified engine rank (optional).
+* The force flag which can be used to override RF check as documented below (optional, use with
+  caution).
 
 Upon successful manual exclusion, the self-healing mechanism will be triggered
 to restore redundancy on the remaining engines.
@@ -1243,6 +1253,29 @@ to restore redundancy on the remaining engines.
     and return the error code -DER_RF. You can proceed with the exclusion by specifying
     the --force option. Please note that forcing the operation may result in data loss,
     and it is strongly recommended to verify the RF status before proceeding.
+
+#### System Exclude
+
+To exclude ranks or hosts from all pools that they belong to, the 'dmg system exclude'
+command can be used. The command takes either a host-set or rank-set:
+
+To exclude a set of hosts from all pools (excludes all ranks on selected hosts):
+
+```Bash
+$ dmg system exclude --rank-hosts foo-[001-100]
+```
+
+To exclude a set of ranks from all pools:
+
+```Bash
+$ dmg system exclude --ranks 1-100
+```
+
+Selected ranks will be set to `AdminExcluded` state in system membership (as shown in output of
+`dmg system query` command). This will exclude all rank targets from all pools and render the ranks
+unusable in pools until `dmg system clear-exclude --ranks=${rank_range_list}` is run to return the
+ranks to the previous (normally `Excluded`) state. Then the engine can be restarted to rejoin the
+system and will enter the `Joined` state and ready to be reintegrated into pools.
 
 ### Drain
 
@@ -1258,16 +1291,28 @@ data would not be integrated into a rebuild and would be lost.
 Drain operation is not allowed if there are other ongoing rebuild operations, otherwise
 it will return -DER_BUSY.
 
-To drain a target from a pool:
+An operator can drain one or more engines or targets from a specific DAOS pool using the rank(s)
+where the target(s) reside, as well as the target index(es) on the rank(s). If a target idx list is
+not provided, all selected targets on the engine rank(s) will be drained.
+
+To drain multiple targets on a single rank from a pool:
 
 ```bash
-$ dmg pool drain --rank=${rank} --target-idx=${idx1},${idx2},${idx3} $DAOS_POOL
+$ dmg pool drain --ranks=${rank} --target-idx=${idx1},${idx2},${idx3} <pool_label>
 ```
 
-The pool target drain command accepts 2 parameters:
+To drain multiple targets on multiple ranks from a pool:
 
-* The engine rank of the target(s) to be drained.
-* The target indices of the targets to be drained from that engine rank (optional).
+```bash
+$ dmg pool drain --ranks=${rank_range_list} --target-idx=${idx1},${idx2},${idx3} <pool_label>
+```
+
+The pool target reintegrate command accepts 3 parameters:
+
+* The label or UUID of the pool that the targets will be reintegrated into.
+* The engine rank(s) of the target(s) to be drained. This can be a single integer or a list of
+  comma-separated ranges e.g. "1" or "1-9,10,12-19".
+* The target indices of the targets to be drained from each specified engine rank (optional).
 
 #### System Drain
 
@@ -1296,15 +1341,28 @@ supplying a target idx list, or reintegrate an entire engine rank by omitting th
 Reintegrate operation is not allowed if there are other ongoing rebuild operations,
 otherwise it will return -DER_BUSY.
 
-```
-$ dmg pool reintegrate $DAOS_POOL --rank=${rank} --target-idx=${idx1},${idx2},${idx3}
+An operator can reintegrate one or more engines or targets from a specific DAOS pool using the
+rank(s) where the target(s) reside, as well as the target index(es) on the rank(s). If a target idx
+list is not provided, all selected targets on the engine rank(s) will be reintegrated.
+
+To reintegrate multiple targets on a single rank from a pool:
+
+```bash
+$ dmg pool reintegrate --ranks=${rank} --target-idx=${idx1},${idx2},${idx3} <pool_label>
 ```
 
-The pool reintegrate command accepts 3 parameters:
+To reintegrate multiple targets on multiple ranks from a pool:
+
+```bash
+$ dmg pool reintegrate --ranks=${rank_range_list} --target-idx=${idx1},${idx2},${idx3} <pool_label>
+```
+
+The pool target reintegrate command accepts 3 parameters:
 
 * The label or UUID of the pool that the targets will be reintegrated into.
-* The engine rank of the affected targets.
-* The target indices of the targets to be reintegrated on that engine rank (optional).
+* The engine rank(s) of the target(s) to be reintegrated. This can be a single integer or a list of
+  comma-separated ranges e.g. "1" or "1-9,10,12-19".
+* The target indices of the targets to be reintegrated from each specified engine rank (optional).
 
 When rebuild is triggered it will list the operations and their related engines/targets
 by their engine rank and target index.
@@ -1320,7 +1378,7 @@ Target (rank 5 idx 1) is down.
 These should be the same values used when reintegrating the targets.
 
 ```
-$ dmg pool reintegrate $DAOS_POOL --rank=5 --target-idx=0,1
+$ dmg pool reintegrate $DAOS_POOL --ranks=5 --target-idx=0,1
 ```
 
 !!! warning
@@ -1328,8 +1386,25 @@ $ dmg pool reintegrate $DAOS_POOL --rank=5 --target-idx=0,1
     pool, there is currently no way to list the targets that have actually
     been disabled. As a result, it is recommended for now to try to reintegrate
     all engine ranks one after the other via `for i in seq $NR_RANKs; do dmg
-    pool reintegrate --rank=$i; done`. This limitation will be addressed in the
+    pool reintegrate --ranks=$i; done`. This limitation will be addressed in the
     next release.
+
+#### System Reintegrate
+
+To reintegrate ranks or hosts from all pools that they belong to, the 'dmg system reintegrate'
+command can be used. The command takes either a host-set or rank-set:
+
+To reintegrate a set of hosts from all pools (reintegrates all ranks on selected hosts):
+
+```Bash
+$ dmg system reintegrate --rank-hosts foo-[001-100]
+```
+
+To reintegrate a set of ranks from all pools:
+
+```Bash
+$ dmg system reintegrate --ranks 1-100
+```
 
 ## Pool Extension
 

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -1393,9 +1393,9 @@ $ dmg pool reintegrate $DAOS_POOL --ranks=5 --target-idx=0,1
 #### System Reintegrate
 
 To reintegrate ranks or hosts from all pools that they belong to, the 'dmg system reintegrate'
-command can be used. The command takes either a host-set or rank-set:
+command can be used. The command takes either a host-set or rank-set. Selecting a host-set reintegrates all ranks on selected hosts.
 
-To reintegrate a set of hosts from all pools (reintegrates all ranks on selected hosts):
+To reintegrate a set of hosts from all pools:
 
 ```Bash
 $ dmg system reintegrate --rank-hosts foo-[001-100]

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -1257,9 +1257,10 @@ to restore redundancy on the remaining engines.
 #### System Exclude
 
 To exclude ranks or hosts from all pools that they belong to, the 'dmg system exclude'
-command can be used. The command takes either a host-set or rank-set:
+command can be used. The command takes either a host-set or rank-set. Requesting a
+host-set excludes all ranks on selected hosts.
 
-To exclude a set of hosts from all pools (excludes all ranks on selected hosts):
+To exclude a set of hosts from all pools:
 
 ```Bash
 $ dmg system exclude --rank-hosts foo-[001-100]

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -1235,7 +1235,7 @@ To exclude multiple targets on multiple ranks from a pool:
 $ dmg pool exclude --ranks=${rank_range_list} --target-idx=${idx1},${idx2},${idx3} <pool_label>
 ```
 
-The pool target reintegrate command accepts 4 parameters:
+The pool target exclude command accepts 4 parameters:
 
 * The label or UUID of the pool that the targets will be reintegrated into.
 * The engine rank(s) of the target(s) to be excluded. This can be a single integer or a list of

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -1310,7 +1310,7 @@ $ dmg pool drain --ranks=${rank_range_list} --target-idx=${idx1},${idx2},${idx3}
 
 The pool target reintegrate command accepts 3 parameters:
 
-* The label or UUID of the pool that the targets will be reintegrated into.
+* The label or UUID of the pool that the targets to be drained.
 * The engine rank(s) of the target(s) to be drained. This can be a single integer or a list of
   comma-separated ranges e.g. "1" or "1-9,10,12-19".
 * The target indices of the targets to be drained from each specified engine rank (optional).

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -1308,7 +1308,7 @@ To drain multiple targets on multiple ranks from a pool:
 $ dmg pool drain --ranks=${rank_range_list} --target-idx=${idx1},${idx2},${idx3} <pool_label>
 ```
 
-The pool target reintegrate command accepts 3 parameters:
+The pool target drain command accepts 3 parameters:
 
 * The label or UUID of the pool that the targets to be drained.
 * The engine rank(s) of the target(s) to be drained. This can be a single integer or a list of


### PR DESCRIPTION
Documentation updates relating to:
- New commands `dmg system drain|reintegrate`
- New command syntax for multiple --ranks
  `dmg pool drain|reintegrate|exclude –ranks 1-9,11-19`
- New command flag `dmg storage format --replace`

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
