### PR TITLE
DAOS-17560 vos: maintain DTX statistical info correctly

### DIFF
--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -212,6 +212,10 @@ cont_free_internal(struct vos_container *cont)
 			vea_hint_unload(cont->vc_hint_ctxt[i]);
 	}
 
+	D_ASSERTF(cont->vc_pool->vp_dtx_committed_count >= cont->vc_dtx_committed_count,
+		  "Unexpected committed DTX entries count: %u vs %u\n",
+		  cont->vc_pool->vp_dtx_committed_count, cont->vc_dtx_committed_count);
+
 	cont->vc_pool->vp_dtx_committed_count -= cont->vc_dtx_committed_count;
 	d_tm_dec_gauge(vos_tls_get(cont->vc_pool->vp_sysdb)->vtl_committed,
 		       cont->vc_dtx_committed_count);

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2988,15 +2988,15 @@ vos_dtx_aggregate(daos_handle_t coh)
 		d_iov_set(&kiov, &dce_df->dce_xid, sizeof(dce_df->dce_xid));
 		rc = dbtree_delete(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
 				   &kiov, NULL);
-		if (rc != 0 && rc != -DER_NONEXIST) {
+		if (rc == 0) {
+			count++;
+		} else if (rc != -DER_NONEXIST) {
 			D_ERROR("Failed to remove entry for DTX aggregation "
 				UMOFF_PF": "DF_RC"\n",
 				UMOFF_P(dbd_off), DP_RC(rc));
 			goto out;
 		}
 	}
-
-	count = dbd->dbd_count;
 
 	if (epoch != cont_df->cd_newest_aggregated) {
 		rc = umem_tx_add_ptr(umm, &cont_df->cd_newest_aggregated,
@@ -3381,7 +3381,8 @@ vos_dtx_cmt_reindex(daos_handle_t coh)
 	struct vos_dtx_blob_df		*dbd;
 	d_iov_t				 kiov;
 	d_iov_t				 riov;
-	int				 rc = 0;
+	int                              rc  = 0;
+	int                              cnt = 0;
 	int				 i;
 
 	cont = vos_hdl2cont(coh);
@@ -3429,6 +3430,8 @@ vos_dtx_cmt_reindex(daos_handle_t coh)
 			D_FREE(dce);
 			D_GOTO(out, rc = 1);
 		}
+
+		cnt++;
 	}
 
 	if (dbd->dbd_count < dbd->dbd_cap || UMOFF_IS_NULL(dbd->dbd_next))
@@ -3437,9 +3440,21 @@ vos_dtx_cmt_reindex(daos_handle_t coh)
 	cont->vc_cmt_dtx_reindex_pos = dbd->dbd_next;
 
 out:
+	if (cnt > 0) {
+		cont->vc_dtx_committed_count += cnt;
+		cont->vc_pool->vp_dtx_committed_count += cnt;
+		d_tm_inc_gauge(vos_tls_get(false)->vtl_committed, cnt);
+	}
+
 	if (rc > 0) {
 		cont->vc_cmt_dtx_reindex_pos = UMOFF_NULL;
 		cont->vc_cmt_dtx_indexed = 1;
+		D_INFO("Reindexed committed DTX table (%u entries) for " DF_UUID "/" DF_UUID "\n",
+		       cont->vc_dtx_committed_count, DP_UUID(cont->vc_pool->vp_id),
+		       DP_UUID(cont->vc_id));
+	} else if (rc < 0) {
+		D_ERROR("Failed to reindex committed DTX for " DF_UUID "/" DF_UUID ": " DF_RC "\n",
+			DP_UUID(cont->vc_pool->vp_id), DP_UUID(cont->vc_id), DP_RC(rc));
 	}
 
 	return rc;
@@ -3779,6 +3794,10 @@ cmt:
 				DP_UUID(cont->vc_id), DP_RC(rc));
 			return rc;
 		}
+
+		D_ASSERTF(cont->vc_pool->vp_dtx_committed_count >= cont->vc_dtx_committed_count,
+			  "Unexpected committed DTX entries count: %u vs %u\n",
+			  cont->vc_pool->vp_dtx_committed_count, cont->vc_dtx_committed_count);
 
 		cont->vc_pool->vp_dtx_committed_count -= cont->vc_dtx_committed_count;
 		D_ASSERT(cont->vc_pool->vp_sysdb == false);


### PR DESCRIPTION
After engine restart or container/pool reopen, DTX related statistical information in DRAM needs to be recalculated with considering existing on-disk DTX information.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
