### PR TITLE
DAOS-17591 dtx: handle orphan DTX entries - b26

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1471,27 +1471,20 @@ ds_cont_child_put(struct ds_cont_child *cont)
 	cont_child_put(tls->dt_cont_cache, cont);
 }
 
-struct ds_dtx_resync_args {
-	struct ds_pool_child	*pool;
-	uuid_t			 co_uuid;
-};
-
 static void
 ds_dtx_resync(void *arg)
 {
-	struct ds_dtx_resync_args	*ddra = arg;
-	int				 rc;
+	struct ds_cont_child *cont = arg;
+	int                   rc;
 
-	rc = dtx_resync(ddra->pool->spc_hdl, ddra->pool->spc_uuid,
-			ddra->co_uuid, ddra->pool->spc_map_version, false);
+	rc = dtx_resync(cont->sc_pool->spc_hdl, cont, cont->sc_pool->spc_map_version, false);
 	if (rc != 0)
 		D_WARN("Fail to resync some DTX(s) for the pool/cont " DF_UUID "/" DF_UUID
 		       " that may affect subsequent "
 		       "operations: rc = " DF_RC "\n",
-		       DP_UUID(ddra->pool->spc_uuid), DP_UUID(ddra->co_uuid), DP_RC(rc));
+		       DP_UUID(cont->sc_pool_uuid), DP_UUID(cont->sc_uuid), DP_RC(rc));
 
-	ds_pool_child_put(ddra->pool);
-	D_FREE(ddra);
+	ds_cont_child_put(cont);
 }
 
 int
@@ -1601,8 +1594,6 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	 *    Both cases are not expected.
 	 */
 	if (cont_uuid != NULL && !uuid_is_null(cont_uuid)) {
-		struct ds_dtx_resync_args	*ddra = NULL;
-
 		/*
 		 * NB: When cont_uuid == NULL, it's not a real container open
 		 *     but for creating rebuild global container handle.
@@ -1626,21 +1617,10 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 			D_GOTO(err_cont, rc);
 		}
 
-		D_ALLOC_PTR(ddra);
-		if (ddra == NULL)
-			D_GOTO(err_dtx, rc = -DER_NOMEM);
-
-		ddra->pool = ds_pool_child_lookup(hdl->sch_cont->sc_pool->spc_uuid);
-		if (ddra->pool == NULL) {
-			D_FREE(ddra);
-			D_GOTO(err_dtx, rc = -DER_NO_HDL);
-		}
-		uuid_copy(ddra->co_uuid, cont_uuid);
-		rc = dss_ult_create(ds_dtx_resync, ddra, DSS_XS_SELF,
-				    0, 0, NULL);
+		ds_cont_child_get(hdl->sch_cont);
+		rc = dss_ult_create(ds_dtx_resync, hdl->sch_cont, DSS_XS_SELF, 0, 0, NULL);
 		if (rc != 0) {
-			ds_pool_child_put(hdl->sch_cont->sc_pool);
-			D_FREE(ddra);
+			ds_cont_child_put(hdl->sch_cont);
 			D_GOTO(err_dtx, rc);
 		}
 

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -259,6 +259,7 @@ extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;
 extern btr_ops_t dtx_btr_cos_ops;
 
+/* clang-format off */
 /* dtx_common.c */
 int dtx_handle_reinit(struct dtx_handle *dth);
 void dtx_batched_commit(void *arg);
@@ -267,6 +268,8 @@ int start_dtx_reindex_ult(struct ds_cont_child *cont);
 void dtx_merge_check_result(int *tgt, int src);
 int dtx_leader_get(struct ds_pool *pool, struct dtx_memberships *mbs,
 		   daos_unit_oid_t *oid, uint32_t version, struct pool_target **p_tgt);
+int dtx_cleanup_internal(struct ds_cont_child *cont, struct sched_request *sr, uint32_t thd,
+			 bool for_orphan);
 
 /* dtx_cos.c */
 int dtx_fetch_committable(struct ds_cont_child *cont, uint32_t max_cnt,
@@ -289,7 +292,8 @@ int dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte,
 	      daos_epoch_t epoch);
 int dtx_coll_check(struct ds_cont_child *cont, struct dtx_coll_entry *dce, daos_epoch_t epoch);
 int dtx_refresh_internal(struct ds_cont_child *cont, int *check_count, d_list_t *check_list,
-			 d_list_t *cmt_list, d_list_t *abt_list, d_list_t *act_list, bool for_io);
+			 d_list_t *cmt_list, d_list_t *abt_list, d_list_t *act_list,
+			 uint32_t intent);
 int dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte, daos_unit_oid_t oid,
 			  uint64_t dkey_hash, daos_epoch_t epoch, int *tgt_array, int *err);
 
