### PR TITLE
DAOS-17120 test: replace pcmd with run_remote (#15915)

### DIFF
--- a/src/tests/ftest/control/log_entry.py
+++ b/src/tests/ftest/control/log_entry.py
@@ -158,7 +158,7 @@ class ControlLogEntry(TestWithServers):
         self.log_step('Restart server')
         expected = [r'Starting I/O Engine instance', r'Listening on']
         with self.verify_journalctl(expected):
-            self.server_managers[0].restart(list(kill_host), wait=True)
+            self.server_managers[0].restart(kill_host, wait=True)
 
         self.log_step('Reintegrate all ranks and wait for rebuild')
         expected = [fr'rank {rank}.*start reintegration' for rank in kill_ranks] \

--- a/src/tests/ftest/control/super_block_versioning.py
+++ b/src/tests/ftest/control/super_block_versioning.py
@@ -1,14 +1,15 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-
-
 import os
 
 from apricot import TestWithServers
-from general_utils import check_file_exists, pcmd
+from command_utils import command_as_user
+from general_utils import check_file_exists
+from run_utils import run_remote
 
 
 class SuperBlockVersioning(TestWithServers):
@@ -39,9 +40,7 @@ class SuperBlockVersioning(TestWithServers):
             self.fail("{}: {} not found".format(check_result[1], fname))
 
         # Make sure that 'version' is in the file, run task to check
-        cmd = "sudo cat {} | grep -F \"version\"".format(fname)
-        result = pcmd(self.hostlist_servers, cmd, timeout=20)
-
-        # Determine if the command completed successfully across all the hosts
-        if len(result) > 1 or 0 not in result:
-            self.fail("Was not able to find version in {} file".format(fname))
+        cmd = command_as_user(f'cat {fname} | grep -F "version"', "root")
+        result = run_remote(self.log, self.hostlist_servers, cmd, timeout=20)
+        if not result.passed:
+            self.fail(f"Was not able to find version in {fname} file")

--- a/src/tests/ftest/daos_racer/parallel.py
+++ b/src/tests/ftest/daos_racer/parallel.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 """
 (C) Copyright 2021-2022 Intel Corporation.
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -52,7 +53,8 @@ class DaosRacerParallelTest(TestWithServers):
             job_manager.run()
 
         except CommandFailure as error:
-            self.log.error("DAOS Racer Failed: %s", str(error))
-            self.fail("Test was expected to pass but it failed.\n")
+            msg = f"daos_racer failed: {error}"
+            self.log.error(msg)
+            self.fail(msg)
 
         self.log.info("Test passed!")

--- a/src/tests/ftest/deployment/agent_failure.py
+++ b/src/tests/ftest/deployment/agent_failure.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2022-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -239,7 +240,7 @@ class AgentFailure(IorTestBase):
         # 6. On the killed client, verify journalctl shows the log that the agent is
         # stopped.
         results = get_journalctl(
-            hosts=[agent_host_kill], since=since, until=until,
+            hosts=NodeSet(agent_host_kill), since=since, until=until,
             journalctl_type="daos_agent")
         self.log.info("journalctl results (kill) = %s", results)
         if "shutting down" not in results[0]["data"]:
@@ -250,7 +251,7 @@ class AgentFailure(IorTestBase):
         # 7. On the other client where agent is still running, verify that the journalctl
         # in the previous step doesn't show that the agent is stopped.
         results = get_journalctl(
-            hosts=[agent_host_keep], since=since, until=until,
+            hosts=NodeSet(agent_host_keep), since=since, until=until,
             journalctl_type="daos_agent")
         self.log.info("journalctl results (keep) = %s", results)
         if "shutting down" in results[0]["data"]:

--- a/src/tests/ftest/deployment/network_failure.py
+++ b/src/tests/ftest/deployment/network_failure.py
@@ -11,11 +11,12 @@ from collections import defaultdict
 from ClusterShell.NodeSet import NodeSet
 from command_utils_base import CommandFailure
 from dmg_utils import check_system_query_status
-from general_utils import report_errors, run_pcmd
+from general_utils import report_errors
 from ior_test_base import IorTestBase
 from ior_utils import IorCommand
 from job_manager_utils import get_job_manager
 from network_utils import NetworkInterface
+from run_utils import run_remote
 
 
 class NetworkFailureTest(IorTestBase):
@@ -98,16 +99,15 @@ class NetworkFailureTest(IorTestBase):
 
         """
         command = "hostname -i"
-        results = run_pcmd(hosts=self.hostlist_servers, command=command)
-        self.log.info("hostname -i results = %s", results)
+        result = run_remote(self.log, self.hostlist_servers, command)
+        if not result.passed:
+            self.fail("Failed to get hostname on servers")
 
         ip_to_host = {}
-        for result in results:
-            ips_str = result["stdout"][0]
+        for hosts, stdout in result.all_stdout.items():
             # There may be multiple IP addresses for one host.
-            ip_addresses = ips_str.split()
-            for ip_address in ip_addresses:
-                ip_to_host[ip_address] = NodeSet(str(result["hosts"]))
+            for ip_address in stdout.split():
+                ip_to_host[ip_address] = NodeSet(hosts)
 
         return ip_to_host
 

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -175,7 +175,7 @@ class NvmeEnospace(ServerFillUp, TestWithTelemetry):
             log_file (str): name prefix of the log files to check.
         """
         logfile_glob = log_file + r".*[0-9]"
-        errors_count = get_errors_count(self.hostlist_clients, logfile_glob)
+        errors_count = get_errors_count(self.log, self.hostlist_clients, logfile_glob)
         for error in self.expected_errors:
             if error not in errors_count:
                 errors_count[error] = 0

--- a/src/tests/ftest/recovery/container_list_consolidation.py
+++ b/src/tests/ftest/recovery/container_list_consolidation.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -74,9 +75,8 @@ class ContainerListConsolidationTest(RecoveryTestBase):
                 server_host=NodeSet(self.hostlist_servers[0]), path=self.bin,
                 mount_point=scm_mount, pool_uuid=pool.uuid, vos_file=vos_file)
             cmd_result = ddb_command.list_component()
-            ls_out = "\n".join(cmd_result[0]["stdout"])
             uuid_regex = r"([0-f]{8}-[0-f]{4}-[0-f]{4}-[0-f]{4}-[0-f]{12})"
-            match = re.search(uuid_regex, ls_out)
+            match = re.search(uuid_regex, cmd_result.joined_stdout)
             if match is None:
                 self.fail("Unexpected output from ddb command, unable to parse.")
             self.log.info("Container UUID from ddb ls = %s", match.group(1))
@@ -133,9 +133,8 @@ class ContainerListConsolidationTest(RecoveryTestBase):
                    "(PMEM only).")
             self.log_step(msg)
             cmd_result = ddb_command.list_component()
-            ls_out = "\n".join(cmd_result[0]["stdout"])
             uuid_regex = r"([0-f]{8}-[0-f]{4}-[0-f]{4}-[0-f]{4}-[0-f]{12})"
-            match = re.search(uuid_regex, ls_out)
+            match = re.search(uuid_regex, cmd_result.joined_stdout)
             if match:
                 errors.append("Container UUID is found in shard! Checker didn't remove it.")
 

--- a/src/tests/ftest/server/daos_server_dump.py
+++ b/src/tests/ftest/server/daos_server_dump.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -51,15 +52,19 @@ class DaosServerDumpTest(TestWithServers):
         :avocado: tags=server
         :avocado: tags=DaosServerDumpTest,test_daos_server_dump_basic
         """
-
-        ret_codes = dump_engines_stacks(self.hostlist_servers,
-                                        added_filter=r"'\<(grep|defunct)\>'")
+        result = dump_engines_stacks(
+            self.hostlist_servers, added_filter=r"'\<(grep|defunct)\>'")
         # at this time there is no way to know when Argobots ULTs stacks
         # has completed, see DAOS-1452/DAOS-9942.
-        if 1 in ret_codes:
-            self.log.info("Dumped daos_engine stacks on %s", str(ret_codes[1]))
-        if 0 in ret_codes:
-            self.fail("No daos_engine processes found on {}".format(str(ret_codes[0])))
+        if result.timeout_hosts:
+            # This is fatal
+            self.fail(f"Timeout dumping daos_engine stacks on {result.timeout_hosts}")
+        if result.failed_hosts:
+            # This is actually what we want
+            self.log.info("Dumped daos_engine stacks on %s", str(result.failed_hosts))
+        if result.passed_hosts:
+            # This is actually a failure
+            self.fail(f"No daos_engine processes found on {result.passed_hosts}")
 
         self.log.info("Test passed!")
 

--- a/src/tests/ftest/util/cpu_utils.py
+++ b/src/tests/ftest/util/cpu_utils.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -451,7 +452,7 @@ class CpuInfo():
         for it in host_data:
             data = it['data']
             if data == DATA_ERROR:
-                self._log.error(f"Error issuing command '{cmd}' on hosts {it.hosts}")
+                self._log.error(f"Error issuing command '{cmd}' on hosts {it['hosts']}")
 
             key = str(it["hosts"])
             self._architectures[key] = CpuArchitecture(self._log, data)

--- a/src/tests/ftest/util/ddb_utils.py
+++ b/src/tests/ftest/util/ddb_utils.py
@@ -1,12 +1,13 @@
 """
   (C) Copyright 2022 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
 
 from command_utils_base import BasicParameter, CommandWithParameters, FormattedParameter
-from general_utils import run_pcmd
+from run_utils import run_remote
 
 
 class DdbCommandBase(CommandWithParameters):
@@ -18,9 +19,9 @@ class DdbCommandBase(CommandWithParameters):
         Args:
             server_host (NodeSet): Server host to run the command.
             path (str): path to the ddb command.
-            verbose (bool, optional): Display command output when run_pcmd is called.
+            verbose (bool, optional): Display command output in run.
                 Defaults to True.
-            timeout (int, optional): Command timeout (sec) used in run_pcmd. Defaults to
+            timeout (int, optional): Command timeout (sec) used in run. Defaults to
                 None.
             sudo (bool, optional): Whether to run ddb with sudo. Defaults to True.
         """
@@ -40,7 +41,7 @@ class DdbCommandBase(CommandWithParameters):
         # VOS file path.
         self.vos_path = BasicParameter(None, position=1)
 
-        # Members needed for run_pcmd().
+        # Members needed for run().
         self.verbose = verbose
         self.timeout = timeout
 
@@ -60,13 +61,11 @@ class DdbCommandBase(CommandWithParameters):
         """Run the command.
 
         Returns:
-            list: A list of dictionaries with each entry containing output, exit status,
-                and interrupted status common to each group of hosts.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
-        return run_pcmd(
-            hosts=self.host, command=str(self), verbose=self.verbose,
-            timeout=self.timeout)
+        return run_remote(
+            self.log, self.host, command=str(self), verbose=self.verbose, timeout=self.timeout)
 
 
 class DdbCommand(DdbCommandBase):
@@ -124,8 +123,7 @@ class DdbCommand(DdbCommandBase):
                 called.
 
         Returns:
-            dict: A list of dictionaries with each entry containing output, exit
-                status, and interrupted status common to each group of hosts.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         cmd = ["ls"]
@@ -150,8 +148,7 @@ class DdbCommand(DdbCommandBase):
                 /var/tmp/daos_testing/<test_name>/my_out.txt
 
         Returns:
-            dict: A list of dictionaries with each entry containing output, exit
-                status, and interrupted status common to each group of hosts.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         self.write_mode.value = False
@@ -173,8 +170,7 @@ class DdbCommand(DdbCommandBase):
             load_file_path (str): Path of the file that contains the data to load.
 
         Returns:
-            dict: A list of dictionaries with each entry containing output, exit
-                status, and interrupted status common to each group of hosts.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         self.write_mode.value = True
@@ -191,8 +187,7 @@ class DdbCommand(DdbCommandBase):
                 container, second object.
 
         Returns:
-            dict: A list of dictionaries with each entry containing output, exit
-                status, and interrupted status common to each group of hosts.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         self.write_mode.value = True
@@ -208,8 +203,7 @@ class DdbCommand(DdbCommandBase):
                 first container, second object, second dkey. Needs to be object or after.
 
         Returns:
-            dict: A list of dictionaries with each entry containing output, exit
-                status, and interrupted status common to each group of hosts.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         self.write_mode.value = False
@@ -225,8 +219,7 @@ class DdbCommand(DdbCommandBase):
                 first container, second object, second dkey. Needs to be object or after.
 
         Returns:
-            dict: A list of dictionaries with each entry containing output, exit
-                status, and interrupted status common to each group of hosts.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         self.write_mode.value = False
@@ -242,8 +235,7 @@ class DdbCommand(DdbCommandBase):
                 first container, second object, second dkey. Needs to be object or after.
 
         Returns:
-            dict: A list of dictionaries with each entry containing output, exit
-                status, and interrupted status common to each group of hosts.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         self.write_mode.value = False
@@ -259,8 +251,7 @@ class DdbCommand(DdbCommandBase):
                 e.g., [0]/[1]/[1] for first container, second object, second dkey.
 
         Returns:
-            dict: A list of dictionaries with each entry containing output, exit
-                status, and interrupted status common to each group of hosts.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         self.write_mode.value = False
@@ -280,8 +271,7 @@ class DdbCommand(DdbCommandBase):
             active (str): -a flag. Defaults to False.
 
         Returns:
-            dict: A list of dictionaries with each entry containing output, exit
-                status, and interrupted status common to each group of hosts.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         self.write_mode.value = False
@@ -305,8 +295,7 @@ class DdbCommand(DdbCommandBase):
                 matter as long as it's valid. Defaults to [0].
 
         Returns:
-            dict: A list of dictionaries with each entry containing output, exit
-                status, and interrupted status common to each group of hosts.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         self.write_mode.value = True

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -15,8 +15,7 @@ from command_utils import ExecutableCommand, SystemctlCommand
 from command_utils_base import BasicParameter, EnvironmentVariables, FormattedParameter
 from env_modules import load_mpi
 from exception_utils import CommandFailure, MPILoadError
-from general_utils import (get_job_manager_class, get_journalctl_command, journalctl_time, pcmd,
-                           run_pcmd)
+from general_utils import get_job_manager_class, get_journalctl_command, journalctl_time
 from run_utils import run_remote, stop_processes
 from write_host_file import write_host_file
 
@@ -181,6 +180,8 @@ class JobManager(ExecutableCommand):
                 parameters to keep them in sync with the hosts. Defaults to True.
         """
         # pylint: disable=unused-argument
+        if not isinstance(hosts, NodeSet):
+            raise ValueError(f'Expected hosts to be type {type(NodeSet)} but got {type(hosts)}')
         self._hosts = hosts.copy()
 
     def _setup_hostfile(self, path=None, slots=None, hostfile=True):
@@ -277,14 +278,9 @@ class JobManager(ExecutableCommand):
         self.log.debug(
             "%s processes still running remotely%s:", self.command,
             " {}".format(message) if message else "")
-        self.log.debug("Running (on %s): %s", self._hosts, command)
-        results = pcmd(self._hosts, command, True, 10, None)
-
-        # The pcmd method will return a dictionary with a single key, e.g.
-        # {1: <NodeSet>}, if there are no remote processes running on any of the
-        # hosts.  If this value is not returned, indicate there are remote
-        # processes running by returning a "R" state.
-        return "R" if 1 not in results or len(results) > 1 else None
+        result = run_remote(self.log, self._hosts, command, timeout=10)
+        # Return "R" if processes were found running on any hosts
+        return "R" if result.passed_hosts else None
 
     def run(self, raise_exception=None):
         """Run the command.
@@ -712,7 +708,6 @@ class Systemctl(JobManager):
         # Start the daos_server.service
         self.service_enable()
         result = self.service_start()
-        # result = self.service_status()
 
         # Determine if the command has launched correctly using its
         # check_subprocess_status() method.
@@ -816,25 +811,21 @@ class Systemctl(JobManager):
             CommandFailure: if there is an issue running the command
 
         Returns:
-            dict: a dictionary of return codes keys and accompanying NodeSet
-                values indicating which hosts yielded the return code.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         self._systemctl.unit_command.value = command
         self.timestamps[command] = journalctl_time()
-        result = pcmd(self._hosts, str(self), self.verbose, self.timeout)
-        if 255 in result:
+        cmd = str(self)
+        result = run_remote(
+            self.log, self._hosts, cmd, verbose=self.verbose, timeout=self.timeout)
+        if result.timeout:
             raise CommandFailure(
                 "Timeout detected running '{}' with a {}s timeout on {}".format(
-                    str(self), self.timeout, NodeSet.fromlist(result[255])))
-
-        if 0 not in result or len(result) > 1:
-            failed = []
-            for item, value in list(result.items()):
-                if item != 0:
-                    failed.extend(value)
+                    cmd, self.timeout, result.timeout_hosts))
+        if not result.passed:
             raise CommandFailure(
-                "Error occurred running '{}' on {}".format(str(self), NodeSet.fromlist(failed)))
+                "Error occurred running '{}' on {}".format(cmd, result.failed_hosts))
         return result
 
     def _report_unit_command(self, command):
@@ -847,8 +838,7 @@ class Systemctl(JobManager):
             CommandFailure: if there is an issue running the command
 
         Returns:
-            dict: a dictionary of return codes keys and accompanying NodeSet
-                values indicating which hosts yielded the return code.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         try:
@@ -867,8 +857,7 @@ class Systemctl(JobManager):
             CommandFailure: if unable to enable
 
         Returns:
-            dict: a dictionary of return codes keys and accompanying NodeSet
-                values indicating which hosts yielded the return code.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         return self._report_unit_command("enable")
@@ -880,8 +869,7 @@ class Systemctl(JobManager):
             CommandFailure: if unable to disable
 
         Returns:
-            dict: a dictionary of return codes keys and accompanying NodeSet
-                values indicating which hosts yielded the return code.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         return self._report_unit_command("disable")
@@ -893,8 +881,7 @@ class Systemctl(JobManager):
             CommandFailure: if unable to start
 
         Returns:
-            dict: a dictionary of return codes keys and accompanying NodeSet
-                values indicating which hosts yielded the return code.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         return self._report_unit_command("start")
@@ -906,8 +893,7 @@ class Systemctl(JobManager):
             CommandFailure: if unable to stop
 
         Returns:
-            dict: a dictionary of return codes keys and accompanying NodeSet
-                values indicating which hosts yielded the return code.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         return self._report_unit_command("stop")
@@ -919,8 +905,7 @@ class Systemctl(JobManager):
             CommandFailure: if unable to get the status
 
         Returns:
-            dict: a dictionary of return codes keys and accompanying NodeSet
-                values indicating which hosts yielded the return code.
+            CommandResult: groups of command results from the same hosts with the same return status
 
         """
         return self._report_unit_command("status")
@@ -941,17 +926,17 @@ class Systemctl(JobManager):
         states = {}
         valid_states = ["active", "activating"]
         self._systemctl.unit_command.value = "is-active"
-        results = run_pcmd(self._hosts, str(self), False, self.timeout, None)
-        for result in results:
-            if result["interrupted"]:
-                states["timeout"] = result["hosts"]
-                status = False
-            else:
-                output = result["stdout"][-1]
-                if output not in states:
-                    states[output] = NodeSet()
-                states[output].add(result["hosts"])
-                status &= output in valid_states
+        result = run_remote(self.log, self._hosts, str(self), verbose=False, timeout=self.timeout)
+        if result.timeout:
+            states["timeout"] = result.timeout_hosts
+        for data in result.output:
+            if data.timeout:
+                continue
+            output = data.stdout[-1]
+            if output not in states:
+                states[output] = NodeSet()
+            states[output].add(data.hosts)
+            status &= output in valid_states
         data = ["=".join([key, str(states[key])]) for key in sorted(states)]
         self.log.info(
             "  Detected %s states: %s",
@@ -988,49 +973,41 @@ class Systemctl(JobManager):
         self.log.info("Gathering log data on %s: %s", str(hosts), command)
 
         # Gather the log information per host
-        results = run_pcmd(hosts, command, False, timeout, None)
+        result = run_remote(self.log, hosts, command, verbose=False, timeout=timeout)
 
         # Determine if the command completed successfully without a timeout
-        status = True
-        for result in results:
-            if result["interrupted"]:
-                self.log.info("  Errors detected running \"%s\":", command)
-                self.log.info(
-                    "    %s: timeout detected after %s seconds",
-                    str(result["hosts"]), timeout)
-                status = False
-            elif result["exit_status"] != 0:
-                self.log.info("  Errors detected running \"%s\":", command)
-                status = False
-            if not status:
-                break
+        if not result.passed:
+            self.log.info('  Errors detected running "%s":', command)
+        if result.timeout:
+            self.log.info(
+                "    %s: timeout detected after %s seconds", str(result.timeout_hosts), timeout)
 
         # Display/return the command output
         log_data = []
-        for result in results:
-            if result["exit_status"] == 0 and not result["interrupted"]:
+        for data in result.output:
+            if data.returncode == 0:
                 # Add the successful output from each node to the dictionary
                 log_data.append(
-                    {"hosts": result["hosts"], "data": result["stdout"]})
+                    {"hosts": data.hosts, "data": data.stdout})
             else:
                 # Display all of the results in the case of an error
-                if len(result["stdout"]) > 1:
+                if len(data.stdout) > 1:
                     self.log.info(
                         "    %s: rc=%s, output:",
-                        str(result["hosts"]), result["exit_status"])
-                    for line in result["stdout"]:
+                        str(data.hosts), data.returncode)
+                    for line in data.stdout:
                         self.log.info("      %s", line)
                 else:
                     self.log.info(
                         "    %s: rc=%s, output: %s",
-                        str(result["hosts"]), result["exit_status"],
-                        result["stdout"][0])
+                        str(data.hosts), data.returncode,
+                        data.stdout[0])
 
         # Report any errors through an exception
