### PR TITLE
DAOS-17598 utils: misc enhancements for DDB - b26

### DIFF
--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2015-2025 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -380,8 +381,10 @@ enum {
 	VOS_IT_UNCOMMITTED = (1 << 8),
 	/** The iterator is for an aggregation operation (EC or VOS) */
 	VOS_IT_FOR_AGG = (1 << 9),
+	/** Checking whether the target is aborted or not. */
+	VOS_IT_FOR_CHECK = (1 << 10),
 	/** Mask for all flags */
-	VOS_IT_MASK = (1 << 10) - 1,
+	VOS_IT_MASK = (1 << 11) - 1,
 };
 
 typedef struct {

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2025 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -559,8 +560,9 @@ dv_path_verify(daos_handle_t poh, struct dv_indexed_tree_path *itp)
 	args.pva_current_idx = 0;
 	args.pva_itp = itp;
 
-	param.ip_hdl = coh;
+	param.ip_hdl        = coh;
 	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+	param.ip_flags      = VOS_IT_FOR_CHECK;
 
 	rc = vos_iterate(&param, VOS_ITER_OBJ, true, &anchors,
 			 verify_path_pre_cb, verify_path_post_cb, &args, NULL);

--- a/src/vos/tests/vts_ts.c
+++ b/src/vos/tests/vts_ts.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2020-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -620,8 +621,7 @@ inplace_test(struct lru_arg *ts_arg, uint32_t idx, uint64_t key1, uint64_t key2)
 	bool			 found;
 	int			 rc;
 
-	rc = lrua_allocx_inplace(ts_arg->array, idx, key1,
-				 &entry);
+	rc = lrua_allocx_inplace(NULL, ts_arg->array, idx, key1, &entry);
 	assert_rc_equal(rc, 0);
 	assert_non_null(entry);
 	assert_true(entry->magic1 == MAGIC1);

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -695,6 +695,9 @@ vos_mod_init(void)
 	d_getenv_bool("DAOS_SKIP_OLD_PARTIAL_DTX", &vos_skip_old_partial_dtx);
 	D_INFO("%s old partial committed DTX record\n", vos_skip_old_partial_dtx ? "Skip" : "Keep");
 
+	d_getenv_bool("DAOS_DIAG_MODE", &vos_diag_mode);
+	D_INFO("VOS disgnose mode is %s\n", vos_diag_mode ? "enabled" : "disabled");
+
 	return rc;
 }
 
@@ -1005,6 +1008,16 @@ vos_self_fini(void)
 }
 
 #define LMMDB_PATH	"/var/daos/"
+
+/*
+ * NOTE: Set environment "DAOS_DIAG_MODE" will enable giagnose mode in VOS. That will allow the
+ *	 pool/container to be opened even if with some corruption or conflict. Then subsequent
+ *	 operation will have chance to fix/handle related issue. But there may be corruption or
+ *	 inconsistency in the pool/container, then it must be careful to enable DAOS_DIAG_MODE.
+ *
+ *	 It is usually used for DDB purpose.
+ */
+bool vos_diag_mode;
 
 int
 vos_self_init_ext(const char *db_path, bool use_sys_db, int tgt_id, bool nvme_init)

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -145,6 +145,7 @@ enum {
 extern unsigned int vos_agg_nvme_thresh;
 extern bool vos_dkey_punch_propagate;
 extern bool vos_skip_old_partial_dtx;
+extern bool            vos_diag_mode;
 
 static inline uint32_t vos_byte2blkcnt(uint64_t bytes)
 {
@@ -1084,7 +1085,8 @@ struct vos_iterator {
 	 * mutual exclusion between aggregation and object discard.
 	 */
 	uint32_t it_from_parent : 1, it_for_purge : 1, it_for_discard : 1, it_for_migration : 1,
-	    it_show_uncommitted : 1, it_ignore_uncommitted : 1, it_for_sysdb : 1, it_for_agg : 1;
+	    it_show_uncommitted : 1, it_ignore_uncommitted : 1, it_for_sysdb : 1, it_for_agg : 1,
+	    it_for_check : 1;
 };
 
 /* Auxiliary structure for passing information between parent and nested
@@ -1365,6 +1367,8 @@ vos_iter_intent(struct vos_iterator *iter)
 		return DAOS_INTENT_IGNORE_NONCOMMITTED;
 	if (iter->it_for_migration)
 		return DAOS_INTENT_MIGRATION;
+	if (iter->it_for_check)
+		return DAOS_INTENT_CHECK;
 	return DAOS_INTENT_DEFAULT;
 }
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1729,6 +1730,8 @@ vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 		oiter->it_iter.it_for_agg = 1;
 	if (is_sysdb)
 		oiter->it_iter.it_for_sysdb = 1;
+	if (param->ip_flags & VOS_IT_FOR_CHECK)
+		oiter->it_iter.it_for_check = 1;
 	if (param->ip_flags == VOS_IT_KEY_TREE) {
 		/** Prepare the iterator from an already open tree handle.   See
 		 *  vos_iterate_key
@@ -1973,6 +1976,8 @@ nested_prep_common_init(struct vos_container *cont, struct vos_obj_iter **oiterp
 		oiter->it_iter.it_for_migration = 1;
 	if (cont->vc_pool->vp_sysdb)
 		oiter->it_iter.it_for_sysdb = 1;
+	if (info->ii_flags & VOS_IT_FOR_CHECK)
+		oiter->it_iter.it_for_check = 1;
 
 	return 0;
 }

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -562,6 +562,8 @@ oi_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 		oiter->oit_iter.it_for_migration = 1;
 	if (cont->vc_pool->vp_sysdb)
 		oiter->oit_iter.it_for_sysdb = 1;
+	if (param->ip_flags & VOS_IT_FOR_CHECK)
+		oiter->oit_iter.it_for_check = 1;
 
 	rc = dbtree_iter_prepare(cont->vc_btr_hdl, 0, &oiter->oit_hdl);
 	if (rc)


### PR DESCRIPTION
1. use IT_FOR_CHECK when iterate OBJ for dv_path_verify

From DDB perspective, the target with non-aborted DTX should be visible even if related DTX is prepared locally but not globally committed yet. It is the caller's duty to decide how to handle non-committed target in subsequent logic, or DTX resync will handle such DTX sometime later.

DDB logic will use DAOS_INTENT_CHECK instead of DAOS_INTENT_DEFAULT to indicate above purpose when iterate OBJ during dv_path_verify().

2. Dump DTX information when conflict being detected.

3. Introduce VOS diagnose mode to allow pool/containter to be opened even if there is some corruption, then related issue may be fixed or handled via subsequent operations. It is controlled via server side environment "DAOS_DIAG_MODE". Usually used for DDB purpose.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
