### PR TITLE
DAOS-17594 cart: allocate iov buffer for deferred bulk

### DIFF
--- a/src/cart/crt_bulk.c
+++ b/src/cart/crt_bulk.c
@@ -123,7 +123,6 @@ crt_bulk_create(crt_context_t crt_ctx, d_sg_list_t *sgl,
 		D_DEBUG(DB_ALL, "Exceeded bulk limit, deferring bulk handle %p allocation\n",
 			ret_hdl);
 		ret_hdl->bound       = false;
-		ret_hdl->sgl         = *sgl;
 		ret_hdl->bulk_perm   = bulk_perm;
 		ret_hdl->hg_bulk_hdl = HG_BULK_NULL;
 		ret_hdl->crt_ctx     = crt_ctx;

--- a/src/cart/crt_bulk.c
+++ b/src/cart/crt_bulk.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -108,7 +109,19 @@ crt_bulk_create(crt_context_t crt_ctx, d_sg_list_t *sgl,
 
 	quota_rc = get_quota_resource(crt_ctx, CRT_QUOTA_BULKS);
 	if (quota_rc == -DER_QUOTA_LIMIT) {
-		D_DEBUG(DB_ALL, "Exceeded bulk limit, deferring bulk handle allocation\n");
+		int i;
+
+		D_ALLOC_ARRAY(ret_hdl->iovs, sgl->sg_nr);
+		if (ret_hdl->iovs == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+		for (i = 0; i < sgl->sg_nr; i++)
+			ret_hdl->iovs[i] = sgl->sg_iovs[i];
+		ret_hdl->sgl.sg_nr     = sgl->sg_nr;
+		ret_hdl->sgl.sg_nr_out = sgl->sg_nr_out;
+		ret_hdl->sgl.sg_iovs   = ret_hdl->iovs;
+
+		D_DEBUG(DB_ALL, "Exceeded bulk limit, deferring bulk handle %p allocation\n",
+			ret_hdl);
 		ret_hdl->bound       = false;
 		ret_hdl->sgl         = *sgl;
 		ret_hdl->bulk_perm   = bulk_perm;
@@ -124,6 +137,9 @@ crt_bulk_create(crt_context_t crt_ctx, d_sg_list_t *sgl,
 	rc = crt_hg_bulk_create(&ctx->cc_hg_ctx, sgl, bulk_perm, &ret_hdl->hg_bulk_hdl);
 	if (rc != 0) {
 		D_ERROR("crt_hg_bulk_create() failed, rc: " DF_RC "\n", DP_RC(rc));
+		if (ret_hdl->iovs != NULL)
+			D_FREE(ret_hdl->iovs);
+
 		D_FREE(ret_hdl);
 		D_GOTO(out, rc);
 	}
@@ -215,7 +231,11 @@ crt_bulk_free(crt_bulk_t crt_bulk)
 	if (bulk->crt_ctx)
 		put_quota_resource(bulk->crt_ctx, CRT_QUOTA_BULKS);
 out:
-	D_FREE(bulk);
+	if (bulk != NULL) {
+		if (bulk->iovs)
+			D_FREE(bulk->iovs);
+		D_FREE(bulk);
+	}
 	return rc;
 }
 

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -204,6 +205,8 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op, crt_bulk_t *pcrt_bul
 		hg_ret = hg_proc_hg_bulk_t(proc, &bulk->hg_bulk_hdl);
 
 		/* Free the wrapper struct */
+		if (bulk->iovs)
+			D_FREE(bulk->iovs);
 		D_FREE(bulk);
 		*pcrt_bulk = NULL;
 		return (hg_ret == HG_SUCCESS) ? 0 : -DER_HG;

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -406,6 +407,7 @@ struct crt_bulk {
 	bool            deferred;    /** whether handle allocation was deferred */
 	crt_context_t   crt_ctx;     /** context on which bulk is to be created  */
 	bool            bound;       /** whether crt_bulk_bind() was used on it */
+	d_iov_t        *iovs;        /** original iovs */
 	d_sg_list_t     sgl;         /** original sgl */
 	crt_bulk_perm_t bulk_perm;   /** bulk permissions */
 };


### PR DESCRIPTION
Allocate iov buffer for deferred bulk, since input sgl may use temporary iovs, which may cause memory corruption or data corruption if they are used by the following bulk creation.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