-        if not status:
+        if not result.passed:
             raise CommandFailure(
-                "Error(s) detected gathering {} log data on {}".format(
-                    self._systemctl.service.value, NodeSet.fromlist(hosts)))
+                f"Error(s) detected gathering {self._systemctl.service.value} "
+                f"log data on {result.failed_hosts}")
 
         # Return the successful command output per set of hosts
         return log_data

--- a/src/tests/ftest/util/macsio_util.py
+++ b/src/tests/ftest/util/macsio_util.py
@@ -1,11 +1,13 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from command_utils import ExecutableCommand
 from command_utils_base import FormattedParameter
-from general_utils import get_log_file, pcmd
+from general_utils import get_log_file
+from run_utils import run_remote
 
 
 class MacsioCommand(ExecutableCommand):
@@ -467,7 +469,9 @@ class MacsioCommand(ExecutableCommand):
         macsio_files = (self.log_file_name.value, self.timings_file_name.value)
         for macsio_file in macsio_files:
             if macsio_file:
-                self.log.info("Output from %s", macsio_file)
-                pcmd(hosts, "cat {}".format(macsio_file), timeout=30)
+                # DAOS-17157 - this needs error checking but is currently failing
+                run_remote(self.log, hosts, f"cat {macsio_file}", timeout=30)
+                # if not result.passed:
+                #     status = False
 
         return status

