### PR TITLE
DAOS-17430 doc: update user guide max rd_fac (#16275)

### DIFF
--- a/docs/QSG/docker.md
+++ b/docs/QSG/docker.md
@@ -72,7 +72,7 @@ $ sysctl -p
 
 ### Base DAOS Image
 
-The first image to create is the `daos-base` image which is not intetended to be used as it, but as
+The first image to create is the `daos-base` image which is not intended to be used as is, but as
 a base image for building the other three daos images.  The easiest way is to use the `docker
 compose` sub command from a local DAOS source file tree.  The first step is to update the docker
 environment file "utils/docker/examples/.env" according to the targeted DAOS system.  The following

--- a/docs/overview/storage.md
+++ b/docs/overview/storage.md
@@ -142,8 +142,8 @@ as shown in the <a href="#t4.2">table</a> below.
 |---|---|---|
 |Small size & RW  |Replication |static SCxRC, e.g. 1x4|
 |Small size & RM  |Erasure code|static SC+PC, e.g. 4+2|
-|Large size & RW  |Replication |static SCxRC over max #targets)|
-|Large size & RM  |Erasure code|static SCx(SC+PC) w/ max #TGT)|
+|Large size & RW  |Replication |static SCxRC over max #targets|
+|Large size & RM  |Erasure code|static SCx(SC+PC) w/ max #TGT|
 |Unknown size & RW|Replication |SCxRC, e.g. 1x4 initially and grows|
 |Unknown size & RM|Erasure code|SC+PC, e.g. 4+2 initially and grows|
 

--- a/docs/user/container.md
+++ b/docs/user/container.md
@@ -330,7 +330,7 @@ properties have been introduced:
 
 - the redundancy factor (rd\_fac) that describes the number of concurrent engine
   exclusions that objects in the container are protected against. The rd\_fac value
-  is an integer between 0 (no data protection) and 5 (support up to 5
+  is an integer between 0 (no data protection) and 4 (support up to 4
   simultaneous failures).
 - a `health` property representing whether any object content might have been
   lost due to cascading engine failures. The value of this property can be


### PR DESCRIPTION
The DAOS user guide states that the redundancy factor (rd_fac) can be set between 0 and 5. We get errors if we set rd_fac to 5. Set the correct max rd_fac value.

Two more minor clean ups are included.

Doc-only:true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
