### PR TITLE
DAOS-17351 engine: shrink MAX_SCHED_REQ_NUM

### DIFF
--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1340,7 +1341,7 @@ req_enqueue(struct dss_xstream *dx, struct sched_request *req)
 	return rc;
 }
 
-#define MAX_SCHED_REQ_NUM	(1 << 20)
+#define MAX_SCHED_REQ_NUM       (1 << 16)
 #define RPC_ROUND_TRIP_TIME	(100)	/* in msecs */
 
 static bool


### PR DESCRIPTION
Shrink MAX_SCHED_REQ_NUM from 1M to 64K for each xstream to avoid OOM, since 1M ULT will use 16G memory, which is too much for single xstream.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
