### PR TITLE
DAOS-17351 pool: load pool handles to IV cache

### DIFF
--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -142,6 +143,24 @@ struct pool_iv_entry {
 	};
 };
 
+static inline size_t
+pool_iv_conn_size(size_t cred_size)
+{
+	return sizeof(struct pool_iv_conn) + cred_size;
+}
+
+static inline struct pool_iv_conn *
+pool_iv_conn_next(struct pool_iv_conn *conn)
+{
+	return (struct pool_iv_conn *)((char *)conn + pool_iv_conn_size(conn->pic_cred_size));
+}
+
+static inline size_t
+pool_iv_conn_ent_size(size_t cred_size)
+{
+	return sizeof(struct pool_iv_entry) + pool_iv_conn_size(cred_size);
+}
+
 struct pool_map_refresh_ult_arg {
 	uint32_t	iua_pool_version;
 	uuid_t		iua_pool_uuid;
@@ -265,6 +284,9 @@ void ds_pool_map_refresh_ult(void *arg);
 int ds_pool_iv_conn_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid,
 			       uint64_t flags, uint64_t capas, d_iov_t *cred,
 			       uint32_t global_ver, uint32_t obj_layout_ver);
+
+int
+      ds_pool_iv_conn_hdls_update(struct ds_pool *pool, struct pool_iv_conns *conns);
 
 int ds_pool_iv_srv_hdl_update(struct ds_pool *pool, uuid_t pool_hdl_uuid,
 			      uuid_t cont_hdl_uuid);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1933,19 +1933,84 @@ out:
 	return rc;
 }
 
+struct add_conn_arg {
+	uint32_t              obj_ver;
+	uint32_t              global_ver;
+	struct pool_iv_conns *iv_hdls;
+};
+
+static int
+add_conn_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
+{
+	struct add_conn_arg  *arg      = varg;
+	struct pool_iv_conns *iv_conns = arg->iv_hdls;
+	struct pool_hdl      *hdl      = val->iov_buf;
+	struct pool_iv_conn  *conn;
+
+	if (key->iov_len != sizeof(uuid_t)) {
+		D_WARN("skip invalid key size: " DF_U64 "\n", key->iov_len);
+		return 0;
+	}
+
+	if (val->iov_len != sizeof(struct pool_hdl) + hdl->ph_cred_len) {
+		D_INFO("skip value size: " DF_U64 " for old pool version or invalid handle\n",
+		       val->iov_len);
+		return 0;
+	}
+
+	if (iv_conns == NULL ||
+	    iv_conns->pic_buf_size < iv_conns->pic_size + pool_iv_conn_size(hdl->ph_cred_len)) {
+		unsigned int          new_size;
+		unsigned int          curr_size;
+		struct pool_iv_conns *new_conns;
+
+		curr_size =
+		    iv_conns ? iv_conns->pic_buf_size + sizeof(*iv_conns) : sizeof(*iv_conns);
+		new_size = curr_size + 32 * pool_iv_conn_size(hdl->ph_cred_len);
+
+		if (iv_conns != NULL)
+			D_REALLOC(new_conns, iv_conns, curr_size, new_size);
+		else
+			D_ALLOC(new_conns, new_size);
+
+		if (new_conns == NULL)
+			return -DER_NOMEM;
+
+		arg->iv_hdls           = new_conns;
+		iv_conns               = new_conns;
+		iv_conns->pic_buf_size = new_size - sizeof(*iv_conns);
+	}
+
+	conn = (struct pool_iv_conn *)((char *)iv_conns->pic_conns + iv_conns->pic_size);
+
+	uuid_copy(conn->pic_hdl, key->iov_buf);
+	conn->pic_flags     = hdl->ph_flags;
+	conn->pic_capas     = hdl->ph_sec_capas;
+	conn->pic_cred_size = hdl->ph_cred_len;
+	memcpy(&conn->pic_creds[0], &hdl->ph_cred[0], hdl->ph_cred_len);
+	conn->pic_global_ver = arg->global_ver;
+	conn->pic_obj_ver    = arg->obj_ver;
+	iv_conns->pic_size += pool_iv_conn_size(hdl->ph_cred_len);
+
+	D_INFO("load handle " DF_UUID "\n", DP_UUID(conn->pic_hdl));
+	return 0;
+}
+
 /*
- * Read the DB for map_buf, map_version, and prop. If the return value is 0,
+ * Read the DB for map_buf, map_version, prop and iv_hdls. If the return value is 0,
  * the caller is responsible for freeing *map_buf_out and *prop_out eventually.
  */
 static int
 read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
