### PR TITLE
DAOS-17598 vos: misc enhancements for handling DTX conflict - b26

### DIFF
--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2015-2025 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -380,8 +381,10 @@ enum {
 	VOS_IT_UNCOMMITTED = (1 << 8),
 	/** The iterator is for an aggregation operation (EC or VOS) */
 	VOS_IT_FOR_AGG = (1 << 9),
+	/** Checking whether the target is aborted or not. */
+	VOS_IT_FOR_CHECK = (1 << 10),
 	/** Mask for all flags */
-	VOS_IT_MASK = (1 << 10) - 1,
+	VOS_IT_MASK = (1 << 11) - 1,
 };
 
 typedef struct {

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2025 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -559,8 +560,9 @@ dv_path_verify(daos_handle_t poh, struct dv_indexed_tree_path *itp)
 	args.pva_current_idx = 0;
 	args.pva_itp = itp;
 
-	param.ip_hdl = coh;
+	param.ip_hdl        = coh;
 	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+	param.ip_flags      = VOS_IT_FOR_CHECK;
 
 	rc = vos_iterate(&param, VOS_ITER_OBJ, true, &anchors,
 			 verify_path_pre_cb, verify_path_post_cb, &args, NULL);
@@ -1808,6 +1810,7 @@ dv_sync_smd(const char *nvme_conf, const char *db_path, dv_smd_sync_complete com
 	rc = smd_init(vos_db_get());
 	if (!SUCCESS(rc)) {
 		D_ERROR("SMD failed to initialize: "DF_RC"\n", DP_RC(rc));
+		vos_self_fini();
 		return rc;
 	}
 
@@ -1819,7 +1822,7 @@ dv_sync_smd(const char *nvme_conf, const char *db_path, dv_smd_sync_complete com
 		rc = sync_cb_args.sync_rc;
 
 	smd_fini();
-	vos_db_fini();
+	vos_self_fini();
 
 	return rc;
 }

--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -156,6 +157,29 @@ ilog_persist(daos_handle_t loh, const struct ilog_id *id);
  */
 int
 ilog_abort(daos_handle_t loh, const struct ilog_id *id);
+
+/** Validate the provided ilog.
+ *
+ * Note: It is designed for catastrophic recovery. Not to perform at run-time.
+ *
+ * \param	loh[in]		Open log handle
+ * \param	log_id[in]	Identifier for log entry
+ *
+ * \return true if ilog is valid.
+ **/
+bool
+ilog_is_valid(daos_handle_t loh, struct ilog_id *log_id);
+
+/** Replace TX local ID for specified ilog entry
+ *
+ *  \param	loh[in]		Open log handle
+ *  \param	log_id[in]	Identifier for log entry
+ *  \param	tx_id[in]	New TX LID for the log entry
+ *
+ *  \return 0 on success, error code on failure
+ */
+int
+ilog_entry_replace(daos_handle_t loh, struct ilog_id *log_id, uint32_t tx_id);
 
 /** Incarnation log entry description */
 struct ilog_entry {

--- a/src/vos/lru_array.h
+++ b/src/vos/lru_array.h
@@ -431,6 +431,8 @@ lrua_allocx_inplace_(struct lru_array *array, uint32_t idx, uint64_t key,
 	entry = &sub->ls_table[ent_idx];
 	if (entry->le_key != key && entry->le_key != 0) {
 		D_ERROR("Cannot allocated idx %d in place\n", idx);
+		/* Return the conflict one for further process. */
+		*entryp = entry->le_payload;
 		return -DER_NO_PERM;
 	}
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -75,7 +75,9 @@ dtx_type2umoff_flag(umem_off_t *rec, uint32_t type)
 static inline uint32_t
 dtx_umoff_flag2type(umem_off_t umoff)
 {
-	switch (umem_off2flags(umoff) & DTX_UMOFF_TYPES) {
+	uint32_t flags = umem_off2flags(umoff) & DTX_UMOFF_TYPES;
+
+	switch (flags) {
 	case DTX_UMOFF_ILOG:
 		return DTX_RT_ILOG;
 	case DTX_UMOFF_SVT:
@@ -83,7 +85,8 @@ dtx_umoff_flag2type(umem_off_t umoff)
 	case DTX_UMOFF_EVT:
 		return DTX_RT_EVT;
 	default:
-		D_ASSERT(0);
+		D_ERROR("Invalid umoff " UMOFF_PF " with bad flags %x\n", UMOFF_P(umoff), flags);
+		return DTX_RT_UNKNOWN;
 	}
 
 	return 0;
@@ -216,11 +219,11 @@ dtx_act_ent_cleanup(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 	D_FREE(dae->dae_records);
 	dae->dae_rec_cap = 0;
 	DAE_REC_CNT(dae) = 0;
-	dae->dae_need_release = 0;
 
 	if (!keep_df) {
-		dae->dae_df_off = UMOFF_NULL;
-		dae->dae_dbd = NULL;
+		dae->dae_need_release = 0;
+		dae->dae_df_off       = UMOFF_NULL;
+		dae->dae_dbd          = NULL;
 	}
 }
 
@@ -673,6 +676,76 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 }
 
 static int
+dtx_dae_df_discard(struct vos_container *cont, struct vos_dtx_blob_df *dbd,
+		   struct vos_dtx_act_ent_df *dae_df)
+{
+	struct umem_instance   *umm     = vos_cont2umm(cont);
+	struct vos_cont_df     *cont_df = cont->vc_cont_df;
+	struct vos_dtx_blob_df *tmp;
+	umem_off_t              dbd_off;
+	int                     rc;
+
+	if (dbd->dbd_count > 1 || dbd->dbd_index < dbd->dbd_cap) {
+		rc = umem_tx_add_ptr(umm, &dae_df->dae_flags, sizeof(dae_df->dae_flags));
+		if (rc != 0)
+			return rc;
+
+		rc = umem_tx_add_ptr(umm, &dbd->dbd_count, sizeof(dbd->dbd_count));
+		if (rc != 0)
+			return rc;
+
+		/* Mark the DTX entry as invalid persistently. */
+		dae_df->dae_flags = DTE_INVALID;
+		dbd->dbd_count--;
+	} else {
+		dbd_off = umem_ptr2off(umm, dbd);
+		tmp     = umem_off2ptr(umm, dbd->dbd_prev);
+		if (tmp != NULL) {
+			rc = umem_tx_add_ptr(umm, &tmp->dbd_next, sizeof(tmp->dbd_next));
+			if (rc != 0)
+				return rc;
+
+			tmp->dbd_next = dbd->dbd_next;
+		}
+
+		tmp = umem_off2ptr(umm, dbd->dbd_next);
+		if (tmp != NULL) {
+			rc = umem_tx_add_ptr(umm, &tmp->dbd_prev, sizeof(tmp->dbd_prev));
+			if (rc != 0)
+				return rc;
+
+			tmp->dbd_prev = dbd->dbd_prev;
+		}
+
+		if (cont_df->cd_dtx_active_head == dbd_off) {
+			rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_head,
+					     sizeof(cont_df->cd_dtx_active_head));
+			if (rc != 0)
+				return rc;
+
+			cont_df->cd_dtx_active_head = dbd->dbd_next;
+		}
+
+		if (cont_df->cd_dtx_active_tail == dbd_off) {
+			rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_tail,
+					     sizeof(cont_df->cd_dtx_active_tail));
+			if (rc != 0)
+				return rc;
+
+			cont_df->cd_dtx_active_tail = dbd->dbd_prev;
+		}
+
+		rc = umem_free(umm, dbd_off);
+
+		DL_CDEBUG(rc != 0, DLOG_ERR, DB_TRACE, rc,
+			  "Release DTX active blob %p (" UMOFF_PF ") for cont " DF_UUID, dbd,
+			  UMOFF_P(dbd_off), DP_UUID(cont->vc_id));
+	}
+
+	return rc;
+}
+
+static int
 dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae, bool abort, bool keep_act)
 {
 	struct umem_instance		*umm = vos_cont2umm(cont);
@@ -748,6 +821,7 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae, bool ab
 			rc = umem_tx_add_ptr(umm, &dae_df->dae_rec_off, sizeof(dae_df->dae_rec_off));
 			if (rc != 0)
 				return rc;
+
 			dae_df->dae_rec_off = UMOFF_NULL;
 		}
 	}
@@ -789,70 +863,7 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae, bool ab
 			return rc;
 	}
 
