### PR TITLE
DAOS-17532 test: Remove local host client use from functional tests

### DIFF
--- a/src/tests/ftest/container/api_basic_attribute.yaml
+++ b/src/tests/ftest/container/api_basic_attribute.yaml
@@ -1,7 +1,6 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers: 1
+  test_clients: 1
 timeout: 60
 server_config:
   name: daos_server

--- a/src/tests/ftest/container/auto_oc_selection.yaml
+++ b/src/tests/ftest/container/auto_oc_selection.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 5
+  test_clients: 1
 timeout: 180
 server_config:
   name: daos_server

--- a/src/tests/ftest/container/basic_snapshot.yaml
+++ b/src/tests/ftest/container/basic_snapshot.yaml
@@ -1,8 +1,7 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 timeout: 120
 hosts:
   test_servers: 2
+  test_clients: 1
 server_config:
   name: daos_server
   engines_per_host: 1

--- a/src/tests/ftest/container/boundary.py
+++ b/src/tests/ftest/container/boundary.py
@@ -133,7 +133,7 @@ class BoundaryTest(TestWithServers):
             3. Launch io and sync-up each container.
             4. Close container.
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium
+        :avocado: tags=hw,large
         :avocado: tags=container,pool,boundary_test
         :avocado: tags=BoundaryTest,test_container_boundary
         """

--- a/src/tests/ftest/container/boundary.py
+++ b/src/tests/ftest/container/boundary.py
@@ -121,6 +121,7 @@ class BoundaryTest(TestWithServers):
 
     def test_container_boundary(self):
         """JIRA ID: DAOS-8464 Test lots of pools and containers in parallel.
+
         Test Description:
             Testcase 1: Test 1 pool with containers boundary condition in parallel.
             Testcase 2: Test large number of pools and containers in parallel.

--- a/src/tests/ftest/container/boundary.yaml
+++ b/src/tests/ftest/container/boundary.yaml
@@ -2,6 +2,7 @@ hosts:
   test_servers: 3
   test_clients: 1
 
+
 timeout: 1200
 
 server_config:

--- a/src/tests/ftest/container/boundary.yaml
+++ b/src/tests/ftest/container/boundary.yaml
@@ -1,5 +1,5 @@
 hosts:
-  test_servers: 4
+  test_servers: 7
   test_clients: 1
 
 timeout: 1200

--- a/src/tests/ftest/container/boundary.yaml
+++ b/src/tests/ftest/container/boundary.yaml
@@ -2,7 +2,6 @@ hosts:
   test_servers: 3
   test_clients: 1
 
-
 timeout: 1200
 
 server_config:
@@ -10,7 +9,7 @@ server_config:
   engines_per_host: 2
   engines:
     0:
-      targets: 1
+      targets: 4
       fabric_iface: ib0
       fabric_iface_port: 31317
       log_file: daos_server0.log
@@ -19,7 +18,7 @@ server_config:
         - DAOS_MD_CAP=1024
       storage: auto
     1:
-      targets: 1
+      targets: 4
       fabric_iface: ib1
       fabric_iface_port: 31417
       log_file: daos_server1.log

--- a/src/tests/ftest/container/boundary.yaml
+++ b/src/tests/ftest/container/boundary.yaml
@@ -1,14 +1,27 @@
 hosts:
-  test_servers: 4
+  test_servers: 2
+  test_clients: 1
 
 timeout: 1200
 
 server_config:
   name: daos_server
-  engines_per_host: 1
+  engines_per_host: 2
   engines:
     0:
       targets: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      env_vars:
+        - DD_MASK=group_metadata_only
+        - DAOS_MD_CAP=1024
+      storage: auto
+    1:
+      targets: 1
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
       env_vars:
         - DD_MASK=group_metadata_only
         - DAOS_MD_CAP=1024

--- a/src/tests/ftest/container/boundary.yaml
+++ b/src/tests/ftest/container/boundary.yaml
@@ -1,5 +1,5 @@
 hosts:
-  test_servers: 7
+  test_servers: 5
   test_clients: 1
 
 timeout: 1200

--- a/src/tests/ftest/container/boundary.yaml
+++ b/src/tests/ftest/container/boundary.yaml
@@ -1,5 +1,5 @@
 hosts:
-  test_servers: 2
+  test_servers: 3
   test_clients: 1
 
 timeout: 1200

