### PR TITLE
DAOS-16817 test: add some sleep in dfs mtime check to acomodate CI

### DIFF
--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -21,10 +21,15 @@ static dfs_t		*dfs_mt;
 static bool
 check_ts(struct timespec l, struct timespec r)
 {
-	if (l.tv_sec == r.tv_sec)
+	if (l.tv_sec == r.tv_sec) {
+		if (l.tv_nsec >= r.tv_nsec)
+			print_error("timestamp difference of %09ld nsec\n", l.tv_nsec - r.tv_nsec);
 		return l.tv_nsec < r.tv_nsec;
-	else
+	} else {
+		if (l.tv_sec >= r.tv_sec)
+			print_error("timestamp difference of %jd sec\n", l.tv_sec - r.tv_sec);
 		return l.tv_sec < r.tv_sec;
+	}
 }
 
 static void
@@ -1580,7 +1585,7 @@ run_time_tests(dfs_obj_t *obj, char *name, int mode)
 
 	printf("Start Time:\n");
 	printtimespec(first_ts);
-
+	usleep(10000);
 	if (S_ISREG(mode)) {
 		d_iov_set(&iov, buf, 64);
 		sgl.sg_nr = 1;


### PR DESCRIPTION
some CI clusters seem to have out of synch client and servers causing dfs mtime check to fail. add some sleeps to accomodate for that.

Quick-Functional: true
Test-tag: test_daos_dfs_unit

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
