### PR TITLE
DAOS-17308 ddb: command 'smd_sync' support for md-on-ssd mode

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -213,8 +213,9 @@ init_chk_cnt()
 }
 
 int
-bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
-	      unsigned int hugepage_size, unsigned int tgt_nr, bool bypass_health_collect)
+bio_nvme_init_ext(const char *nvme_conf, int numa_node, unsigned int mem_size,
+		  unsigned int hugepage_size, unsigned int tgt_nr, bool bypass_health_collect,
+		  bool init_spdk)
 {
 	char		*env;
 	int		 rc, fd;
@@ -326,6 +327,9 @@ bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
 		bio_numa_node = SPDK_ENV_SOCKET_ID_ANY;
 	}
 
+	if (!init_spdk)
+		return 0;
+
 	nvme_glb.bd_mem_size = mem_size;
 	if (nvme_conf) {
 		D_STRNDUP(nvme_glb.bd_nvme_conf, nvme_conf, strlen(nvme_conf));
@@ -363,6 +367,14 @@ free_mutex:
 	ABT_mutex_free(&nvme_glb.bd_mutex);
 
 	return rc;
+}
+
+int
+bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
+	      unsigned int hugepage_size, unsigned int tgt_nr, bool bypass_health_collect)
+{
+	return bio_nvme_init_ext(nvme_conf, numa_node, mem_size, hugepage_size, tgt_nr,
+				 bypass_health_collect, true);
 }
 
 static void

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2018-2025 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -505,6 +506,23 @@ void bio_register_bulk_ops(int (*bulk_create)(void *ctxt, d_sg_list_t *sgl,
  */
 int bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
 		  unsigned int hugepage_size, unsigned int tgt_nr, bool bypass);
+
+/**
+ * Global NVMe initialization.
+ *
+ * \param[IN] nvme_conf		NVMe config file
+ * \param[IN] numa_node		NUMA node that engine is assigned to
+ * \param[IN] mem_size		SPDK memory alloc size when using primary mode
+ * \param[IN] hugepage_size	Configured hugepage size on system
+ * \paran[IN] tgt_nr		Number of targets
+ * \param[IN] bypass		Set to bypass health data collection
+ * \param[IN] init_spdk		Check if need call bio_spdk_env_init()
+ *
+ * \return		Zero on success, negative value on error
+ */
+int
+     bio_nvme_init_ext(const char *nvme_conf, int numa_node, unsigned int mem_size,
+		       unsigned int hugepage_size, unsigned int tgt_nr, bool bypass, bool init_spdk);
 
 /**
  * Global NVMe finalization.

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -336,7 +336,7 @@ int
 vos_self_init(const char *db_path, bool use_sys_db, int tgt_id);
 
 int
-vos_self_init_ext(const char *db_path, bool use_sys_db, int tgt_id, bool nvme_init);
+vos_self_init_ext(const char *db_path, bool use_sys_db, int tgt_id, bool init_spdk);
 
 /**
  * Finalize the environment for a VOS instance

--- a/src/utils/ddb/ddb_commands.c
+++ b/src/utils/ddb/ddb_commands.c
@@ -713,16 +713,33 @@ done:
 	return rc;
 }
 
+static inline char *
+dev_type2str(enum smd_dev_type st)
+{
+	switch (st) {
+	case SMD_DEV_TYPE_DATA:
+		return "Data";
+	case SMD_DEV_TYPE_META:
+		return "Meta";
+	case SMD_DEV_TYPE_WAL:
+		return "WAL";
+	default:
+		return "Unknown";
+	}
+}
+
 static int
-sync_smd_cb(void *cb_args, uuid_t pool_id, uint32_t vos_id, uint64_t blob_id,
-	    daos_size_t blob_size, uuid_t dev_id)
+sync_smd_cb(void *cb_args, uuid_t pool_id, uint32_t vos_id, uint64_t blob_id, daos_size_t blob_size,
+	    uuid_t dev_id, enum smd_dev_type st)
 {
 	struct ddb_ctx *ctx = cb_args;
 
-	ddb_printf(ctx, "> Sync Info - pool: "DF_UUIDF", target id: %d, blob id: %lu, "
-		   "blob_size: %lu\n", DP_UUID(pool_id),
-		   vos_id, blob_id, blob_size);
-	ddb_printf(ctx, "> Sync Info - dev: "DF_UUIDF", target id: %d\n", DP_UUID(dev_id), vos_id);
+	ddb_printf(ctx,
+		   "> Sync Info - pool: " DF_UUIDF ", target id: %d, \t[%s],\t blob id: %#lx, "
+		   "blob_size: %lu\n",
+		   DP_UUID(pool_id), vos_id, dev_type2str(st), blob_id, blob_size);
+	ddb_printf(ctx, "> Sync Info - dev : " DF_UUIDF ", target id: %d\n", DP_UUID(dev_id),
+		   vos_id);
 
 	return 0;
 }

--- a/src/utils/ddb/ddb_spdk.h
+++ b/src/utils/ddb/ddb_spdk.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -10,8 +11,17 @@
 #include <daos_srv/bio.h>
 
 struct ddbs_sync_info {
-	struct bio_blob_hdr	*dsi_hdr;
+	union {
+		/* SMD_DEV_TYPE_DATA */
+		struct bio_blob_hdr *dsi_hdr;
+		/* SMD_DEV_TYPE_META */
+		struct meta_header  *dsi_meta_hdr;
+		/* SMD_DEV_TYPE_WAL */
+		struct wal_header   *dsi_wal_hdr;
+	};
+	enum smd_dev_type        st;
 	uuid_t			 dsi_dev_id;