--- a/src/tests/ftest/container/boundary.yaml
+++ b/src/tests/ftest/container/boundary.yaml
@@ -1,5 +1,5 @@
 hosts:
-  test_servers: 3
+  test_servers: 4
   test_clients: 1
 
 timeout: 1200

--- a/src/tests/ftest/container/destroy.yaml
+++ b/src/tests/ftest/container/destroy.yaml
@@ -2,6 +2,7 @@
 
 hosts:
   test_servers: 1
+  test_clients: 1
 
 timeout: 60
 

--- a/src/tests/ftest/container/fill_destroy_loop.yaml
+++ b/src/tests/ftest/container/fill_destroy_loop.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 
 timeout: 900
 

--- a/src/tests/ftest/container/label.yaml
+++ b/src/tests/ftest/container/label.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 timeouts:
   test_container_label_valid: 120
   test_container_label_invalid: 60

--- a/src/tests/ftest/container/list.yaml
+++ b/src/tests/ftest/container/list.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 
 timeout: 360
 

--- a/src/tests/ftest/container/open.yaml
+++ b/src/tests/ftest/container/open.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 timeout: 50
 server_config:
   name: daos_server

--- a/src/tests/ftest/container/per_server_fault_domain.py
+++ b/src/tests/ftest/container/per_server_fault_domain.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -89,7 +90,7 @@ class PerServerFaultDomainTest(IorTestBase):
         8. Verify container's Health status is HEALTHY.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium
+        :avocado: tags=hw,large
         :avocado: tags=container
         :avocado: tags=PerServerFaultDomainTest,test_rf1_healthy
         """
@@ -122,7 +123,7 @@ class PerServerFaultDomainTest(IorTestBase):
         8. Verify container's Health status is UNCLEAN.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium
+        :avocado: tags=hw,large
         :avocado: tags=container
         :avocado: tags=PerServerFaultDomainTest,test_rf1_unclean
         """
@@ -160,7 +161,7 @@ class PerServerFaultDomainTest(IorTestBase):
         8. Verify container's Health status is HEALTHY.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium
+        :avocado: tags=hw,large
         :avocado: tags=container
         :avocado: tags=PerServerFaultDomainTest,test_rf2_healthy
         """
@@ -236,7 +237,7 @@ class PerServerFaultDomainTest(IorTestBase):
         8. Verify container's Health status is HEALTHY.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium
+        :avocado: tags=hw,large
         :avocado: tags=container
         :avocado: tags=PerServerFaultDomainTest,test_rf2_unclean
         """

--- a/src/tests/ftest/container/per_server_fault_domain.yaml
+++ b/src/tests/ftest/container/per_server_fault_domain.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 4
+  test_clients: 1
 
 timeout: 300
 

--- a/src/tests/ftest/container/query_attribute.yaml
+++ b/src/tests/ftest/container/query_attribute.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 timeout: 180
 server_config:
   name: daos_server

--- a/src/tests/ftest/container/query_properties.yaml
+++ b/src/tests/ftest/container/query_properties.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 
 timeout: 100
 

--- a/src/tests/ftest/container/snapshot.yaml
+++ b/src/tests/ftest/container/snapshot.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 2
+  test_clients: 1
 timeout: 600
 faults:
   no_faults:

--- a/src/tests/ftest/control/daos_object_query.yaml
+++ b/src/tests/ftest/control/daos_object_query.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 4
+  test_clients: 1
 timeout: 80
 server_config:
   name: daos_server

--- a/src/tests/ftest/control/daos_snapshot.yaml
+++ b/src/tests/ftest/control/daos_snapshot.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 timeout: 400
 server_config:
   name: daos_server

