### PR TITLE
DAOS-17653 test: Resolve daos_build.py ofi failed to build

### DIFF
--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -147,6 +147,8 @@ def run_build_test(self, cache_mode, il_lib=None, run_on_vms=False):
         timeout = 10 * 60
         if cmd.startswith('scons'):
             timeout = build_time * 60
+        elif cmd.endswith('install.sh -y'):
+            timeout *= 2
         self.log_step(f"Running '{cmd}' with a {timeout}s timeout")
         start = time.time()
         result = run_remote(

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -132,7 +132,7 @@ def run_build_test(self, cache_mode, il_lib=None, run_on_vms=False):
             f'git -C {build_dir} checkout {__get_daos_build_checkout(self)}',
             f'git -C {build_dir} submodule update --init --recursive',
             f'cp {build_dir}/utils/scripts/install-{distro}.sh /tmp/install.sh',
-            'sudo /tmp/install.sh -y',
+            'sudo -E /tmp/install.sh -y',
             'python3 -m pip install pip --upgrade',
             f'python3 -m pip install -r {build_dir}/requirements-build.txt',
             f'scons -C {build_dir} --jobs {build_jobs} --build-deps=only',

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -131,7 +131,7 @@ def run_build_test(self, cache_mode, il_lib=None, run_on_vms=False):
             f'git -C {build_dir} checkout {__get_daos_build_checkout(self)}',
             f'git -C {build_dir} submodule update --init --recursive',
             f'cp {build_dir}/utils/scripts/install-{distro}.sh /tmp/install.sh',
-            'sudo /tmp/install.sh -y'
+            'sudo /tmp/install.sh -y',
             'python3 -m pip install pip --upgrade',
             f'python3 -m pip install -r {build_dir}/requirements-build.txt',
             f'scons -C {build_dir} --jobs {build_jobs} --build-deps=only',

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -130,7 +130,8 @@ def run_build_test(self, cache_mode, il_lib=None, run_on_vms=False):
             f'git clone https://github.com/daos-stack/daos.git {build_dir}',
             f'git -C {build_dir} checkout {__get_daos_build_checkout(self)}',
             f'git -C {build_dir} submodule update --init --recursive',
-            f'sudo {build_dir}/utils/scripts/install-{distro}.sh',
+            f'cp {build_dir}/utils/scripts/install-{distro}.sh /tmp/install.sh',
+            'sudo /tmp/install.sh -y'
             'python3 -m pip install pip --upgrade',
             f'python3 -m pip install -r {build_dir}/requirements-build.txt',
             f'scons -C {build_dir} --jobs {build_jobs} --build-deps=only',

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -104,6 +104,7 @@ def run_build_test(self, cache_mode, il_lib=None, run_on_vms=False):
     remote_env['PATH'] = f"{os.path.join(mount_dir, 'venv', 'bin')}:$PATH"
     remote_env['VIRTUAL_ENV'] = os.path.join(mount_dir, 'venv')
     remote_env['COVFILE'] = os.environ['COVFILE']
+    remote_env['HTTPS_PROXY'] = os.environ['HTTPS_PROXY']
 
     if il_lib is not None:
         remote_env['LD_PRELOAD'] = os.path.join(self.prefix, 'lib64', il_lib)

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -14,7 +14,7 @@ arch=$(uname -m)
 
 dnf_install_args="${1:-}"
 
-dnf --nodocs install ""${dnf_install_args}"" \
+dnf --nodocs install "${dnf_install_args}" \
     boost-python3-devel \
     bzip2 \
     capstone-devel \

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -14,7 +14,8 @@ arch=$(uname -m)
 
 dnf_install_args="${1:-}"
 
-dnf --nodocs install "${dnf_install_args}" \
+# shellcheck disable=SC2086
+dnf --nodocs install ${dnf_install_args} \
     boost-python3-devel \
     bzip2 \
     capstone-devel \
@@ -81,14 +82,16 @@ dnf --nodocs install "${dnf_install_args}" \
     yasm
 
 ruby_version=$(dnf module list ruby | grep -Eow "3\.[0-9]+" | tail -1)
-dnf --nodocs install "${dnf_install_args}" \
+# shellcheck disable=SC2086
+dnf --nodocs install ${dnf_install_args} \
     "@ruby:${ruby_version}" \
     rubygems \
     rubygem-json
 
 # ipmctl is only available on x86_64
 if [ "$arch" = x86_64 ]; then
-    dnf --nodocs install "${dnf_install_args}" \
+    # shellcheck disable=SC2086
+    dnf --nodocs install ${dnf_install_args} \
         ipmctl \
         libipmctl-devel
 fi
@@ -98,9 +101,11 @@ fi
 # installed specifically.
 
 if [ -e /etc/fedora-release ]; then
-        dnf install "${dnf_install_args}" java-1.8.0-openjdk-devel maven-openjdk8
+    # shellcheck disable=SC2086
+    dnf install ${dnf_install_args} java-1.8.0-openjdk-devel maven-openjdk8
 else
-        dnf install "${dnf_install_args}" maven
+    # shellcheck disable=SC2086
+    dnf install ${dnf_install_args} maven
 fi
 
 gem install fpm

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -14,7 +14,7 @@ arch=$(uname -m)
 
 dnf_install_args="${1:-}"
 
-dnf --nodocs install ${dnf_install_args} \
+dnf --nodocs install ""${dnf_install_args}"" \
     boost-python3-devel \
     bzip2 \
     capstone-devel \
@@ -81,14 +81,14 @@ dnf --nodocs install ${dnf_install_args} \
     yasm
 
 ruby_version=$(dnf module list ruby | grep -Eow "3\.[0-9]+" | tail -1)
-dnf --nodocs install ${dnf_install_args} \
+dnf --nodocs install "${dnf_install_args}" \
     "@ruby:${ruby_version}" \
     rubygems \
     rubygem-json
 
 # ipmctl is only available on x86_64
 if [ "$arch" = x86_64 ]; then
-    dnf --nodocs install ${dnf_install_args}\
+    dnf --nodocs install "${dnf_install_args}" \
         ipmctl \
         libipmctl-devel
 fi
@@ -98,9 +98,9 @@ fi
 # installed specifically.
 
 if [ -e /etc/fedora-release ]; then
-        dnf install ${dnf_install_args} java-1.8.0-openjdk-devel maven-openjdk8
+        dnf install "${dnf_install_args}" java-1.8.0-openjdk-devel maven-openjdk8
 else
-        dnf install ${dnf_install_args} maven
+        dnf install "${dnf_install_args}" maven
 fi
 
 gem install fpm

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -12,7 +12,7 @@ set -e
 
 arch=$(uname -m)
 
-dnf_install_args=${1:=''}
+dnf_install_args="${1:-}"
 
 dnf --nodocs install ${dnf_install_args} \
     boost-python3-devel \

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -12,7 +12,9 @@ set -e
 
 arch=$(uname -m)
 
-dnf --nodocs install \
+dnf_install_args=${1:=''}
+
+dnf --nodocs install ${dnf_install_args} \
     boost-python3-devel \
     bzip2 \
     capstone-devel \
@@ -79,14 +81,14 @@ dnf --nodocs install \
     yasm
 
 ruby_version=$(dnf module list ruby | grep -Eow "3\.[0-9]+" | tail -1)
-dnf --nodocs install \
+dnf --nodocs install ${dnf_install_args} \
     "@ruby:${ruby_version}" \
     rubygems \
     rubygem-json
 
 # ipmctl is only available on x86_64
 if [ "$arch" = x86_64 ]; then
-    dnf --nodocs install \
+    dnf --nodocs install ${dnf_install_args}\
         ipmctl \
         libipmctl-devel
 fi
@@ -96,9 +98,9 @@ fi
 # installed specifically.
 
 if [ -e /etc/fedora-release ]; then
-        dnf install java-1.8.0-openjdk-devel maven-openjdk8
+        dnf install ${dnf_install_args} java-1.8.0-openjdk-devel maven-openjdk8
 else
-        dnf install maven
+        dnf install ${dnf_install_args} maven
 fi
 
 gem install fpm

--- a/utils/scripts/install-el9.sh
+++ b/utils/scripts/install-el9.sh
@@ -12,7 +12,8 @@ set -e
 
 dnf_install_args="${1:-}"
 
-dnf --nodocs install "${dnf_install_args}" \
+# shellcheck disable=SC2086
+dnf --nodocs install ${dnf_install_args} \
     boost-python3-devel \
     bzip2 \
     capstone-devel \
@@ -80,7 +81,8 @@ dnf --nodocs install "${dnf_install_args}" \
     yasm
 
 ruby_version=$(dnf module list ruby | grep -Eow "3\.[0-9]+" | tail -1)
-dnf --nodocs install "${dnf_install_args}" \
+# shellcheck disable=SC2086
+dnf --nodocs install ${dnf_install_args} \
     "@ruby:${ruby_version}" \
     rubygems \
     rubygem-json

--- a/utils/scripts/install-el9.sh
+++ b/utils/scripts/install-el9.sh
@@ -10,7 +10,9 @@
 
 set -e
 
-dnf --nodocs install \
+dnf_install_args=${1:=''}
+
+dnf --nodocs install ${dnf_install_args} \
     boost-python3-devel \
     bzip2 \
     capstone-devel \
@@ -78,7 +80,7 @@ dnf --nodocs install \
     yasm
 
 ruby_version=$(dnf module list ruby | grep -Eow "3\.[0-9]+" | tail -1)
-dnf --nodocs install \
+dnf --nodocs install ${dnf_install_args} \
     "@ruby:${ruby_version}" \
     rubygems \
     rubygem-json

--- a/utils/scripts/install-el9.sh
+++ b/utils/scripts/install-el9.sh
@@ -12,7 +12,7 @@ set -e
 
 dnf_install_args="${1:-}"
 
-dnf --nodocs install ${dnf_install_args} \
+dnf --nodocs install "${dnf_install_args}" \
     boost-python3-devel \
     bzip2 \
     capstone-devel \
@@ -80,7 +80,7 @@ dnf --nodocs install ${dnf_install_args} \
     yasm
 
 ruby_version=$(dnf module list ruby | grep -Eow "3\.[0-9]+" | tail -1)
-dnf --nodocs install ${dnf_install_args} \
+dnf --nodocs install "${dnf_install_args}" \
     "@ruby:${ruby_version}" \
     rubygems \
     rubygem-json

--- a/utils/scripts/install-el9.sh
+++ b/utils/scripts/install-el9.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-dnf_install_args=${1:=''}
+dnf_install_args="${1:-}"
 
 dnf --nodocs install ${dnf_install_args} \
     boost-python3-devel \

--- a/utils/scripts/install-leap15.sh
+++ b/utils/scripts/install-leap15.sh
@@ -14,7 +14,7 @@ arch=$(uname -i)
 
 dnf_install_args="${1:-}"
 
-dnf --nodocs install ${dnf_install_args} \
+dnf --nodocs install "${dnf_install_args}" \
     boost-devel \
     bzip2 \
     curl \
@@ -74,7 +74,7 @@ dnf --nodocs install ${dnf_install_args} \
     which \
     yasm
 
-dnf install ${dnf_install_args} ruby-devel
+dnf install "${dnf_install_args}" ruby-devel
 gem install json -v 2.7.6
 gem install dotenv -v 2.8.1
 gem install fpm
@@ -84,6 +84,6 @@ fi
 
 # ipmctl is only available on x86_64
 if [ "$arch" = x86_64 ]; then
-    dnf --nodocs install ${dnf_install_args} \
+    dnf --nodocs install "${dnf_install_args}" \
         ipmctl-devel
 fi

--- a/utils/scripts/install-leap15.sh
+++ b/utils/scripts/install-leap15.sh
@@ -12,7 +12,9 @@ set -e
 
 arch=$(uname -i)
 
-dnf --nodocs install \
+dnf_install_args=${1:=''}
+
+dnf --nodocs install ${dnf_install_args} \
     boost-devel \
     bzip2 \
     curl \
@@ -72,7 +74,7 @@ dnf --nodocs install \
     which \
     yasm
 
-dnf install ruby-devel
+dnf install ${dnf_install_args} ruby-devel
 gem install json -v 2.7.6
 gem install dotenv -v 2.8.1
 gem install fpm
@@ -82,6 +84,6 @@ fi
 
 # ipmctl is only available on x86_64
 if [ "$arch" = x86_64 ]; then
-    dnf --nodocs install \
+    dnf --nodocs install ${dnf_install_args} \
         ipmctl-devel
 fi

--- a/utils/scripts/install-leap15.sh
+++ b/utils/scripts/install-leap15.sh
@@ -14,7 +14,8 @@ arch=$(uname -i)
 
 dnf_install_args="${1:-}"
 
-dnf --nodocs install "${dnf_install_args}" \
+# shellcheck disable=SC2086
+dnf --nodocs install ${dnf_install_args} \
     boost-devel \
     bzip2 \
     curl \
@@ -74,7 +75,8 @@ dnf --nodocs install "${dnf_install_args}" \
     which \
     yasm
 
-dnf install "${dnf_install_args}" ruby-devel
+# shellcheck disable=SC2086
+dnf install ${dnf_install_args} ruby-devel
 gem install json -v 2.7.6
 gem install dotenv -v 2.8.1
 gem install fpm
@@ -84,6 +86,7 @@ fi
 
 # ipmctl is only available on x86_64
 if [ "$arch" = x86_64 ]; then
-    dnf --nodocs install "${dnf_install_args}" \
+    # shellcheck disable=SC2086
+    dnf --nodocs install ${dnf_install_args} \
         ipmctl-devel
 fi

--- a/utils/scripts/install-leap15.sh
+++ b/utils/scripts/install-leap15.sh
@@ -12,7 +12,7 @@ set -e
 
 arch=$(uname -i)
 
-dnf_install_args=${1:=''}
+dnf_install_args="${1:-}"
 
 dnf --nodocs install ${dnf_install_args} \
     boost-devel \

--- a/utils/scripts/install-ubuntu.sh
+++ b/utils/scripts/install-ubuntu.sh
@@ -16,7 +16,8 @@ arch=$(uname -i)
 
 apt_get_install_args="${1:-}"
 
-apt-get install "${apt_get_install_args}" \
+# shellcheck disable=SC2086
+apt-get install ${apt_get_install_args} \
     autoconf \
     build-essential \
     clang \
@@ -70,6 +71,7 @@ sudo gem install fpm
 
 # ipmctl is only available on x86_64
 if [ "$arch" = x86_64 ]; then
-    apt-get install "${apt_get_install_args}" \
+    # shellcheck disable=SC2086
+    apt-get install ${apt_get_install_args} \
         libipmctl-dev
 fi

--- a/utils/scripts/install-ubuntu.sh
+++ b/utils/scripts/install-ubuntu.sh
@@ -14,7 +14,7 @@ set -e
 
 arch=$(uname -i)
 
-apt_get_install_args=${1:=''}
+apt_get_install_args="${1:-}"
 
 apt-get install ${apt_get_install_args} \
     autoconf \

--- a/utils/scripts/install-ubuntu.sh
+++ b/utils/scripts/install-ubuntu.sh
@@ -14,7 +14,9 @@ set -e
 
 arch=$(uname -i)
 
-apt-get install \
+apt_get_install_args=${1:=''}
+
+apt-get install ${apt_get_install_args} \
     autoconf \
     build-essential \
     clang \
@@ -68,6 +70,6 @@ sudo gem install fpm
 
 # ipmctl is only available on x86_64
 if [ "$arch" = x86_64 ]; then
-    apt-get install \
+    apt-get install ${apt_get_install_args} \
         libipmctl-dev
 fi

--- a/utils/scripts/install-ubuntu.sh
+++ b/utils/scripts/install-ubuntu.sh
@@ -16,7 +16,7 @@ arch=$(uname -i)
 
 apt_get_install_args="${1:-}"
 
-apt-get install ${apt_get_install_args} \
+apt-get install "${apt_get_install_args}" \
     autoconf \
     build-essential \
     clang \
@@ -70,6 +70,6 @@ sudo gem install fpm
 
 # ipmctl is only available on x86_64
 if [ "$arch" = x86_64 ]; then
-    apt-get install ${apt_get_install_args} \
+    apt-get install "${apt_get_install_args}" \
         libipmctl-dev
 fi


### PR DESCRIPTION
Use the utils/scripts/install-<distro>.sh scripts to ensure the required pacakges are installed to be able to buid DAOS in the dfuse/daos_build.py test.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: DaosBuild DaosBuildVM

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
