### PR TITLE
DAOS-17345 vos: reduce sys space reserving (#16215)

### DIFF
--- a/src/vos/vos_space.c
+++ b/src/vos/vos_space.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2020-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -25,8 +26,8 @@
 static inline void
 frag_reserve_space(uuid_t uuid, daos_size_t *rsrvd, daos_size_t scm_tot)
 {
-	const daos_size_t min_sz = (2ULL << 30);  /* 2GB */
-	const daos_size_t max_sz = (10ULL << 30); /* 10GB */
+	const daos_size_t min_sz = (600ULL << 20); /* 600MB */
+	const daos_size_t max_sz = (6ULL << 30);   /* 6GB */
 	daos_size_t       ovhd_sz;
 
 	ovhd_sz = (scm_tot * 5) / 100;


### PR DESCRIPTION
Keep reserving 5% of total_scm_size for anti-fragmentation, but reduce the min reservation from 2GB to 600MB, reduce the max reservation from 10GB to 6GB.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
