### PR TITLE
DAOS-17381 rebuild: refine rebuild IO scheduling and rebuild IV

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -473,14 +473,20 @@ again:
 				rc = cont_iv_snap_ent_create(entry, key);
 				if (rc == 0)
 					goto again;
-				DL_ERROR(rc, "cont " DF_UUID " create IV_CONT_SNAP iv entry failed",
-					 DP_UUID(civ_key->cont_uuid));
+				/* convert to more specific errno */
+				if (rc == -DER_NONEXIST)
+					rc = -DER_CONT_NONEXIST;
+				DL_ERROR(rc, DF_CONT " create IV_CONT_SNAP iv entry failed",
+					 DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
 			} else if (class_id == IV_CONT_PROP) {
 				rc = cont_iv_prop_ent_create(entry, key);
 				if (rc == 0)
 					goto again;
-				DL_ERROR(rc, "cont " DF_UUID " create IV_CONT_PROP iv entry failed",
-					 DP_UUID(civ_key->cont_uuid));
+				/* convert to more specific errno */
+				if (rc == -DER_NONEXIST)
+					rc = -DER_CONT_NONEXIST;
+				DL_ERROR(rc, DF_CONT " create IV_CONT_PROP iv entry failed",
+					 DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
 			} else if (class_id == IV_CONT_CAPA) {
 				struct container_hdl	chdl = { 0 };
 				int			rc1;
@@ -543,7 +549,8 @@ again:
 				}
 			}
 		}
-		D_DEBUG(DB_MGMT, "lookup cont: rc "DF_RC"\n", DP_RC(rc));
+		D_DEBUG(DB_MGMT, DF_CONT "lookup cont: rc " DF_RC "\n",
+			DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid), DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -5675,9 +5675,9 @@ out:
 
 		prop = cqo->cqo_prop;
 	} else if ((opc == CONT_OPEN) || (opc == CONT_OPEN_BYLABEL)) {
-		struct cont_open_out *cout = crt_reply_get(rpc);
+		struct cont_open_out *co_out = crt_reply_get(rpc);
 
-		prop = cout->coo_prop;
+		prop = co_out->coo_prop;
 	}
 
 	out->co_rc = rc;

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -701,8 +701,10 @@ ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 
 	rc = read_snap_list(&tx, cont, snapshots, snap_count);
 	cont_put(cont);
-	if (rc != 0)
+	if (rc != 0) {
+		DL_ERROR(rc, DF_CONT " read_snap_list failed", DP_CONT(pool_uuid, cont_uuid));
 		D_GOTO(out_lock, rc);
+	}
 
 out_lock:
 	ABT_rwlock_unlock(svc->cs_lock);

--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -130,11 +130,11 @@ test_d_errstr(void **state)
 	assert_string_equal(value, "DER_UNKNOWN");
 
 	/* Check the end of the DAOS error numbers. */
-	value = d_errstr(-DER_NOT_RESUME);
-	assert_string_equal(value, "DER_NOT_RESUME");
-	value = d_errstr(-2049);
-	assert_string_equal(value, "DER_NOT_RESUME");
-	value = d_errstr(-(DER_NOT_RESUME + 1));
+	value = d_errstr(-DER_CONT_NONEXIST);
+	assert_string_equal(value, "DER_CONT_NONEXIST");
+	value = d_errstr(-2050);
+	assert_string_equal(value, "DER_CONT_NONEXIST");
+	value = d_errstr(-(DER_CONT_NONEXIST + 1));
 	assert_string_equal(value, "DER_UNKNOWN");
 }
 

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -212,7 +213,8 @@ extern "C" {
 	ACTION(DER_DIV_BY_ZERO,	Division by zero)						   \
 	/** Target is overload, retry RPC */							   \
 	ACTION(DER_OVERLOAD_RETRY, retry later because of overloaded service)			   \
-	ACTION(DER_NOT_RESUME, Cannot resume former DAOS check instance)
+	ACTION(DER_NOT_RESUME, Cannot resume former DAOS check instance)			   \
+	ACTION(DER_CONT_NONEXIST, The specified container does not exist)
 
 /* clang-format on */
 

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -498,6 +498,12 @@ daos_obj_id2class(daos_obj_id_t oid)
 	return (ord << OC_REDUN_SHIFT) | nr_grps;
 }
 
