### PR TITLE
 DAOS-17561 object: Force SGL copies for fetch when IOV buffer length exceeds requested length

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4751,7 +4751,7 @@ obj_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args, bool updat
 				continue;
 			}
 			/* Detect need for iov_buf_len normalization */
-			if (update && iov->iov_len < iov->iov_buf_len)
+			if (iov->iov_len < iov->iov_buf_len)
 				dup = true;
 			valid_iov_count++;
 
@@ -4843,8 +4843,7 @@ obj_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args, bool updat
 				iov_dup  = &sg_dup->sg_iovs[sgl_idx++];
 				iov      = &sg->sg_iovs[j++];
 				*iov_dup = *iov;
-				if (update)
-					iov_dup->iov_buf_len = iov_dup->iov_len;
+				iov_dup->iov_buf_len = iov_dup->iov_len;
 				continue;
 			}
 			/* Calculate merge range within size constraints */
@@ -4893,8 +4892,7 @@ obj_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args, bool updat
 			merged_iov = &sgls_dup[i].sg_iovs[sgl_idx++];
 			d_iov_set(merged_iov, merged_buf, merged_buf_size);
 			merged_iov->iov_len = merged_size;
-			if (update)
-				merged_iov->iov_buf_len = merged_iov->iov_len;
+			merged_iov->iov_buf_len = merged_iov->iov_len;
 		}
 		sg_dup->sg_nr = sgl_idx;
 	}


### PR DESCRIPTION
 Some applications may allocate larger IOV buffers than the requested length for
 fetch operations. By trimming SGL iov_buf_len to match iov_len and enforcing SGL
 copies during fetching, we can significantly reduce latency.### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
