### PR TITLE
Merge release/2.6 into google/2.6

### DIFF
--- a/src/control/go.mod
+++ b/src/control/go.mod
@@ -5,7 +5,7 @@ module github.com/daos-stack/daos/src/control
 // - debian packaging version checks: debian/control
 // Scons uses this file to extract the minimum version.
 go 1.21
-toolchain go1.23.7
+toolchain go1.23.0
 
 require (
 	github.com/Jille/raft-grpc-transport v1.2.0


### PR DESCRIPTION
The version of the Go toolchain in go.mod serves as a minimum. One
of our dependencies requires 1.23--it does not matter which version
of 1.23.

Signed-off-by: Kris Jacque <kris.jacque@hpe.com>