### PR TITLE
DAOS-17438 chk: per pool based check query result - b26

### DIFF
--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -117,9 +118,13 @@ CRT_RPC_DECLARE(chk_stop, DAOS_ISEQ_CHK_STOP, DAOS_OSEQ_CHK_STOP);
  * CHK_QUERY:
  * From check leader to check engine to query the check process for specified pools(s) or all pools.
  */
+/* clang-format off */
 #define DAOS_ISEQ_CHK_QUERY							\
 	((uint64_t)		(cqi_gen)		CRT_VAR)		\
+	((uint32_t)		(cqi_flags)		CRT_VAR)		\
+	((uint32_t)		(cqi_padding)		CRT_VAR)		\
 	((uuid_t)		(cqi_uuids)		CRT_ARRAY)
+/* clang-format on */
 
 #define DAOS_OSEQ_CHK_QUERY							\
 	((int32_t)			(cqo_status)		CRT_VAR)	\
@@ -757,9 +762,11 @@ int chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
 
 int chk_engine_stop(uint64_t gen, int pool_nr, uuid_t pools[], uint32_t *flags);
 
-int chk_engine_query(uint64_t gen, int pool_nr, uuid_t pools[], uint32_t *ins_status,
-		     uint32_t *ins_phase, uint32_t *shard_nr, struct chk_query_pool_shard **shards,
-		     uint64_t *l_gen);
+/* clang-format off */
+int chk_engine_query(uint64_t gen, uint32_t flags, int pool_nr, uuid_t pools[],
+		     uint32_t *ins_status, uint32_t *ins_phase, uint32_t *shard_nr,
+		     struct chk_query_pool_shard **shards, uint64_t *l_gen);
+/* clang-format on */
 
 int chk_engine_mark_rank_dead(uint64_t gen, d_rank_t rank, uint32_t version);
 
@@ -820,8 +827,10 @@ int chk_start_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t rank_nr, d
 int chk_stop_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t pools[],
 		    chk_co_rpc_cb_t stop_cb, void *args);
 
-int chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t pools[],
-		     chk_co_rpc_cb_t query_cb, void *args);
+/* clang-format off */
+int chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t flags, int pool_nr,
+		     uuid_t pools[], chk_co_rpc_cb_t query_cb, void *args);
+/* clang-format on */
 
 int chk_mark_remote(d_rank_list_t *rank_list, uint64_t gen, d_rank_t rank, uint32_t version);
 

--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -639,8 +640,8 @@ out:
 }
 
 int
-chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t pools[],
-		 chk_co_rpc_cb_t query_cb, void *args)
+chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t flags, int pool_nr,
+		 uuid_t pools[], chk_co_rpc_cb_t query_cb, void *args)
 {
 	struct chk_co_rpc_cb_args	 cb_args = { 0 };
 	crt_rpc_t			*req = NULL;
@@ -652,9 +653,10 @@ chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t poo
 	if (rc != 0)
 		goto out;
 
-	cqi = crt_req_get(req);
-	cqi->cqi_gen = gen;
-	cqi->cqi_uuids.ca_count = pool_nr;
+	cqi                      = crt_req_get(req);
+	cqi->cqi_gen             = gen;
+	cqi->cqi_flags           = flags;
+	cqi->cqi_uuids.ca_count  = pool_nr;
 	cqi->cqi_uuids.ca_arrays = pools;
 
 	rc = dss_rpc_send(req);
@@ -685,8 +687,8 @@ out:
 	}
 
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
-		 "Rank %u query DAOS check with gen "DF_X64", pool_nr %d: "DF_RC"\n",
-		 dss_self_rank(), gen, pool_nr, DP_RC(rc));
+		 "Rank %u query DAOS check with gen " DF_X64 ", pool_nr %d, flags %x: " DF_RC "\n",
+		 dss_self_rank(), gen, pool_nr, flags, DP_RC(rc));
 
 	return rc;
 }

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -100,9 +101,9 @@ ds_chk_query_hdlr(crt_rpc_t *rpc)
 	uint32_t			 shard_nr = 0;
 	int				 rc;
 
