### PR TITLE
DAOS-17631 cart: Print self_uri on context create

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -350,7 +350,7 @@ crt_context_provider_create(crt_context_t *crt_ctx, crt_provider_t provider, boo
 	}
 
 	*crt_ctx = (crt_context_t)ctx;
-	D_DEBUG(DB_TRACE, "created context (idx %d)\n", ctx->cc_idx);
+	D_INFO("created context (idx %d, self_uri %s)\n", ctx->cc_idx, ctx->cc_self_uri);
 
 out:
 	return rc;


### PR DESCRIPTION
Useful for seeing historical port usage, something we would like to have had on a recent investigation.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
