### PR TITLE
DAOS-17317 control: Quiet misleading server error (#16126)

### DIFF
--- a/src/control/server/mgmt_check.go
+++ b/src/control/server/mgmt_check.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2022-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -51,7 +52,7 @@ func (svc *mgmtSvc) checkerIsEnabled() bool {
 	value, err := system.GetMgmtProperty(svc.sysdb, checkerEnabledKey)
 	if err != nil {
 		if !system.IsNotLeader(err) && !system.IsErrSystemAttrNotFound(err) &&
-			!system.IsNotReplica(err) {
+			!system.IsNotReplica(err) && !errors.Is(err, system.ErrUninitialized) {
 			svc.log.Errorf("failed to get checker enabled value: %s", err)
 		}
 		return false


### PR DESCRIPTION
It's expected that querying the MS properties will
fail before the storage is formatted, so we shouldn't
log it as an error.

Signed-off-by: Michael MacDonald <mjmac@google.com>