### PR TITLE
DAOS-17644 gurt: Add server object I/O latency histogram

### DIFF
--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -680,7 +680,7 @@ static uint64_t
 metrics_region_size(int num_tgts)
 {
 	const uint64_t	est_std_metrics = 1024; /* high estimate to allow for pool links */
-	const uint64_t	est_tgt_metrics = 128; /* high estimate */
+	const uint64_t  est_tgt_metrics = 1024; /* high estimate */
 
 	return (est_std_metrics + est_tgt_metrics * num_tgts) * D_TM_METRIC_SIZE;
 }

--- a/src/gurt/examples/telem_consumer_example.c
+++ b/src/gurt/examples/telem_consumer_example.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2020-2022 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -124,8 +125,8 @@ void read_metrics(struct d_tm_context *ctx, struct d_tm_node_t *root,
 				       DP_RC(rc));
 				break;
 			}
-			d_tm_print_gauge(val, &stats, name, D_TM_STANDARD,
-					 units, options, stdout);
+			d_tm_print_gauge(val, &stats, NULL, name, D_TM_STANDARD, units, options,
+					 stdout);
 			break;
 		default:
 			printf("Item: %s has unknown type: 0x%x\n",

--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -1318,11 +1318,72 @@ d_tm_print_duration(struct timespec *tms, struct d_tm_stats_t *stats,
 		d_tm_print_stats(stream, stats, format);
 }
 
+static uint64_t
+d_tm_histogram_get_value(struct d_tm_histogram_t *histogram, uint64_t total_count,
+			 uint32_t percentile)
+{
+	double target_num;
+	double current_num = 0;
+	double prev_num    = 0;
+	int    i;
+
+	if (percentile == 0)
+		return histogram->dth_buckets[0].dtb_min;
+
+	if (percentile >= 100)
+		return histogram->dth_buckets[histogram->dth_num_buckets - 1].dtb_max;
+
+	target_num = total_count * ((double)percentile / 100);
+	for (i = 0; i < histogram->dth_num_buckets; i++) {
+		uint64_t current_val;
+
+		current_val = histogram->dth_buckets[i].dtb_bucket->dtn_metric->dtm_data.value;
+		prev_num    = current_num;
+		current_num += current_val;
+		if (target_num <= current_num) {
+			uint64_t low            = histogram->dth_buckets[i].dtb_min;
+			uint64_t high           = histogram->dth_buckets[i].dtb_max;
+			double   cur_percentage = (target_num - prev_num) / current_val;
+
+			return low + cur_percentage * (high - low);
+		}
+	}
+
+	return histogram->dth_buckets[histogram->dth_num_buckets - 1].dtb_max;
+}
+
+static void
+d_tm_print_histogram(FILE *stream, struct d_tm_histogram_t *histogram, int format)
+{
+	uint64_t total_count = 0;
+	uint64_t p50;
+	uint64_t p90;
+	uint64_t p99;
+	int      i;
+
+	for (i = 0; i < histogram->dth_num_buckets; i++)
+		total_count += histogram->dth_buckets[i].dtb_bucket->dtn_metric->dtm_data.value;
+
+	if (total_count == 0)
+		return;
+
+	p50 = d_tm_histogram_get_value(histogram, total_count, 50);
+	p90 = d_tm_histogram_get_value(histogram, total_count, 90);
+	p99 = d_tm_histogram_get_value(histogram, total_count, 99);
+	if (format == D_TM_CSV) {
+		fprintf(stream, "%ju,%ju,%ju", p50, p90, p99);
+		return;
+	}
+
+	fprintf(stream, " [p50: %ju, p90: %ju, p99: %ju]", p50, p90, p99);
+}
+
 /**
  * Prints the gauge \a val and \a stats with \a name to the \a stream provided
  *
  * \param[in]	tms		Timer value
  * \param[in]	stats		Optional statistics
+ * \param[in]	histogram	Optional histogram statistics
  * \param[in]	name		Timer name
  * \param[in]	format		Output format.
  *				Choose D_TM_STANDARD for standard output.
@@ -1333,8 +1394,8 @@ d_tm_print_duration(struct timespec *tms, struct d_tm_stats_t *stats,
  * \param[in]	stream		Output stream (stdout, stderr)
  */
 void
-d_tm_print_gauge(uint64_t val, struct d_tm_stats_t *stats, char *name,
-		 int format, char *units, int opt_fields, FILE *stream)
+d_tm_print_gauge(uint64_t val, struct d_tm_stats_t *stats, struct d_tm_histogram_t *histogram,
+		 char *name, int format, char *units, int opt_fields, FILE *stream)
 {
 	if ((name == NULL) || (stream == NULL))
 		return;
@@ -1354,6 +1415,9 @@ d_tm_print_gauge(uint64_t val, struct d_tm_stats_t *stats, char *name,
 
 	if ((stats != NULL) && (stats->sample_size > 0))
 		d_tm_print_stats(stream, stats, format);
+
+	if (histogram != NULL && histogram->dth_num_buckets > 0)
+		d_tm_print_histogram(stream, histogram, format);
 }
 
 /**
@@ -1390,6 +1454,9 @@ d_tm_print_metadata(char *desc, char *units, int format, FILE *stream)
 static int
 d_tm_get_meminfo(struct d_tm_context *ctx, struct d_tm_meminfo_t *meminfo,
 		 struct d_tm_node_t *node);
+static int
+d_tm_get_histogram(struct d_tm_context *ctx, uint64_t *val, struct d_tm_histogram_t *histogram,
+		   struct d_tm_node_t *node);
 /**
  * Prints a single \a node.
  * Used as a convenience function to demonstrate usage for the client
@@ -1414,6 +1481,10 @@ d_tm_print_node(struct d_tm_context *ctx, struct d_tm_node_t *node, int level,
 		char *path, int format, int opt_fields, FILE *stream)
 {
 	struct d_tm_stats_t stats = {0};
+	struct d_tm_histogram_t histogram = {0};
+	struct d_tm_bucket_t    h_buckets[20];
+	struct d_tm_node_t      h_nodes[20];
+	struct d_tm_metric_t    h_metrics[20];
 	struct timespec     tms;
 	uint64_t            val;
 	time_t              clk;
@@ -1533,8 +1604,19 @@ d_tm_print_node(struct d_tm_context *ctx, struct d_tm_node_t *node, int level,
 			fprintf(stream, "Error on gauge read: %d\n", rc);
 			break;
 		}
-		d_tm_print_gauge(val, &stats, name, format, units, opt_fields,
-				 stream);
+
+		histogram.dth_buckets = h_buckets;
+		for (i = 0; i < 20; i++) {
+			h_nodes[i].dtn_metric   = &h_metrics[i];
+			h_buckets[i].dtb_bucket = &h_nodes[i];
+		}
+		rc = d_tm_get_histogram(ctx, &val, &histogram, node);
+		if (rc != DER_SUCCESS) {
+			fprintf(stream, "Error on gauge read: %d\n", rc);
+			break;
+		}
+
+		d_tm_print_gauge(val, &stats, &histogram, name, format, units, opt_fields, stream);
 		if (stats.sample_size > 0)
 			stats_printed = true;
 		break;
@@ -3784,6 +3866,64 @@ d_tm_get_gauge(struct d_tm_context *ctx, uint64_t *val,
 						      stats->mean);
 			stats->sum_of_squares = dtm_stats->sum_of_squares;
 			stats->sample_size = dtm_stats->sample_size;
+		}
+		d_tm_node_unlock(node);
+	} else {
+		return -DER_METRIC_NOT_FOUND;
+	}
+	return DER_SUCCESS;
+}
+
+static int
+d_tm_get_histogram(struct d_tm_context *ctx, uint64_t *val, struct d_tm_histogram_t *histogram,
+		   struct d_tm_node_t *node)
+{
+	struct d_tm_metric_t *metric_data = NULL;
+	struct d_tm_mem_hdr  *mem_hdr     = NULL;
+	int                   rc;
+
+	if (ctx == NULL || val == NULL || node == NULL)
+		return -DER_INVAL;
+
+	rc = validate_node_ptr(ctx, node, &mem_hdr);
+	if (rc != 0)
+		return rc;
+
+	if (!is_gauge(node))
+		return -DER_OP_NOT_PERMITTED;
+
+	if (unlikely(!node_is_readable(node)))
+		return -DER_AGAIN;
+
+	metric_data = conv_ptr(mem_hdr, node->dtn_metric);
+	if (metric_data != NULL) {
+		struct d_tm_histogram_t *dtm_histogram = NULL;
+
+		dtm_histogram = conv_ptr(mem_hdr, metric_data->dtm_histogram);
+		d_tm_node_lock(node);
+		if (has_stats(node) && histogram != NULL && dtm_histogram != NULL) {
+			struct d_tm_bucket_t *buckets;
+			uint64_t              total = 0;
+			int                   i;
+
+			buckets                    = conv_ptr(mem_hdr, dtm_histogram->dth_buckets);
+			histogram->dth_num_buckets = dtm_histogram->dth_num_buckets;
+			histogram->dth_initial_width    = dtm_histogram->dth_initial_width;
+			histogram->dth_value_multiplier = dtm_histogram->dth_value_multiplier;
+			for (i = 0; i < histogram->dth_num_buckets; i++) {
+				struct d_tm_node_t   *bucket_node;
+				struct d_tm_metric_t *metric;
+
+				histogram->dth_buckets[i].dtb_min = buckets[i].dtb_min;
+				histogram->dth_buckets[i].dtb_max = buckets[i].dtb_max;
+				bucket_node = conv_ptr(mem_hdr, buckets[i].dtb_bucket);
+				metric      = conv_ptr(mem_hdr, bucket_node->dtn_metric);
+				histogram->dth_buckets[i].dtb_bucket->dtn_metric->dtm_data.value =
+				    metric->dtm_data.value;
+				total += metric->dtm_data.value;
+			}
+			if (val != NULL)
+				*val = total;
 		}
 		d_tm_node_unlock(node);
 	} else {

--- a/src/include/gurt/telemetry_common.h
+++ b/src/include/gurt/telemetry_common.h
@@ -253,10 +253,10 @@ struct d_tm_nodeList_t {
  * Estimate of a metric size. This leans toward a large estimate, but is not the absolute maximum
  * possible size.
  */
-#define D_TM_METRIC_SIZE (sizeof(struct d_tm_node_t) + sizeof(struct d_tm_metric_t) + \
-			  D_TM_MAX_DESC_LEN + D_TM_MAX_NAME_LEN + D_TM_MAX_UNIT_LEN + \
-			  sizeof(struct d_tm_stats_t))
-
+#define D_TM_METRIC_SIZE                                                                           \
+	(sizeof(struct d_tm_node_t) + sizeof(struct d_tm_metric_t) + D_TM_MAX_DESC_LEN +           \
+	 D_TM_MAX_NAME_LEN + D_TM_MAX_UNIT_LEN + sizeof(struct d_tm_stats_t) +                     \
+	 sizeof(struct d_tm_histogram_t))
 /** Context for a telemetry instance */
 struct d_tm_context;
 

--- a/src/include/gurt/telemetry_consumer.h
+++ b/src/include/gurt/telemetry_consumer.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -74,8 +75,9 @@ void d_tm_print_timer_snapshot(struct timespec *tms, char *name, int tm_type,
 void d_tm_print_duration(struct timespec *tms, struct d_tm_stats_t *stats,
 			 char *name, int tm_type, int format, int opt_fields,
 			 FILE *stream);
-void d_tm_print_gauge(uint64_t val, struct d_tm_stats_t *stats, char *name,
-		      int format, char *units, int opt_fields, FILE *stream);
+void
+      d_tm_print_gauge(uint64_t val, struct d_tm_stats_t *stats, struct d_tm_histogram_t *histogram,
+		       char *name, int format, char *units, int opt_fields, FILE *stream);
 void d_tm_print_metadata(char *desc, char *units, int format, FILE *stream);
 int d_tm_clock_id(int clk_id);
 char *d_tm_clock_string(int clk_id);

--- a/src/object/obj_utils.c
+++ b/src/object/obj_utils.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -131,6 +132,11 @@ obj_latency_tm_init(uint32_t opc, int tgt_id, struct d_tm_node_t **tm, char *op,
 		if (rc)
 			D_WARN("Failed to create per-I/O size latency "
 			       "sensor: " DF_RC "\n",
+			       DP_RC(rc));
+
+		rc = d_tm_init_histogram(tm[i], path, 18, 256, 2, "ns");
+		if (rc)
+			D_WARN("Failed to create per-I/O size latency histogram: " DF_RC "\n",
 			       DP_RC(rc));
 		D_FREE(path);
 


### PR DESCRIPTION
Add server I/O latency histogram, and add %50 90% 99% latency to metrics.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
