### PR TITLE
DAOS-17148 common: disable BTR_FEAT_SKIP_LEAF_REBAL

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -2820,17 +2820,6 @@ btr_node_del_leaf(struct btr_context *tcx,
 		if (rc != 0)
 			return rc;
 
-		if (tcx->tc_feats & BTR_FEAT_SKIP_LEAF_REBAL) {
-			struct btr_node	*nd;
-
-			nd = btr_off2ptr(tcx, cur_tr->tr_node);
-			/* Current leaf node become empty,
-			 * will be removed from parent node.
-			 */
-			if (nd->tn_keyn == 0)
-				return 0;
-		}
-
 		return 1;
 	}
 
@@ -3147,13 +3136,12 @@ btr_node_del_rec(struct btr_context *tcx, struct btr_trace *par_tr,
 		is_leaf ? "record" : "child", is_leaf ? "leaf" : "non-leaf",
 		cur_nd->tn_keyn);
 
-	if (cur_nd->tn_keyn > 1 ||
-	    (is_leaf && tcx->tc_feats & BTR_FEAT_SKIP_LEAF_REBAL)) {
+	if (cur_nd->tn_keyn > 1) {
 		/* OK to delete record without doing any extra work */
 		D_DEBUG(DB_TRACE, "Straight away deletion, no rebalance.\n");
-		sib_off	= BTR_NODE_NULL;
+		sib_off      = BTR_NODE_NULL;
 		sib_on_right = false; /* whatever... */
-	} else { /* needs to rebalance or merge nodes */
+	} else {                      /* needs to rebalance or merge nodes */
 		D_DEBUG(DB_TRACE, "Parent trace at=%d, key_nr=%d\n",
 			par_tr->tr_at, par_nd->tn_keyn);
 
@@ -4518,9 +4506,6 @@ btr_class_init(umem_off_t root_off, struct btr_root *root,
 
 	if (tc->tc_feats & BTR_FEAT_DYNAMIC_ROOT)
 		*tree_feats |= BTR_FEAT_DYNAMIC_ROOT;
-
-	if (tc->tc_feats & BTR_FEAT_SKIP_LEAF_REBAL)
-		*tree_feats |= BTR_FEAT_SKIP_LEAF_REBAL;
 
 	if ((*tree_feats & (BTR_FEAT_UINT_KEY | BTR_FEAT_EMBED_FIRST)) ==
 	    (BTR_FEAT_UINT_KEY | BTR_FEAT_EMBED_FIRST)) {

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -487,7 +488,7 @@ enum btr_feats {
 	 *  tree class
 	 */
 	BTR_FEAT_DYNAMIC_ROOT = (1 << 2),
-	/** Skip rebalance leaf when delete some record from the leaf. */
+	/** Skip rebalance leaf when delete some record from the leaf. Obsolete, DAOS-17148. */
 	BTR_FEAT_SKIP_LEAF_REBAL = (1 << 3),
 	/** Tree supports embedded root. */
 	BTR_FEAT_EMBED_FIRST = (1 << 4),

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -445,9 +445,7 @@ vos_dtx_table_register(void)
 		return rc;
 	}
 
-	rc = dbtree_class_register(VOS_BTR_DTX_CMT_TABLE,
-				   BTR_FEAT_SKIP_LEAF_REBAL,
-				   &dtx_committed_btr_ops);
+	rc = dbtree_class_register(VOS_BTR_DTX_CMT_TABLE, 0, &dtx_committed_btr_ops);
 	if (rc != 0)
 		D_ERROR("Failed to register DTX committed dbtree: %d\n", rc);
 


### PR DESCRIPTION
The dbtree feature BTR_FEAT_SKIP_LEAF_REBAL was introduced to optimize
DTX aggregation. It does not only affect the balance among leaves, but
also changes some dbtree general behaviors, such as removing leaf node
from any position instead of only from the right side, then breaks the
assumption for some dbtree general logic, such as del_xxx_merge(). The
usages for the changes are very limited as to related verification may
be not enough. To be safe, disable the feature to avoid some potential
issue. It may affect DTX aggregation efficiency a bit under some cases,
but may be not important, because we prepare to handle DTX aggregation
with more efficient solution.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