+static inline uint32_t
+daos_obj_id2grp_nr(daos_obj_id_t oid)
+{
+	return (oid.hi & OID_FMT_META_MASK) >> OID_FMT_META_SHIFT;
+}
+
 static inline bool
 daos_obj_id_is_nil(daos_obj_id_t oid)
 {

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2443,6 +2443,7 @@ ec_agg_object(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *ag
 	struct pl_map		*map;
 	struct daos_oclass_attr  oca;
 	struct cont_props	 props;
+	uint32_t                 shard_nr;
 	int			 rc = 0;
 
 	/** We should have filtered it if it isn't EC */
@@ -2462,6 +2463,8 @@ ec_agg_object(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *ag
 	md.omd_fdom_lvl = props.dcp_redun_lvl;
 	md.omd_pdom_lvl = props.dcp_perf_domain;
 	md.omd_pda = props.dcp_ec_pda;
+	shard_nr        = daos_oclass_grp_size(&oca) * daos_obj_id2grp_nr(md.omd_id);
+	agg_param->ap_credits += roundup(shard_nr, 128) / 128;
 	rc = pl_obj_place(map, agg_entry->ae_oid.id_layout_ver, &md, DAOS_OO_RO, NULL,
 			  &agg_entry->ae_obj_layout);
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1536,12 +1536,11 @@ post:
 			 * the rebuild and retry.
 			 */
 			rc = -DER_STALE;
-			D_DEBUG(DB_REBUILD,
-				DF_RB ": " DF_UOID " %p dkey " DF_KEY " " DF_KEY
-				      " nr %d/%d eph " DF_U64 " " DF_RC "\n",
-				DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid), mrone,
-				DP_KEY(&mrone->mo_dkey), DP_KEY(&iods[i].iod_name), iod_num, i,
-				mrone->mo_epoch, DP_RC(rc));
+			D_INFO(DF_RB ": " DF_UOID " %p dkey " DF_KEY " " DF_KEY
+				     " nr %d/%d eph " DF_U64 " " DF_RC "\n",
+			       DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid), mrone,
+			       DP_KEY(&mrone->mo_dkey), DP_KEY(&iods[i].iod_name), iod_num, i,
+			       mrone->mo_epoch, DP_RC(rc));
 			stale = true;
 			D_GOTO(end, rc);
 		}
@@ -1555,7 +1554,7 @@ end:
 		rc = rc1;
 
 	if (rc)
-		DL_CDEBUG(stale, DB_REBUILD, DLOG_ERR, rc, DF_RB ": " DF_UOID " migrate error",
+		DL_CDEBUG(stale, DLOG_INFO, DLOG_ERR, rc, DF_RB ": " DF_UOID " migrate error",
 			  DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid));
 
 	return rc;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7520,45 +7520,9 @@ out:
 	return rc;
 }
 
