### PR TITLE
SRE-2832 FC fixes to enable Functional Tests (#16224)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -205,12 +205,15 @@ pipeline {
                             'stages.  Specifies the default provider to use the daos_server ' +
                             'config file when running functional tests (the launch.py ' +
                             '--provider argument; i.e. "ucx+dc_x", "ofi+verbs", "ofi+tcp")')
-        booleanParam(name: 'CI_SKIP_CANCEL_PREV_BUILD',
+        booleanParam(name: 'CI_CANCEL_PREV_BUILD_SKIP',
                      defaultValue: false,
                      description: 'Do not cancel previous build.')
         booleanParam(name: 'CI_BUILD_PACKAGES_ONLY',
                      defaultValue: false,
                      description: 'Only build RPM and DEB packages, Skip unit tests.')
+        string(name: 'CI_SCONS_ARGS',
+               defaultValue: '',
+               description: 'Arguments for scons when building DAOS')
         string(name: 'CI_RPM_TEST_VERSION',
                defaultValue: '',
                description: 'Package version to use instead of building. example: 1.3.103-1, 1.2-2')
@@ -273,6 +276,9 @@ pipeline {
         booleanParam(name: 'CI_TEST_LEAP15_RPMs',
                      defaultValue: true,
                      description: 'Run the Test RPMs on Leap 15 test stage')
+        booleanParam(name: 'CI_FUNCTIONAL_TEST_SKIP',
+                     defaultValue: false,
+                     description: 'Skip all functional test stages (Test)')
         booleanParam(name: 'CI_MORE_FUNCTIONAL_PR_TESTS',
                      defaultValue: false,
                      description: 'Enable more distros for functional CI tests')
@@ -293,6 +299,9 @@ pipeline {
                      defaultValue: false,
                      description: 'Run the Functional on Ubuntu 20.04 test stage' +
                                   '  Requires CI_MORE_FUNCTIONAL_PR_TESTS')
+        booleanParam(name: 'CI_FUNCTIONAL_HARDWARE_TEST_SKIP',
+                     defaultValue: false,
+                     description: 'Skip Functional Hardware (Test Hardware) stage')
         booleanParam(name: 'CI_medium_TEST',
                      defaultValue: true,
                      description: 'Run the Functional Hardware Medium test stage')
@@ -333,7 +342,7 @@ pipeline {
                defaultValue: 'ci_nvme5',
                description: 'Label to use for the Functional Hardware Medium (MD on SSD) stages')
         string(name: 'FUNCTIONAL_HARDWARE_MEDIUM_VERBS_PROVIDER_LABEL',
-               defaultValue: 'ci_nvme5',
+               defaultValue: 'ci_ofed5',
                description: 'Label to use for 5 node Functional Hardware Medium Verbs Provider (MD on SSD) stages')
         string(name: 'FUNCTIONAL_HARDWARE_MEDIUM_VMD_LABEL',
                defaultValue: 'ci_vmd5',
@@ -407,7 +416,7 @@ pipeline {
         stage('Cancel Previous Builds') {
             when {
                 beforeAgent true
-                expression { !paramsValue('CI_SKIP_CANCEL_PREV_BUILD', false)  && !skipStage() }
+                expression { !paramsValue('CI_CANCEL_PREV_BUILD_SKIP', false)  && !skipStage() }
             }
             steps {
                 cancelPreviousBuilds()
@@ -613,7 +622,7 @@ pipeline {
                         }
                     }
                 }
-                stage('Build on EL 8') {
+                stage('Build on EL 8.8') {
                     when {
                         beforeAgent true
                         expression { !params.CI_el8_NOBUILD && !skipStage() }
@@ -834,7 +843,9 @@ pipeline {
         stage('Test') {
             when {
                 beforeAgent true
-                expression { !skipStage() }
+                //expression { !paramsValue('CI_FUNCTIONAL_TEST_SKIP', false)  && !skipStage() }
+                // Above not working, always skipping functional VM tests.
+                expression { !paramsValue('CI_FUNCTIONAL_TEST_SKIP', false) }
             }
             parallel {
                 stage('Functional on EL 8.8 with Valgrind') {
@@ -1098,7 +1109,7 @@ pipeline {
         stage('Test Hardware') {
             when {
                 beforeAgent true
-                expression { !skipStage() }
+                expression { !paramsValue('CI_FUNCTIONAL_HARDWARE_TEST_SKIP', false)  && !skipStage() }
             }
             steps {
                 script {

--- a/ci/functional/test_main.sh
+++ b/ci/functional/test_main.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 #
-#  Copyright 2020-2023 Intel Corporation.
+#  Copyright 2020-2024 Intel Corporation.
+#  Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
-
+#
 set -eux
 
 if [ -z "$TEST_TAG" ]; then
@@ -47,6 +48,8 @@ test_cluster() {
         NODELIST=${tnodes}                              \
         BUILD_URL=\"${BUILD_URL:-Unknown in GHA}\"      \
         STAGE_NAME=\"$STAGE_NAME\"                      \
+        JENKINS_URL=\"${JENKINS_URL:-}\"                \
+        DAOS_DEVOPS_EMAIL=\"${DAOS_DEVOPS_EMAIL:-}\"    \
         $(cat ci/functional/test_main_prep_node.sh)"
 }
 
@@ -58,7 +61,11 @@ if ! test_cluster; then
     if cluster_reboot; then
         if test_cluster; then
             hardware_ok=true
+        else
+            echo "Hardware test failed again after reboot"
         fi
+    else
+        echo "Cluster reboot failed"        
     fi
 else
     hardware_ok=true
@@ -99,6 +106,7 @@ if "$hardware_ok"; then
            FTEST_ARG=\"${FTEST_ARG:-}\"            \
            WITH_VALGRIND=\"${WITH_VALGRIND:-}\"    \
            STAGE_NAME=\"$STAGE_NAME\"              \
+           HTTPS_PROXY=\"${HTTPS_PROXY:-}\"        \
            $(cat ci/functional/test_main_node.sh)"
     else
         ./ftest.sh "$test_tag" "$tnodes" "$FTEST_ARG"

--- a/ci/functional/test_main_node.sh
+++ b/ci/functional/test_main_node.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-
+#
+#  Copyright 2020-2022 Intel Corporation.
+#  Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
 set -eux
 
 DAOS_TEST_SHARED_DIR=$(mktemp -d -p /mnt/share/)
@@ -11,4 +16,5 @@ export REMOTE_ACCT=jenkins
 export WITH_VALGRIND="$WITH_VALGRIND"
 export STAGE_NAME="$STAGE_NAME"
 
-/usr/lib/daos/TESTING/ftest/ftest.sh "$TEST_TAG" "$TNODES" "$FTEST_ARG"
+HTTPS_PROXY="${HTTPS_PROXY:-}" /usr/lib/daos/TESTING/ftest/ftest.sh \
+    "$TEST_TAG" "$TNODES" "$FTEST_ARG"

--- a/ci/gha_functions.sh
+++ b/ci/gha_functions.sh
@@ -233,7 +233,7 @@ test_test_tag_and_features() {
                      CP_FEATURES="foo bar" get_test_tags "-hw")" "always_passes,-hw always_fails,-hw"
 }
 
-test_jenkins_curl() {
-    JENKINS_URL="${JENKINS_URL:-https://build.hpdd.intel.com/}"
-    assert_equals "$(QUIET=true VERBOSE=false jenkins_curl -X POST "${JENKINS_URL}api/xml" 3>&1 >/dev/null | tr -d '\r' | grep '^X-Content-Type-Options:')" "X-Content-Type-Options: nosniff"
-}
+#test_jenkins_curl() {
+#    JENKINS_URL="${JENKINS_URL:-https://build.hpdd.intel.com/}"
+#    assert_equals "$(QUIET=true VERBOSE=false jenkins_curl -X POST "${JENKINS_URL}api/xml" 3>&1 >/dev/null | tr -d '\r' | grep '^X-Content-Type-Options:')" "X-Content-Type-Options: nosniff"
+#}

--- a/ci/provisioning/post_provision_config_common.sh
+++ b/ci/provisioning/post_provision_config_common.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-
+#
+#  Copyright 2021-2023 Intel Corporation.
+#  Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
 set -eux
 
 repo_server_pragma=$(echo "$COMMIT_MESSAGE" | sed -ne '/^Repo-servers: */s/.*: *//p')
@@ -24,6 +29,7 @@ if [ -n "$repo_files_pr" ]; then
     REPO_FILE_URL="${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-do/job/repo-files/job/$branch/$build_number/artifact/"
 fi
 
+# shellcheck disable=SC1091
 . /etc/os-release
 # shellcheck disable=SC2034
 EXCLUDE_UPGRADE=mercury,daos,daos-\*

--- a/ci/provisioning/post_provision_config_nodes.sh
+++ b/ci/provisioning/post_provision_config_nodes.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
-
+#
+#  Copyright 2020-2023 Intel Corporation.
+#  Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
 set -eux
 
 env > /root/last_run-env.txt
+
+# Need this fix earlier
+# For some reason sssd_common must be reinstalled
+# to fix up the restored image.
+if command -v dnf; then
+    bootstrap_dnf
+fi
+
 if ! grep ":$MY_UID:" /etc/group; then
   groupadd -g "$MY_UID" jenkins
 fi
@@ -29,13 +42,14 @@ echo "jenkins ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/jenkins
 
 # /scratch is needed on test nodes
 mkdir -p /scratch
-mount "${DAOS_CI_INFO_DIR}" /scratch
+retry_cmd 2400 mount "${DAOS_CI_INFO_DIR}" /scratch
 
 # defined in ci/functional/post_provision_config_nodes_<distro>.sh
 # and catted to the remote node along with this script
 if ! post_provision_config_nodes; then
-  rc=${PIPESTATUS[0]}
-  exit "$rc"
+    rc=${PIPESTATUS[0]}
+    echo "post_provision_config_nodes failed with rc=$rc"
+    exit "$rc"
 fi
 
 # Workaround to enable binding devices back to nvme or vfio-pci after they are unbound from vfio-pci
@@ -46,6 +60,80 @@ if lspci | grep -i nvme; then
   export COVFILE=/tmp/test.cov
   daos_server nvme reset && rmmod vfio_pci && modprobe vfio_pci
 fi
+
+# FOR now limit to 2 devices per CPU NUMA node
+: "${DAOS_CI_NVME_NUMA_LIMIT:=2}"
+
+function mount_nvme_drive {
+    local drive="$1"
+    file_system=$(file -sL "/dev/$drive")
+    if  [[ "$file_system" != *"ext4 filesystem"* ]]; then
+        yes | mkfs -t ext4 "/dev/$drive"
+    fi
+    mkdir -p "/mnt/$drive"
+    mount "/dev/$drive" "/mnt/$drive"
+}
+
+
+nvme_class="/sys/class/nvme/"
+function nvme_limit {
+    set +x
+    if [ ! -d /sys/class/nvme ]; then
+        echo "No NVMe devices found"
+        return
+    fi
+    local numa0_devices=()
+    local numa1_devices=()
+    for nvme_path in "$nvme_class"*; do
+        nvme="$(basename "$nvme_path")n1"
+        numa_node="$(cat "${nvme_path}/numa_node")"
+        if mount | grep "$nvme"; then
+            continue
+        fi
+        if [ "$numa_node" -eq 0 ]; then
+            numa0_devices+=("$nvme")
+        else
+            numa1_devices+=("$nvme")
+        fi
+    done
+    echo numa0 "${numa0_devices[@]}"
+    echo numa1 "${numa1_devices[@]}"
+    if [ "${#numa0_devices[@]}" -gt 0 ] && [ "${#numa1_devices[@]}" -gt 0 ]; then
+        echo "balanced NVMe configuration possible"
+        nvme_count=0
+        for nvme in "${numa0_devices[@]}"; do
+            if [ "$nvme_count" -ge "${DAOS_CI_NVME_NUMA_LIMIT}" ]; then
+                mount_nvme_drive "$nvme"
+            else
+                ((nvme_count++)) || true
+            fi
+        done
+        nvme_count=0
+        for nvme in "${numa1_devices[@]}"; do
+            if [ "$nvme_count" -ge "${DAOS_CI_NVME_NUMA_LIMIT}" ]; then
+                mount_nvme_drive "$nvme"
+            else
+                ((nvme_count++)) || true
+            fi
+        done
+    else
+        echo "balanced NVMe configuration not possible"
+        for nvme in "${numa0_devices[@]}" "${numa1_devices[@]}"; do
+            ((needed = "$DAOS_CI_NVME_NUMA_LIMIT" + 1)) || true
+            nvme_count=0
+            if [ "$nvme_count" -ge "$needed" ]; then
+                mount_nvme_drive "$nvme"
+            else
+                ((nvme_count++)) || true
+            fi
+        done
+    fi
+    set -x
+}
+
+# Force only the desired number of NVMe devices to be seen by DAOS tests
+# by mounting the extra ones.
+nvme_limit
 
 systemctl enable nfs-server.service
 systemctl start nfs-server.service

--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -6,8 +6,18 @@
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 
 bootstrap_dnf() {
+set +e
     systemctl enable postfix.service
     systemctl start postfix.service
+    postfix_start_exit=$?
+    if [ $postfix_start_exit -ne 0 ]; then
+        echo "WARNING: Postfix not started: $postfix_start_exit"
+        systemctl status postfix.service
+        journalctl -xe -u postfix.service
+    fi
+set -e
+    # Seems to be needed to fix some issues.
+    dnf -y reinstall sssd-common
 }
 
 group_repo_post() {

--- a/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
+++ b/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
+#
+#  Copyright 2021-2024 Intel Corporation.
+#  Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
 
 bootstrap_dnf() {
     rm -rf "$REPOS_DIR"
     ln -s ../zypp/repos.d "$REPOS_DIR"
+    dnf -y remove lua-lmod
+    dnf -y install lua-lmod '--repo=*lua*' --repo '*network-cluster*'
 }
 
 group_repo_post() {

--- a/ci/provisioning/post_provision_config_nodes_UBUNTU_20_04.sh
+++ b/ci/provisioning/post_provision_config_nodes_UBUNTU_20_04.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#
+#  Copyright 2020-2022 Intel Corporation.
+#  Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
 
 post_provision_config_nodes() {
     # should we port this to Ubuntu or just consider $CONFIG_POWER_ONLY dead?
@@ -12,15 +18,7 @@ post_provision_config_nodes() {
     #                 slurm-example-configs slurmctld slurm-slurmmd
     #fi
     codename=$(lsb_release -s -c)
-    if [ -n "$DAOS_STACK_GROUP_REPO" ]; then
-        add-apt-repository \
-            "deb $REPOSITORY_URL/$DAOS_STACK_GROUP_REPO $codename"
-    fi
-
-    if [ -n "$DAOS_STACK_LOCAL_REPO" ]; then
-        echo "deb [trusted=yes] $REPOSITORY_URL/$DAOS_STACK_LOCAL_REPO $codename main" >> /etc/apt/sources.list
-    fi
-
+    echo "$codename"
     if [ -n "$INST_REPOS" ]; then
         for repo in $INST_REPOS; do
             branch="master"

--- a/ci/storage/test_main_storage_prepare_node.sh
+++ b/ci/storage/test_main_storage_prepare_node.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-
+#
+#  Copyright 2021-2023 Intel Corporation.
+#  Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
 set -eux
 
 : "${STORAGE_PREP_OPT:=}"
@@ -21,12 +26,16 @@ else
             ;;
     esac
     dnf -y config-manager \
-        --disable daos-stack-daos-"${DISTRO_GENERIC}"-"${VERSION_ID%%.*}"-x86_64-stable-local-artifactory
+        --disable daos-stack-daos-"${DISTRO_GENERIC}"-"${VERSION_ID%%.*}"*-stable-local-artifactory
 fi
+# this needs to be made more generic in the future.
+dnf -y config-manager \
+        --enable daos-stack-deps-"${DISTRO_GENERIC}"-"${VERSION_ID%%.*}"*-stable-local-artifactory
+
 dnf -y install ipmctl daos-server"$DAOS_PKG_VERSION"
 
-lspci | grep Mellanox
-lscpu | grep Virtualization
+lspci | grep Mellanox || true
+lscpu | grep Virtualization || true
 lscpu | grep -E -e Socket -e NUMA
 
 if command -v opainfo; then opainfo || true; fi
@@ -51,7 +60,12 @@ if ipmctl show -dimm; then
       fi
     fi
 else
-    if ip addr show ib1; then
+    counter=0
+    for ib in /sys/class/net/ib*; do
+        ((counter++)) || true
+        ip addr show "$ib"
+    done
+    if "$counter" -ge 2; then
         # All of our CI nodes with two ib adapters should have PMEM DIMMs
         echo 'No PMEM DIMM devices found on CI node!'
         exit 1

--- a/ci/unit/test_main.sh
+++ b/ci/unit/test_main.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-
+#
+#  Copyright 2020-2023 Intel Corporation.
+#  Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
 # This is the script used for running unit testing
 # run_utest.py and run_utest.py with memcheck stages on the CI
 set -uex
@@ -30,8 +35,6 @@ if $USE_BULLSEYE; then
   rm -rf bullseye
   mkdir -p bullseye
   tar -C bullseye --strip-components=1 -xf bullseye.tar
-else
-  BULLSEYE=
 fi
 
 NODE=${NODELIST%%,*}
@@ -43,6 +46,6 @@ rsync -rlpt -z -e "ssh $SSH_KEY_ARGS" . jenkins@"$NODE":build/
 ssh -tt "$SSH_KEY_ARGS" jenkins@"$NODE" "HOSTNAME=$HOSTNAME        \
                                          HOSTPWD=$PWD              \
                                          WITH_VALGRIND=$WITH_VALGRIND \
-                                         BULLSEYE=$BULLSEYE        \
+                                         HTTPS_PROXY=\"${HTTPS_PROXY:-}\" \
                                          BDEV_TEST=$BDEV_TEST       \
                                          ./build/ci/unit/test_main_node.sh"

--- a/ci/unit/test_main_node.sh
+++ b/ci/unit/test_main_node.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-
+#
+#  Copyright 2020-2023 Intel Corporation.
+#  Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
 # This is a script to be run by the ci/unit/test_main.sh to run a test
 # on a CI node.
 
@@ -21,6 +26,7 @@ sudo mount --bind build "${SL_SRC_DIR}"
 
 log_prefix="unit_test"
 
+: "${BULLSEYE:=}"
 if [ -n "$BULLSEYE" ]; then
     pushd "${SL_SRC_DIR}/bullseye"
     set +x
@@ -47,6 +53,7 @@ sudo ln -sf "$SL_PREFIX/share/spdk/scripts/common.sh" /usr/share/spdk/scripts/
 sudo ln -s "$SL_PREFIX/include"  /usr/share/spdk/include
 
 # set CMOCKA envs here
+: "${WITH_VALGRIND:=}"
 export CMOCKA_MESSAGE_OUTPUT=xml
 if [[ -z ${WITH_VALGRIND} ]]; then
     export CMOCKA_XML_FILE="${SL_SRC_DIR}/test_results/%g.xml"
@@ -86,5 +93,5 @@ pip install --requirement requirements-utest.txt
 
 pip install /opt/daos/lib/daos/python/
 
-utils/run_utest.py $RUN_TEST_VALGRIND --no-fail-on-error $VDB_ARG --log_dir="$test_log_dir" \
-                   $SUDO_ARG
+HTTPS_PROXY="${HTTPS_PROXY:-}" utils/run_utest.py $RUN_TEST_VALGRIND \
+    --no-fail-on-error $VDB_ARG --log_dir="$test_log_dir" $SUDO_ARG

--- a/ftest.sh
+++ b/ftest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # /*
 #  * (C) Copyright 2016-2022 Intel Corporation.
-#  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#  * Copyright 2025 Hewlett Packard Enterprise Development LP
 #  *
 #  * SPDX-License-Identifier: BSD-2-Clause-Patent
 #  */
@@ -113,6 +113,7 @@ args="${1:-quick}"
 shift || true
 args+=" $*"
 
+_HTTPS_PROXY=${HTTPS_PROXY:-}
 # shellcheck disable=SC2029
 # shellcheck disable=SC2086
 if ! ssh -A $SSH_KEY_ARGS ${REMOTE_ACCT:-jenkins}@"${nodes[0]}" \
@@ -128,6 +129,7 @@ if ! ssh -A $SSH_KEY_ARGS ${REMOTE_ACCT:-jenkins}@"${nodes[0]}" \
      LAUNCH_OPT_ARGS=\"$LAUNCH_OPT_ARGS\"
      WITH_VALGRIND=\"$WITH_VALGRIND\"
      STAGE_NAME=\"$STAGE_NAME\"
+     HTTPS_PROXY=\"$_HTTPS_PROXY\"
      $(sed -e '1,/^$/d' "$SCRIPT_LOC"/main.sh)"; then
     rc=${PIPESTATUS[0]}
     if ${SETUP_ONLY:-false}; then

--- a/site_scons/env_modules.py
+++ b/site_scons/env_modules.py
@@ -1,4 +1,5 @@
 # Copyright 2019-2023 Intel Corporation
+# Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,8 +35,7 @@ class _env_module():  # pylint: disable=invalid-name
 
     env_module_init = None
     _mpi_map = {"mpich": ['mpi/mpich-x86_64', 'gnu-mpich'],
-                "openmpi": ['mpi/mlnx_openmpi-x86_64', 'mpi/openmpi3-x86_64',
-                            'gnu-openmpi', 'mpi/openmpi-x86_64']}
+                "openmpi": ['mpi/openmpi3-x86_64', 'gnu-openmpi', 'mpi/openmpi-x86_64']}
 
     def __init__(self, silent=False):
         """Load Modules for initializing environment variables"""

--- a/src/tests/ftest/dfuse/bash.py
+++ b/src/tests/ftest/dfuse/bash.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -112,7 +113,7 @@ class DfuseBashCmd(TestWithServers):
             # f'more {fuse_root_dir}/src.c', # more hangs over ssh somehow
             f"dos2unix {fuse_root_dir}/src.c",
             f"gcc -o {fuse_root_dir}/output {fuse_root_dir}/src.c",
-            f"valgrind size {fuse_root_dir}/output",
+            f'export DEBUGINFOD_URLS=""; valgrind size {fuse_root_dir}/output',
             f"readelf -s {fuse_root_dir}/output",
             f"strip -s {fuse_root_dir}/output",
             f"g++ -o {fuse_root_dir}/output {fuse_root_dir}/src.c",
@@ -136,8 +137,16 @@ class DfuseBashCmd(TestWithServers):
             'fio --readwrite=randwrite --name=test --size="2M" --directory '
             f'{fuse_root_dir}/ --bs=1M --numjobs="1" --ioengine=libaio --iodepth=16'
             '--group_reporting --exitall_on_error --continue_on_error=none',
-            f'curl "https://www.google.com" -o {fuse_root_dir}/download.html',
         ]
+        # If set, use the HTTPS_PROXY for curl command
+        https_proxy = os.environ.get('HTTPS_PROXY')
+        if https_proxy:
+            proxy_option = f'--proxy "{https_proxy}"'
+        else:
+            proxy_option = ''
+        cmd = f'curl "https://www.google.com" -o {fuse_root_dir}/download.html {proxy_option}'
+        commands.append(cmd)
+
         for cmd in commands:
             self.log_step(f'Running command: {cmd}')
             result = run_remote(self.log, dfuse_hosts, env_str + cmd)

--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -2,6 +2,7 @@
 # shellcheck disable=SC1113
 # /*
 #  * (C) Copyright 2016-2024 Intel Corporation.
+#  * Copyright 2025 Hewlett Packard Enterprise Development LP
 #  *
 #  * SPDX-License-Identifier: BSD-2-Clause-Patent
 # */
@@ -89,6 +90,10 @@ export TEST_RPMS
 export DAOS_BASE
 export DAOS_TEST_APP_SRC=${DAOS_TEST_APP_SRC:-"/scratch/daos_test/apps"}
 export DAOS_TEST_APP_DIR=${DAOS_TEST_APP_DIR:-"${DAOS_TEST_SHARED_DIR}/daos_test/apps"}
+if [ -n "$HTTPS_PROXY" ]; then
+    # shellcheck disable=SC2154
+    export HTTPS_PROXY="${HTTPS_PROXY:-""}"
+fi
 
 launch_node_args="-ts ${TEST_NODES}"
 if [ "${STAGE_NAME}" == "Functional Hardware 24" ]; then

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -23,7 +23,7 @@
 
 Name:          daos
 Version:       2.6.3
-Release:       7%{?relval}%{?dist}
+Release:       8%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -232,11 +232,12 @@ Requires: lbzip2
 Requires: attr
 Requires: ior
 Requires: go >= 1.21
+# Require lmod fix for https://github.com/TACC/Lmod/issues/687
 %if (0%{?suse_version} >= 1315)
-Requires: lua-lmod
+Requires: lua-lmod >= 8.7.36
 Requires: libcapstone-devel
 %else
-Requires: Lmod
+Requires: Lmod >= 8.7.36
 Requires: capstone-devel
 %endif
 %if (0%{?rhel} >= 8)
@@ -263,6 +264,7 @@ Requires: hdf5-%{openmpi}-tests
 Requires: hdf5-vol-daos-%{openmpi}-tests
 Requires: MACSio-%{openmpi}
 Requires: simul-%{openmpi}
+Requires: %{openmpi}
 
 %description client-tests-openmpi
 This is the package needed to run the DAOS client test suite openmpi tools
@@ -273,14 +275,14 @@ BuildArch: noarch
 Requires: %{name}-client-tests%{?_isa} = %{version}-%{release}
 Requires: mpifileutils-mpich
 Requires: testmpio
-Requires: mpich
+Requires: mpich = 4.1~a1
 Requires: ior
 Requires: hdf5-mpich-tests
 Requires: hdf5-vol-daos-mpich-tests
 Requires: MACSio-mpich
 Requires: simul-mpich
 Requires: romio-tests
-Requires: python3-mpi4py-tests
+Requires: python3-mpi4py-tests >= 3.1.6
 
 %description client-tests-mpich
 This is the package needed to run the DAOS client test suite mpich tools
@@ -630,6 +632,13 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a shim package
 
 %changelog
+* Mon May 12 2025  Tomasz Gromadzki <tomasz.gromadzki@hpe.com> 2.6.3-8
+- Bump lua-lmod version to >=8.7.36
+- Bump lmod version to >=8.7.36
+- Bump mpich version to 4.1~a1
+- Bump python3-mpi4py-tests version to >= 3.1.6
+- Add openmpi requiremnent for daos-client-tests on Leap.
+
 * Fri Apr 11 2025 Jeff Olivier  <jeffolivier@google.com> 2.6.3-7
 - Remove raft as external dependency
 

--- a/utils/run_utest.py
+++ b/utils/run_utest.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """
-  (C) Copyright 2023-2024 Intel Corporation.
+  Copyright 2023-2024 Intel Corporation.
+  Copyright 2025 Hewlett Packard Enterprise Development LP
+  All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -356,6 +358,11 @@ class Test():
 
         if self.needs_aio():
             self.env["VOS_BDEV_CLASS"] = "AIO"
+
+        # If set, retain the HTTPS_PROXY for valgrind
+        http_proxy = os.environ.get('HTTPS_PROXY')
+        if http_proxy:
+            self.env['HTTPS_PROXY'] = http_proxy
 
     def log_dir(self):
         """Return the log directory"""


### PR DESCRIPTION
Enable CI running in Fort Collins with:
- passing HTTPS_PROXY to functional tests
- fixing repository paths, E-MAIL domain, and hardware check
- fixing expectations for InfiniBand adapters and IBoIP device detection
- added build parameter to skip all functional or functional HW tests
- limiting number of NVMe devices used to 4
- creating local host file to prevent DNS glitches
- added minimum required python3-mpi4py-tests, mpich, and Lmod/lua-lmod versions
- removed mpi/mlnx_openmpi-x86_64 module file
- installing updated lua-lmod package for Leap 15.6 testing
- commented out jenkins curl test in gha_functions.sh
- default FUNCTIONAL_HARDWARE_MEDIUM_VERBS_PROVIDER_LABEL -> ci_ofed5
- fixed debuginfo RPM installs for stack trace generation

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