--- a/src/tests/ftest/util/performance_test_base.py
+++ b/src/tests/ftest/util/performance_test_base.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -111,10 +112,10 @@ class PerformanceTestBase(IorTestBase, MdtestBase):
         os.makedirs(metrics_dir, exist_ok=True)
         per_engine_results = self.server_managers[0].get_daos_metrics()
         for engine_idx, engine_results in enumerate(per_engine_results):
-            for host_results in engine_results:
-                log_name = "{}_engine{}.csv".format(host_results["hosts"], engine_idx)
+            for hosts, stdout in engine_results.all_stdout.items():
+                log_name = "{}_engine{}.csv".format(hosts, engine_idx)
                 log_path = os.path.join(metrics_dir, log_name)
-                self.log_performance(host_results["stdout"], False, log_path)
+                self.log_performance(stdout, False, log_path)
 
     @property
     def unique_id(self):

--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2022-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -266,6 +267,15 @@ class CommandResult():
             NodeSet: all nodes where the command failed
         """
         return NodeSet.fromlist(data.hosts for data in self.output if data.returncode != 0)
+
+    @property
+    def timeout_hosts(self):
+        """Get all timeout hosts.
+
+        Returns:
+            NodeSet: all nodes where the command timed out
+        """
+        return NodeSet.fromlist(data.hosts for data in self.output if data.timeout)
 
     @property
     def all_stdout(self):

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -16,10 +17,9 @@ from command_utils import SubprocessManager
 from command_utils_base import BasicParameter, CommonConfig
 from dmg_utils import get_dmg_command
 from exception_utils import CommandFailure
-from general_utils import (get_default_config_file, get_display_size, get_log_file, list_to_str,
-                           pcmd, run_pcmd)
+from general_utils import get_default_config_file, get_display_size, get_log_file, list_to_str
 from host_utils import get_local_host
-from run_utils import run_remote, stop_processes
+from run_utils import command_as_user, run_remote, stop_processes
 from server_utils_base import DaosServerCommand, DaosServerInformation, ServerFailed
 from server_utils_params import DaosServerTransportCredentials, DaosServerYamlParameters
 from user_utils import get_chown_command
@@ -614,7 +614,7 @@ class DaosServerManager(SubprocessManager):
             )
 
         if cmd_list:
-            pcmd(self._hosts, "; ".join(cmd_list), verbose)
+            run_remote(self.log, self._hosts, "; ".join(cmd_list), verbose=verbose)
 
     def restart(self, hosts, wait=False):
         """Restart the specified servers after a stop.