-void
-ds_pool_extend_handler(crt_rpc_t *rpc)
-{
-	struct pool_extend_in	*in = crt_req_get(rpc);
-	struct pool_extend_out	*out = crt_reply_get(rpc);
-	struct pool_svc		*svc;
-	uuid_t			pool_uuid;
-	d_rank_list_t		rank_list;
-	uint32_t		ndomains;
-	uint32_t		*domains;
-	int			rc;
-
-	D_DEBUG(DB_MD, DF_UUID": processing rpc %p\n", DP_UUID(in->pei_op.pi_uuid), rpc);
-
-	uuid_copy(pool_uuid, in->pei_op.pi_uuid);
-	rank_list.rl_nr = in->pei_tgt_ranks->rl_nr;
-	rank_list.rl_ranks = in->pei_tgt_ranks->rl_ranks;
-	ndomains = in->pei_ndomains;
-	domains = in->pei_domains.ca_arrays;
-
-	rc = pool_svc_lookup_leader(in->pei_op.pi_uuid, &svc, &out->peo_op.po_hint);
-	if (rc != 0)
-		goto out;
-
-	rc =
-	    pool_svc_update_map(svc, pool_opc_2map_opc(opc_get(rpc->cr_opc)),
-				false /* exclude_rank */, &rank_list, domains, ndomains, NULL, NULL,
-				&out->peo_op.po_map_version, &out->peo_op.po_hint, MUS_DMG, true);
-
-	pool_svc_put_leader(svc);
-out:
-	out->peo_op.po_rc = rc;
-	D_DEBUG(DB_MD, DF_UUID ": replying rpc: %p " DF_RC "\n", DP_UUID(in->pei_op.pi_uuid), rpc,
-		DP_RC(rc));
-	crt_reply_send(rpc);
-}
-
 static int