@@ -300,6 +304,7 @@ int dtx_coll_prep(uuid_t po_uuid, daos_unit_oid_t oid, struct dtx_id *xid,
 		  uint32_t pm_ver, bool for_check, bool need_hint, struct dtx_coll_entry **p_dce);
 int dtx_coll_local_exec(uuid_t po_uuid, uuid_t co_uuid, struct dtx_id *xid, daos_epoch_t epoch,
 			uint32_t opc, uint32_t bitmap_sz, uint8_t *bitmap, int **p_results);
+/* clang-format on */
 
 enum dtx_status_handle_result {
 	DSHR_NEED_COMMIT	= 1,
@@ -310,8 +315,15 @@ enum dtx_status_handle_result {
 };
 
 enum dtx_rpc_flags {
-	DRF_INITIAL_LEADER	= (1 << 0),
-	DRF_SYNC_COMMIT		= (1 << 1),
+	DRF_INITIAL_LEADER = (1 << 0),
+	DRF_SYNC_COMMIT    = (1 << 1),
+	DRF_FOR_ORPHAN     = (1 << 2),
+};
+
+enum dtx_refresh_intent {
+	DRI_IO     = 1,
+	DRI_STALE  = 2,
+	DRI_ORPHAN = 3,
 };
 
 enum dtx_cos_flags {

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -588,9 +588,8 @@ out:
 }
 
 int
-dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, bool block)
+dtx_resync(daos_handle_t po_hdl, struct ds_cont_child *cont, uint32_t ver, bool block)
 {
-	struct ds_cont_child		*cont = NULL;
 	struct ds_pool			*pool;
 	struct pool_target		*target;
 	struct dtx_resync_args		 dra = { 0 };
@@ -598,23 +597,16 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, b
 	int				 rc = 0;
 	int				 rc1 = 0;
 
-	rc = ds_cont_child_lookup(po_uuid, co_uuid, &cont);
-	if (rc != 0) {
-		D_ERROR("Failed to open container for resync DTX "
-			DF_UUID"/"DF_UUID": rc = %d\n",
-			DP_UUID(po_uuid), DP_UUID(co_uuid), rc);
-		return rc;
-	}
-
-	D_DEBUG(DB_MD, "Enter DTX resync (%s) for "DF_UUID"/"DF_UUID" with ver %u\n",
-		block ? "block" : "non-block", DP_UUID(po_uuid), DP_UUID(co_uuid), ver);
+	D_DEBUG(DB_MD, "Enter DTX resync (%s) for " DF_UUID "/" DF_UUID " with ver %u\n",
+		block ? "sync" : "async", DP_UUID(cont->sc_pool_uuid), DP_UUID(cont->sc_uuid), ver);
 
 	crt_group_rank(NULL, &myrank);
 
 	pool = cont->sc_pool->spc_pool;
 	if (pool->sp_disable_dtx_resync) {
 		D_DEBUG(DB_MD, "Skip DTX resync (%s) for " DF_UUID "/" DF_UUID " with ver %u\n",
-			block ? "block" : "non-block", DP_UUID(po_uuid), DP_UUID(co_uuid), ver);
+			block ? "sync" : "async", DP_UUID(cont->sc_pool_uuid),
+			DP_UUID(cont->sc_uuid), ver);
 		goto out;
 	}
 
@@ -625,8 +617,8 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, b
 
 	if (target->ta_comp.co_status == PO_COMP_ST_UP) {
 		dra.discard_version = target->ta_comp.co_in_ver;
-		D_DEBUG(DB_MD, "DTX resync for "DF_UUID"/"DF_UUID" discard version: %u\n",
-			DP_UUID(po_uuid), DP_UUID(co_uuid), dra.discard_version);
+		D_DEBUG(DB_MD, "DTX resync for " DF_UUID "/" DF_UUID " discard version: %u\n",
+			DP_UUID(cont->sc_pool_uuid), DP_UUID(cont->sc_uuid), dra.discard_version);
 	}
 
 	ABT_rwlock_unlock(pool->sp_lock);
@@ -638,8 +630,7 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, b
 			ABT_mutex_unlock(cont->sc_mutex);
 			goto out;
 		}