+	uint64_t                 dsi_blob_id;
 	uint64_t		 dsi_cluster_size;
 	uint64_t		 dsi_cluster_nr;
 };

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -10,6 +10,7 @@
 #include <gurt/debug.h>
 #include <vos_internal.h>
 #include <daos_srv/smd.h>
+#include <bio_wal.h>
 #include "ddb_common.h"
 #include "ddb_parse.h"
 #include "ddb_vos.h"
@@ -1734,35 +1735,35 @@ struct dv_sync_cb_args {
 	dv_smd_sync_complete	 sync_complete_cb;
 	void			*sync_cb_args;
 	int			 sync_rc;
+	d_list_t                 pool_list;
+	int                      pool_list_cnt;
 };
 
 static void
-sync_cb(struct ddbs_sync_info *info, void *cb_args)
+do_sync_cb(uuid_t pool_id, int tgt_id, uint64_t blob_id, enum smd_dev_type st,
+	   struct smd_pool_info *pool_info, struct ddbs_sync_info *info, void *cb_args)
 {
-	uint8_t			*pool_id = info->dsi_hdr->bbh_pool;
-	struct smd_pool_info	*pool_info = NULL;
+	struct smd_pool_info    *pinfo = NULL;
 	daos_size_t		 blob_size;
-	struct dv_sync_cb_args	*args = cb_args;
-	enum smd_dev_type	 st = SMD_DEV_TYPE_DATA; /* FIXME: support other types? */
+	struct dv_sync_cb_args  *args = cb_args;
 	int			 rc;
 
 	D_ASSERT(args != NULL);
 
-	if (info->dsi_hdr == NULL) {
-		D_ERROR("Got called without the header. Unable to sync.\n");
-		args->sync_rc = -DER_UNKNOWN;
-		return;
-	}
-	rc = smd_dev_add_tgt(info->dsi_dev_id, info->dsi_hdr->bbh_vos_id, st);
+	rc = smd_dev_add_tgt(info->dsi_dev_id, tgt_id, st);
 	smd_dev_set_state(info->dsi_dev_id, SMD_DEV_NORMAL);
 	if (rc == -DER_EXIST)
-		D_INFO("tgt_id(%d) already mapped to dev_id("DF_UUID")",
-		       info->dsi_hdr->bbh_vos_id, info->dsi_dev_id);
+		D_INFO("tgt_id(%d) already mapped to dev_id(" DF_UUID ")", tgt_id,
+		       DP_UUID(info->dsi_dev_id));
 	else if (rc != 0)
-		D_ERROR("Error mapping tgt_id(%d) to dev_id("DF_UUID")",
-			info->dsi_hdr->bbh_vos_id, info->dsi_dev_id);
+		D_ERROR("Error mapping tgt_id(%d) to dev_id(" DF_UUID ")", tgt_id,
+			DP_UUID(info->dsi_dev_id));
 
-	rc = smd_pool_get_info(pool_id, &pool_info);
+	rc = 0;
+	if (pool_info == NULL)
+		rc = smd_pool_get_info(pool_id, &pinfo);
+	else
+		pinfo = pool_info;
 	if (!SUCCESS(rc)) {
 		D_ERROR("Failed to get smd pool info. Going to continue rebuilding smd_pool "
 			"table with spdk cluster size and cluster count: "DF_RC". \n", DP_RC(rc));
@@ -1772,18 +1773,18 @@ sync_cb(struct ddbs_sync_info *info, void *cb_args)
 		 */
 		blob_size = info->dsi_cluster_nr * info->dsi_cluster_size;
 	} else {
-		blob_size = pool_info->spi_blob_sz[st];
-		smd_pool_free_info(pool_info);
+		blob_size = pinfo->spi_blob_sz[st];
+		if (pool_info == NULL)
+			smd_pool_free_info(pinfo);
 	}
 
 	/* Try to delete the target first */
-	rc = smd_pool_del_tgt(pool_id, info->dsi_hdr->bbh_vos_id, st);
+	rc = smd_pool_del_tgt(pool_id, tgt_id, st);
 	if (!SUCCESS(rc))
 		/* Ignore error for now ... might not exist*/
 		D_WARN("delete target failed: " DF_RC "\n", DP_RC(rc));
 
-	rc = smd_pool_add_tgt(pool_id, info->dsi_hdr->bbh_vos_id, info->dsi_hdr->bbh_blob_id, st,
-			      blob_size, 0, false);
+	rc = smd_pool_add_tgt(pool_id, tgt_id, blob_id, st, blob_size, 0, true);
 	if (!SUCCESS(rc)) {
 		D_ERROR("add target failed: "DF_RC"\n", DP_RC(rc));
 		args->sync_rc = rc;
@@ -1791,10 +1792,76 @@ sync_cb(struct ddbs_sync_info *info, void *cb_args)
 	}
 
 	if (args->sync_complete_cb) {
-		rc = args->sync_complete_cb(args->sync_cb_args, pool_id,
-					    info->dsi_hdr->bbh_vos_id,
-					    info->dsi_hdr->bbh_blob_id,
-					    blob_size, info->dsi_dev_id);
+		rc = args->sync_complete_cb(args->sync_cb_args, pool_id, tgt_id, blob_id, blob_size,
+					    info->dsi_dev_id, st);
+	}
+}
+
+static void
+sync_cb_data(struct ddbs_sync_info *info, void *cb_args)
+{
+	do_sync_cb(info->dsi_hdr->bbh_pool, info->dsi_hdr->bbh_vos_id, info->dsi_hdr->bbh_blob_id,
+		   info->st, NULL, info, cb_args);
+}
+
+static void
+sync_cb_meta(struct ddbs_sync_info *info, void *cb_args)
+{
+	struct dv_sync_cb_args *args = cb_args;
+	struct meta_header     *hdr  = info->dsi_meta_hdr;
+
+	if (hdr->mh_version == 1) {
+		/* For Phase 1, No pool id in meta blob. get from Data Blob */
+		D_ERROR("unsupported old meta header.\n");
+		args->sync_rc = -DER_NOTSUPPORTED;
+		return;
+	}
+
+	D_ASSERT(hdr->mh_meta_blobid == info->dsi_blob_id);
+
+	/* Sync Meta Blob */
+	do_sync_cb(hdr->mh_pool_id, hdr->mh_vos_id, hdr->mh_meta_blobid, SMD_DEV_TYPE_META, NULL,
+		   info, cb_args);
+
+	return;
+}
+
+static void
+sync_cb_wal(struct ddbs_sync_info *info, void *cb_args)
+{
+	struct dv_sync_cb_args *args = cb_args;
+	struct wal_header      *hdr  = info->dsi_wal_hdr;
+
+	if (hdr->wh_version == 1) {
+		/* For Phase 1, No pool id in meta blob. get from Data Blob */
+		D_ERROR("unsupported old wal header.\n");
+		args->sync_rc = -DER_NOTSUPPORTED;
+		return;
+	}
+
+	/* Sync Wal Blob */
+	do_sync_cb(hdr->wh_pool_id, hdr->wh_vos_id, info->dsi_blob_id, SMD_DEV_TYPE_WAL, NULL, info,
+		   cb_args);
+
+	return;
+}
+
+static void
+sync_cb(struct ddbs_sync_info *info, void *cb_args)
+{
+	switch (info->st) {
+	case SMD_DEV_TYPE_DATA:
+		sync_cb_data(info, cb_args);
+		break;
+	case SMD_DEV_TYPE_META:
+		sync_cb_meta(info, cb_args);
+		break;
+	case SMD_DEV_TYPE_WAL:
+		sync_cb_wal(info, cb_args);
+		break;
+	default:
+		D_ERROR("unexpected smd_dev_type %d\n", info->st);
+		break;
 	}
 }
 
