### PR TITLE
DAOS-17576 chk: keep orphan pool shard which status is DOWN or DOWNOUT - b26

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -473,7 +473,8 @@ enum ds_pool_dir {
 enum ds_pool_tgt_status {
 	DS_POOL_TGT_NONEXIST,
 	DS_POOL_TGT_EMPTY,
-	DS_POOL_TGT_NORMAL
+	DS_POOL_TGT_NORMAL,
+	DS_POOL_TGT_ORPHAN
 };
 
 int


### PR DESCRIPTION
When check engine verifies pool membership, it may discard the rank or target which status is ‘DOWN' or 'DOWNOUT’ to release related space. Such logic was fine before. But as incremental reintegration feature is on the way, such logic needs to be improved; otherwise, if related orphan pool shard is removed by check engine, subsequent reintegration has to be started from the scratch instead of incremental work.

Test-tag: cat_recov

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
