### PR TITLE
DAOS-17598 vos: misc enhancements for handling DTX conflict

### DIFF
--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -1586,33 +1586,86 @@ ilog_version_get(daos_handle_t loh)
 }
 
 bool
-ilog_is_valid(struct umem_instance *umm, umem_off_t rec, uint32_t dtx_lid, daos_epoch_t epoch)
+ilog_is_valid(daos_handle_t loh, struct ilog_id *log_id)
 {
-	struct ilog_root  *root = umem_off2ptr(umm, umem_off2offset(rec));
-	struct ilog_array *array;
-	struct ilog_id    *id;
+	struct ilog_context    *lctx;
+	struct ilog_root       *root;
+	struct ilog_array_cache cache;
+	int                     i;
 
-	// !ILOG_ASSERT_VALID(ilog)
-	if (root == NULL || !ILOG_MAGIC_VALID(root->lr_magic)) {
+	lctx = ilog_hdl2lctx(loh);
+	if (lctx == NULL)
 		return false;
-	}
 
-	if (ilog_empty(root)) {
+	root = lctx->ic_root;
+	if (ilog_empty(root))
 		return false;
-	}
 
 	if (root->lr_tree.it_embedded) {
-		id = &root->lr_id;
-		return (id->id_tx_id == dtx_lid && id->id_epoch == epoch);
-	}
-
-	array = umem_off2ptr(umm, root->lr_tree.it_root);
-	for (int i = 0; i < array->ia_len; ++i) {
-		id = &array->ia_id[i];
-		if (id->id_tx_id == dtx_lid && id->id_epoch == epoch) {
+		if (root->lr_id.id_epoch == log_id->id_epoch &&
+		    root->lr_id.id_tx_id == log_id->id_tx_id)
 			return true;
+	} else {
+		ilog_log2cache(lctx, &cache);
+		for (i = cache.ac_nr - 1; i >= 0; i--) {
+			if (cache.ac_entries[i].id_epoch < log_id->id_epoch)
+				return false;
+
+			if (cache.ac_entries[i].id_epoch == log_id->id_epoch &&
+			    cache.ac_entries[i].id_tx_id == log_id->id_tx_id)
+				return true;
 		}
 	}
 
 	return false;
+}
+
+int
+ilog_entry_replace(daos_handle_t loh, struct ilog_id *log_id, uint32_t tx_id)
+{
+	struct ilog_context    *lctx;
+	struct ilog_root       *root;
+	struct ilog_array_cache cache;
+	int                     rc;
+	int                     i;
+
+	D_ASSERT(log_id->id_epoch != 0);
+	D_ASSERT(log_id->id_tx_id != tx_id);
+	D_ASSERT(log_id->id_tx_id >= DTX_LID_RESERVED);
+	D_ASSERT(tx_id >= DTX_LID_RESERVED);
+
+	lctx = ilog_hdl2lctx(loh);
+	if (lctx == NULL) {
+		D_ERROR("Invalid log handle\n");
+		return -DER_INVAL;
+	}
+
+	D_ASSERT(!lctx->ic_in_txn);
+
+	root = lctx->ic_root;
+	if (ilog_empty(root))
+		return -DER_NONEXIST;
+
+	if (root->lr_tree.it_embedded) {
+		if (root->lr_id.id_epoch != log_id->id_epoch ||
+		    root->lr_id.id_tx_id != log_id->id_tx_id)
+			return -DER_NONEXIST;
+
+		rc = ilog_ptr_set(lctx, &root->lr_id.id_tx_id, &tx_id);
+	} else {
+		rc = -DER_NONEXIST;
+		ilog_log2cache(lctx, &cache);
+		for (i = cache.ac_nr - 1; i >= 0; i--) {
+			if (cache.ac_entries[i].id_epoch < log_id->id_epoch)
+				break;
+
+			if (cache.ac_entries[i].id_epoch == log_id->id_epoch &&
+			    cache.ac_entries[i].id_tx_id == log_id->id_tx_id) {
+				rc = ilog_ptr_set(lctx, &cache.ac_entries[i].id_tx_id, &tx_id);
+				break;
+			}
+		}
+	}
+
+	return ilog_tx_end(lctx, rc);
 }

--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -158,6 +158,29 @@ ilog_persist(daos_handle_t loh, const struct ilog_id *id);
 int
 ilog_abort(daos_handle_t loh, const struct ilog_id *id);
 
+/** Validate the provided ilog.
+ *
+ * Note: It is designed for catastrophic recovery. Not to perform at run-time.
+ *
+ * \param	loh[in]		Open log handle
+ * \param	log_id[in]	Identifier for log entry
+ *
+ * \return true if ilog is valid.
+ **/
+bool
+ilog_is_valid(daos_handle_t loh, struct ilog_id *log_id);
+
+/** Replace TX local ID for specified ilog entry
+ *
+ *  \param	loh[in]		Open log handle
+ *  \param	log_id[in]	Identifier for log entry
+ *  \param	tx_id[in]	New TX LID for the log entry
+ *
+ *  \return 0 on success, error code on failure
+ */
+int
+ilog_entry_replace(daos_handle_t loh, struct ilog_id *log_id, uint32_t tx_id);
+
 /** Incarnation log entry description */
 struct ilog_entry {
 	/** The epoch and tx_id for the log entry */
@@ -319,19 +342,5 @@ ilog_is_punch(const struct ilog_entry *entry)
 	return entry->ie_id.id_punch_minor_eph >
 		entry->ie_id.id_update_minor_eph;
 }
-
-/** Validate the provided ilog.
- *
- * Note: It is designed for catastrophic recovery. Not to perform at run-time.
- *
- * \param	umm[in]		unified memory class instance
- * \param	rec[in]		offset of the ilog
- * \param	dtx_lid[in]	expected local DTX id
- * \param	epoch[in]	expected epoch
- *
- * \return true if ilog is valid.
- **/
-bool
-ilog_is_valid(struct umem_instance *umm, umem_off_t rec, uint32_t dtx_lid, daos_epoch_t epoch);
 
 #endif /* __ILOG_H__ */

--- a/src/vos/lru_array.h
+++ b/src/vos/lru_array.h
@@ -431,6 +431,8 @@ lrua_allocx_inplace_(struct lru_array *array, uint32_t idx, uint64_t key,
 	entry = &sub->ls_table[ent_idx];
 	if (entry->le_key != key && entry->le_key != 0) {
 		D_ERROR("Cannot allocated idx %d in place\n", idx);
+		/* Return the conflict one for further process. */
+		*entryp = entry->le_payload;
 		return -DER_NO_PERM;
 	}
 

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -594,13 +594,12 @@ vos_tls_init(int tags, int xs_id, int tgt_id)
 		if (rc)
 			D_WARN("Failed to create vos obj cnt: "DF_RC"\n", DP_RC(rc));
 
+		rc = d_tm_add_metric(&tls->vtl_lru_alloc_size, D_TM_GAUGE,
+				     "Active DTX table LRU size", "byte",
+				     "mem/vos/vos_lru_size/tgt_%d", tgt_id);
+		if (rc)
+			D_WARN("Failed to create LRU alloc size: " DF_RC "\n", DP_RC(rc));
 	}
-
-	rc = d_tm_add_metric(&tls->vtl_lru_alloc_size, D_TM_GAUGE,
-			     "Active DTX table LRU size", "byte",
-			     "mem/vos/vos_lru_size/tgt_%d", tgt_id);
-	if (rc)
-		D_WARN("Failed to create LRU alloc size: "DF_RC"\n", DP_RC(rc));
 
 	return tls;
 failed:
@@ -663,6 +662,17 @@ vos_get_agg_gap(void)
 {
 	return vos_agg_gap;
 }
+
+/*
+ * NOTE: Set environment "DAOS_DIAG_MODE" (as non-zero) will enable diagnose mode in VOS.
+ *       That will allow the pool/container to be opened even if with some corruption or
+ *       conflict. Then subsequent operation will have chance to fix/handle related issue.
+ *       But since there may be corruption or inconsistency in the pool/container even if
+ *       engine started under diagnose mode, so must be careful to enable DAOS_DIAG_MODE.
+ *
+ *	 It is usually used for DDB or recovery purpose.
+ */
+unsigned int vos_diag_mode;
 
 static int
 vos_mod_init(void)
@@ -740,6 +750,16 @@ vos_mod_init(void)
 		vos_agg_gap = VOS_AGG_GAP_DEF;
 	}
 	D_INFO("Set DAOS VOS aggregation gap as %u (second)\n", vos_agg_gap);