@@ -1147,10 +1147,10 @@ class DaosServerManager(SubprocessManager):
             timeout (int, optional): pass timeout to each execution ofrun_pcmd. Defaults to 60.
 
         Returns:
-            list: list of pcmd results for each host. See general_utils.run_pcmd for details.
+            list: list of CommandResult results for each host. See run_utils.run_remote for details.
                 [
-                    general_utils.run_pcmd(), # engine 0
-                    general_utils.run_pcmd()  # engine 1
+                    run_utils.run_remote(), # engine 0
+                    run_utils.run_remote()  # engine 1
                 ]
 
         """
@@ -1158,8 +1158,7 @@ class DaosServerManager(SubprocessManager):
         engines = []
         daos_metrics_exe = os.path.join(self.manager.job.command_path, "daos_metrics")
         for engine in range(engines_per_host):
-            results = run_pcmd(
-                hosts=self._hosts, verbose=verbose, timeout=timeout,
-                command="sudo {} -S {} --csv".format(daos_metrics_exe, engine))
-            engines.append(results)
+            command = command_as_user(f"{daos_metrics_exe} -S {engine} --csv", "root")
+            result = run_remote(self.log, self._hosts, command, verbose=verbose, timeout=timeout)
+            engines.append(result)
         return engines

--- a/src/tests/ftest/util/soak_utils.py
+++ b/src/tests/ftest/util/soak_utils.py
@@ -1,5 +1,6 @@
 """
 (C) Copyright 2019-2024 Intel Corporation.
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -27,8 +28,8 @@ from duns_utils import format_path
 from exception_utils import CommandFailure
 from fio_utils import FioCommand
 from general_utils import (DaosTestError, check_ping, check_ssh, get_journalctl, get_log_file,
-                           get_random_bytes, get_random_string, list_to_str, pcmd, run_command,
-                           run_pcmd, wait_for_result)
+                           get_random_bytes, get_random_string, list_to_str, run_command,
+                           wait_for_result)
 from ior_utils import IorCommand
 from job_manager_utils import Mpirun
 from macsio_util import MacsioCommand