@@ -1805,7 +1872,7 @@ dv_sync_smd(const char *nvme_conf, const char *db_path, dv_smd_sync_complete com
 	struct dv_sync_cb_args	 sync_cb_args = {0};
 	int			 rc;
 
-	/* don't initialize NVMe within VOS. Will happen in ddb_spdk module */
+	/* don't initialize NVMe(spdk) within VOS. Will happen in ddb_spdk module */
 	rc = vos_self_init_ext(db_path, true, 0, false);
 
 	if (!SUCCESS(rc)) {

--- a/src/utils/ddb/ddb_vos.h
+++ b/src/utils/ddb/ddb_vos.h
@@ -196,7 +196,8 @@ dv_dtx_active_entry_discard_invalid(daos_handle_t coh, struct dtx_id *dti, int *
 
 /* Sync the smd table with information saved in blobs */
 typedef int (*dv_smd_sync_complete)(void *cb_args, uuid_t pool_id, uint32_t vos_id,
-				    uint64_t blob_id, daos_size_t blob_size, uuid_t dev_id);
+				    uint64_t blob_id, daos_size_t blob_size, uuid_t dev_id,
+				    enum smd_dev_type st);
 int dv_sync_smd(const char *nvme_conf, const char *db_path, dv_smd_sync_complete complete_cb,
 		void *cb_args);
 

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -954,7 +954,7 @@ vos_self_nvme_fini(void)
 #define VOS_NVME_NR_TARGET	1
 
 static int
-vos_self_nvme_init(const char *vos_path)
+vos_self_nvme_init(const char *vos_path, bool init_spdk)
 {
 	char	*nvme_conf;
 	int	 rc, fd;
@@ -980,12 +980,11 @@ vos_self_nvme_init(const char *vos_path)
 	/* Only use hugepages if NVME SSD configuration existed. */
 	fd = open(nvme_conf, O_RDONLY, 0600);
 	if (fd < 0) {
-		rc = bio_nvme_init(NULL, VOS_NVME_NUMA_NODE, 0, 0,
-				   VOS_NVME_NR_TARGET, true);
+		rc = bio_nvme_init_ext(NULL, VOS_NVME_NUMA_NODE, 0, 0, VOS_NVME_NR_TARGET, true,
+				       init_spdk);
 	} else {
-		rc = bio_nvme_init(nvme_conf, VOS_NVME_NUMA_NODE,
-				   VOS_NVME_MEM_SIZE, VOS_NVME_HUGEPAGE_SIZE,
-				   VOS_NVME_NR_TARGET, true);
+		rc = bio_nvme_init_ext(nvme_conf, VOS_NVME_NUMA_NODE, VOS_NVME_MEM_SIZE,
+				       VOS_NVME_HUGEPAGE_SIZE, VOS_NVME_NR_TARGET, true, init_spdk);
 		close(fd);
 	}
 
@@ -1034,7 +1033,7 @@ vos_self_fini(void)
 #define LMMDB_PATH	"/var/daos/"
 
 int
-vos_self_init_ext(const char *db_path, bool use_sys_db, int tgt_id, bool nvme_init)
+vos_self_init_ext(const char *db_path, bool use_sys_db, int tgt_id, bool init_spdk)
 {
 	char		*evt_mode;
 	int		 rc = 0;
@@ -1059,11 +1058,9 @@ vos_self_init_ext(const char *db_path, bool use_sys_db, int tgt_id, bool nvme_in
 		goto out;
 	}
 #endif
-	if (nvme_init) {
-		rc = vos_self_nvme_init(db_path);
-		if (rc)
-			goto failed;
-	}
+	rc = vos_self_nvme_init(db_path, init_spdk);
+	if (rc)
+		goto failed;
 
 	rc = vos_mod_init();
 	if (rc)


### PR DESCRIPTION
 Make sure smd_sync can slove data/meta/wal blobs.
Signed-off-by: Wang Yunpeng <ywang@panasas.com>

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