-		D_DEBUG(DB_TRACE, "Waiting for resync of "DF_UUID"\n",
-			DP_UUID(co_uuid));
+		D_DEBUG(DB_TRACE, "Waiting for resync of " DF_UUID "\n", DP_UUID(cont->sc_uuid));
 		ABT_cond_wait(cont->sc_dtx_resync_cond, cont->sc_mutex);
 	}
 
@@ -681,10 +672,10 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, b
 		}
 	}
 
-	D_DEBUG(DB_MD, "Start DTX resync (%s) scan for "DF_UUID"/"DF_UUID" with ver %u\n",
-		block ? "block" : "non-block", DP_UUID(po_uuid), DP_UUID(co_uuid), ver);
+	D_DEBUG(DB_MD, "Start DTX resync (%s) scan for " DF_UUID "/" DF_UUID " with ver %u\n",
+		block ? "sync" : "async", DP_UUID(cont->sc_pool_uuid), DP_UUID(cont->sc_uuid), ver);
 
-	rc = ds_cont_iter(po_hdl, co_uuid, dtx_iter_cb, &dra, VOS_ITER_DTX, 0);
+	rc = ds_cont_iter(po_hdl, cont->sc_uuid, dtx_iter_cb, &dra, VOS_ITER_DTX, 0);
 
 	/* Handle the DTXs that have been scanned even if some failure happened
 	 * in above ds_cont_iter() step.
@@ -699,8 +690,10 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, b
 	if (rc >= 0)
 		vos_set_dtx_resync_version(cont->sc_hdl, ver);
 
-	D_DEBUG(DB_MD, "Stop DTX resync (%s) scan for "DF_UUID"/"DF_UUID" with ver %u: rc = %d\n",
-		block ? "block" : "non-block", DP_UUID(po_uuid), DP_UUID(co_uuid), ver, rc);
+	DL_CDEBUG(rc != 0, DLOG_ERR, DB_MD, rc,
+		  "Stop DTX resync (%s) scan for " DF_UUID "/" DF_UUID " with ver %u",
+		  block ? "sync" : "async", DP_UUID(cont->sc_pool_uuid), DP_UUID(cont->sc_uuid),
+		  ver);
 
 fail:
 	ABT_mutex_lock(cont->sc_mutex);
@@ -709,10 +702,11 @@ fail:
 	ABT_mutex_unlock(cont->sc_mutex);
 
 out:
-	D_DEBUG(DB_MD, "Exit DTX resync (%s) for "DF_UUID"/"DF_UUID" with ver %u, rc = %d\n",
-		block ? "block" : "non-block", DP_UUID(po_uuid), DP_UUID(co_uuid), ver, rc);
+	DL_CDEBUG(rc != 0, DLOG_ERR, DB_MD, rc,
+		  "Exit DTX resync (%s) scan for " DF_UUID "/" DF_UUID " with ver %u",
+		  block ? "sync" : "async", DP_UUID(cont->sc_pool_uuid), DP_UUID(cont->sc_uuid),
+		  ver);
 
-	ds_cont_child_put(cont);
 	return rc > 0 ? 0 : rc;
 }
 
@@ -726,24 +720,41 @@ container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		  vos_iter_type_t type, vos_iter_param_t *iter_param,
 		  void *data, unsigned *acts)
 {
-	struct dtx_container_scan_arg	*scan_arg = data;
-	struct dtx_scan_args		*arg = &scan_arg->arg;
-	int				rc;
+	struct dtx_container_scan_arg *scan_arg = data;
+	struct dtx_scan_args          *arg      = &scan_arg->arg;
+	struct ds_cont_child          *cont     = NULL;
+	int                            rc;
 
-	if (uuid_compare(scan_arg->co_uuid, entry->ie_couuid) == 0) {
-		D_DEBUG(DB_REBUILD, DF_UUID" already scan\n",
-			DP_UUID(scan_arg->co_uuid));
+	if (uuid_compare(scan_arg->co_uuid, entry->ie_couuid) == 0)
 		return 0;
-	}
+
+	rc = ds_cont_child_lookup(arg->pool_uuid, entry->ie_couuid, &cont);
+	if (rc != 0)
+		goto out;
 
 	uuid_copy(scan_arg->co_uuid, entry->ie_couuid);
-	rc = dtx_resync(iter_param->ip_hdl, arg->pool_uuid, entry->ie_couuid, arg->version, true);
-	if (rc)
-		D_ERROR(DF_UUID" dtx resync failed: rc %d\n",
-			DP_UUID(arg->pool_uuid), rc);
+	if (arg->for_orphan) {
+again:
+		rc = dtx_cleanup_internal(cont, NULL, arg->version, true);
+		if (rc == -DER_INPROGRESS || rc == -DER_OOG || rc == -DER_HG) {
+			D_WARN("Cleanup DTX for " DF_UUID "/" DF_UUID " is blocked " DF_RC "\n",
+			       DP_UUID(arg->pool_uuid), DP_UUID(entry->ie_couuid), DP_RC(rc));
+			ABT_thread_yield();
+			goto again;
+		}
+	} else {
+		rc = dtx_resync(iter_param->ip_hdl, cont, arg->version, true);
+	}
+	if (rc == 0)
+		/* Since dtx_{cleanup,resync} might yield, let's reprobe anyway */
+		*acts |= VOS_ITER_CB_YIELD;
 