-	if (dbd->dbd_count > 1 || dbd->dbd_index < dbd->dbd_cap) {
-		rc = umem_tx_add_ptr(umm, &dae_df->dae_flags, sizeof(dae_df->dae_flags));
-		if (rc != 0)
-			return rc;
-
-		rc = umem_tx_add_ptr(umm, &dbd->dbd_count, sizeof(dbd->dbd_count));
-		if (rc != 0)
-			return rc;
-
-		/* Mark the DTX entry as invalid persistently. */
-		dae_df->dae_flags = DTE_INVALID;
-		dbd->dbd_count--;
-	} else {
-		struct vos_cont_df	*cont_df = cont->vc_cont_df;
-		umem_off_t		 dbd_off;
-		struct vos_dtx_blob_df	*tmp;
-
-		dbd_off = umem_ptr2off(umm, dbd);
-		tmp = umem_off2ptr(umm, dbd->dbd_prev);
-		if (tmp != NULL) {
-			rc = umem_tx_add_ptr(umm, &tmp->dbd_next,
-					     sizeof(tmp->dbd_next));
-			if (rc != 0)
-				return rc;
-
-			tmp->dbd_next = dbd->dbd_next;
-		}
-
-		tmp = umem_off2ptr(umm, dbd->dbd_next);
-		if (tmp != NULL) {
-			rc = umem_tx_add_ptr(umm, &tmp->dbd_prev,
-					     sizeof(tmp->dbd_prev));
-			if (rc != 0)
-				return rc;
-
-			tmp->dbd_prev = dbd->dbd_prev;
-		}
-
-		if (cont_df->cd_dtx_active_head == dbd_off) {
-			rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_head,
-					sizeof(cont_df->cd_dtx_active_head));
-			if (rc != 0)
-				return rc;
-
-			cont_df->cd_dtx_active_head = dbd->dbd_next;
-		}
-
-		if (cont_df->cd_dtx_active_tail == dbd_off) {
-			rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_tail,
-					sizeof(cont_df->cd_dtx_active_tail));
-			if (rc != 0)
-				return rc;
-
-			cont_df->cd_dtx_active_tail = dbd->dbd_prev;
-		}
-
-		rc = umem_free(umm, dbd_off);
-
-		DL_CDEBUG(rc != 0, DLOG_ERR, DB_IO, rc,
-			  "Release DTX active blob %p (" UMOFF_PF ") for cont " DF_UUID, dbd,
-			  UMOFF_P(dbd_off), DP_UUID(cont->vc_id));
-	}
-
-	return rc;
+	return dtx_dae_df_discard(cont, dbd, dae_df);
 }
 
 static int
