### PR TITLE
DAOS-17470 cart: add out of quota RPC to timeout

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -1487,6 +1487,52 @@ crt_context_req_untrack_internal(struct crt_rpc_priv *rpc_priv)
 }
 
 static void
+add_rpc_to_list(struct crt_rpc_priv *rpc_priv, d_list_t *submit_list)
+{
+	struct crt_context     *crt_ctx = rpc_priv->crp_pub.cr_ctx;
+	struct crt_ep_inflight *epi     = rpc_priv->crp_epi;
+
+	D_ASSERT(epi != NULL);
+
+	RPC_ADDREF(rpc_priv);
+
+	crt_rpc_lock(rpc_priv);
+	D_MUTEX_LOCK(&epi->epi_mutex);
+	if (rpc_priv->crp_state == RPC_STATE_QUEUED) {
+		bool submit_rpc = true;
+		int  rc;
+
+		rpc_priv->crp_state = RPC_STATE_INITED;
+		/* RPC got cancelled or timed out before it got here */
+		if (rpc_priv->crp_timeout_ts == 0) {
+			submit_rpc = false;
+		} else {
+			crt_set_timeout(rpc_priv);
+
+			D_MUTEX_LOCK(&crt_ctx->cc_mutex);
+			rc = crt_req_timeout_track(rpc_priv);
+			D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);
+			if (rc != 0)
+				RPC_ERROR(rpc_priv, "crt_req_timeout_track failed, rc: %d.\n", rc);
+		}
+
+		d_list_move_tail(&rpc_priv->crp_epi_link, &epi->epi_req_q);
+		/* add to submit list if not cancelled or timed out already  */
+		if (submit_rpc) {
+			/* prevent rpc from being released before it is dispatched below */
+			RPC_ADDREF(rpc_priv);
+
+			D_ASSERTF(d_list_empty(&rpc_priv->crp_tmp_link_submit),
+				  "already on submit list\n");
+			d_list_add_tail(&rpc_priv->crp_tmp_link_submit, submit_list);
+		}
+	}
+	D_MUTEX_UNLOCK(&epi->epi_mutex);
+	crt_rpc_unlock(rpc_priv);
+	RPC_DECREF(rpc_priv);
+}
+
+static void
 dispatch_rpc(struct crt_rpc_priv *rpc) {
 	int rc;
 
@@ -1519,8 +1565,7 @@ crt_context_req_untrack(struct crt_rpc_priv *rpc_priv)
 	struct crt_context	*crt_ctx = rpc_priv->crp_pub.cr_ctx;
 	struct crt_ep_inflight	*epi;
 	d_list_t		 submit_list;
-	struct crt_rpc_priv	*tmp_rpc;
-	int			 rc;
+	struct crt_rpc_priv     *tmp_rpc;
 
 	D_ASSERT(crt_ctx != NULL);
 
@@ -1536,8 +1581,9 @@ crt_context_req_untrack(struct crt_rpc_priv *rpc_priv)
 				   struct crt_rpc_priv, crp_waitq_link);
 	D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);
 
+	D_INIT_LIST_HEAD(&submit_list);
 	if (tmp_rpc != NULL) {
-		dispatch_rpc(tmp_rpc);
+		add_rpc_to_list(tmp_rpc, &submit_list);
 		d_tm_dec_gauge(crt_ctx->cc_quotas.rpc_waitq_depth, 1);
 	} else {
 		put_quota_resource(rpc_priv->crp_pub.cr_ctx, CRT_QUOTA_RPCS);
@@ -1547,65 +1593,26 @@ crt_context_req_untrack(struct crt_rpc_priv *rpc_priv)
 
 	/* done if ep credit flow control is disabled */
 	if (crt_gdata.cg_credit_ep_ctx == 0)
-		return;
-
-	D_INIT_LIST_HEAD(&submit_list);
-
-	D_MUTEX_LOCK(&epi->epi_mutex);
+		goto out;
 
 	/* process waitq */
+	D_MUTEX_LOCK(&epi->epi_mutex);
 	while (credits_available(epi) > 0 && !d_list_empty(&epi->epi_req_waitq)) {
-		D_ASSERT(epi->epi_req_wait_num > 0);
-		tmp_rpc = d_list_entry(epi->epi_req_waitq.next, struct crt_rpc_priv, crp_epi_link);
-		RPC_ADDREF(tmp_rpc);
+		tmp_rpc = d_list_pop_entry(&epi->epi_req_waitq, struct crt_rpc_priv, crp_epi_link);
+		epi->epi_req_wait_num--;
+		D_ASSERTF(epi->epi_req_wait_num >= 0, "wait %jd\n", epi->epi_req_wait_num);
+		/* remove from waitq and add to in-flight queue */
+		epi->epi_req_num++;
+		D_ASSERTF(epi->epi_req_num >= epi->epi_reply_num, "req %jd reply %jd\n",
+			  epi->epi_req_num, epi->epi_reply_num);
 		D_MUTEX_UNLOCK(&epi->epi_mutex);
-
-		crt_rpc_lock(tmp_rpc);
-		D_MUTEX_LOCK(&epi->epi_mutex);
-		if (tmp_rpc->crp_state == RPC_STATE_QUEUED && credits_available(epi) > 0) {
-			bool submit_rpc = true;
-
-			tmp_rpc->crp_state = RPC_STATE_INITED;
-			/* RPC got cancelled or timed out before it got here */
-			if (tmp_rpc->crp_timeout_ts == 0) {
-				submit_rpc = false;
-			} else {
-				crt_set_timeout(tmp_rpc);
-
-				D_MUTEX_LOCK(&crt_ctx->cc_mutex);
-				rc = crt_req_timeout_track(tmp_rpc);
-				D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);
-				if (rc != 0)
-					RPC_ERROR(tmp_rpc,
-						  "crt_req_timeout_track failed, rc: %d.\n", rc);
-			}
-
-			/* remove from waitq and add to in-flight queue */
-			d_list_move_tail(&tmp_rpc->crp_epi_link, &epi->epi_req_q);
-			epi->epi_req_wait_num--;
-			D_ASSERT(epi->epi_req_wait_num >= 0);
-			epi->epi_req_num++;
-			D_ASSERT(epi->epi_req_num >= epi->epi_reply_num);
-
-			/* add to submit list if not cancelled or timed out already  */
-			if (submit_rpc) {
-				/* prevent rpc from being released before it is dispatched below */
-				RPC_ADDREF(tmp_rpc);
-
-				D_ASSERTF(d_list_empty(&tmp_rpc->crp_tmp_link_submit),
-					  "already on submit list\n");
-				d_list_add_tail(&tmp_rpc->crp_tmp_link_submit, &submit_list);
-			}
-		}
-		D_MUTEX_UNLOCK(&epi->epi_mutex);
-		crt_rpc_unlock(tmp_rpc);
-		RPC_DECREF(tmp_rpc);
-
+		add_rpc_to_list(tmp_rpc, &submit_list);
 		D_MUTEX_LOCK(&epi->epi_mutex);
 	}
 
 	D_MUTEX_UNLOCK(&epi->epi_mutex);
 
+out:
 	/* re-submit the rpc req */
 	while (
 	    (tmp_rpc = d_list_pop_entry(&submit_list, struct crt_rpc_priv, crp_tmp_link_submit))) {


### PR DESCRIPTION
Add out of quota RPC to timeout list once resubmit them.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