+
+	vos_diag_mode = VOS_DIAG_DEF;
+	d_getenv_uint("DAOS_DIAG_MODE", &vos_diag_mode);
+	if (vos_diag_mode >= VOS_DIAG_MAX) {
+		D_WARN("Invalid DAOS diagnose mode %d. Valid values: %u (non-diagnose by default), "
+		       "%u (only check), %u (check and repair)\n",
+		       vos_diag_mode, VOS_DIAG_DEF, VOS_DIAG_CHECK, VOS_DIAG_REPAIR);
+		vos_diag_mode = VOS_DIAG_DEF;
+	}
+	D_INFO("Set VOS disgnose mode as %d\n", vos_diag_mode);
 
 	return rc;
 }

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -139,6 +139,19 @@ enum {
 	AGG_CREDS_MERGE_SLACK	= 2,
 };
 
+enum {
+	/** Disable VOS disagnose mode by default. */
+	VOS_DIAG_DEF = 0,
+	/** Only check potential corruption/inconsistency in VOS without repairing. */
+	VOS_DIAG_CHECK,
+	/** Check and repair potential corruption/inconsistency in VOS. */
+	VOS_DIAG_REPAIR,
+	/** Guard for boundary. */
+	VOS_DIAG_MAX
+};
+
+extern unsigned int vos_diag_mode;
+
 /* Throttle ENOSPACE error message */
 #define VOS_NOSPC_ERROR_INTVL	60	/* seconds */
 

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -170,9 +170,10 @@ struct vos_pool_df {
  * array value that is changed in the transaction (DTX).
  */
 enum vos_dtx_record_types {
-	DTX_RT_ILOG	= 1,
-	DTX_RT_SVT	= 2,
-	DTX_RT_EVT	= 3,
+	DTX_RT_UNKNOWN = 0,
+	DTX_RT_ILOG    = 1,
+	DTX_RT_SVT     = 2,
+	DTX_RT_EVT     = 3,
 };
 
 #define DTX_INLINE_REC_CNT	4


### PR DESCRIPTION
1. Do not create VOS LRU metrics entry when initialize standalone tls. That will avoid confused error message from DDB utils.

2. Dump DTX information when conflict being detected.

3. Introduce VOS diagnose mode to allow pool/container to be opened even if there is some corruption, then related issue may be fixed or handled via subsequent operations. It is controlled via server side environment "DAOS_DIAG_MODE". It is set as zero by default. If user wants to handle potential VOS corruption when open the pool/container, then set it as 1 for "check" or 2 for "repair" explicitly when start the engine. If some corruption is detected under "check" mode, then related inconsistency or corruption will be dump, but opening related pool/container will finally fail to avoid further damaging the system.

4. Verify active DTX validity when reindex them, filter out invalid ones. Reassign new local ID if hit conflict DTX if DAOS_DIAG_MODE set as "repair" mode. Then subsequent DTX resync can handle them globally.

5. Do not clear "dae_need_release" flags after partial commit to avoid DTX entry being evicted from DRAM but left on-disk.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
