### PR TITLE
DAOS-17651 test: Increase timeout for recovery/pool_list_consolidatio…

### DIFF
--- a/src/tests/ftest/recovery/pool_list_consolidation.yaml
+++ b/src/tests/ftest/recovery/pool_list_consolidation.yaml
@@ -1,7 +1,7 @@
 hosts:
   test_servers: 4
 
-timeout: 240
+timeout: 285
 
 server_config:
   name: daos_server

--- a/src/tests/ftest/recovery/pool_list_consolidation.yaml
+++ b/src/tests/ftest/recovery/pool_list_consolidation.yaml
@@ -11,8 +11,8 @@ server_config:
       nr_xs_helpers: 1
       storage: auto
 
-# We need to restart the servers and clean up after each test because we manually corrupt
-# the pool directory. The tests will have unpredictable behavior if we don't.
+# We need to restart servers and clean up after each test because we manually corrupt the
+# pool directory. The tests will have unpredictable behavior if we don't.
 setup:
   start_servers_once: False
 

--- a/src/tests/ftest/recovery/pool_list_consolidation.yaml
+++ b/src/tests/ftest/recovery/pool_list_consolidation.yaml
@@ -11,8 +11,8 @@ server_config:
       nr_xs_helpers: 1
       storage: auto
 
-# We need to restart servers and clean up after each test because we manually corrupt the
-# pool directory. The tests will have unpredictable behavior if we don't.
+# We need to restart the servers and clean up after each test because we manually corrupt
+# the pool directory. The tests will have unpredictable behavior if we don't.
 setup:
   start_servers_once: False
 


### PR DESCRIPTION
…n.yaml

test_lost_majority_ps_replicas timed out at pool destroy during tearDown (while other tests passed). Increase the timeout by 45 sec.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: pool_list_consolidation

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
