### PR TITLE
DAOS-17422 chk: enhance dmg check repair API - b26

### DIFF
--- a/src/control/server/mgmt_check.go
+++ b/src/control/server/mgmt_check.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2022-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -527,13 +528,15 @@ func (svc *mgmtSvc) SystemCheckRepair(ctx context.Context, req *mgmtpb.CheckActR
 		return nil, err
 	}
 
-	f, err := svc.sysdb.GetCheckerFinding(req.Seq)
-	if err != nil {
-		return nil, err
-	}
+	if !req.ForAll {
+		f, err := svc.sysdb.GetCheckerFinding(req.Seq)
+		if err != nil {
+			return nil, err
+		}
 
-	if !f.HasChoice(req.Act) {
-		return nil, errors.Errorf("invalid action %s (must be one of %s)", req.Act, f.ValidChoicesString())
+		if !f.HasChoice(req.Act) {
+			return nil, errors.Errorf("invalid action %s (must be one of %s)", req.Act, f.ValidChoicesString())
+		}
 	}
 
 	dResp, err := svc.makeCheckerCall(ctx, drpc.MethodCheckerAction, req)
@@ -546,7 +549,7 @@ func (svc *mgmtSvc) SystemCheckRepair(ctx context.Context, req *mgmtpb.CheckActR
 		return nil, errors.Wrap(err, "unmarshal CheckRepair response")
 	}
 
-	if resp.Status == 0 {
+	if !req.ForAll && resp.Status == 0 {
 		if err := svc.sysdb.SetCheckerFindingAction(req.Seq, int32(req.Act)); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When -f option is specified for "dmg check repair" command, we allows the user/admin to handle the same type of inconsistencies with the same action subsequently. Under such scenario, using the inconsistency-class is more clear instead of the seq-num. Then the SYNOPSIS will be as following:

dmg [OPTIONS] check repair [repair-OPTIONS] <seq-num|inconsistency-class>
        <interact-opt|action>
...
[repair command options]
        -f, --for-all   Take the same action for all (potential) inconsistencies
                        with the same class. If this option is specified, then
                        "inconsistency-class" and "action" will be accepted for
                        subsequent parameters; otherwise, "seq-num" and "interact-opt"
                        will be used.

Enhance test logic to make it to be workable after landing c9745d82982.

Test-tag: test_daos_cat_recov_core

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