--- a/src/tests/ftest/control/dmg_system_cleanup.py
+++ b/src/tests/ftest/control/dmg_system_cleanup.py
@@ -38,8 +38,8 @@ class DmgSystemCleanupTest(TestWithServers):
         :avocado: tags=DmgSystemCleanupTest,test_dmg_system_cleanup_one_host
         """
         # Print out where this is running
-        hostname = gethostname().split(".")[0]
-        self.log.info("Script is running on %s", hostname)
+        control_host = gethostname().split(".")[0]
+        self.log.info("Script is running on %s", control_host)
 
         # Create 2 pools and create a container in each pool.
         self.pool = []
@@ -67,15 +67,7 @@ class DmgSystemCleanupTest(TestWithServers):
 
         # Call dmg system cleanup on the host and create cleaned pool list.
         dmg_cmd = self.get_dmg_command()
-        # result = dmg_cmd.system_cleanup(self.agent_managers[0].hosts, verbose=True)
-
-        # Debug
-        result = None
-        agent_hosts = self.agent_managers[0].hosts
-        self.log.debug(f"## agent_hosts = {agent_hosts}")
-        for agent_host in agent_hosts:
-            self.log.debug(f"## agent_host = {agent_host}")
-            result = dmg_cmd.system_cleanup(agent_host, verbose=True)
+        result = dmg_cmd.system_cleanup(machinename=control_host)
 
         # Build list of pools and how many handles were cleaned (should be 6 each)
         actual_counts = {}

--- a/src/tests/ftest/control/dmg_system_cleanup.py
+++ b/src/tests/ftest/control/dmg_system_cleanup.py
@@ -67,7 +67,15 @@ class DmgSystemCleanupTest(TestWithServers):
 
         # Call dmg system cleanup on the host and create cleaned pool list.
         dmg_cmd = self.get_dmg_command()
-        result = dmg_cmd.system_cleanup(self.agent_managers[0].hosts, verbose=True)
+        # result = dmg_cmd.system_cleanup(self.agent_managers[0].hosts, verbose=True)
+
+        # Debug
+        result = None
+        agent_hosts = self.agent_managers[0].hosts
+        self.log.debug(f"## agent_hosts = {agent_hosts}")
+        for agent_host in agent_hosts:
+            self.log.debug(f"## agent_host = {agent_host}")
+            result = dmg_cmd.system_cleanup(agent_host, verbose=True)
 
         # Build list of pools and how many handles were cleaned (should be 6 each)
         actual_counts = {}

--- a/src/tests/ftest/control/dmg_system_cleanup.py
+++ b/src/tests/ftest/control/dmg_system_cleanup.py
@@ -1,6 +1,5 @@
 """
   (C) Copyright 2020-2022 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -68,7 +67,7 @@ class DmgSystemCleanupTest(TestWithServers):
 
         # Call dmg system cleanup on the host and create cleaned pool list.
         dmg_cmd = self.get_dmg_command()
-        result = dmg_cmd.system_cleanup(self.server_managers[0].hosts, verbose=True)
+        result = dmg_cmd.system_cleanup(self.agent_managers[0].hosts, verbose=True)
 
         # Build list of pools and how many handles were cleaned (should be 6 each)
         actual_counts = {}

--- a/src/tests/ftest/control/dmg_system_cleanup.py
+++ b/src/tests/ftest/control/dmg_system_cleanup.py
@@ -28,8 +28,7 @@ class DmgSystemCleanupTest(TestWithServers):
     """
 
     def test_dmg_system_cleanup_one_host(self):
-        """
-        JIRA ID: DAOS-6471
+        """Jira ID: DAOS-6471
 
         Test Description: Test dmg system cleanup.
 

--- a/src/tests/ftest/control/dmg_system_cleanup.py
+++ b/src/tests/ftest/control/dmg_system_cleanup.py
@@ -28,7 +28,8 @@ class DmgSystemCleanupTest(TestWithServers):
     """
 
     def test_dmg_system_cleanup_one_host(self):
-        """Jira ID: DAOS-6471
+        """
+        JIRA ID: DAOS-6471
 
         Test Description: Test dmg system cleanup.
 

--- a/src/tests/ftest/control/dmg_system_cleanup.py
+++ b/src/tests/ftest/control/dmg_system_cleanup.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2022 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -67,7 +68,7 @@ class DmgSystemCleanupTest(TestWithServers):
 
         # Call dmg system cleanup on the host and create cleaned pool list.
         dmg_cmd = self.get_dmg_command()
-        result = dmg_cmd.system_cleanup(self.agent_managers[0].hosts, verbose=True)
+        result = dmg_cmd.system_cleanup(self.server_managers[0].hosts, verbose=True)
 
         # Build list of pools and how many handles were cleaned (should be 6 each)
         actual_counts = {}

