### PR TITLE
DAOS-17522 telemetry: Handle negative variance in std_dev

### DIFF
--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -1856,11 +1856,15 @@ double
 d_tm_compute_standard_dev(double sum_of_squares, uint64_t sample_size,
 			  double mean)
 {
+	double variance = sum_of_squares - (sample_size * mean * mean);
+
+	if (variance <= 0)
+		return 0;
+
 	if (sample_size < 2)
 		return 0;
 
-	return sqrtl((sum_of_squares - (sample_size * mean * mean)) /
-		     (sample_size - 1));
+	return sqrtl(variance / (sample_size - 1));
 }
 
 /**


### PR DESCRIPTION
In some scenarios the computed variance may be less than
zero, and therefore the sqrtl() function will return NaN.
Guard against this and return zero instead.

Features: telemetry
Signed-off-by: Michael MacDonald <mjmac@google.com>
