### PR TITLE
DAOS-17547 rebuild: error on stopped ds_pool_child

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -493,8 +493,9 @@ migrate_pool_tls_create_one(void *data)
 
 	pool_child = ds_pool_child_lookup(arg->pool_uuid);
 	if (pool_child == NULL) {
-		D_ASSERTF(dss_get_module_info()->dmi_xs_id == 0,
-			  "Cannot find the pool "DF_UUIDF"\n", DP_UUID(arg->pool_uuid));
+		/* Local ds_pool_child isn't started yet, return a retry-able error */
+		if (dss_get_module_info()->dmi_xs_id != 0)
+			return -DER_STALE;
 	} else if (unlikely(pool_child->spc_no_storage)) {
 		D_DEBUG(DB_REBUILD, DF_UUID" "DF_UUID" lost pool shard, ver %d, skip.\n",
 			DP_UUID(arg->pool_uuid), DP_UUID(arg->pool_hdl_uuid), arg->version);

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -494,8 +494,11 @@ migrate_pool_tls_create_one(void *data)
 	pool_child = ds_pool_child_lookup(arg->pool_uuid);
 	if (pool_child == NULL) {
 		/* Local ds_pool_child isn't started yet, return a retry-able error */
-		if (dss_get_module_info()->dmi_xs_id != 0)
+		if (dss_get_module_info()->dmi_xs_id != 0) {
+			D_INFO(DF_UUID ": Local VOS pool isn't ready yet.\n",
+			       DP_UUID(arg->pool_uuid));
 			return -DER_STALE;
+		}
 	} else if (unlikely(pool_child->spc_no_storage)) {
 		D_DEBUG(DB_REBUILD, DF_UUID" "DF_UUID" lost pool shard, ver %d, skip.\n",
 			DP_UUID(arg->pool_uuid), DP_UUID(arg->pool_hdl_uuid), arg->version);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -2669,8 +2669,10 @@ rebuild_prepare_one(void *data)
 
 	dpc = ds_pool_child_lookup(rpt->rt_pool_uuid);
 	/* Local ds_pool_child isn't started yet, return a retry-able error */
-	if (dpc == NULL)
+	if (dpc == NULL) {
+		D_INFO(DF_UUID ": Local VOS pool isn't ready yet.\n", DP_UUID(rpt->rt_pool_uuid));
 		return -DER_STALE;
+	}
 
 	if (unlikely(dpc->spc_no_storage))
 		D_GOTO(put, rc = 0);


### PR DESCRIPTION
When a faulty SSD is replaced, reintegration will be auto triggered once local setup completed (ds_pool_child started).

Howerver, admin could manually run "dmg pool reintegrate" before the local setup done, then we need to return a retry-able error to make reintegration keep retry until the local ds_pool_child started.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
