### PR TITLE
DAOS-17541 control: Reduce minimum Go toolchain version

### DIFF
--- a/src/control/go.mod
+++ b/src/control/go.mod
@@ -5,7 +5,7 @@ module github.com/daos-stack/daos/src/control
 // - debian packaging version checks: debian/control
 // Scons uses this file to extract the minimum version.
 go 1.21
-toolchain go1.23.7
+toolchain go1.23.0
 
 require (
 	github.com/Jille/raft-grpc-transport v1.2.0


### PR DESCRIPTION
The version of the Go toolchain in go.mod serves as a minimum. One of our dependencies requires 1.23--it does not matter which version of 1.23.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
