### PR TITLE
DAOS-17589 pool: not changing fseq for exclude during drain

### DIFF
--- a/src/pool/srv_pool_map.c
+++ b/src/pool/srv_pool_map.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2021-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -72,13 +73,13 @@ update_one_tgt(uuid_t pool_uuid, struct pool_map *map, struct pool_target *targe
 		switch (target->ta_comp.co_status) {
 		case PO_COMP_ST_DOWN:
 		case PO_COMP_ST_DOWNOUT:
+		case PO_COMP_ST_DRAIN:
 			/* Nothing to do, already excluded */
 			D_INFO(DF_MAP ": Skip exclude down " DF_TARGET "\n", DP_MAP(pool_uuid, map),
 			       DP_TARGET(target));
 			break;
 		case PO_COMP_ST_UP:
 		case PO_COMP_ST_UPIN:
-		case PO_COMP_ST_DRAIN:
 			D_DEBUG(DB_MD, DF_MAP ": change " DF_TARGET " to DOWN\n",
 				DP_MAP(pool_uuid, map), DP_TARGET(target));
 			target->ta_comp.co_status = PO_COMP_ST_DOWN;


### PR DESCRIPTION
If the target is being drained, then exclude should not change its fseq number, otherwise it may get wrong object layout and interfere the drain process.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