@@ -2850,18 +2861,425 @@ vos_dtx_mark_sync(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch)
 	return 0;
 }
 
+static void
+vos_dae_df_dump(struct umem_instance *umm, struct vos_dtx_act_ent_df *dae_df, const char *title)
+{
+	struct dtx_daos_target *ddt;
+	char                    buf[80];
+	char                   *ptr = buf;
+	int                     cnt = dae_df->dae_tgt_cnt;
+	int                     rc;
+	int                     i;
+
+	if (dae_df->dae_mbs_dsize <= sizeof(dae_df->dae_mbs_inline))
+		ddt = dae_df->dae_mbs_inline;
+	else
+		ddt = umem_off2ptr(umm, dae_df->dae_mbs_off);
+
+	D_INFO("%s\n"
+	       "xid: " DF_DTI "\n"
+	       "lid: %u\n"
+	       "epoch: " DF_U64 "\n"
+	       "oid: " DF_UOID "\n"
+	       "dkey_hash: " DF_X64 "\n"
+	       "flags: 0x%x\n"
+	       "mbs_flags: 0x%x\n"
+	       "version: %u\n"
+	       "index: %u\n"
+	       "rec_cnt: %u\n"
+	       "grp_cnt: %u\n"
+	       "tgt_cnt: %u\n"
+	       "participants:",
+	       title, DP_DTI(&dae_df->dae_xid), dae_df->dae_lid, dae_df->dae_epoch,
+	       DP_UOID(dae_df->dae_oid), dae_df->dae_dkey_hash, dae_df->dae_flags,
+	       dae_df->dae_mbs_flags, dae_df->dae_ver, dae_df->dae_index, dae_df->dae_rec_cnt,
+	       dae_df->dae_grp_cnt, dae_df->dae_tgt_cnt);
+
+	while (cnt >= 8) {
+		D_INFO("%8u%8u%8u%8u%8u%8u%8u%8u\n", ddt[0].ddt_id, ddt[1].ddt_id, ddt[2].ddt_id,
+		       ddt[3].ddt_id, ddt[4].ddt_id, ddt[5].ddt_id, ddt[6].ddt_id, ddt[7].ddt_id);
+		cnt -= 8;
+		ddt += 8;
+	}
+
+	if (cnt > 0) {
+		for (i = 0; i < cnt; i++) {
+			rc = snprintf(ptr, 79 - 8 * i, "%8u", ddt[i].ddt_id);
+			D_ASSERT(rc > 0);
+			ptr += rc;
+		}
+		D_INFO("%s\n", buf);
+	}
+}
+
+static bool
+vos_dtx_rec_is_invalid(struct vos_container *cont, struct vos_dtx_blob_df *dbd,
+		       struct vos_dtx_act_ent_df *dae_df, umem_off_t rec)
+{
+	struct umem_instance *umm = vos_cont2umm(cont);
+
+	if (UMOFF_IS_NULL(rec))
+		return false;
+
+	switch (dtx_umoff_flag2type(rec)) {
+	case DTX_RT_ILOG: {
+		struct ilog_df      *ilog = umem_off2ptr(umm, umem_off2offset(rec));
+		daos_handle_t        loh;
+		struct ilog_desc_cbs cbs;
+		struct ilog_id       id;
+		int                  rc;
+
+		vos_ilog_desc_cbs_init(&cbs, vos_cont2hdl(cont));
+		rc = ilog_open(umm, ilog, &cbs, false, &loh);
+		if (rc == 0) {
+			id.id_epoch = dae_df->dae_epoch;
+			id.id_tx_id = dae_df->dae_lid;
+			if (!ilog_is_valid(loh, &id))
+				rc = 1;
+			ilog_close(loh);
+		}
+
+		if (rc != 0) {
+			D_ERROR("Invalid ILOG rec " UMOFF_PF " for DTX " DF_DTI " in %p at %d\n",
+				UMOFF_P(rec), DP_DTI(&dae_df->dae_xid), dbd, dae_df->dae_index);
+			return true;
+		}
+		break;
+	}
+	case DTX_RT_SVT: {
+		struct vos_irec_df *svt = umem_off2ptr(umm, umem_off2offset(rec));
+
+		if (!vos_irec_is_valid(svt, dae_df->dae_lid)) {
+			D_ERROR("Invalid SVT rec " UMOFF_PF " for DTX " DF_DTI " in %p at %d\n",
+				UMOFF_P(rec), DP_DTI(&dae_df->dae_xid), dbd, dae_df->dae_index);
+			return true;
+		}
+		break;
+	}
+	case DTX_RT_EVT: {
+		struct evt_desc *evt = umem_off2ptr(umm, umem_off2offset(rec));
+
+		if (!evt_desc_is_valid(evt, dae_df->dae_lid)) {
+			D_ERROR("Invalid EVT rec " UMOFF_PF " for DTX " DF_DTI " in %p at %d\n",
+				UMOFF_P(rec), DP_DTI(&dae_df->dae_xid), dbd, dae_df->dae_index);
+			return true;
+		}
+		break;
+	}
+	default:
+		D_ERROR("Unknown DTX rec " UMOFF_PF " for DTX " DF_DTI " in %p at %d\n",
+			UMOFF_P(rec), DP_DTI(&dae_df->dae_xid), dbd, dae_df->dae_index);
+		return true;
+	}
+
+	return false;
+}
+
+static bool
+vos_dae_df_is_invalid(struct vos_container *cont, struct vos_dtx_blob_df *dbd,
+		      struct vos_dtx_act_ent_df *dae_df)
+{
+	struct umem_instance *umm = vos_cont2umm(cont);
+	umem_off_t           *rec_df;
+	int                   cnt;
+	int                   i;
+
+	if (daos_is_zero_dti(&dae_df->dae_xid)) {
+		D_ERROR("Zero XID for active DTX in %p at %d\n", dbd, dae_df->dae_index);
+		return true;
+	}
+
+	if (dae_df->dae_lid < DTX_LID_RESERVED) {
+		D_ERROR("Corrupted lid %d for DTX " DF_DTI " in %p at %d\n", dae_df->dae_lid,
+			DP_DTI(&dae_df->dae_xid), dbd, dae_df->dae_index);
+		return true;
+	}
+
+	if (dae_df->dae_rec_cnt > DTX_INLINE_REC_CNT)
+		cnt = DTX_INLINE_REC_CNT;
+	else
+		cnt = dae_df->dae_rec_cnt;
+
+	for (i = 0; i < cnt; i++) {
+		if (vos_dtx_rec_is_invalid(cont, dbd, dae_df, dae_df->dae_rec_inline[i]))
+			return true;
+	}
+
+	if (!UMOFF_IS_NULL(dae_df->dae_rec_off)) {
+		cnt = dae_df->dae_rec_cnt - DTX_INLINE_REC_CNT;
+		if (unlikely(cnt <= 0)) {
+			D_ERROR("Invalid rec count %d for DTX " DF_DTI " in %p at %d\n",
+				dae_df->dae_rec_cnt, DP_DTI(&dae_df->dae_xid), dbd,
+				dae_df->dae_index);
+			return true;
+		}
+
+		rec_df = umem_off2ptr(umm, dae_df->dae_rec_off);
+		for (i = 0; i < cnt; i++) {
+			if (vos_dtx_rec_is_invalid(cont, dbd, dae_df, rec_df[i]))
+				return true;
+		}
+	}
+
+	return false;
+}
+
+struct vos_dae_df_pending {
+	d_list_t                   vddp_link;
+	struct vos_dtx_blob_df    *vddp_dbd;
+	struct vos_dtx_act_ent_df *vddp_dae;
+	uint32_t                   vddp_invalid : 1;
+};
+
+static int
+vos_dae_df_add_pending(d_list_t *head, struct vos_dtx_blob_df *dbd,
+		       struct vos_dtx_act_ent_df *dae_df, bool invalid)
+{
+	struct vos_dae_df_pending *vddp;
+
+	D_ALLOC_PTR(vddp);
+	if (vddp == NULL)
+		return -DER_NOMEM;
+
+	vddp->vddp_dbd     = dbd;
+	vddp->vddp_dae     = dae_df;
+	vddp->vddp_invalid = invalid ? 1 : 0;
+	d_list_add_tail(&vddp->vddp_link, head);
+
+	return 0;
+}
+
+static int
+vos_dae_df_discard_pending(struct vos_container *cont, struct vos_dae_df_pending *vddp)
+{
+	struct umem_instance *umm = vos_cont2umm(cont);
+	int                   rc;
+
+	rc = umem_tx_begin(umm, NULL);
+	if (rc != 0)
+		return rc;
+
+	rc = dtx_dae_df_discard(cont, vddp->vddp_dbd, vddp->vddp_dae);
+	if (rc != 0) {
+		rc = umem_tx_abort(umm, rc);
+	} else {
+		rc = umem_tx_commit(umm);
+		D_ASSERTF(rc == 0, "local TX commit failure: %d\n", rc);
+	}
+
+	return rc;
+}
+
+static int
+vos_dae_df_load(struct vos_container *cont, struct vos_dtx_blob_df *dbd,
+		struct vos_dtx_act_ent_df *dae_df, uint64_t start_time, struct vos_dtx_act_ent *dae)
+{
+	struct umem_instance *umm = vos_cont2umm(cont);
+	d_iov_t               kiov;
+	d_iov_t               riov;
+	size_t                size;
+	int                   count;
+	int                   rc;
+
+	memcpy(&dae->dae_base, dae_df, sizeof(dae->dae_base));
+
+	dae->dae_df_off       = umem_ptr2off(umm, dae_df);
+	dae->dae_dbd          = dbd;
+	dae->dae_prepared     = 1;
+	dae->dae_need_release = 1;
+	D_INIT_LIST_HEAD(&dae->dae_link);
+
+	if (vos_skip_old_partial_dtx && DAE_FLAGS(dae) & DTE_PARTIAL_COMMITTED)
+		DAE_REC_CNT(dae) = 0;
+
+	if (DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT) {
+		count = DAE_REC_CNT(dae) - DTX_INLINE_REC_CNT;
+		size  = sizeof(*dae->dae_records) * count;
+
+		D_ALLOC_NZ(dae->dae_records, size);
+		if (dae->dae_records == NULL) {
+			dtx_evict_lid(cont, dae);
+			D_GOTO(out, rc = -DER_NOMEM);
+		}
+
+		memcpy(dae->dae_records, umem_off2ptr(umm, dae_df->dae_rec_off), size);
+		dae->dae_rec_cap = count;
+	}
+
+	d_iov_set(&kiov, &DAE_XID(dae), sizeof(DAE_XID(dae)));
+	d_iov_set(&riov, dae, sizeof(*dae));
+	rc = dbtree_upsert(cont->vc_dtx_active_hdl, BTR_PROBE_EQ, DAOS_INTENT_UPDATE, &kiov, &riov,
+			   NULL);
+	if (rc != 0) {
+		D_FREE(dae->dae_records);
+		dtx_evict_lid(cont, dae);
+		goto out;
+	}
+
+	dae->dae_start_time = start_time;
+	d_list_add_tail(&dae->dae_link, &cont->vc_dtx_act_list);
+
+out:
+	DL_CDEBUG(rc != 0, DLOG_ERR, DB_TRACE, rc, "Re-indexed active DTX " DF_DTI " with lid %d",
+		  DP_DTI(&DAE_XID(dae)), DAE_LID(dae));
+
+	return rc;
+}
+
+static int
+vos_dtx_rec_reset_lid(struct vos_container *cont, daos_epoch_t epoch, umem_off_t rec, int old,
+		      uint32_t new)
+{
+	struct umem_instance *umm = vos_cont2umm(cont);
+	int                   rc  = 0;
+
+	if (UMOFF_IS_NULL(rec))
+		return 0;
+
+	switch (dtx_umoff_flag2type(rec)) {
+	case DTX_RT_ILOG: {
+		struct ilog_df      *ilog = umem_off2ptr(umm, umem_off2offset(rec));
+		daos_handle_t        loh;
+		struct ilog_desc_cbs cbs;
+		struct ilog_id       id;
+
+		vos_ilog_desc_cbs_init(&cbs, vos_cont2hdl(cont));
+		rc = ilog_open(umm, ilog, &cbs, false, &loh);
+		if (rc != 0)
+			goto out;
+
+		id.id_epoch = epoch;
+		id.id_tx_id = old;
+		rc          = ilog_entry_replace(loh, &id, new);
+		ilog_close(loh);
+		if (rc == -DER_NONEXIST)
+			rc = 0;
+		break;
+	}
+	case DTX_RT_SVT: {
+		struct vos_irec_df *svt = umem_off2ptr(umm, umem_off2offset(rec));
+
+		if (unlikely(svt->ir_dtx != old)) {
+			rc = -DER_MISMATCH;
+		} else {
+			rc = umem_tx_add_ptr(umm, &svt->ir_dtx, sizeof(svt->ir_dtx));
+			if (rc == 0)
+				svt->ir_dtx = new;
+		}
+		break;
+	}
+	case DTX_RT_EVT: {
+		struct evt_desc *evt = umem_off2ptr(umm, umem_off2offset(rec));
+
+		if (unlikely(evt->dc_dtx != old)) {
+			rc = -DER_MISMATCH;
+		} else {
+			rc = umem_tx_add_ptr(umm, &evt->dc_dtx, sizeof(evt->dc_dtx));
+			if (rc == 0)
+				evt->dc_dtx = new;
+		}
+		break;
+	}
+	default:
+		rc = -DER_INVAL;
+		break;
+	}
+
+out:
+	if (rc != 0)
+		D_ERROR("Failed to reset DTX rec lid %d => %d: " DF_RC "\n", old, new, DP_RC(rc));
+
+	return rc;
+}
+
+static int
+vos_dae_df_reassign_pending(struct vos_container *cont, struct vos_dae_df_pending *vddp,
+			    uint64_t start_time)
+{
+	struct umem_instance      *umm    = vos_cont2umm(cont);
+	struct vos_dtx_act_ent    *dae    = NULL;
+	struct vos_dtx_act_ent_df *dae_df = vddp->vddp_dae;
+	umem_off_t                *rec_df;
+	uint32_t                   old = dae_df->dae_lid;
+	uint32_t                   idx = -1;
+	int                        cnt;
+	int                        rc;
+	int                        i;
+
+	rc = lrua_allocx(cont->vc_dtx_array, &idx, dae_df->dae_epoch, &dae, NULL);
+	if (rc != 0)
+		goto log;
+
+	rc = umem_tx_begin(umm, NULL);
+	if (rc != 0)
+		goto log;
+
+	rc = umem_tx_add_ptr(umm, &dae_df->dae_lid, sizeof(&dae_df->dae_lid));
+	if (rc != 0)
+		goto out;
+
+	/* Reassign the local ID in LRU array. */
+	dae_df->dae_lid = idx + DTX_LID_RESERVED;
+
+	if (dae_df->dae_rec_cnt > DTX_INLINE_REC_CNT)
+		cnt = DTX_INLINE_REC_CNT;
+	else
+		cnt = dae_df->dae_rec_cnt;
+
+	for (i = 0; i < cnt; i++) {
+		rc = vos_dtx_rec_reset_lid(cont, dae_df->dae_epoch, dae_df->dae_rec_inline[i], old,
+					   idx);
+		if (rc != 0)
+			goto out;
+	}
+
+	if (!UMOFF_IS_NULL(dae_df->dae_rec_off)) {
+		cnt    = dae_df->dae_rec_cnt - DTX_INLINE_REC_CNT;
+		rec_df = umem_off2ptr(umm, dae_df->dae_rec_off);
+		for (i = 0; i < cnt; i++) {
+			rc = vos_dtx_rec_reset_lid(cont, dae_df->dae_epoch, rec_df[i], old, idx);
+			if (rc != 0)
+				goto out;
+		}
+	}
+
+out:
+	if (rc != 0) {
+		rc = umem_tx_abort(umm, rc);
+	} else {
+		rc = umem_tx_commit(umm);
+		D_ASSERTF(rc == 0, "local TX commit failure: %d\n", rc);
+
+		/*
+		 * The on-disk lid has been reassigned. It is no matter even if failed to load
+		 * "dae" from disk into DRAM. That can be done when restart next time and will
+		 * not be reassigned again.
+		 */
+		rc = vos_dae_df_load(cont, vddp->vddp_dbd, dae_df, start_time, dae);
+	}
+
+log:
+	D_INFO("Reassign DTX lid from %d to %d for " DF_DTI ": " DF_RC "\n", old, idx,
+	       DP_DTI(&dae_df->dae_xid), DP_RC(rc));
+
+	return rc;
+}
+
 int
 vos_dtx_act_reindex(struct vos_container *cont)
 {
 	struct umem_instance		*umm = vos_cont2umm(cont);
 	struct vos_cont_df		*cont_df = cont->vc_cont_df;
 	struct vos_dtx_blob_df		*dbd;
-	umem_off_t			 dbd_off = cont_df->cd_dtx_active_head;
-	d_iov_t				 kiov;
-	d_iov_t				 riov;
-	uint64_t			 start_time = daos_wallclock_secs();
-	int				 rc = 0;
-	int				 i;
+	struct vos_dae_df_pending       *vddp;
+	d_list_t                         pending;
+	umem_off_t                       dbd_off    = cont_df->cd_dtx_active_head;
+	uint64_t                         start_time = daos_wallclock_secs();
+	int                              skips      = 0;
+	int                              rc         = 0;
+	int                              i;
+
+	D_INIT_LIST_HEAD(&pending);
 
 	while (!UMOFF_IS_NULL(dbd_off)) {
 		int	dbd_count = 0;
@@ -2870,87 +3288,95 @@ vos_dtx_act_reindex(struct vos_container *cont)
 		D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
 
 		for (i = 0; i < dbd->dbd_index; i++) {
-			struct vos_dtx_act_ent_df	*dae_df;
-			struct vos_dtx_act_ent		*dae;
+			struct vos_dtx_act_ent_df *dae_df;
+			struct vos_dtx_act_ent    *dae = NULL;
 
 			dae_df = &dbd->dbd_active_data[i];
 			if (dae_df->dae_flags & DTE_INVALID)
 				continue;
 
-			if (daos_is_zero_dti(&dae_df->dae_xid)) {
-				D_WARN("Hit zero active DTX entry.\n");
-				continue;
+			if (unlikely(vos_dae_df_is_invalid(cont, dbd, dae_df))) {
+				if (likely(vos_diag_mode == VOS_DIAG_DEF))
+					D_GOTO(out, rc = -DER_IO);
+
+				vos_dae_df_dump(umm, dae_df, "Invalid active DTX entry:");
+
+				if (vos_diag_mode == VOS_DIAG_CHECK) {
+					D_WARN("Skip invalid active DTX " DF_DTI "\n",
+					       DP_DTI(&dae_df->dae_xid));
+				} else {
+					rc = vos_dae_df_add_pending(&pending, dbd, dae_df, true);
+					if (rc != 0)
+						goto out;
+				}
+				goto next;
 			}
 
-			if (dae_df->dae_lid < DTX_LID_RESERVED) {
-				D_ERROR("Corruption in DTX table found, lid=%d"
-					" is invalid\n", dae_df->dae_lid);
+again:
+			rc = lrua_allocx_inplace(cont->vc_dtx_array,
+						 dae_df->dae_lid - DTX_LID_RESERVED,
+						 dae_df->dae_epoch, &dae);
+			if (rc == 0) {
+				D_ASSERT(dae != NULL);
+
+				rc = vos_dae_df_load(cont, dbd, dae_df, start_time, dae);
+				if (rc != 0)
+					goto out;
+				goto next;
+			}
+
+			if (rc != -DER_NO_PERM) {
+				D_ERROR("Failed to reindex active DTX " DF_DTI
+					", lid %u, epoch " DF_U64 ": " DF_RC "\n",
+					DP_DTI(&dae_df->dae_xid), dae_df->dae_lid,
+					dae_df->dae_epoch, DP_RC(rc));
 				D_GOTO(out, rc = -DER_IO);
 			}
-			rc = lrua_allocx_inplace(cont->vc_dtx_array,
-					 dae_df->dae_lid - DTX_LID_RESERVED,
-					 dae_df->dae_epoch, &dae);
-			if (rc != 0) {
-				if (rc == -DER_NOMEM) {
-					D_ERROR("Not enough memory for DTX "
-						"table\n");
-				} else {
-					D_ERROR("Corruption in DTX table found,"
-						" lid=%d is invalid rc="DF_RC
-						"\n", dae_df->dae_lid,
-						DP_RC(rc));
-					rc = -DER_IO;
-				}
-				D_GOTO(out, rc);
-			}
+
 			D_ASSERT(dae != NULL);
 
-			D_DEBUG(DB_TRACE, "Re-indexed lid DTX: "DF_DTI
-				" lid=%d\n", DP_DTI(&DAE_XID(dae)),
-				DAE_LID(dae));
+			D_WARN("Conflict between DTX " DF_DTI " and " DF_DTI
+			       " at lid %u with epoch " DF_U64 " vs " DF_U64 "\n",
+			       DP_DTI(&DAE_XID(dae)), DP_DTI(&dae_df->dae_xid), dae_df->dae_lid,
+			       DAE_EPOCH(dae), dae_df->dae_epoch);
 
-			memcpy(&dae->dae_base, dae_df, sizeof(dae->dae_base));
-			dae->dae_df_off = umem_ptr2off(umm, dae_df);
-			dae->dae_dbd = dbd;
-			dae->dae_prepared = 1;
-			dae->dae_need_release = 1;
-			D_INIT_LIST_HEAD(&dae->dae_link);
+			vos_dae_df_dump(umm, &dae->dae_base, "Conflict DTX pairs-A:");
+			vos_dae_df_dump(umm, dae_df, "Conflict DTX pairs-B:");
 
-			if (vos_skip_old_partial_dtx && DAE_FLAGS(dae) & DTE_PARTIAL_COMMITTED)
-				DAE_REC_CNT(dae) = 0;
+			if (likely(vos_diag_mode == VOS_DIAG_DEF))
+				D_GOTO(out, rc = -DER_IO);
 
-			if (DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT) {
-				size_t	size;
-				int	count;
+			D_ASSERT(!daos_dti_equal(&DAE_XID(dae), &dae_df->dae_xid));
 
-				count = DAE_REC_CNT(dae) - DTX_INLINE_REC_CNT;
-				size = sizeof(*dae->dae_records) * count;
-
-				D_ALLOC_NZ(dae->dae_records, size);
-				if (dae->dae_records == NULL) {
-					dtx_evict_lid(cont, dae);
-					D_GOTO(out, rc = -DER_NOMEM);
-				}
-
-				memcpy(dae->dae_records,
-				       umem_off2ptr(umm, dae_df->dae_rec_off),
-				       size);
-				dae->dae_rec_cap = count;
+			if (vos_diag_mode == VOS_DIAG_CHECK) {
+				D_WARN("Skip conflict active DTX " DF_DTI "\n",
+				       DP_DTI(&dae_df->dae_xid));
+				skips++;
+				rc = 0;
+				goto next;
 			}
 
-			d_iov_set(&kiov, &DAE_XID(dae), sizeof(DAE_XID(dae)));
-			d_iov_set(&riov, dae, sizeof(*dae));
-			rc = dbtree_upsert(cont->vc_dtx_active_hdl,
-					   BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
-					   &kiov, &riov, NULL);
-			if (rc != 0) {
-				D_FREE(dae->dae_records);
-				dtx_evict_lid(cont, dae);
+			/*
+			 * If conflict pairs-A DTX only has header, then add it into pending list.
+			 * Otherwise, add conflict pairs-B DTX into the pending list.
+			 */
+			if (DAE_REC_CNT(dae) != 0 || dae_df->dae_rec_cnt == 0) {
+				rc = vos_dae_df_add_pending(&pending, dbd, dae_df, false);
+				if (rc != 0)
+					goto out;
+				goto next;
+			}
+
+			rc = vos_dae_df_add_pending(&pending, dae->dae_dbd,
+						    umem_off2ptr(umm, dae->dae_df_off), false);
+			if (rc != 0)
 				goto out;
-			}
 
-			dae->dae_start_time = start_time;
-			d_list_add_tail(&dae->dae_link, &cont->vc_dtx_act_list);
+			vos_dtx_post_handle(cont, &dae, NULL, 1, false, false, false);
+			dae = NULL;
+			goto again;
+
+next:
 			dbd_count++;
 		}
 
@@ -2968,7 +3394,31 @@ vos_dtx_act_reindex(struct vos_container *cont)
 		dbd_off = dbd->dbd_next;
 	}
 
+	d_list_for_each_entry(vddp, &pending, vddp_link) {
+		if (vddp->vddp_invalid)
+			rc = vos_dae_df_discard_pending(cont, vddp);
+		else
+			rc = vos_dae_df_reassign_pending(cont, vddp, start_time);
+		if (rc != 0)
+			goto out;
+	}
+
 out:
+	while ((vddp = d_list_pop_entry(&pending, struct vos_dae_df_pending, vddp_link)) != NULL)
+		D_FREE(vddp);
+
+	/*
+	 * Under VOS_DIAG_CHECK mode, if we skip some valid conflict DTX entries, then the in-DRAM
+	 * status may be inconsistent. Under such case, since we have already dump the information
+	 * for related conflict and inconsistency, then let's fail opening the container to avoid
+	 * further damaging the system.
+	 */
+	if (skips > 0 && rc >= 0) {
+		D_WARN("Skip %d valid DTX entries, not open the container to avoid damaging\n",
+		       skips);
+		rc = -DER_IO;
+	}
+
 	return rc > 0 ? 0 : rc;
 }
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -142,6 +142,18 @@ enum {
 /* Throttle ENOSPACE error message */
 #define VOS_NOSPC_ERROR_INTVL	60	/* seconds */
 
+enum {
+	/** Disable VOS disagnose mode by default. */
+	VOS_DIAG_DEF = 0,
+	/** Only check potential corruption/inconsistency in VOS without repairing. */
+	VOS_DIAG_CHECK,
+	/** Check and repair potential corruption/inconsistency in VOS. */
+	VOS_DIAG_REPAIR,
+	/** Guard for boundary. */
+	VOS_DIAG_MAX
+};
+
+extern unsigned int    vos_diag_mode;
 extern unsigned int vos_agg_nvme_thresh;
 extern bool vos_dkey_punch_propagate;
 extern bool vos_skip_old_partial_dtx;
@@ -1084,7 +1096,8 @@ struct vos_iterator {
 	 * mutual exclusion between aggregation and object discard.
 	 */
 	uint32_t it_from_parent : 1, it_for_purge : 1, it_for_discard : 1, it_for_migration : 1,
-	    it_show_uncommitted : 1, it_ignore_uncommitted : 1, it_for_sysdb : 1, it_for_agg : 1;
+	    it_show_uncommitted : 1, it_ignore_uncommitted : 1, it_for_sysdb : 1, it_for_agg : 1,
+	    it_for_check : 1;
 };
 
 /* Auxiliary structure for passing information between parent and nested
@@ -1365,6 +1378,8 @@ vos_iter_intent(struct vos_iterator *iter)
 		return DAOS_INTENT_IGNORE_NONCOMMITTED;
 	if (iter->it_for_migration)
 		return DAOS_INTENT_MIGRATION;
+	if (iter->it_for_check)
+		return DAOS_INTENT_CHECK;
 	return DAOS_INTENT_DEFAULT;
 }
 

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -146,9 +147,10 @@ struct vos_pool_df {
  * array value that is changed in the transaction (DTX).
  */
 enum vos_dtx_record_types {
-	DTX_RT_ILOG	= 1,
-	DTX_RT_SVT	= 2,
-	DTX_RT_EVT	= 3,
+	DTX_RT_UNKNOWN = 0,
+	DTX_RT_ILOG    = 1,
+	DTX_RT_SVT     = 2,
+	DTX_RT_EVT     = 3,
 };
 
 #define DTX_INLINE_REC_CNT	4

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1729,6 +1730,8 @@ vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 		oiter->it_iter.it_for_agg = 1;
 	if (is_sysdb)
 		oiter->it_iter.it_for_sysdb = 1;
+	if (param->ip_flags & VOS_IT_FOR_CHECK)
+		oiter->it_iter.it_for_check = 1;
 	if (param->ip_flags == VOS_IT_KEY_TREE) {
 		/** Prepare the iterator from an already open tree handle.   See
 		 *  vos_iterate_key
@@ -1973,6 +1976,8 @@ nested_prep_common_init(struct vos_container *cont, struct vos_obj_iter **oiterp
 		oiter->it_iter.it_for_migration = 1;
 	if (cont->vc_pool->vp_sysdb)
 		oiter->it_iter.it_for_sysdb = 1;
+	if (info->ii_flags & VOS_IT_FOR_CHECK)
+		oiter->it_iter.it_for_check = 1;
 
 	return 0;
 }

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -562,6 +562,8 @@ oi_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 		oiter->oit_iter.it_for_migration = 1;
 	if (cont->vc_pool->vp_sysdb)
 		oiter->oit_iter.it_for_sysdb = 1;
+	if (param->ip_flags & VOS_IT_FOR_CHECK)
+		oiter->oit_iter.it_for_check = 1;
 
 	rc = dbtree_iter_prepare(cont->vc_btr_hdl, 0, &oiter->oit_hdl);
 	if (rc)


### PR DESCRIPTION
1. Use IT_FOR_CHECK when iterate OBJ for DDB dv_path_verify

From DDB perspective, the target with non-aborted DTX should be visible
even if related DTX is prepared locally but not globally committed yet.
It is the caller's duty to decide how to handle non-committed target in
subsequent logic, or DTX resync will handle such DTX sometime later.

DDB logic will use DAOS_INTENT_CHECK instead of DAOS_INTENT_DEFAULT to
indicate above purpose when iterate OBJ during dv_path_verify().

2. Do not create VOS LRU metrics entry when initialize standalone tls.
   That will avoid confused error message from DDB utils.

3. Dump DTX information when conflict being detected.

4. Introduce VOS diagnose mode to allow pool/container to be opened
   even if there is some corruption, then related issue may be fixed
   or handled via subsequent operations. It is controlled via server
   side environment "DAOS_DIAG_MODE". It is set as zero by default.
   If user wants to handle potential VOS corruption when open the
   pool/container, then set it as 1 for "check" or 2 for "repair"
   explicitly when start the engine. If some corruption is detected
   under "check" mode, then related inconsistency or corruption will
   be dump, but opening related pool/container will finally fail to
   avoid further damaging the system.

5. Verify active DTX validity when reindex them, filter out invalid
   ones. Reassign new local ID if hit conflict DTX if DAOS_DIAG_MODE
   set as "repair" mode. Then subsequent DTX resync can handle them
   globally.

6. Do not clear "dae_need_release" flags after partial commit to avoid
   DTX entry being evicted from DRAM but left on-disk.

Signed-off-by: Fan Yong <fan.yong@hpe.com>
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
