### PR TITLE
DAOS-17444 engine: reduce lock contention during rebuild

### DIFF
--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -753,10 +754,9 @@ server_init(int argc, char *argv[])
 		D_GOTO(exit_mod_init, rc);
 	D_INFO("Network successfully initialized\n");
 
-	rc = daos_hhash_init();
+	rc = daos_hhash_init_feats(D_HASH_FT_RWLOCK);
 	if (rc != 0) {
-		D_ERROR("daos_hhash_init failed, rc: "DF_RC"\n",
-			DP_RC(rc));
+		D_ERROR("daos_hhash_init_feats failed, rc: " DF_RC "\n", DP_RC(rc));
 		D_GOTO(exit_crt, rc);
 	}
 


### PR DESCRIPTION
Previously, the engine used a global lock for hash operations which created significant performance bottlenecks. This lock was shared across multiple target threads on the server side, leading to high contention during rebuild operations.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