-pool_discard(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr_list *list)
+pool_discard(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr_list *list,
+	     bool reint)
 {
 	struct pool_tgt_discard_in	*ptdi_in;
 	struct pool_tgt_discard_out	*ptdi_out;
@@ -7568,7 +7532,9 @@ pool_discard(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr_li
 	int				i;
 	int				rc;
 
-	D_ASSERTF(svc->ps_pool->sp_incr_reint == 0, "incremental reint should not get here\n");
+	if (reint)
+		D_ASSERTF(svc->ps_pool->sp_incr_reint == 0,
+			  "incremental reint should not get here\n");
 
 	rank_list = d_rank_list_alloc(list->pta_number);
 	if (rank_list == NULL)
@@ -7618,6 +7584,62 @@ out:
 	return rc;
 }
 
+void
+ds_pool_extend_handler(crt_rpc_t *rpc)
+{
+	struct pool_extend_in       *in  = crt_req_get(rpc);
+	struct pool_extend_out      *out = crt_reply_get(rpc);
+	struct pool_svc             *svc;
+	struct pool_target_addr_list tgt_addr_list;
+	uuid_t                       pool_uuid;
+	d_rank_list_t                rank_list;
+	uint32_t                     ndomains;
+	uint32_t                    *domains;
+	int                          i;
+	int                          rc;
+
+	D_DEBUG(DB_MD, DF_UUID ": processing rpc %p\n", DP_UUID(in->pei_op.pi_uuid), rpc);
+
+	uuid_copy(pool_uuid, in->pei_op.pi_uuid);
+	rank_list.rl_nr          = in->pei_tgt_ranks->rl_nr;
+	rank_list.rl_ranks       = in->pei_tgt_ranks->rl_ranks;
+	ndomains                 = in->pei_ndomains;
+	domains                  = in->pei_domains.ca_arrays;
+	tgt_addr_list.pta_number = rank_list.rl_nr;
+	D_ALLOC_ARRAY(tgt_addr_list.pta_addrs, tgt_addr_list.pta_number);
+	if (tgt_addr_list.pta_addrs == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+	for (i = 0; i < tgt_addr_list.pta_number; i++) {
+		tgt_addr_list.pta_addrs[i].pta_rank   = rank_list.rl_ranks[i];
+		tgt_addr_list.pta_addrs[i].pta_target = -1;
+	}
+
+	rc = pool_svc_lookup_leader(in->pei_op.pi_uuid, &svc, &out->peo_op.po_hint);
+	if (rc != 0)
+		goto out;
+
+	rc = pool_discard(rpc->cr_ctx, svc, &tgt_addr_list, false);
+	if (rc) {
+		DL_ERROR(rc, DF_UUID ": pool_discard failed.", DP_UUID(in->pei_op.pi_uuid));
+		goto failed;
+	}
+
+	rc =
+	    pool_svc_update_map(svc, pool_opc_2map_opc(opc_get(rpc->cr_opc)),
+				false /* exclude_rank */, &rank_list, domains, ndomains, NULL, NULL,
+				&out->peo_op.po_map_version, &out->peo_op.po_hint, MUS_DMG, true);
+
+failed:
+	pool_svc_put_leader(svc);
+out:
+	if (tgt_addr_list.pta_addrs != NULL)
+		D_FREE(tgt_addr_list.pta_addrs);
+	out->peo_op.po_rc = rc;
+	D_DEBUG(DB_MD, DF_UUID ": replying rpc: %p " DF_RC "\n", DP_UUID(in->pei_op.pi_uuid), rpc,
+		DP_RC(rc));
+	crt_reply_send(rpc);
+}
+
 static void
 pool_update_handler(crt_rpc_t *rpc, int handler_version)
 {
@@ -7644,7 +7666,7 @@ pool_update_handler(crt_rpc_t *rpc, int handler_version)
 
 	if (opc_get(rpc->cr_opc) == POOL_REINT &&
 	    svc->ps_pool->sp_reint_mode == DAOS_REINT_MODE_DATA_SYNC) {
-		rc = pool_discard(rpc->cr_ctx, svc, &list);
+		rc = pool_discard(rpc->cr_ctx, svc, &list, true);
 		if (rc)
 			goto out_svc;
 	}

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -2676,8 +2676,7 @@ ds_pool_tgt_discard_ult(void *data)
 		D_GOTO(free, rc = 0);
 	}
 
-	ex_status = PO_COMP_ST_UP | PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN |
-		    PO_COMP_ST_DOWN | PO_COMP_ST_NEW;
+	ex_status = PO_COMP_ST_UP | PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN | PO_COMP_ST_NEW;
 	ds_pool_thread_collective(arg->pool_uuid, ex_status, pool_child_discard, arg,
 				  DSS_ULT_DEEP_STACK);
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -2676,7 +2676,7 @@ ds_pool_tgt_discard_ult(void *data)
 		D_GOTO(free, rc = 0);
 	}
 
-	ex_status = PO_COMP_ST_UP | PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN | PO_COMP_ST_NEW;
+	ex_status = PO_COMP_ST_UP | PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN;
 	ds_pool_thread_collective(arg->pool_uuid, ex_status, pool_child_discard, arg,
 				  DSS_ULT_DEEP_STACK);
 

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -310,9 +310,6 @@ struct rebuild_iv {
 
 };
 
-#define SCAN_YIELD_FREQ		4096
-#define SCAN_OBJ_YIELD_CNT	128
-
 extern struct dss_module_key rebuild_module_key;
 static inline struct rebuild_tls *
 rebuild_tls_get()

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -109,7 +110,14 @@ rebuild_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	if (rc)
 		return rc;
 
-	if (rank != src_iv->riv_master_rank)
+	/* possibly the iv_master_rank changed due to PS leader switch */
+	if (entry->ns->iv_master_rank != src_iv->riv_master_rank)
+		D_WARN(DF_UUID ":ns->iv_master_rank %d mismatch with src_iv->riv_master_rank %d, "
+			       "on rank %d\n",
+		       DP_UUID(entry->ns->iv_pool_uuid), entry->ns->iv_master_rank,
+		       src_iv->riv_master_rank, rank);
+
+	if (rank != entry->ns->iv_master_rank)
 		return -DER_IVCB_FORWARD;
 
 	if (src_iv->riv_sync)

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -667,7 +667,7 @@ void
 dv_oid_to_obj(daos_obj_id_t oid, struct ddb_obj *obj)
 {
 	obj->ddbo_oid = oid;
-	obj->ddbo_nr_grps = (oid.hi & OID_FMT_META_MASK) >> OID_FMT_META_SHIFT;
+	obj->ddbo_nr_grps = daos_obj_id2grp_nr(oid);
 
 	/*
 	 * It would be nice to get the object class name, but currently that is client


### PR DESCRIPTION
1. refine rebuild IV detailed handling
2. for rebuild IO, apply SCHED_REQ_MIGRATE for scheduler throttling
3. refine yield for rebuild scanner
4. use d_list_del_init for rgt delete
5. skip orphan container for rebuild scanner

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
