### PR TITLE
DAOS-17534 dtx: not batched commit for container in stopping

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1687,7 +1687,7 @@ out:
 	if (rc < 0) {
 		D_ERROR(DF_UUID": Fail to flush CoS cache: rc = %d\n",
 			DP_UUID(cont->sc_uuid), rc);
-		if (likely(!dtx_cont_opened(cont))) {
+		if (likely(!dtx_cont_opened(cont)) && !dbca->dbca_deregister) {
 			d_list_del(&dbca->dbca_sys_link);
 			/* Give it to the batched commit for further handling asynchronously. */
 			d_list_add_tail(&dbca->dbca_sys_link, &dmi->dmi_dtx_batched_cont_open_list);
@@ -1923,6 +1923,9 @@ dtx_cont_open(struct ds_cont_child *cont)
 
 		d_list_for_each_entry(dbca, &dbpa->dbpa_cont_list, dbca_pool_link) {
 			if (dbca->dbca_cont == cont) {
+				if (unlikely(dbca->dbca_deregister))
+					return -DER_SHUTDOWN;
+
 				rc = start_dtx_reindex_ult(cont);
 				if (rc != 0)
 					return rc;


### PR DESCRIPTION
If the container is in stopping process, we need to stop related DTX batched commit and aggregation ASAP, do not trigger more DTX related tasks for such container.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
