### PR TITLE
DAOS-17658 object: more delay before retry RPC - b26

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1715,30 +1715,28 @@ dc_obj_layout_refresh(daos_handle_t oh)
 }
 
 uint32_t
-dc_obj_retry_delay(tse_task_t *task, int err, uint16_t *retry_cnt, uint16_t *inprogress_cnt,
-		   uint32_t timeout_sec)
+dc_obj_retry_delay(tse_task_t *task, uint32_t opc, int err, uint16_t *retry_cnt,
+		   uint16_t *inprogress_cnt, uint32_t timeout_sec)
 {
-	uint32_t	delay = 0;
-	uint32_t	limit = 4;
+	uint32_t delay = 0;
 
-	/*
-	 * Randomly delay 5 ~ 1028 us if it is not the first retry for
-	 * -DER_INPROGRESS || -DER_UPDATE_AGAIN cases.
-	 */
-	++(*retry_cnt);
-	if (err == -DER_INPROGRESS || err == -DER_UPDATE_AGAIN) {
-		if (++(*inprogress_cnt) > 1) {
-			limit += *inprogress_cnt;
-			if (limit > 10)
-				limit = 10;
+	if (err == -DER_INPROGRESS || err == -DER_UPDATE_AGAIN)
+		++(*inprogress_cnt);
 
-			delay = (d_rand() & ((1 << limit) - 1)) + 5;
-			/* Rebuild is being established on the server side, wait a bit longer */
-			if (err == -DER_UPDATE_AGAIN)
-				delay <<= 10;
-			D_DEBUG(DB_IO, "Try to re-sched task %p for %d/%d times with %u us delay\n",
-				task, (int)*inprogress_cnt, (int)*retry_cnt, delay);
-		}
+	if (++(*retry_cnt) > 1) {
+		/* Randomly delay [31 ~ 1023] us if it is not the first retried object RPC. */
+		delay = (d_rand() | ((1 << 5) - 1)) & ((1 << 10) - 1);
+		/* Rebuild is being established on the server side, wait a bit longer */
+		if (err == -DER_UPDATE_AGAIN)
+			delay <<= 10;
+		else if (opc == DAOS_OBJ_RPC_COLL_PUNCH)
+			/* 128 times of the delay for collective object RPC. */
+			delay <<= 7;
+		else if (opc == DAOS_OBJ_RPC_CPD)
+			/* 8 times of the delay for compounded RPC. */
+			delay <<= 3;
+		D_DEBUG(DB_IO, "Try to re-sched task %p (%u) for %u/%u times with %u us delay\n",
+			task, opc, *inprogress_cnt, *retry_cnt, delay);
 	}
 
 	/*
@@ -1780,8 +1778,9 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 		if (!pmap_stale) {
 			uint32_t now = daos_gettime_coarse();
 
-			delay = dc_obj_retry_delay(task, result, &obj_auxi->retry_cnt,
-						   &obj_auxi->inprogress_cnt, obj_auxi->max_delay);
+			delay =
+			    dc_obj_retry_delay(task, obj_auxi->opc, result, &obj_auxi->retry_cnt,
+					       &obj_auxi->inprogress_cnt, obj_auxi->max_delay);
 			if (result == -DER_INPROGRESS &&
 			    ((obj_auxi->retry_warn_ts == 0 && obj_auxi->inprogress_cnt >= 10) ||
 			     (obj_auxi->retry_warn_ts > 0 && obj_auxi->retry_warn_ts + 10 < now))) {

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -912,8 +912,9 @@ struct dc_object *obj_addref(struct dc_object *obj);
 void obj_decref(struct dc_object *obj);
 int obj_get_grp_size(struct dc_object *obj);
 struct dc_object *obj_hdl2ptr(daos_handle_t oh);
-uint32_t dc_obj_retry_delay(tse_task_t *task, int err, uint16_t *retry_cnt,
-			    uint16_t *inprogress_cnt, uint32_t timeout_secs);
+uint32_t
+dc_obj_retry_delay(tse_task_t *task, uint32_t opc, int err, uint16_t *retry_cnt,
+		   uint16_t *inprogress_cnt, uint32_t timeout_secs);
 
 /* handles, pointers for handling I/O */
 struct obj_io_context {

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1094,7 +1094,8 @@ dc_tx_commit_cb(tse_task_t *task, void *data)
 	if (rc != -DER_TX_RESTART) {
 		uint32_t now = daos_gettime_coarse();
 
-		delay = dc_obj_retry_delay(task, rc, &tx->tx_retry_cnt, &tx->tx_inprogress_cnt, 0);
+		delay = dc_obj_retry_delay(task, DAOS_OBJ_RPC_CPD, rc, &tx->tx_retry_cnt,
+					   &tx->tx_inprogress_cnt, 0);
 		if (rc == -DER_INPROGRESS &&
 		    ((tx->tx_retry_warn_ts == 0 && tx->tx_inprogress_cnt >= 10) ||
 		     (tx->tx_retry_warn_ts > 0 && tx->tx_retry_warn_ts + 10 < now))) {


### PR DESCRIPTION
If an object RPC hit conflict with former non-committed transaction, then related client with retry the RPC sometime later. If the retry interval is too short, it is quite possible to hit conflict again, that will waste system resource and increase server load.

The patch introduces 31 ~ 1023 us random delay for non-collective and non-compounded object RPC. 128 times of such delay for collective RPC, 8 times for compounded RPC.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
