### PR TITLE
DAOS-16908 control: change the firewall config name

### DIFF
--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -597,7 +597,7 @@ disable_hugepages: false
 control_log_mask: INFO
 control_log_file: /tmp/daos_server.log
 core_dump_filter: 19
-disable_client_firewall_mode: true
+client_behind_firewall: false
 name: daos_server
 socket_dir: /var/run/daos_server
 provider: ofi+verbs

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -49,27 +49,27 @@ type deprecatedParams struct {
 // See utils/config/daos_server.yml for parameter descriptions.
 type Server struct {
 	// control-specific
-	ControlPort               int                       `yaml:"port"`
-	TransportConfig           *security.TransportConfig `yaml:"transport_config"`
-	Engines                   []*engine.Config          `yaml:"engines"`
-	BdevExclude               []string                  `yaml:"bdev_exclude,omitempty"`
-	DisableVFIO               bool                      `yaml:"disable_vfio"`
-	DisableVMD                *bool                     `yaml:"disable_vmd"`
-	EnableHotplug             bool                      `yaml:"enable_hotplug"`
-	NrHugepages               int                       `yaml:"nr_hugepages"`        // total for all engines
-	SystemRamReserved         int                       `yaml:"system_ram_reserved"` // total for all engines
-	DisableHugepages          bool                      `yaml:"disable_hugepages"`
-	ControlLogMask            common.ControlLogLevel    `yaml:"control_log_mask"`
-	ControlLogFile            string                    `yaml:"control_log_file,omitempty"`
-	ControlLogJSON            bool                      `yaml:"control_log_json,omitempty"`
-	HelperLogFile             string                    `yaml:"helper_log_file,omitempty"`
-	FWHelperLogFile           string                    `yaml:"firmware_helper_log_file,omitempty"`
-	FaultPath                 string                    `yaml:"fault_path,omitempty"`
-	TelemetryPort             int                       `yaml:"telemetry_port,omitempty"`
-	CoreDumpFilter            uint8                     `yaml:"core_dump_filter,omitempty"`
-	ClientEnvVars             []string                  `yaml:"client_env_vars,omitempty"`
-	SupportConfig             SupportConfig             `yaml:"support_config,omitempty"`
-	DisableClientFirewallMode *bool                     `yaml:"disable_client_firewall_mode,omitempty"`
+	ControlPort        int                       `yaml:"port"`
+	TransportConfig    *security.TransportConfig `yaml:"transport_config"`
+	Engines            []*engine.Config          `yaml:"engines"`
+	BdevExclude        []string                  `yaml:"bdev_exclude,omitempty"`
+	DisableVFIO        bool                      `yaml:"disable_vfio"`
+	DisableVMD         *bool                     `yaml:"disable_vmd"`
+	EnableHotplug      bool                      `yaml:"enable_hotplug"`
+	NrHugepages        int                       `yaml:"nr_hugepages"`        // total for all engines
+	SystemRamReserved  int                       `yaml:"system_ram_reserved"` // total for all engines
+	DisableHugepages   bool                      `yaml:"disable_hugepages"`
+	ControlLogMask     common.ControlLogLevel    `yaml:"control_log_mask"`
+	ControlLogFile     string                    `yaml:"control_log_file,omitempty"`
+	ControlLogJSON     bool                      `yaml:"control_log_json,omitempty"`
+	HelperLogFile      string                    `yaml:"helper_log_file,omitempty"`
+	FWHelperLogFile    string                    `yaml:"firmware_helper_log_file,omitempty"`
+	FaultPath          string                    `yaml:"fault_path,omitempty"`
+	TelemetryPort      int                       `yaml:"telemetry_port,omitempty"`
+	CoreDumpFilter     uint8                     `yaml:"core_dump_filter,omitempty"`
+	ClientEnvVars      []string                  `yaml:"client_env_vars,omitempty"`
+	SupportConfig      SupportConfig             `yaml:"support_config,omitempty"`
+	ClientFirewallMode *bool                     `yaml:"client_behind_firewall,omitempty"`
 
 	// duplicated in engine.Config
 	SystemName string              `yaml:"name"`
@@ -276,9 +276,9 @@ func (cfg *Server) WithNrHugepages(nr int) *Server {
 	return cfg
 }
 
-// WithDisableClientFirewallMode enables or disable client firewall mode.
-func (cfg *Server) WithDisableClientFirewallMode(disableClientFirewallMode bool) *Server {
-	cfg.DisableClientFirewallMode = &disableClientFirewallMode
+// WithClientFirewallMode enables or disable client firewall mode.
+func (cfg *Server) WithClientFirewallMode(clientFirewallMode bool) *Server {
+	cfg.ClientFirewallMode = &clientFirewallMode
 	return cfg
 }
 
@@ -334,7 +334,7 @@ func (cfg *Server) WithTelemetryPort(port int) *Server {
 // DefaultServer creates a new instance of configuration struct
 // populated with defaults.
 func DefaultServer() *Server {
-	disableClientFirewallMode := true
+	clientFirewallMode := false
 
 	return &Server{
 		SystemName:        build.DefaultSystemName,
@@ -348,8 +348,8 @@ func DefaultServer() *Server {
 		ControlLogMask:    common.ControlLogLevel(logging.LogLevelInfo),
 		EnableHotplug:     false, // disabled by default
 		// https://man7.org/linux/man-pages/man5/core.5.html
-		CoreDumpFilter:            0b00010011, // private, shared, ELF
-		DisableClientFirewallMode: &disableClientFirewallMode,
+		CoreDumpFilter:     0b00010011, // private, shared, ELF
+		ClientFirewallMode: &clientFirewallMode,
 	}
 }
 

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -246,7 +246,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 		WithDisableVFIO(true).   // vfio enabled by default
 		WithDisableVMD(true).    // vmd enabled by default
 		WithEnableHotplug(true). // hotplug disabled by default
-		WithDisableClientFirewallMode(false).
+		WithClientFirewallMode(true).
 		WithControlLogMask(common.ControlLogLevelError).
 		WithControlLogFile("/tmp/daos_server.log").
 		WithHelperLogFile("/tmp/daos_server_helper.log").

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -418,8 +418,8 @@ func (srv *server) setupGrpc() error {
 	clientNetHints := make([]*mgmtpb.ClientNetHint, 0, len(providers))
 	for i, p := range providers {
 		clientFirewallMode := false
-		if srv.cfg.DisableClientFirewallMode != nil {
-			clientFirewallMode = !(*srv.cfg.DisableClientFirewallMode)
+		if srv.cfg.ClientFirewallMode != nil {
+			clientFirewallMode = *srv.cfg.ClientFirewallMode
 		}
 
 		clientNetHints = append(clientNetHints, &mgmtpb.ClientNetHint{

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -126,8 +126,8 @@
 ## for servers to establish TCP connections to clients.
 ## NB: Has no effect on non-TCP configurations.
 #
-## default: true
-#disable_client_firewall_mode: false
+## default: false
+#client_behind_firewall: true
 #
 #
 ## CART: Fabric authorization key

--- a/utils/config/examples/daos_server_tcp.yml
+++ b/utils/config/examples/daos_server_tcp.yml
@@ -7,7 +7,7 @@ mgmt_svc_replicas: ['example1', 'example2', 'example3']
 # control listen port, default 10001
 # port: 10001
 provider: ofi+tcp
-disable_client_firewall_mode: true
+client_behind_firewall: false
 
 control_log_mask: DEBUG
 control_log_file: /tmp/daos_server.log


### PR DESCRIPTION
Change the firewall mode name from `disable_client_firewall_mode` to `client_behind_firewall` in daos_server.yml.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
