### PR TITLE
ofi: better error handling in libfabric

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -30,4 +30,4 @@ argobots=https://github.com/pmodels/argobots/pull/397/commits/411e5b344642ebc821
 spdk=https://github.com/spdk/spdk/commit/b0aba3fcd5aceceea530a702922153bc75664978.diff,https://github.com/spdk/spdk/commit/445a4c808badbad3942696ecf16fa60e8129a747.diff
 mercury=https://raw.githubusercontent.com/daos-stack/mercury/f3dc286fb40ec1a3a38a2e17c45497bc2aa6290d/na_ucx.patch,https://raw.githubusercontent.com/daos-stack/mercury/48df263212604336b2dbe0430dcab4482eb43437/na_ucx_ep_flush.patch,utils/mrecv_err.patch,utils/0001-enable-diagnostic-counters-without-debug.patch,utils/na_tag_rpc.patch,utils/na_tag_rpc_fix.patch
 pmdk=https://github.com/pmem/pmdk/commit/2abe15ac0b4eed894b6768cd82a3b0a7c4336284.diff
-ofi=https://github.com/ofiwg/libfabric/commit/31d023f097ffde2c5141ea78c30fbb980e98b080.diff,utils/ofi_tcp.patch,utils/ofi_debug_ip.patch,utils/ofi_retry_failure.patch,utils/ofi_tag_rpc.patch,utils/ofi_tag_rpc_fix.patch
+ofi=https://github.com/ofiwg/libfabric/commit/31d023f097ffde2c5141ea78c30fbb980e98b080.diff,utils/ofi_tcp.patch,utils/ofi_debug_ip.patch,utils/ofi_retry_failure.patch,utils/ofi_tag_rpc.patch,utils/ofi_tag_rpc_fix.patch,utils/ofi_error_handling.patch

--- a/utils/ofi_error_handling.patch
+++ b/utils/ofi_error_handling.patch
@@ -1,0 +1,47 @@
+diff --git a/prov/tcp/src/xnet_cm.c b/prov/tcp/src/xnet_cm.c
+index 1ae35d27d..cea78b4bc 100644
+--- a/prov/tcp/src/xnet_cm.c
++++ b/prov/tcp/src/xnet_cm.c
+@@ -63,7 +63,7 @@ xnet_recv_cm_msg(SOCKET sock, struct xnet_cm_msg *msg)
+ 			"Failed to read cm header, ret: %zd, sockerr: %d\n",
+ 			ret, ofi_sockerr());
+ 		msg->hdr.seg_size = 0;
+-		return ofi_sockerr() ? -ofi_sockerr() : -FI_EIO;
++		return ret >= 0 ? -FI_EIO : -ofi_sockerr();
+ 	}
+ 
+ 	return 0;
+@@ -105,7 +105,7 @@ xnet_handle_cm_msg(SOCKET sock, struct xnet_cm_msg *msg, uint8_t exp_msg)
+ 			FI_WARN(&xnet_prov, FI_LOG_EP_CTRL,
+ 				"Failed to read cm data, ret: %zd, sockerr: %d\n",
+ 				ret, ofi_sockerr());
+-			ret = ofi_sockerr() ? -ofi_sockerr() : -FI_EIO;
++			ret = ret >= 0 ? -FI_EIO : -ofi_sockerr();
+ 			goto err;
+ 		}
+ 	}
+diff --git a/src/common.c b/src/common.c
+index 2f619b191..71a9aab75 100644
+--- a/src/common.c
++++ b/src/common.c
+@@ -1417,6 +1417,20 @@ int ofi_bsock_async_done(const struct fi_provider *prov,
+ 	uint8_t ctrl[CMSG_SPACE(sizeof(*serr) * 2)];
+ 	int ret;
+ 
++	int val = 0;
++	socklen_t len = sizeof(val);
++	ret = getsockopt(bsock->sock, SOL_SOCKET, SO_ERROR, &val, &len);
++	if (ret < 0) {
++		FI_WARN(prov, FI_LOG_EP_DATA,
++			"Error reading socket error (%s)\n", strerror(errno));
++		return -errno;
++	}
++	if (val != 0) {
++		FI_WARN(prov, FI_LOG_EP_DATA,
++			"Socket error (%s)\n", strerror(val));
++		return -val;
++	}
++
+ 	msg.msg_control = &ctrl;
+ 	msg.msg_controllen = sizeof(ctrl);
+ 	ret = recvmsg(bsock->sock, &msg, MSG_ERRQUEUE);


### PR DESCRIPTION
This PR merges two commits from upstream 86ae6d745df6f6463a261558dcb62ff0854bc2f6 and b3103f4007408b80b99e736774cfb2cfb68ac4ff for better error handling.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
