### PR TITLE
DAOS-17531 object: Fix pl_map ref leak in EC agg

### DIFF
--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1,5 +1,7 @@
 /**
  * (C) Copyright 2020-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2458,6 +2460,9 @@ ec_agg_object(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *ag
 			  &agg_entry->ae_obj_layout);
 
 out:
+	if (map != NULL)
+		pl_map_decref(map);
+
 	return rc;
 }
 

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -350,6 +351,7 @@ pl_hop_rec_addref(struct d_hash_table *htab, d_list_t *link)
 
 	D_SPIN_LOCK(&map->pl_lock);
 	map->pl_ref++;
+	D_ASSERTF(map->pl_ref > 0, "refct overflow: %d\n", map->pl_ref);
 	D_SPIN_UNLOCK(&map->pl_lock);
 }
 


### PR DESCRIPTION
Call pl_map_decref() after pl_map_find() in order
to avoid a weird assertion on a long-running system.

Change-Id: Ia2a735856b14abede3ddf1b4cdd7a30cc0e9b1c2
Signed-off-by: Michael MacDonald <mjmac@google.com>