-	rc = chk_engine_query(cqi->cqi_gen, cqi->cqi_uuids.ca_count, cqi->cqi_uuids.ca_arrays,
-			      &cqo->cqo_ins_status, &cqo->cqo_ins_phase, &shard_nr, &shards,
-			      &cqo->cqo_gen);
+	rc = chk_engine_query(cqi->cqi_gen, cqi->cqi_flags, cqi->cqi_uuids.ca_count,
+			      cqi->cqi_uuids.ca_arrays, &cqo->cqo_ins_status, &cqo->cqo_ins_phase,
+			      &shard_nr, &shards, &cqo->cqo_gen);
 	if (rc != 0) {
 		cqo->cqo_status = rc;
 		cqo->cqo_cap = 0;

--- a/src/include/daos_srv/daos_chk.h
+++ b/src/include/daos_srv/daos_chk.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -9,6 +10,10 @@
 
 #include <daos_prop.h>
 #include <daos_types.h>
+
+enum chk_query_flags {
+	CQF_SHOW_DETAIL = (1 << 0),
+};
 
 struct chk_policy {
 	uint32_t		cp_class;
@@ -79,8 +84,10 @@ int chk_leader_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
 
 int chk_leader_stop(int pool_nr, uuid_t pools[]);
 
-int chk_leader_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+/* clang-format off */
+int chk_leader_query(uint32_t flags, int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 		     chk_query_pool_cb_t pool_cb, void *buf);
+/* clang-format on */
 
 int chk_leader_prop(chk_prop_cb_t prop_cb, void *buf);
 

--- a/src/mgmt/srv_chk.c
+++ b/src/mgmt/srv_chk.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -94,7 +95,7 @@ ds_mgmt_check_stop(int32_t pool_nr, char **pools)
 }
 
 int
-ds_mgmt_check_query(int32_t pool_nr, char **pools, chk_query_head_cb_t head_cb,
+ds_mgmt_check_query(uint32_t flags, int32_t pool_nr, char **pools, chk_query_head_cb_t head_cb,
 		    chk_query_pool_cb_t pool_cb, void *buf)
 {
 	uuid_t	*uuids = NULL;
@@ -102,7 +103,7 @@ ds_mgmt_check_query(int32_t pool_nr, char **pools, chk_query_head_cb_t head_cb,
 
 	rc = ds_mgmt_chk_parse_uuid(pool_nr, pools, &uuids);
 	if (rc == 0) {
-		rc = chk_leader_query(pool_nr, uuids, head_cb, pool_cb, buf);
+		rc = chk_leader_query(flags, pool_nr, uuids, head_cb, pool_cb, buf);
 		D_FREE(uuids);
 	}
 

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -2762,11 +2762,14 @@ ds_chk_query_pool_cb(struct chk_query_pool_shard *shard, uint32_t idx, void *buf
 	if (pool->time == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
+	pool->n_targets = shard->cqps_target_nr;
+	if (pool->n_targets == 0)
+		goto out;
+
 	D_ALLOC_ARRAY(pool->targets, shard->cqps_target_nr);
 	if (pool->targets == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	pool->n_targets = shard->cqps_target_nr;
 	for (i = 0; i < shard->cqps_target_nr; i++) {
 		D_ALLOC_PTR(target);
 		if (target == NULL)
@@ -2833,15 +2836,19 @@ ds_mgmt_drpc_check_query(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 		return;
 	}
 
-	D_INFO("Received request to query check\n");
+	D_INFO("Received request to query check %s shallow\n", req->shallow ? "with" : "without");
 
-	rc = ds_mgmt_check_query(req->n_uuids, req->uuids, ds_chk_query_head_cb,
-				 ds_chk_query_pool_cb, &resp);
+	rc = ds_mgmt_check_query(req->shallow ? CQF_SHOW_DETAIL : 0, req->n_uuids, req->uuids,
+				 ds_chk_query_head_cb, ds_chk_query_pool_cb, &resp);
 	if (rc != 0)
 		D_ERROR("Failed to query check: "DF_RC"\n", DP_RC(rc));
 
 	resp.req_status = rc;
 	len = mgmt__check_query_resp__get_packed_size(&resp);
+	if (unlikely(len >= (1 << 20)))
+		D_WARN("Too large CHK query reply buffer (%ld) for %ld pools (%s shallow)\n", len,
+		       resp.n_pools, req->shallow ? "with" : "without");
+
 	D_ALLOC(body, len);
 	if (body == NULL) {
 		D_ERROR("Failed to allocate response body (query check)\n");

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -132,8 +132,10 @@ int ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
 			Mgmt__CheckInconsistPolicy **policies, int pool_nr, char **pools,
 			uint32_t flags, int phase);
 int ds_mgmt_check_stop(int pool_nr, char **pools);
-int ds_mgmt_check_query(int pool_nr, char **pools, chk_query_head_cb_t head_cb,
+/* clang-format off */
+int ds_mgmt_check_query(uint32_t flags, int pool_nr, char **pools, chk_query_head_cb_t head_cb,
 			chk_query_pool_cb_t pool_cb, void *buf);
+/* clang-format on */
 int ds_mgmt_check_prop(chk_prop_cb_t prop_cb, void *buf);
 int ds_mgmt_check_act(uint64_t seq, uint32_t act, bool for_all);
 bool ds_mgmt_check_enabled(void);

--- a/src/mgmt/tests/mocks.c
+++ b/src/mgmt/tests/mocks.c
@@ -639,7 +639,7 @@ ds_mgmt_check_stop(int pool_nr, char **pools)
 }
 
 int
-ds_mgmt_check_query(int pool_nr, char **pools, chk_query_head_cb_t head_cb,
+ds_mgmt_check_query(uint32_t flags, int pool_nr, char **pools, chk_query_head_cb_t head_cb,
 		    chk_query_pool_cb_t pool_cb, void *buf)
 {
 	return 0;


### PR DESCRIPTION
Currently, querying the checker progress for a pool will return per target based result. For large scaled pool, the results may be huge as to overflow related dRPC. Be as some temporary solution, we will merge the per target based result on check engine and only transfer per engine based checker progress to the leader and then the leader will further merge them into per pool based result, then to control plane. That will much reduce the query buffer usage. In the future, when we supports arbitrary sized dRPC, then we can reply per target based query results as required.

Above merge behavior is controlled by Mgmt__CheckQueryReq::shallow. If it is not set (by default), then merge query results; otherwise, return detailed per target based query results to control plane.

Test-tag: test_daos_cat_recov_core

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