-	/* Since dtx_resync might yield, let's reprobe anyway */
-	*acts |= VOS_ITER_CB_YIELD;
+	ds_cont_child_put(cont);
+
+out:
+	DL_CDEBUG(rc != 0, DLOG_ERR, DB_MD, rc, "%s DTX for " DF_UUID "/" DF_UUID,
+		  arg->for_orphan ? "cleanup" : "resync", DP_UUID(arg->pool_uuid),
+		  DP_UUID(entry->ie_couuid));
 
 	return rc;
 }
@@ -829,10 +840,29 @@ dtx_resync_ult(void *data)
 		D_ERROR("dtx resync collective "DF_UUID" %d.\n",
 			DP_UUID(arg->pool_uuid), rc);
 	}
-	pool->sp_dtx_resync_version = arg->version;
+
+	if (pool->sp_dtx_resync_version < arg->version)
+		pool->sp_dtx_resync_version = arg->version;
 
 out:
 	if (pool != NULL)
 		ds_pool_put(pool);
 	D_FREE(arg);
+}
+
+int
+dtx_cleanup_orphan(uuid_t po_uuid, uint32_t pm_ver)
+{
+	struct dtx_scan_args arg;
+	int                  rc = 0;
+
+	uuid_copy(arg.pool_uuid, po_uuid);
+	arg.version    = pm_ver;
+	arg.for_orphan = true;
+	rc             = dtx_resync_one(&arg);
+
+	DL_CDEBUG(rc != 0, DLOG_ERR, DB_MD, rc, "DTX cleanup orphan for " DF_UUID " with ver %u",
+		  DP_UUID(po_uuid), pm_ver);
+
+	return rc;
 }

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -277,6 +277,9 @@ dtx_req_send(struct dtx_req_rec *drr, daos_epoch_t epoch)
 		if (dra->dra_opc == DTX_REFRESH) {
 			if (DAOS_FAIL_CHECK(DAOS_DTX_RESYNC_DELAY))
 				rc = crt_req_set_timeout(req, 3);
+			else if (drr->drr_flags != NULL && drr->drr_flags[0] & DRF_FOR_ORPHAN)
+				/* DRF_FOR_ORPHAN case may need longer timeout. */
+				rc = crt_req_set_timeout(req, 60);
 			else
 				/*
 				 * If related DTX is committable, then it will be committed
@@ -983,7 +986,7 @@ dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 
 int
 dtx_refresh_internal(struct ds_cont_child *cont, int *check_count, d_list_t *check_list,
-		     d_list_t *cmt_list, d_list_t *abt_list, d_list_t *act_list, bool for_io)
+		     d_list_t *cmt_list, d_list_t *abt_list, d_list_t *act_list, uint32_t intent)
 {
 	struct ds_pool		*pool = cont->sc_pool->spc_pool;
 	struct pool_target	*target;
@@ -1001,6 +1004,7 @@ dtx_refresh_internal(struct ds_cont_child *cont, int *check_count, d_list_t *che
 	int			 count;
 	int			 i;
 	bool			 drop;
+	bool                     for_io = (intent == DRI_IO);
 
 	D_INIT_LIST_HEAD(&head);
 	D_INIT_LIST_HEAD(&self);
@@ -1013,7 +1017,8 @@ dtx_refresh_internal(struct ds_cont_child *cont, int *check_count, d_list_t *che
 		if (dsp->dsp_mbs == NULL) {
 			rc = vos_dtx_load_mbs(cont->sc_hdl, &dsp->dsp_xid, NULL, &dsp->dsp_mbs);
 			if (rc != 0) {
-				if (rc < 0 && rc != -DER_NONEXIST && for_io) {
+				if (rc < 0 && rc != -DER_NONEXIST &&
+				    (intent == DRI_IO || intent == DRI_ORPHAN)) {
 					D_ERROR("Failed to load mbs for "DF_DTI": "DF_RC"\n",
 						DP_DTI(&dsp->dsp_xid), DP_RC(rc));
 					goto out;
@@ -1035,7 +1040,7 @@ again:
 			 */
 			D_WARN("Failed to find DTX leader for "DF_DTI", ver %d: "DF_RC"\n",
 			       DP_DTI(&dsp->dsp_xid), pool->sp_map_version, DP_RC(rc));
-			if (for_io)
+			if (intent == DRI_IO || intent == DRI_ORPHAN)
 				goto out;
 
 			drop = true;
@@ -1046,14 +1051,21 @@ again:
 		 *
 		 * 1. In DTX resync, the status may be resolved sometime later.
 		 * 2. The DTX resync is done, but failed to handle related DTX.
+		 * 3. For orphan cleanup, that is almost impossible unless another
+		 *    pool map changes between DTX resync and DTX orphan cleanup.
+		 *    Under such case, another DTX resync will be triggered. For
+		 *    current DTX orphan cleanup, just ignore such case.
 		 */
 		if (myrank == target->ta_comp.co_rank &&
 		    dss_get_module_info()->dmi_tgt_id == target->ta_comp.co_index) {
 			d_list_del(&dsp->dsp_link);
-			if (for_io)
+			if (for_io) {
 				d_list_add_tail(&dsp->dsp_link, &self);
-			else
+			} else {
+				D_WARN("Hit self leader for DTX " DF_DTI " when cleanup\n",
+				       DP_DTI(&dsp->dsp_xid));
 				dtx_dsp_free(dsp);
+			}
 			if (--(*check_count) == 0)
 				break;
 			continue;
@@ -1079,6 +1091,9 @@ again:
 			flags = DRF_INITIAL_LEADER;
 		else
 			flags = 0;
+
+		if (intent == DRI_ORPHAN)
+			flags |= DRF_FOR_ORPHAN;
 
 		d_list_for_each_entry(drr, &head, drr_link) {
 			if (drr->drr_rank == target->ta_comp.co_rank &&
@@ -1365,7 +1380,7 @@ dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont)
 
 	rc = dtx_refresh_internal(cont, &dth->dth_share_tbd_count, &dth->dth_share_tbd_list,
 				  &dth->dth_share_cmt_list, &dth->dth_share_abt_list,
-				  &dth->dth_share_act_list, true);
+				  &dth->dth_share_act_list, DRI_IO);
 	if (rc == 0) {
 		D_ASSERT(dth->dth_share_tbd_count == 0);
 

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -436,9 +436,13 @@ dtx_is_real_handle(const struct dtx_handle *dth)
 struct dtx_scan_args {
 	uuid_t		pool_uuid;
 	uint32_t	version;
+	bool            for_orphan;
 };
 
-int dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, bool block);
+/* clang-format off */
+int dtx_cleanup_orphan(uuid_t po_uuid, uint32_t pm_ver);
+int dtx_resync(daos_handle_t po_hdl, struct ds_cont_child *cont, uint32_t ver, bool block);
 void dtx_resync_ult(void *arg);
+/* clang-format on */
 
 #endif /* __DAOS_DTX_SRV_H__ */

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -998,6 +998,11 @@ rebuild_scanner(void *data)
 	if (tls == NULL)
 		return 0;
 
+	/* There maybe orphan DTX entries after DTX resync, let's cleanup before rebuild scan. */
+	rc = dtx_cleanup_orphan(rpt->rt_pool_uuid, rpt->rt_pool->sp_dtx_resync_version);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
 	if (!is_rebuild_scanning_tgt(rpt)) {
 		D_DEBUG(DB_REBUILD, DF_UUID" skip scan\n", DP_UUID(rpt->rt_pool_uuid));
 		D_GOTO(out, rc = 0);


### PR DESCRIPTION
Our current DTX resync mechanism does DTX leader sponsored scanning for the specified container. But if current DTX leader is dead, the new DTX leader will switch to another target on which related entry may be not exist or has been committed. Under such case, DTX resync on the new DTX leader will not handle such DTX entry, as to the DTX entry on other non-leaders may become "orphan".

Such kind of orphan DTX entries may affect subsequent rebuild. This patch introduces DTX orphan cleanup mechanism to handle them before rebuild scanning related container.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
