### PR TITLE
DAOS-17496 client: Avoid premature inode invalidation

### DIFF
--- a/src/client/dfuse/inval.c
+++ b/src/client/dfuse/inval.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -74,7 +75,7 @@
 /* Grace period before invalidating directories or non-directories.  Needs to be long enough so that
  * entries in the working set are not invalidated but short enough to be meaningful.
  */
-#define INVAL_DIRECTORY_GRACE (60 * 30)
+#define INVAL_DIRECTORY_GRACE (60 * 60 * 24 * 365 * 20) /* 20 years to avoid getcwd failures */
 #define INVAL_FILE_GRACE      2
 
 /* Represents one timeout value (time).  Maintains a ordered list of dentries that are using


### PR DESCRIPTION
The kernel doesn't release directory inodes aggresively so dfuse added a 30 minute timeout to release them but it can cause getcwd to fail.  Set the timeout to a ridiculous number. If there is memory pressure, the kernel will tell dfuse to forget them.

Change-Id: I22559f7caa54e9d6312e5c4800ee1be618a4b9e1

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
