### PR TITLE
DAOS-16895 control: Show pool in degraded state only when rebuild busy

### DIFF
--- a/src/control/cmd/daos/pretty/pool.go
+++ b/src/control/cmd/daos/pretty/pool.go
@@ -72,6 +72,7 @@ func PrintPoolInfo(pi *daos.PoolInfo, out io.Writer) error {
 	w := txtfmt.NewErrWriter(out)
 
 	// Maintain output compatibility with the `daos pool query` output.
+	// Pool state should only show degraded when rebuild is active.
 	fmt.Fprintf(w, "Pool %s, ntarget=%d, disabled=%d, leader=%d, version=%d, state=%s\n",
 		pi.UUID, pi.TotalTargets, pi.DisabledTargets, pi.ServiceLeader, pi.Version, pi.State)
 

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -548,8 +548,8 @@ func (pqr *PoolQueryResp) UpdateState() error {
 		pqr.State = daos.PoolServiceStateUnknown
 	}
 
-	// Update the Pool state as Degraded, if initial state is Ready and any target is disabled
-	if pqr.State == daos.PoolServiceStateReady && pqr.DisabledTargets > 0 {
+	// Update the Pool state as Degraded if initial state is Ready and rebuild is busy.
+	if pqr.Rebuild != nil && pqr.Rebuild.State == daos.PoolRebuildStateBusy {
 		pqr.State = daos.PoolServiceStateDegraded
 	}
 

--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -1245,8 +1245,8 @@ func TestControl_UpdateState(t *testing.T) {
 				Status: 0,
 				PoolInfo: daos.PoolInfo{
 					UUID:            poolUUID,
-					TotalTargets:    1,
-					DisabledTargets: 0,
+					TotalTargets:    2,
+					DisabledTargets: 1,
 				},
 			},
 			expState: daos.PoolServiceStateReady.String(),
@@ -1255,10 +1255,14 @@ func TestControl_UpdateState(t *testing.T) {
 			pqr: &PoolQueryResp{
 				Status: 0,
 				PoolInfo: daos.PoolInfo{
-					UUID:            poolUUID,
-					TotalTargets:    1,
-					DisabledTargets: 4,
-					State:           daos.PoolServiceStateReady,
+					UUID:         poolUUID,
+					TotalTargets: 1,
+					State:        daos.PoolServiceStateReady,
+					Rebuild: &daos.PoolRebuildStatus{
+						State:   daos.PoolRebuildStateBusy,
+						Objects: 1,
+						Records: 2,
+					},
 				},
 			},
 			expState: daos.PoolServiceStateDegraded.String(),

--- a/src/control/lib/daos/api/pool.go
+++ b/src/control/lib/daos/api/pool.go
@@ -147,11 +147,12 @@ func newPoolInfo(cpi *C.daos_pool_info_t) *daos.PoolInfo {
 	poolInfo.ServiceLeader = uint32(cpi.pi_leader)
 	poolInfo.Version = uint32(cpi.pi_map_ver)
 	poolInfo.State = daos.PoolServiceStateReady
-	if poolInfo.DisabledTargets > 0 {
+
+	poolInfo.Rebuild = newPoolRebuildStatus(&cpi.pi_rebuild_st)
+	if poolInfo.Rebuild.State == daos.PoolRebuildStateBusy {
 		poolInfo.State = daos.PoolServiceStateDegraded
 	}
 
-	poolInfo.Rebuild = newPoolRebuildStatus(&cpi.pi_rebuild_st)
 	if poolInfo.QueryMask.HasOption(daos.PoolQueryOptionSpace) {
 		poolInfo.TierStats = []*daos.StorageUsageStats{
 			newPoolSpaceInfo(&cpi.pi_space, C.DAOS_MEDIA_SCM),


### PR DESCRIPTION
Features: control

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