@@ -203,10 +204,9 @@ def run_event_check(self, since, until):
     detected = 0
     events = self.params.get("events", "/run/*")
     # check events on all server nodes
-    hosts = list(set(self.hostlist_servers))
     if events:
         for journalctl_type in ["kernel", "daos_server"]:
-            for output in get_journalctl(hosts, since, until, journalctl_type):
+            for output in get_journalctl(self.hostlist_servers, since, until, journalctl_type):
                 for event in events:
                     lines = output["data"].splitlines()
                     for line in lines:
@@ -218,33 +218,6 @@ def run_event_check(self, since, until):
                         "Found %s instances of %s in system log from %s through %s",
                         detected, event, since, until)
     return events_found
-
-
-def get_journalctl_logs(self, hosts, since, until, journalctl_type):
-    """Run the journalctl on daos servers.
-
-    Args:
-        self (obj): soak obj
-        since (str): start time
-        until (str): end time
-        journalctl_type (str): the -t param for journalctl
-        log (bool):  If true; write the events to a logfile
-
-    Returns:
-        list: a list of dictionaries containing the following key/value pairs:
-            "hosts": NodeSet containing the hosts with this data
-            "data":  data requested for the group of hosts
-
-    """
-    results = get_journalctl(hosts, since, until, journalctl_type)
-    name = f"journalctl_{journalctl_type}.log"
-    destination = self.outputsoak_dir
-    for result in results:
-        for host in result["hosts"]:
-            log_name = name + "-" + str(host)
-            self.log.info("Logging output to %s", log_name)
-            write_logfile(result["data"], log_name, destination)
-    return results
 
 
 def get_daos_server_logs(self):
