### PR TITLE
DAOS-17562 test: Add missing EL 8 debuginfo packages

### DIFF
--- a/src/tests/ftest/process_core_files.py
+++ b/src/tests/ftest/process_core_files.py
@@ -268,11 +268,16 @@ class CoreFileProcessing():
         # -debuginfo packages that don't get installed with debuginfo-install
         self.log.debug("Installing -debuginfo packages that don't get installed",
                        " with debuginfo-install")
-        for pkg in ['systemd', 'ndctl', 'mercury', 'hdf5',
-                    'libabt0' if "suse" in self.distro_info.name.lower() else "argobots",
-                    'libfabric', 'hdf5-vol-daos', 'hdf5-vol-daos-mpich',
-                    'hdf5-vol-daos-mpich-tests', 'hdf5-vol-daos-openmpi',
-                    'hdf5-vol-daos-openmpi-tests', 'ior']:
+        package_list = ['systemd', 'ndctl', 'mercury', 'hdf5', 'libfabric', 'ior', 'hdf5-vol-daos',
+                        'hdf5-vol-daos-mpich', 'hdf5-vol-daos-mpich-tests', 'hdf5-vol-daos-openmpi',
+                        'hdf5-vol-daos-openmpi-tests']
+        if "suse" in self.distro_info.name.lower():
+            package_list.append('libabt0')
+        else:
+            package_list.append('argobots')
+        if self.is_el() and int(self.distro_info.version) >= 9:
+            package_list.extend(['systemd-libs', 'ndctl-libs', 'daxctl-libs'])
+        for pkg in package_list:
             debug_pkg = self.resolve_debuginfo(pkg)
             if debug_pkg and debug_pkg not in install_pkgs:
                 install_pkgs.append(debug_pkg)

--- a/src/tests/ftest/process_core_files.py
+++ b/src/tests/ftest/process_core_files.py
@@ -294,7 +294,8 @@ class CoreFileProcessing():
                          "python36", "openmpi3", "gcc"])
                 elif self.is_el() and int(self.distro_info.version) >= 8:
                     dnf_args.extend(
-                        ["libpmemobj", "python3", "openmpi", "gcc"])
+                        ["libpmemobj", "python3", "openmpi", "gcc", 'libpmem', "ndctl-libs",
+                         "daxctl-libs", "libgcc", "systemd-libs"])
                 else:
                     raise RunException(f"Unsupported distro: {self.distro_info}")
                 cmds.append(["sudo", "dnf", "-y", "install"] + dnf_args)
@@ -332,7 +333,7 @@ class CoreFileProcessing():
 
         retry = False
         for cmd in cmds:
-            if not run_local(self.log, " ".join(cmd), True, 120).passed:
+            if not run_local(self.log, " ".join(cmd)).passed:
                 # got an error, so abort this list of commands and re-run
                 # it with a dnf clean, makecache first
                 retry = True


### PR DESCRIPTION
Avoid 'missing debuginfo' messages in EL 8.8 generated stack traces.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test: true
Test-tag: test_core_files

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
