### PR TITLE
DAOS-17492 control: Ensure updated members can become voters

### DIFF
--- a/src/control/system/raft/database.go
+++ b/src/control/system/raft/database.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -816,6 +817,10 @@ func (db *Database) UpdateMember(m *system.Member) error {
 
 	_, err := db.FindMemberByUUID(m.UUID)
 	if err != nil {
+		return err
+	}
+
+	if err := db.manageVoter(m, raftOpUpdateMember); err != nil {
 		return err
 	}
 

--- a/src/control/system/raft/database_test.go
+++ b/src/control/system/raft/database_test.go
@@ -431,12 +431,11 @@ func ignoreFaultDomainIDOption() cmp.Option {
 		}, cmp.Ignore())
 }
 
-func TestSystem_Database_memberRaftOps(t *testing.T) {
+func genTestMembers(t *testing.T, num int) []*Member {
 	ctx := test.Context(t)
-
-	testMembers := make([]*Member, 0)
-	nextAddr := ctrlAddrGen(ctx, net.IPv4(127, 0, 0, 1), 4)
-	for i := 0; i < 3; i++ {
+	nextAddr := ctrlAddrGen(ctx, net.IPv4(127, 0, 0, 1), 1)
+	testMembers := make([]*Member, 0, num)
+	for i := 0; i < num; i++ {
 		testMembers = append(testMembers, &Member{
 			Rank:        Rank(i),
 			UUID:        uuid.New(),
@@ -445,6 +444,57 @@ func TestSystem_Database_memberRaftOps(t *testing.T) {
 			FaultDomain: MustCreateFaultDomainFromString("/rack0"),
 		})
 	}
+	return testMembers
+}
+
+func expectMembersInDB(t *testing.T, db *Database, expMembers []*Member) {
+	cmpOpts := []cmp.Option{
+		cmp.AllowUnexported(Member{}),
+		cmpopts.IgnoreFields(Member{}, "LastUpdate"),
+	}
+	for _, expMember := range expMembers {
+		uuidM, ok := db.data.Members.Uuids[expMember.UUID]
+		if !ok {
+			t.Errorf("member not found for UUID %s", expMember.UUID)
+		}
+		if diff := cmp.Diff(expMember, uuidM, cmpOpts...); diff != "" {
+			t.Fatalf("member wrong in UUID DB (-want, +got):\n%s\n", diff)
+		}
+
+		rankM, ok := db.data.Members.Ranks[expMember.Rank]
+		if !ok {
+			t.Errorf("member not found for rank %d", expMember.Rank)
+		}
+		if diff := cmp.Diff(expMember, rankM, cmpOpts...); diff != "" {
+			t.Fatalf("member wrong in rank DB (-want, +got):\n%s\n", diff)
+		}
+
+		addrMs, ok := db.data.Members.Addrs[expMember.Addr.String()]
+		if !ok {
+			t.Errorf("slice not found for addr %s", expMember.Addr.String())
+		}
+
+		found := false
+		for _, am := range addrMs {
+			if am.Rank == expMember.Rank {
+				found = true
+				if diff := cmp.Diff(expMember, am, cmpOpts...); diff != "" {
+					t.Fatalf("member wrong in addr DB (-want, +got):\n%s\n", diff)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("expected member %+v not found for addr %s", expMember, expMember.Addr.String())
+		}
+	}
+
+	if len(db.data.Members.Uuids) != len(expMembers) {
+		t.Fatalf("expected %d members, got %d", len(expMembers), len(db.data.Members.Uuids))
+	}
+}
+
+func TestSystem_Database_memberRaftOps(t *testing.T) {
+	testMembers := genTestMembers(t, 3)
 
 	changedFaultDomainMember := &Member{
 		Rank:        testMembers[1].Rank,
@@ -454,15 +504,12 @@ func TestSystem_Database_memberRaftOps(t *testing.T) {
 		FaultDomain: MustCreateFaultDomainFromString("/rack1"),
 	}
 
-	cmpOpts := []cmp.Option{
-		cmp.AllowUnexported(Member{}),
-	}
-
 	for name, tc := range map[string]struct {
 		startingMembers []*Member
 		op              raftOp
 		updateMember    *Member
 		expMembers      []*Member
+		expVotersAdded  []string
 		expFDTree       *FaultDomainTree
 	}{
 		"add success": {
@@ -544,49 +591,125 @@ func TestSystem_Database_memberRaftOps(t *testing.T) {
 			raftUpdateTestMember(t, db, tc.op, tc.updateMember)
 
 			// Check member DB was updated
-			for _, expMember := range tc.expMembers {
-				uuidM, ok := db.data.Members.Uuids[expMember.UUID]
-				if !ok {
-					t.Errorf("member not found for UUID %s", expMember.UUID)
-				}
-				if diff := cmp.Diff(expMember, uuidM, cmpOpts...); diff != "" {
-					t.Fatalf("member wrong in UUID DB (-want, +got):\n%s\n", diff)
-				}
-
-				rankM, ok := db.data.Members.Ranks[expMember.Rank]
-				if !ok {
-					t.Errorf("member not found for rank %d", expMember.Rank)
-				}
-				if diff := cmp.Diff(expMember, rankM, cmpOpts...); diff != "" {
-					t.Fatalf("member wrong in rank DB (-want, +got):\n%s\n", diff)
-				}
-
-				addrMs, ok := db.data.Members.Addrs[expMember.Addr.String()]
-				if !ok {
-					t.Errorf("slice not found for addr %s", expMember.Addr.String())
-				}
-
-				found := false
-				for _, am := range addrMs {
-					if am.Rank == expMember.Rank {
-						found = true
-						if diff := cmp.Diff(expMember, am, cmpOpts...); diff != "" {
-							t.Fatalf("member wrong in addr DB (-want, +got):\n%s\n", diff)
-						}
-					}
-				}
-				if !found {
-					t.Fatalf("expected member %+v not found for addr %s", expMember, expMember.Addr.String())
-				}
-
-			}
-			if len(db.data.Members.Uuids) != len(tc.expMembers) {
-				t.Fatalf("expected %d members, got %d", len(tc.expMembers), len(db.data.Members.Uuids))
-			}
+			expectMembersInDB(t, db, tc.expMembers)
 
 			if diff := cmp.Diff(tc.expFDTree, db.data.Members.FaultDomains, ignoreFaultDomainIDOption()); diff != "" {
 				t.Fatalf("wrong FaultDomainTree in DB (-want, +got):\n%s\n", diff)
 			}
+		})
+	}
+}
+
+func TestSystem_Database_UpdateMember(t *testing.T) {
+	const numReplicas = 3
+	testMembers := genTestMembers(t, 5)
+	fakeUUID := uuid.MustParse("ffffffff-ffff-ffff-ffff-ffffffffffff")
+
+	for name, tc := range map[string]struct {
+		startingMembers []*Member
+		notLeader       bool
+		updateMember    *Member
+		expMembers      []*Member
+		expErr          error
+		expVotersAdded  []string
+	}{
+		"not leader": {
+			startingMembers: testMembers,
+			updateMember:    testMembers[1],
+			notLeader:       true,
+			expMembers:      testMembers,
+			expErr:          errors.New("Management Service leader"),
+		},
+		"member not found": {
+			startingMembers: testMembers,
+			updateMember: &Member{
+				Rank: 123,
+				UUID: fakeUUID,
+			},
+			expMembers: testMembers,
+			expErr:     ErrMemberUUIDNotFound(fakeUUID),
+		},
+		"update replica": {
+			startingMembers: testMembers,
+			updateMember: &Member{
+				Rank:        testMembers[1].Rank,
+				UUID:        testMembers[1].UUID,
+				Addr:        testMembers[1].Addr,
+				State:       MemberStateReady,
+				FaultDomain: testMembers[1].FaultDomain,
+			},
+			expMembers: []*Member{
+				testMembers[0],
+				{
+					Rank:        testMembers[1].Rank,
+					UUID:        testMembers[1].UUID,
+					Addr:        testMembers[1].Addr,
+					State:       MemberStateReady,
+					FaultDomain: testMembers[1].FaultDomain,
+				},
+				testMembers[2],
+				testMembers[3],
+				testMembers[4],
+			},
+			expVotersAdded: []string{testMembers[1].Addr.String()},
+		},
+		"update non-replica": {
+			startingMembers: testMembers,
+			updateMember: &Member{
+				Rank:        testMembers[4].Rank,
+				UUID:        testMembers[4].UUID,
+				Addr:        testMembers[4].Addr,
+				State:       MemberStateReady,
+				FaultDomain: testMembers[4].FaultDomain,
+			},
+			expMembers: []*Member{
+				testMembers[0],
+				testMembers[1],
+				testMembers[2],
+				testMembers[3],
+				{
+					Rank:        testMembers[4].Rank,
+					UUID:        testMembers[4].UUID,
+					Addr:        testMembers[4].Addr,
+					State:       MemberStateReady,
+					FaultDomain: testMembers[4].FaultDomain,
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := test.MustLogContext(t)
+
+			replicaAddrs := make([]*net.TCPAddr, 0, numReplicas)
+			for i := 0; i < numReplicas; i++ {
+				replicaAddrs = append(replicaAddrs, tc.startingMembers[i].Addr)
+			}
+			t.Logf("%+v", replicaAddrs)
+
+			db := MockDatabaseWithCfg(t, logging.FromContext(ctx), &DatabaseConfig{
+				Replicas: replicaAddrs,
+			})
+			db.replicaAddr = replicaAddrs[0]
+
+			// setup initial member DB
+			for _, initMember := range tc.startingMembers {
+				raftUpdateTestMember(t, db, raftOpAddMember, initMember)
+			}
+
+			mockRaftSvc, ok := db.raft.svc.(*mockRaftService)
+			if !ok {
+				t.Fatal("raft service used wasn't a mockRaftService!")
+			}
+			if tc.notLeader {
+				mockRaftSvc.cfg.State = raft.Follower
+			}
+
+			err := db.UpdateMember(tc.updateMember)
+
+			test.CmpErr(t, tc.expErr, err)
+			expectMembersInDB(t, db, tc.expMembers)
+
+			test.CmpAny(t, "AddVoter calls", tc.expVotersAdded, mockRaftSvc.addVoterCalledForAddrs)
 		})
 	}
 }


### PR DESCRIPTION
When adding a new access point to config and restarting, the member is updated, not added, so it was not being considered a voter in the MS leader election.

Features: control

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
