### PR TITLE
DAOS-17106 cart: Fix floods of swim debug messages

### DIFF
--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -859,11 +859,8 @@ out_unlock:
 	crt_swim_csm_unlock(csm);
 out:
 	if (cst.cst_id != SWIM_ID_INVALID)
-		D_DEBUG(DB_TRACE, "select dping target: %lu => {%lu %c %lu}\n",
-			self_id, cst.cst_id, SWIM_STATUS_CHARS[cst.cst_state.sms_status],
-			cst.cst_state.sms_incarnation);
-	else
-		D_DEBUG(DB_TRACE, "there is no dping target\n");
+		D_DEBUG(DB_TRACE, "select dping target: %lu => {%lu %c %lu}\n", self_id, cst.cst_id,
+			SWIM_STATUS_CHARS[cst.cst_state.sms_status], cst.cst_state.sms_incarnation);
 	return cst.cst_id;
 }
 


### PR DESCRIPTION
The removal of the swim "shutdown" logic in swim_progress may result in ~240,000 of the following debug message being logged in ~1.7 s when an engine starts:

    crt_swim_get_dping_target() there is no dping target

This patch removes the debug message as a temporary solution.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