-			uint32_t *map_version_out, daos_prop_t **prop_out)
+			uint32_t *map_version_out, daos_prop_t **prop_out,
+			struct pool_iv_conns **iv_hdls)
 {
 	struct rdb_tx		tx;
 	d_iov_t			value;
 	struct pool_buf	       *map_buf;
-	struct daos_prop_entry *svc_rf_entry;
+	struct daos_prop_entry *prop_entry;
 	daos_prop_t	       *prop = NULL;
+	struct add_conn_arg     arg  = {0};
 	uint32_t                map_version;
 	int                     rc;
 
@@ -1966,16 +2031,27 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to read pool properties: "DF_RC"\n",
 			DP_UUID(svc->ps_uuid), DP_RC(rc));
-		daos_prop_free(prop);
-		goto out_map_buf;
+		goto out_free;
 	}
 
-	svc_rf_entry = daos_prop_entry_get(prop, DAOS_PROP_PO_SVC_REDUN_FAC);
-	D_ASSERT(svc_rf_entry != NULL);
-	if (daos_prop_is_set(svc_rf_entry))
-		svc->ps_svc_rf = svc_rf_entry->dpe_val;
+	prop_entry = daos_prop_entry_get(prop, DAOS_PROP_PO_SVC_REDUN_FAC);
+	D_ASSERT(prop_entry != NULL);
+	if (daos_prop_is_set(prop_entry))
+		svc->ps_svc_rf = prop_entry->dpe_val;
 	else
 		svc->ps_svc_rf = -1;
+
+	prop_entry = daos_prop_entry_get(prop, DAOS_PROP_PO_OBJ_VERSION);
+	D_ASSERT(prop_entry != NULL);
+	arg.obj_ver    = prop_entry->dpe_val;
+	arg.global_ver = svc->ps_global_version;
+	arg.iv_hdls    = NULL;
+	rc = rdb_tx_iterate(&tx, &svc->ps_handles, false /* backward */, add_conn_cb, &arg);
+	if (rc != 0) {
+		DL_ERROR(rc, "Failed to find hdls for evict pool " DF_UUIDF " connections.\n",
+			 DP_UUID(svc->ps_uuid));
+		D_GOTO(out_free, rc);
+	}
 
 	if (svc->ps_global_version >= DAOS_POOL_GLOBAL_VERSION_WITH_SVC_OPS_KVS) {
 		uint64_t rdb_size;
@@ -1984,7 +2060,7 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 		/* Check if duplicate operations detection is enabled, for informative debug log */
 		rc = rdb_get_size(svc->ps_rsvc.s_db, &rdb_size);
 		if (rc != 0)
-			goto out_lock;
+			goto out_free;
 		rdb_size_ok = (rdb_size >= DUP_OP_MIN_RDB_SIZE);
 
 		d_iov_set(&value, &svc->ps_ops_enabled, sizeof(svc->ps_ops_enabled));
@@ -1992,7 +2068,7 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 		if (rc != 0) {
 			D_ERROR(DF_UUID ": failed to lookup svc_ops_enabled: " DF_RC "\n",
 				DP_UUID(svc->ps_uuid), DP_RC(rc));
-			goto out_lock;
+			goto out_free;
 		}
 
 		d_iov_set(&value, &svc->ps_ops_age, sizeof(svc->ps_ops_age));
@@ -2000,7 +2076,7 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 		if (rc != 0) {
 			DL_ERROR(rc, DF_UUID ": failed to lookup svc_ops_age",
 				 DP_UUID(svc->ps_uuid));
-			goto out_lock;
+			goto out_free;
 		}
 
 		d_iov_set(&value, &svc->ps_ops_max, sizeof(svc->ps_ops_max));
@@ -2008,7 +2084,7 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 		if (rc != 0) {
 			DL_ERROR(rc, DF_UUID ": failed to lookup svc_ops_max",
 				 DP_UUID(svc->ps_uuid));
-			goto out_lock;
+			goto out_free;
 		}
 
 		D_DEBUG(DB_MD,
@@ -2024,15 +2100,21 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 		D_DEBUG(DB_MD, DF_UUID ": duplicate ops detection unavailable\n",
 			DP_UUID(svc->ps_uuid));
 	}
-
 	D_ASSERTF(rc == 0, DF_RC"\n", DP_RC(rc));
+	*iv_hdls         = arg.iv_hdls;
 	*map_buf_out = map_buf;
 	*map_version_out = map_version;
 	*prop_out = prop;
 
-out_map_buf:
-	if (rc != 0)
-		D_FREE(map_buf);
+out_free:
+	if (rc != 0) {
+		if (map_buf != NULL)
+			D_FREE(map_buf);
+		if (prop != NULL)
+			daos_prop_free(prop);
+		if (arg.iv_hdls != NULL)
+			D_FREE(arg.iv_hdls);
+	}
 out_lock:
 	ABT_rwlock_unlock(svc->ps_lock);
 	rdb_tx_end(&tx);
@@ -2267,6 +2349,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	uuid_t			pool_hdl_uuid;
 	uuid_t			cont_hdl_uuid;
 	daos_prop_t	       *prop = NULL;
+	struct pool_iv_conns   *iv_hdls            = NULL;
 	bool			cont_svc_up = false;
 	bool			events_initialized = false;
 	d_rank_t		rank = dss_self_rank();
@@ -2288,7 +2371,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	if (!primary_group_initialized())
 		return -DER_GRPVER;
 
-	rc = read_db_for_stepping_up(svc, &map_buf, &map_version, &prop);
+	rc = read_db_for_stepping_up(svc, &map_buf, &map_version, &prop, &iv_hdls);
 	if (rc != 0)
 		goto out;
 
@@ -2363,6 +2446,16 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 		goto out;
 	}
 
