### PR TITLE
DAOS-17438 chk: per engine based check query result - b26

### DIFF
--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -3376,10 +3377,10 @@ again:
 		}
 	}
 out:
-	chk_cqa_free(cqa);
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
-		 "Leader query check with gen "DF_X64" for %d pools: "DF_RC"\n",
-		 gen, pool_nr, DP_RC(rc));
+		 "Leader query check with gen "DF_X64" for %d pools: "DF_RC"\n", gen,
+		 rc != 0 ? pool_nr : cqa->cqa_count, DP_RC(rc));
+	chk_cqa_free(cqa);
 
 	return rc;
 }


### PR DESCRIPTION
Currently, querying the checker progress for a pool will return per target based result. For large scaled pool, the results may be huge as to overflow related dRPC. Be as some temporary solution, we will merge the per target based result on check engine and only transfer per engine based checker progress to the leader and then to control plane. That will much reduce the query buffer usage. In the future, when we supports arbitrary sized dRPC, then we can reply per target based query results as required.

Test-tag: test_daos_cat_recov_core

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
