### PR TITLE
DAOS-17644 gurt:Add server object I/O latency histogram

### DIFF
--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -730,7 +731,7 @@ static uint64_t
 metrics_region_size(int num_tgts)
 {
 	const uint64_t	est_std_metrics = 1024; /* high estimate to allow for pool links */
-	const uint64_t	est_tgt_metrics = 128; /* high estimate */
+	const uint64_t  est_tgt_metrics = 1024; /* high estimate */
 
 	return (est_std_metrics + est_tgt_metrics * num_tgts) * D_TM_METRIC_SIZE;
 }

--- a/src/gurt/examples/telem_consumer_example.c
+++ b/src/gurt/examples/telem_consumer_example.c
@@ -1,5 +1,7 @@
 /*
  * (C) Copyright 2020-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -124,8 +126,8 @@ void read_metrics(struct d_tm_context *ctx, struct d_tm_node_t *root,
 				       DP_RC(rc));
 				break;
 			}
-			d_tm_print_gauge(val, &stats, name, D_TM_STANDARD,
-					 units, options, stdout);
+			d_tm_print_gauge(val, &stats, NULL, name, D_TM_STANDARD, units, options,
+					 stdout);
 			break;
 		default:
 			printf("Item: %s has unknown type: 0x%x\n",

--- a/src/include/gurt/telemetry_common.h
+++ b/src/include/gurt/telemetry_common.h
@@ -1,5 +1,7 @@
 /**
  * (C) Copyright 2020-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -250,9 +252,10 @@ struct d_tm_nodeList_t {
  * Estimate of a metric size. This leans toward a large estimate, but is not the absolute maximum
  * possible size.
  */
-#define D_TM_METRIC_SIZE (sizeof(struct d_tm_node_t) + sizeof(struct d_tm_metric_t) + \
-			  D_TM_MAX_DESC_LEN + D_TM_MAX_NAME_LEN + D_TM_MAX_UNIT_LEN + \
-			  sizeof(struct d_tm_stats_t))
+#define D_TM_METRIC_SIZE                                                                           \
+	(sizeof(struct d_tm_node_t) + sizeof(struct d_tm_metric_t) + D_TM_MAX_DESC_LEN +           \
+	 D_TM_MAX_NAME_LEN + D_TM_MAX_UNIT_LEN + sizeof(struct d_tm_stats_t) +                     \
+	 sizeof(struct d_tm_histogram_t))
 
 /** Context for a telemetry instance */
 struct d_tm_context;

--- a/src/include/gurt/telemetry_consumer.h
+++ b/src/include/gurt/telemetry_consumer.h
@@ -1,5 +1,7 @@
 /**
  * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -74,8 +76,9 @@ void d_tm_print_timer_snapshot(struct timespec *tms, char *name, int tm_type,
 void d_tm_print_duration(struct timespec *tms, struct d_tm_stats_t *stats,
 			 char *name, int tm_type, int format, int opt_fields,
 			 FILE *stream);
-void d_tm_print_gauge(uint64_t val, struct d_tm_stats_t *stats, char *name,
-		      int format, char *units, int opt_fields, FILE *stream);
+void
+      d_tm_print_gauge(uint64_t val, struct d_tm_stats_t *stats, struct d_tm_histogram_t *histogram,
+		       char *name, int format, char *units, int opt_fields, FILE *stream);
 void d_tm_print_metadata(char *desc, char *units, int format, FILE *stream);
 int d_tm_clock_id(int clk_id);
 char *d_tm_clock_string(int clk_id);

--- a/src/object/obj_utils.c
+++ b/src/object/obj_utils.c
@@ -1,5 +1,7 @@
 /**
  * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -131,6 +133,11 @@ obj_latency_tm_init(uint32_t opc, int tgt_id, struct d_tm_node_t **tm, char *op,
 		if (rc)
 			D_WARN("Failed to create per-I/O size latency "
 			       "sensor: " DF_RC "\n",
+			       DP_RC(rc));
+
+		rc = d_tm_init_histogram(tm[i], path, 18, 256, 2, "ns");
+		if (rc)
+			D_WARN("Failed to create per-I/O size latency histogram: " DF_RC "\n",
 			       DP_RC(rc));
 		D_FREE(path);
 


### PR DESCRIPTION
Add server I/O latency histogram, and add %50 90% 99% latency to metrics.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