+	if (iv_hdls != NULL) {
+		rc = ds_pool_iv_conn_hdls_update(svc->ps_pool, iv_hdls);
+		if (rc != 0) {
+			DL_ERROR(rc, DF_UUID ": ds_pool_iv_conn_hdls_update failed",
+				 DP_UUID(svc->ps_uuid));
+			goto out;
+		}
+		D_INFO(DF_UUID ": distribute existing hdls\n", DP_UUID(svc->ps_uuid));
+	}
+
 	/* resume pool upgrade if needed */
 	rc = ds_pool_upgrade_if_needed(svc->ps_uuid, NULL, svc, NULL);
 	if (rc != 0)
@@ -2396,6 +2489,9 @@ out:
 		D_FREE(map_buf);
 	if (prop != NULL)
 		daos_prop_free(prop);
+	if (iv_hdls != NULL)
+		D_FREE(iv_hdls);
+
 	if (svc->ps_error != 0) {
 		/*
 		 * Step up with the error anyway, so that RPCs to the PS

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2048,7 +2048,7 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 	arg.iv_hdls    = NULL;
 	rc = rdb_tx_iterate(&tx, &svc->ps_handles, false /* backward */, add_conn_cb, &arg);
 	if (rc != 0) {
-		DL_ERROR(rc, "Failed to find hdls for evict pool " DF_UUIDF " connections.\n",
+		DL_ERROR(rc, "Failed to find hdls for evict pool " DF_UUIDF " connections.",
 			 DP_UUID(svc->ps_uuid));
 		D_GOTO(out_free, rc);
 	}

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2025 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -1706,8 +1707,8 @@ out:
 	if (rc != 0)
 		D_FREE(hdl);
 
-	D_DEBUG(DB_MD, DF_UUID": connect "DF_RC"\n",
-		DP_UUID(pool->sp_uuid), DP_RC(rc));
+	D_DEBUG(DB_MD, DF_UUID ": connect " DF_UUID " " DF_RC "\n", DP_UUID(pool->sp_uuid),
+		DP_UUID(pic->pic_hdl), DP_RC(rc));
 	return rc;
 }
 


### PR DESCRIPTION
Pool handles should be loaded to IV cache in step up callback, in case all pool svc handles are restarted.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
