### PR TITLE
 DAOS-15947 docs: Update admin guide dmg system command syntax (#16261)

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -1043,7 +1043,8 @@ An examples workflow would be:
 - Storage server is rebooted after running `daos_server scm prepare` and command is run again.
 - Now PMem is intact, clear with `wipefs -a /dev/pmemX` where "X" refers to the repaired PMem ID.
 - `daos_server` can be started again. On start-up repaired engine prompts for "SCM format required".
-- Running `dmg storage format` now will create new "Joined" rank, instead run with `--replace` flag.
+- Run `dmg storage format --replace` to rejoin with existing rank (if --replace isn't used, a new
+  rank will be created).
 - Formatted engine will join using the existing (old) rank which is mapped to the engine's hardware.
 
 ### System Erase

--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -1029,6 +1029,23 @@ DAOS I/O Engines will be started, and all DAOS pools will have been removed.
     Then restart DAOS Servers and format.
 
 
+### Storage Format Replace
+
+If storage metadata for a rank is lost, for example after losing PMem contents after NVDIMM failure,
+storage for that rank will need to be formatted and rank metadata regenerated. If other hardware on
+the storage server has not changed the old rank can be "reused" by formatting using the
+`dmg storage format --replace` option.
+
+An examples workflow would be:
+- `daos_server` is running and PMem NVDIMM fails causing an engine to enter excluded state.
+- `daos_server` is stopped, storage server powered down, faulty PMem NVDIMM is replaced.
+- After powering up storage server, `daos_server scm prepare` command is used to repair PMem.
+- Storage server is rebooted after running `daos_server scm prepare` and command is run again.
+- Now PMem is intact, clear with `wipefs -a /dev/pmemX` where "X" refers to the repaired PMem ID.
+- `daos_server` can be started again. On start-up repaired engine prompts for "SCM format required".
+- Running `dmg storage format` now will create new "Joined" rank, instead run with `--replace` flag.
+- Formatted engine will join using the existing (old) rank which is mapped to the engine's hardware.
+
 ### System Erase
 
 To erase the DAOS sorage configuration, the `dmg system erase`

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -975,12 +975,11 @@ $ dmg pool reintegrate $DAOS_POOL --ranks=5 --target-idx=0,1
 ```
 
 !!! warning
-    While dmg pool query and list show how many targets are disabled for each
-    pool, there is currently no way to list the targets that have actually
-    been disabled. As a result, it is recommended for now to try to reintegrate
-    all engine ranks one after the other via `for i in seq $NR_RANKs; do dmg
-    pool reintegrate --ranks=$i; done`. This limitation will be addressed in the
-    next release.
+    While dmg pool query and list show how many targets are disabled for each pool, there is
+    currently no way to list the targets that have actually been disabled. As a result, it is
+    recommended for now to try to reintegrate all engine ranks reported as disabled in
+    `dmg pool query`. The string output after "Disabled ranks:" in the pool query output can
+    be used as the `--ranks=<disabled_ranks>` option value in `dmg pool reintegrate` command.
 
 #### System Reintegrate
 


### PR DESCRIPTION
Documentation updates relating to:
- New commands dmg system drain|reintegrate
- New command syntax for multiple --ranks dmg pool drain|reintegrate|exclude –ranks 1-9,11-19
- New command flag dmg storage format --replace

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
