### PR TITLE
DAOS-17049 control: Allow graceful shutdown for specific ranks

### DIFF
--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -50,8 +50,6 @@ const (
 	domainLabelsSep      = "=" // invalid in a label name
 )
 
-var errSysForceNotFull = errors.New("force must be used if not full system stop")
-
 // GetAttachInfo handles a request to retrieve a map of ranks to fabric URIs, in addition
 // to client network autoconfiguration hints.
 //
@@ -982,10 +980,6 @@ func (svc *mgmtSvc) SystemStop(ctx context.Context, req *mgmtpb.SystemStopReq) (
 	// First phase: Prepare the ranks for shutdown, but only if the request is for an unforced
 	// full system stop.
 	if !fReq.Force {
-		if !fReq.FullSystem {
-			return nil, errSysForceNotFull
-		}
-
 		fReq.Method = control.PrepShutdownRanks
 		fResp, _, err = svc.rpcFanout(ctx, fReq, fResp, true)
 		if err != nil {

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -1896,9 +1896,32 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 			expFanoutRanks: ranklist.MustCreateRankSet("0-1,3"),
 		},
 		"full system stop; partial ranks in req": {
-			req:       &mgmtpb.SystemStopReq{Ranks: "0,1"},
-			mResps:    hostRespStopSuccess,
-			expAPIErr: errSysForceNotFull,
+			req: &mgmtpb.SystemStopReq{Ranks: "0,1"},
+			members: system.Members{
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 3, 2, "joined"),
+			},
+			mResps: [][]*control.HostResponse{
+				{
+					hr(1, mockRankSuccess("prep shutdown", 0), mockRankSuccess("prep shutdown", 1)),
+				},
+				{
+					hr(1, mockRankSuccess("stop", 0), mockRankSuccess("stop", 1)),
+				},
+			},
+			expResults: []*sharedpb.RankResult{
+				mockRankSuccess("stop", 0, 1), mockRankSuccess("stop", 1, 1),
+			},
+			expMembers: func() system.Members {
+				return system.Members{
+					mockMember(t, 0, 1, "stopped"),
+					mockMember(t, 1, 1, "stopped"),
+					mockMember(t, 3, 2, "joined"),
+				}
+			},
+			expInvokeCount: 2, // prep should be called
+			expFanoutRanks: ranklist.MustCreateRankSet("0-1"),
 		},
 		"full system stop (forced)": {
 			req:        &mgmtpb.SystemStopReq{Force: true},


### PR DESCRIPTION
The CR checker tool needs to use a graceful shutdown when stopping ranks. It may select a subset of ranks if some are admin-excluded.

- Remove the limitation that non-forced shutdown may only be used on the whole system, not while specifying ranks.

Features: control

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
