### PR TITLE
DAOS-17506 rebuild: delay rebuild should not be regarded as active re…

### DIFF
--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -793,7 +794,8 @@ ds_rebuild_query(uuid_t pool_uuid, struct daos_rebuild_status *status)
 		struct rebuild_task *task;
 
 		d_list_for_each_entry(task, &rebuild_gst.rg_queue_list, dst_list) {
-			if (uuid_compare(task->dst_pool_uuid, pool_uuid) == 0) {
+			if (uuid_compare(task->dst_pool_uuid, pool_uuid) == 0 &&
+			    task->dst_schedule_time != (uint64_t)(-1)) {
 				status->rs_state = DRS_IN_PROGRESS;
 				D_GOTO(out, rc);
 			}


### PR DESCRIPTION
…build

Delay rebuild should not be regarded as active rebuild, so pool query should show rebuild is idle.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
