### PR TITLE
DAOS-17564 vos: fix dth_rsrvd_cnt

### DIFF
--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -310,9 +310,12 @@ vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
 			goto cancel;
 		}
 
-		dru = &dth->dth_rsrvds[dth->dth_rsrvd_cnt++];
+		dru          = &dth->dth_rsrvds[dth->dth_rsrvd_cnt];
 		dru->dru_scm = *rsrvd_scmp;
-		*rsrvd_scmp = NULL;
+		if (*rsrvd_scmp != NULL) {
+			*rsrvd_scmp = NULL;
+			dth->dth_rsrvd_cnt++;
+		}
 
 		D_INIT_LIST_HEAD(&dru->dru_nvme);
 		d_list_splice_init(nvme_exts, &dru->dru_nvme);


### PR DESCRIPTION
Don't bump dth_rsrvd_cnt when there is nothing reserved.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
