### PR TITLE
DAOS-17598 utils: misc enhancements for DDB - b26

### DIFF
--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2015-2025 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -380,8 +381,10 @@ enum {
 	VOS_IT_UNCOMMITTED = (1 << 8),
 	/** The iterator is for an aggregation operation (EC or VOS) */
 	VOS_IT_FOR_AGG = (1 << 9),
+	/** Checking whether the target is aborted or not. */
+	VOS_IT_FOR_CHECK = (1 << 10),
 	/** Mask for all flags */
-	VOS_IT_MASK = (1 << 10) - 1,
+	VOS_IT_MASK = (1 << 11) - 1,
 };
 
 typedef struct {

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2025 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -559,8 +560,9 @@ dv_path_verify(daos_handle_t poh, struct dv_indexed_tree_path *itp)
 	args.pva_current_idx = 0;
 	args.pva_itp = itp;
 
-	param.ip_hdl = coh;
+	param.ip_hdl        = coh;
 	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+	param.ip_flags      = VOS_IT_FOR_CHECK;
 
 	rc = vos_iterate(&param, VOS_ITER_OBJ, true, &anchors,
 			 verify_path_pre_cb, verify_path_post_cb, &args, NULL);

--- a/src/vos/lru_array.h
+++ b/src/vos/lru_array.h
@@ -15,6 +15,7 @@
 #define __LRU_ARRAY__
 
 #include <daos/common.h>
+#include <daos/mem.h>
 
 struct lru_callbacks {
 	/** Called when an entry is going to be evicted from cache */
@@ -27,6 +28,8 @@ struct lru_callbacks {
 	void	(*lru_on_alloc)(void *arg, daos_size_t size);
 	/** Called on free of any LRU entries */
 	void	(*lru_on_free)(void *arg, daos_size_t size);
+	/** Called on conflict being detected. */
+	void    (*lru_on_conflict)(struct umem_instance *umm, void *arg);
 };
 
 struct lru_entry {
@@ -397,10 +400,10 @@ lrua_alloc_(struct lru_array *array, uint32_t *idx, void **entryp)
  *		-DER_NO_PERM	Attempted to overwrite existing entry
  *		-DER_INVAL	Index is not in range of array
  */
-#define lrua_allocx_inplace(array, idx, key, entryp)	\
-	lrua_allocx_inplace_(array, idx, key, (void **)(entryp))
+#define lrua_allocx_inplace(umm, array, idx, key, entryp)	\
+	lrua_allocx_inplace_(umm, array, idx, key, (void **)(entryp))
 static inline int
-lrua_allocx_inplace_(struct lru_array *array, uint32_t idx, uint64_t key,
+lrua_allocx_inplace_(struct umem_instance *umm, struct lru_array *array, uint32_t idx, uint64_t key,
 		     void **entryp)
 {
 	struct lru_entry	*entry;
@@ -430,7 +433,9 @@ lrua_allocx_inplace_(struct lru_array *array, uint32_t idx, uint64_t key,
 
 	entry = &sub->ls_table[ent_idx];
 	if (entry->le_key != key && entry->le_key != 0) {
-		D_ERROR("Cannot allocated idx %d in place\n", idx);
+		D_ERROR("Cannot allocated idx %u, key " DF_U64 " in place\n", idx, key);
+		if (array->la_cbs.lru_on_conflict != NULL && umm != NULL)
+			array->la_cbs.lru_on_conflict(umm, entry->le_payload);
 		return -DER_NO_PERM;
 	}
 

--- a/src/vos/tests/vts_ts.c
+++ b/src/vos/tests/vts_ts.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2020-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -620,8 +621,7 @@ inplace_test(struct lru_arg *ts_arg, uint32_t idx, uint64_t key1, uint64_t key2)
 	bool			 found;
 	int			 rc;
 
-	rc = lrua_allocx_inplace(ts_arg->array, idx, key1,
-				 &entry);
+	rc = lrua_allocx_inplace(NULL, ts_arg->array, idx, key1, &entry);
 	assert_rc_equal(rc, 0);
 	assert_non_null(entry);
 	assert_true(entry->magic1 == MAGIC1);

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -695,6 +695,9 @@ vos_mod_init(void)
 	d_getenv_bool("DAOS_SKIP_OLD_PARTIAL_DTX", &vos_skip_old_partial_dtx);
 	D_INFO("%s old partial committed DTX record\n", vos_skip_old_partial_dtx ? "Skip" : "Keep");
 
+	d_getenv_bool("DAOS_DIAG_MODE", &vos_diag_mode);
+	D_INFO("VOS disgnose mode is %s\n", vos_diag_mode ? "enabled" : "disabled");
+
 	return rc;
 }
 
@@ -1005,6 +1008,15 @@ vos_self_fini(void)
 }
 
 #define LMMDB_PATH	"/var/daos/"
+
+/*
+ * NOTE: Set environment "DAOS_DIAG_MODE" will enable giagnose mode in VOS. That will allow the
+ *	 pool/continer to be opened even if with some corruption (or conflict). Then subsequent
+ *	 opertion will have chance to fix/handle related issues. But there may be corruption or
+ *	 inconsistency in the pool/container, then it must be careful to enable DAOS_DIAG_MODE.
+ *	 It is usually used for DDB purpose.
+ */
+bool vos_diag_mode;
 
 int
 vos_self_init_ext(const char *db_path, bool use_sys_db, int tgt_id, bool nvme_init)

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2887,18 +2887,29 @@ vos_dtx_act_reindex(struct vos_container *cont)
 					" is invalid\n", dae_df->dae_lid);
 				D_GOTO(out, rc = -DER_IO);
 			}
-			rc = lrua_allocx_inplace(cont->vc_dtx_array,
+			rc = lrua_allocx_inplace(umm, cont->vc_dtx_array,
 					 dae_df->dae_lid - DTX_LID_RESERVED,
 					 dae_df->dae_epoch, &dae);
 			if (rc != 0) {
 				if (rc == -DER_NOMEM) {
-					D_ERROR("Not enough memory for DTX "
-						"table\n");
+					D_ERROR("Not enough memory for DTX " DF_DTI "reindex\n",
+						DP_DTI(&dae_df->dae_xid));
 				} else {
-					D_ERROR("Corruption in DTX table found,"
-						" lid=%d is invalid rc="DF_RC
-						"\n", dae_df->dae_lid,
-						DP_RC(rc));
+					/*
+					 * NOTE: Under diagnose mode (usually for DDB purpose),
+					 *	 ignore the DTX conflict to allow the container
+					 *	 to be opened, then it will be fixed/handled by
+					 *	 subsequent operation if possible.
+					 */
+					if (rc == -DER_NO_PERM && unlikely(vos_diag_mode)) {
+						D_ERROR("Ignore conflict for " DF_DTI " lid = %u\n",
+							DP_DTI(&dae_df->dae_xid),  dae_df->dae_lid);
+						continue;
+					}
+
+					D_ERROR("Corruption for active DTX " DF_DTI " reindex, "
+						"lid %u: " DF_RC "\n", DP_DTI(&dae_df->dae_xid),
+						dae_df->dae_lid, DP_RC(rc));
 					rc = -DER_IO;
 				}
 				D_GOTO(out, rc);
@@ -3301,9 +3312,57 @@ vos_dtx_rsrvd_fini(struct dtx_handle *dth)
 	}
 }
 
+static void
+vos_lru_dtx_conflict(struct umem_instance *umm, void *arg)
+{
+	struct vos_dtx_act_ent *dae = arg;
+	struct dtx_daos_target *ddt;
+	char                    buf[80];
+	char                   *ptr = buf;
+	int                     cnt = DAE_TGT_CNT(dae);
+	int                     rc;
+	int                     i;
+
+	if (DAE_MBS_DSIZE(dae) <= sizeof(DAE_MBS_INLINE(dae)))
+		ddt = DAE_MBS_INLINE(dae);
+	else
+		ddt = umem_off2ptr(umm, DAE_MBS_OFF(dae));
+
+	D_WARN("Detect conflict for the following DTX:\n"
+	       "xid: " DF_DTI "\n"
+	       "lid: %u\n"
+	       "oid: " DF_UOID "\n"
+	       "epoch: " DF_U64 "\n"
+	       "flags: %x\n"
+	       "mbs_flags: %x\n"
+	       "version: %u\n"
+	       "rec_cnt: %u\n"
+	       "tgt_cnt: %u\n"
+	       "participants:",
+	       DP_DTI(&DAE_XID(dae)), DAE_LID(dae), DP_UOID(DAE_OID(dae)), DAE_EPOCH(dae),
+	       DAE_FLAGS(dae), DAE_MBS_FLAGS(dae), DAE_VER(dae), DAE_REC_CNT(dae), cnt);
+
+	while (cnt >= 8) {
+		D_WARN("%8u%8u%8u%8u%8u%8u%8u%8u\n", ddt[0].ddt_id, ddt[1].ddt_id, ddt[2].ddt_id,
+		       ddt[3].ddt_id, ddt[4].ddt_id, ddt[5].ddt_id, ddt[6].ddt_id, ddt[7].ddt_id);
+		cnt -= 8;
+		ddt += 8;
+	}
+
+	if (cnt > 0) {
+		for (i = 0; i < cnt; i++) {
+			rc = snprintf(ptr, 79 - 8 * i, "%8u", ddt[i].ddt_id);
+			D_ASSERT(rc > 0);
+			ptr += rc;
+		}
+		D_WARN("%s\n", buf);
+	}
+}
+
 static const struct lru_callbacks lru_dtx_cache_cbs = {
-	.lru_on_alloc = vos_lru_alloc_track,
-	.lru_on_free = vos_lru_free_track,
+	.lru_on_alloc    = vos_lru_alloc_track,
+	.lru_on_free     = vos_lru_free_track,
+	.lru_on_conflict = vos_lru_dtx_conflict,
 };
 
 int

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -145,6 +145,7 @@ enum {
 extern unsigned int vos_agg_nvme_thresh;
 extern bool vos_dkey_punch_propagate;
 extern bool vos_skip_old_partial_dtx;
+extern bool vos_diag_mode;
 
 static inline uint32_t vos_byte2blkcnt(uint64_t bytes)
 {
@@ -1084,7 +1085,8 @@ struct vos_iterator {
 	 * mutual exclusion between aggregation and object discard.
 	 */
 	uint32_t it_from_parent : 1, it_for_purge : 1, it_for_discard : 1, it_for_migration : 1,
-	    it_show_uncommitted : 1, it_ignore_uncommitted : 1, it_for_sysdb : 1, it_for_agg : 1;
+	    it_show_uncommitted : 1, it_ignore_uncommitted : 1, it_for_sysdb : 1, it_for_agg : 1,
+	    it_for_check : 1;
 };
 
 /* Auxiliary structure for passing information between parent and nested
@@ -1365,6 +1367,8 @@ vos_iter_intent(struct vos_iterator *iter)
 		return DAOS_INTENT_IGNORE_NONCOMMITTED;
 	if (iter->it_for_migration)
 		return DAOS_INTENT_MIGRATION;
+	if (iter->it_for_check)
+		return DAOS_INTENT_CHECK;
 	return DAOS_INTENT_DEFAULT;
 }
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1729,6 +1730,8 @@ vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 		oiter->it_iter.it_for_agg = 1;
 	if (is_sysdb)
 		oiter->it_iter.it_for_sysdb = 1;
+	if (param->ip_flags & VOS_IT_FOR_CHECK)
+		oiter->it_iter.it_for_check = 1;
 	if (param->ip_flags == VOS_IT_KEY_TREE) {
 		/** Prepare the iterator from an already open tree handle.   See
 		 *  vos_iterate_key
@@ -1973,6 +1976,8 @@ nested_prep_common_init(struct vos_container *cont, struct vos_obj_iter **oiterp
 		oiter->it_iter.it_for_migration = 1;
 	if (cont->vc_pool->vp_sysdb)
 		oiter->it_iter.it_for_sysdb = 1;
+	if (info->ii_flags & VOS_IT_FOR_CHECK)
+		oiter->it_iter.it_for_check = 1;
 
 	return 0;
 }

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -562,6 +562,8 @@ oi_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 		oiter->oit_iter.it_for_migration = 1;
 	if (cont->vc_pool->vp_sysdb)
 		oiter->oit_iter.it_for_sysdb = 1;
+	if (param->ip_flags & VOS_IT_FOR_CHECK)
+		oiter->oit_iter.it_for_check = 1;
 
 	rc = dbtree_iter_prepare(cont->vc_btr_hdl, 0, &oiter->oit_hdl);
 	if (rc)


### PR DESCRIPTION
1. use IT_FOR_CHECK when iterate OBJ for dv_path_verify

From DDB perspective, the target with non-aborted DTX should be visible even if related DTX is prepared locally but not globally committed yet. It is the caller's duty to decide how to handle non-committed target in subsequent logic, or DTX resync will handle such DTX sometime later.

DDB logic will use DAOS_INTENT_CHECK instead of DAOS_INTENT_DEFAULT to indicate above purpose when iterate OBJ during dv_path_verify().

2. Dump DTX information when conflict being detected.

3. Introduce VOS diagnose mode to allow pool/containter to be opened even if there is some corruption, then related issue may be fixed or handled via subsequent operations. It is controlled via server side environment "DAOS_DIAG_MODE". Usually used for DDB purpose.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
