### PR TITLE
DAOS-17438 chk: per engine based check query result

### DIFF
--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -3376,10 +3377,10 @@ again:
 		}
 	}
 out:
-	chk_cqa_free(cqa);
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
-		 "Leader query check with gen "DF_X64" for %d pools: "DF_RC"\n",
-		 gen, pool_nr, DP_RC(rc));
+		 "Leader query check with gen "DF_X64" for %d pools: "DF_RC"\n", gen,
+		 rc != 0 ? pool_nr : cqa->cqa_count, DP_RC(rc));
+	chk_cqa_free(cqa);
 
 	return rc;
 }

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -2784,11 +2784,14 @@ ds_chk_query_pool_cb(struct chk_query_pool_shard *shard, uint32_t idx, void *buf
 	if (pool->time == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
+	pool->n_targets = shard->cqps_target_nr;
+	if (pool->n_targets == 0)
+		goto out;
+
 	D_ALLOC_ARRAY(pool->targets, shard->cqps_target_nr);
 	if (pool->targets == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	pool->n_targets = shard->cqps_target_nr;
 	for (i = 0; i < shard->cqps_target_nr; i++) {
 		D_ALLOC_PTR(target);
 		if (target == NULL)
@@ -2864,6 +2867,10 @@ ds_mgmt_drpc_check_query(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 
 	resp.req_status = rc;
 	len = mgmt__check_query_resp__get_packed_size(&resp);
+	if (unlikely(len >= (1 << 20)))
+		D_WARN("Too large CHK query reply buffer (%ld) for %ld pools, maybe overflow\n",
+		       len, resp.n_pools);
+
 	D_ALLOC(body, len);
 	if (body == NULL) {
 		D_ERROR("Failed to allocate response body (query check)\n");


### PR DESCRIPTION
Currently, querying the checker progress for a pool will return per target based result. For large scaled pool, the results may be huge as to overflow related dRPC. Be as some temporary solution, we will merge the per target based result on check engine and only transfer per engine based checker progress to the leader and then to control plane. That will much reduce the query buffer usage. In the future, when we supports arbitrary sized dRPC, then we can reply per target based query results as required.

Test-tag: test_daos_cat_recov_core

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
