### PR TITLE
DAOS-17460 client: Add parallel_direct_writes flag

### DIFF
--- a/src/client/dfuse/ops/open.c
+++ b/src/client/dfuse/ops/open.c
@@ -63,8 +63,10 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		goto err;
 
 	if (ie->ie_dfs->dfc_data_timeout != 0) {
-		if (fi->flags & O_DIRECT)
+		if (fi->flags & O_DIRECT) {
 			fi_out.direct_io = 1;
+			fi_out.parallel_direct_writes = 1;
+		}
 
 		/* If the file is already open or (potentially) in cache then allow any existing
 		 * kernel cache to be used.  If not then use pre-read.
@@ -110,10 +112,13 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		fi_out.direct_io  = 0;
 		fi_out.keep_cache = 0;
 
-		if (fi->flags & O_DIRECT)
+		if (fi->flags & O_DIRECT) {
 			fi_out.direct_io = 1;
+			fi_out.parallel_direct_writes = 1;
+		}
 	} else {
 		fi_out.direct_io = 1;
+		fi_out.parallel_direct_writes = 1;
 	}
 
 	if (ie->ie_dfs->dfc_direct_io_disable)


### PR DESCRIPTION
Try to avoid serialization in dfuse

Features: dfuse

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
