### PR TITLE
DAOS-17551 object: enforce server protocol in rebuild handler

### DIFF
--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -37,6 +38,9 @@ obj_mod_init(void)
 		D_ERROR("failed to obj_ec_codec_init\n");
 		goto out_class;
 	}
+
+	/* Enforce server protocol when reusing client stack during rebuild */
+	dc_obj_proto_version = DAOS_OBJ_VERSION;
 
 	return 0;
 


### PR DESCRIPTION
When reusing client-originated stacks for rebuild I/O, bind protocol version to DAOS_OBJ_VERSION to prevent accidental client protocol leakage in server contexts.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
