### PR TITLE
DAOS-15947 control: Support replace flag with empty tmpfs

### DIFF
--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -828,7 +828,7 @@ func formatScm(ctx context.Context, req formatScmReq, resp *ctlpb.StorageFormatR
 		}
 	}
 
-	if req.replace && len(needFormat) == 0 {
+	if req.replace && len(needFormat) == 0 && len(emptyTmpfs) == 0 {
 		// Only valid if at least one engine requires format.
 		return nil, nil, errors.New("format replace option only valid if at " +
 			"least one engine requires format but no engines need format")

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 // (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -1349,6 +1350,47 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 		"ram already mounted but empty": {
 			scmMounted: true,
 			tmpfsEmpty: true,
+			sMounts:    []string{"/mnt/daos"},
+			sClass:     storage.ClassRam,
+			sSize:      6,
+			bClass:     storage.ClassNvme,
+			bDevs:      [][]string{{mockNvmeController0.PciAddr}},
+			bmbcs: []*bdev.MockBackendConfig{
+				{
+					ScanRes: &storage.BdevScanResponse{
+						Controllers: storage.NvmeControllers{mockNvmeController0},
+					},
+					FormatRes: &storage.BdevFormatResponse{
+						DeviceResponses: storage.BdevDeviceFormatResponses{
+							mockNvmeController0.PciAddr: &storage.BdevDeviceFormatResponse{
+								Formatted: true,
+							},
+						},
+					},
+				},
+			},
+			expResp: &ctlpb.StorageFormatResp{
+				Crets: []*ctlpb.NvmeControllerResult{
+					{
+						PciAddr: mockNvmeController0.PciAddr,
+						State:   new(ctlpb.ResponseState),
+					},
+				},
+				Mrets: []*ctlpb.ScmMountResult{
+					{
+						Mntpoint: "/mnt/daos",
+						State: &ctlpb.ResponseState{
+							Status: ctlpb.ResponseStatus_CTL_SUCCESS,
+							Info:   "SCM is already formatted",
+						},
+					},
+				},
+			},
+		},
+		"ram already mounted but empty and replace set": {
+			scmMounted: true,
+			tmpfsEmpty: true,
+			replace:    true,
 			sMounts:    []string{"/mnt/daos"},
 			sClass:     storage.ClassRam,
 			sSize:      6,


### PR DESCRIPTION
DAOS-14251 added support for premounted but empty tmpfs,
but this scenario was not included in the code which
added the rank replacement feature. Fix the oversight
and add a unit test for the scenario.

Features: control
Change-Id: I90bf79958a953f5954a28541179126feb194d5ed
Signed-off-by: Michael MacDonald <mjmac@google.com>