--- a/src/tests/ftest/control/dmg_system_cleanup.py
+++ b/src/tests/ftest/control/dmg_system_cleanup.py
@@ -1,5 +1,6 @@
 """
-  (C) Copyright 2020-2022 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/ftest/control/dmg_system_cleanup.yaml
+++ b/src/tests/ftest/control/dmg_system_cleanup.yaml
@@ -1,6 +1,6 @@
 hosts:
   test_servers: 1
-  # test_clients: 1
+  test_clients: 1
 timeout: 600
 server_config:
   name: daos_server

--- a/src/tests/ftest/control/dmg_system_cleanup.yaml
+++ b/src/tests/ftest/control/dmg_system_cleanup.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 timeout: 600
 server_config:
   name: daos_server

--- a/src/tests/ftest/control/dmg_system_cleanup.yaml
+++ b/src/tests/ftest/control/dmg_system_cleanup.yaml
@@ -1,6 +1,5 @@
 hosts:
   test_servers: 1
-  test_clients: 1
 timeout: 600
 server_config:
   name: daos_server

--- a/src/tests/ftest/control/dmg_system_cleanup.yaml
+++ b/src/tests/ftest/control/dmg_system_cleanup.yaml
@@ -1,6 +1,6 @@
 hosts:
   test_servers: 1
-  test_clients: 1
+  # test_clients: 1
 timeout: 600
 server_config:
   name: daos_server

--- a/src/tests/ftest/dfuse/bash.yaml
+++ b/src/tests/ftest/dfuse/bash.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 timeout: 900
 server_config:
   name: daos_server

--- a/src/tests/ftest/dfuse/bash_dcache.yaml
+++ b/src/tests/ftest/dfuse/bash_dcache.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 timeout: 900
 server_config:
   name: daos_server

--- a/src/tests/ftest/dfuse/bash_fd.yaml
+++ b/src/tests/ftest/dfuse/bash_fd.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 timeout: 900
 server_config:
   name: daos_server

--- a/src/tests/ftest/dfuse/enospace.yaml
+++ b/src/tests/ftest/dfuse/enospace.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 timeout: 120
 server_config:
   name: daos_server

--- a/src/tests/ftest/dfuse/il_whitelist.yaml
+++ b/src/tests/ftest/dfuse/il_whitelist.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 timeout: 300
 server_config:
   name: daos_server

--- a/src/tests/ftest/dfuse/root_container.yaml
+++ b/src/tests/ftest/dfuse/root_container.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 
 timeout: 1800
 

--- a/src/tests/ftest/dtx/basic.yaml
+++ b/src/tests/ftest/dtx/basic.yaml
@@ -1,7 +1,6 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers: 2
+  test_clients: 1
 timeout: 120
 faults: !mux
   # commenting out the fault injection bit

--- a/src/tests/ftest/object/create_many_dkeys.yaml
+++ b/src/tests/ftest/object/create_many_dkeys.yaml
@@ -1,7 +1,6 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers: 2
+  test_clients: 1
 timeout: 3600
 server_config:
   name: daos_server

--- a/src/tests/ftest/object/fetch_bad_param.yaml
+++ b/src/tests/ftest/object/fetch_bad_param.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 2
+  test_clients: 1
 timeouts:
   test_null_ptrs: 240
 server_config:

--- a/src/tests/ftest/object/integrity.yaml
+++ b/src/tests/ftest/object/integrity.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 2
+  test_clients: 1
 # JIRA-3132 tmp update timeout from 2400 to 4800
 timeout: 4800
 server_config:

--- a/src/tests/ftest/object/open_bad_param.yaml
+++ b/src/tests/ftest/object/open_bad_param.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 server_config:
   name: daos_server
   engines_per_host: 1

--- a/src/tests/ftest/object/punch_test.yaml
+++ b/src/tests/ftest/object/punch_test.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 2
+  test_clients: 1
 timeout: 60
 server_config:
   name: daos_server

--- a/src/tests/ftest/object/same_key_different_value.yaml
+++ b/src/tests/ftest/object/same_key_different_value.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 timeout: 180
 server_config:
   name: daos_server

--- a/src/tests/ftest/object/update_bad_param.yaml
+++ b/src/tests/ftest/object/update_bad_param.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 2
+  test_clients: 1
 server_config:
   name: daos_server
   engines_per_host: 1

--- a/src/tests/ftest/pool/evict.yaml
+++ b/src/tests/ftest/pool/evict.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 4
+  test_clients: 1
 
 server_config:
   name: daos_server

--- a/src/tests/ftest/pool/pda.yaml
+++ b/src/tests/ftest/pool/pda.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 timeout: 90
 server_config:
   name: daos_server

--- a/src/tests/ftest/pool/permission.yaml
+++ b/src/tests/ftest/pool/permission.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 2
+  test_clients: 1
 
 timeout: 300
 

--- a/src/tests/ftest/rebuild/basic.yaml
+++ b/src/tests/ftest/rebuild/basic.yaml
@@ -1,7 +1,6 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers: 6
+  test_clients: 1
 timeout: 600
 server_config:
   name: daos_server

--- a/src/tests/ftest/rebuild/with_io.yaml
+++ b/src/tests/ftest/rebuild/with_io.yaml
@@ -1,7 +1,6 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers: 6
+  test_clients: 1
 timeout: 5000
 server_config:
   name: daos_server

--- a/src/tests/ftest/recovery/container_cleanup.yaml
+++ b/src/tests/ftest/recovery/container_cleanup.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 
 timeout: 360
 

--- a/src/tests/ftest/recovery/container_list_consolidation.yaml
+++ b/src/tests/ftest/recovery/container_list_consolidation.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 
 timeout: 360
 

--- a/src/tests/ftest/recovery/ddb.yaml
+++ b/src/tests/ftest/recovery/ddb.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 
 timeout: 1800
 

--- a/src/tests/ftest/recovery/pool_list_consolidation.yaml
+++ b/src/tests/ftest/recovery/pool_list_consolidation.yaml
@@ -1,13 +1,23 @@
 hosts:
-  test_servers: 4
+  test_servers: 2
+  test_clients: 1
 
 timeout: 240
 
 server_config:
   name: daos_server
-  engines_per_host: 1
+  engines_per_host: 2
   engines:
     0:
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      nr_xs_helpers: 1
+      storage: auto
+    1:
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
       nr_xs_helpers: 1
       storage: auto
 

--- a/src/tests/ftest/recovery/pool_membership.yaml
+++ b/src/tests/ftest/recovery/pool_membership.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 2
+  test_clients: 1
 
 timeout: 360
 

--- a/src/tests/ftest/security/cont_create_acl.yaml
+++ b/src/tests/ftest/security/cont_create_acl.yaml
@@ -1,7 +1,6 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers: 1
+  test_clients: 1
 timeout: 60
 server_config:
   name: daos_server

--- a/src/tests/ftest/telemetry/dkey_akey_enum_punch.yaml
+++ b/src/tests/ftest/telemetry/dkey_akey_enum_punch.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 2
+  test_clients: 1
 
 timeout: 320
 


### PR DESCRIPTION
Add "test_clients: 1" to the test yaml for the tests that use client such as creating a container.

Some tests are already using up the available nodes, so update the test yaml to use dual engines per node to make room for the client node.

container/per_server_fault_domain needs to move to Hardware Large.

control/dmg_system_cleanup.py - dmg system cleanup should take control node. It used to take self.agent_managers[0].hosts and this used to work when there was only one server node because the agent and the control node were the same. However, now we added a client node, so we need to specify the control node.

container/boundary.py - Originally test_servers was 4. We added test_client: 1, so it had to move to hw,large. To stay in hw,medium, we made it to dual engine and reduced the server count to 2. However, this resulted in smaller targets and caused "No space on storage target" error during pool create. To fix this, I could have made it back to single engine with 4 servers, but instead I kept the dual engine and added more servers, so now there are 5 servers.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-medium-md-on-ssd: false
Test-tag: ContainerAPIBasicAttributeTest AutoOCSelectionTest BasicSnapshot ContainerDestroyTest BoundaryPoolContainerSpace ContainerLabelTest OpenContainerTest ContainerQueryAttributeTest QueryPropertiesTest Snapshot DaosObjectQuery DaosSnapshotTest DmgSystemCleanupTest DFuseBashdcacheTest DFuseFdTest DfuseBashCmd DfuseEnospace ILWhiteList RootContainerTest BasicTxTest CreateManyDkeys ObjFetchBadParam ObjectDataValidation ObjOpenBadParam PunchTest SameKeyDifferentValue ObjUpdateBadParam PoolEvictTest PoolPDAProperty Permission RbldBasic RbldWithIO ContainerCleanupTest ContainerListConsolidationTest DdbTest PoolMembershipTest CreateContainterACLTest DkeyAkeyEnumPunch

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