@@ -300,11 +273,9 @@ def run_monitor_check(self):
         self (obj): soak obj
 
     """
-    monitor_cmds = self.params.get("monitor", "/run/*")
-    hosts = self.hostlist_servers
-    if monitor_cmds:
-        for cmd in monitor_cmds:
-            pcmd(hosts, cmd, timeout=30)
+    monitor_cmds = self.params.get("monitor", "/run/*") or []
+    for cmd in monitor_cmds:
+        run_remote(self.log, self.hostlist_servers, cmd, timeout=30)
 
 
 def run_metrics_check(self, logging=True, prefix=None):
@@ -325,17 +296,13 @@ def run_metrics_check(self, logging=True, prefix=None):
                 name = prefix + f"_metrics_{engine}.csv"
             destination = self.outputsoak_dir
             daos_metrics = f"{self.sudo_cmd} daos_metrics -S {engine} --csv"
-            self.log.info("Running %s", daos_metrics)
-            results = run_pcmd(hosts=self.hostlist_servers,
-                               command=daos_metrics,
-                               verbose=(not logging),
-                               timeout=60)
+            result = run_remote(
+                self.log, self.hostlist_servers, daos_metrics, verbose=(not logging), timeout=60)
             if logging:
-                for result in results:
-                    hosts = result["hosts"]
-                    log_name = name + "-" + str(hosts)
+                for data in result.output:
+                    log_name = name + "-" + str(data.hosts)
                     self.log.info("Logging %s output to %s", daos_metrics, log_name)
-                    write_logfile(result["stdout"], log_name, destination)
+                    write_logfile(data.stdout, log_name, destination)
 
 
 def get_harassers(harasser):


### PR DESCRIPTION
Replace usage of pcmd with run_remote

Features: CPUUsage DAOSVersion DmgStorageScanSCMTest Ecodtruncate NetworkFailureTest POSIXStatTest SSDSocketTest SuperBlockVersioning soak_smoke MacsioTest daos_racer OSAOnlineExtend OSAOnlineParallelTest DdbTest ContainerListConsolidationTest performance,-manual NvmeEnospace TestWithScrubberTargetEviction Pil4dfsFio AgentFailure ControlLogEntry test_ras ContinuesAfterStop test_scrubber_ssd_auto_eviction
Skip-unit-tests: true
Skip-fault-injection-test: true
Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
