### PR TITLE
DAOS-17423 test: disable test_dfuse_find_perf in CI (#16262)

### DIFF
--- a/src/tests/ftest/dfuse/find.py
+++ b/src/tests/ftest/dfuse/find.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2021-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -52,7 +53,6 @@ class DfuseFind(TestWithServers):
             challenger performance.
 
         :avocado: tags=all,manual
-        :avocado: tags=hw,medium
         :avocado: tags=DfuseFind,test_dfuse_find_perf
         """
         # Number of repetitions each test will run.


### PR DESCRIPTION
test_dfuse_find_perf is a manual test that requires Lustre and we do not have Lustre so disable it.

Test-tag: test_dfuse_find_perf
Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
