### PR TITLE
DAOS-17674 vos: add missing ABT mutex lock protection

### DIFF
--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -202,7 +202,9 @@ vos_meta_load(struct umem_store *store, char *start)
 		}
 
 		if (mlc.mlc_inflights > META_READ_QD_NR) {
+			ABT_mutex_lock(mlc.mlc_lock);
 			ABT_cond_wait(mlc.mlc_cond, mlc.mlc_lock);
+			ABT_mutex_unlock(mlc.mlc_lock);
 			D_ASSERT(mlc.mlc_inflights <= META_READ_QD_NR);
 		}
 
@@ -213,7 +215,9 @@ vos_meta_load(struct umem_store *store, char *start)
 
 	mlc.mlc_wait_finished = 1;
 	if (mlc.mlc_inflights > 0) {
+		ABT_mutex_lock(mlc.mlc_lock);
 		ABT_cond_wait(mlc.mlc_cond, mlc.mlc_lock);
+		ABT_mutex_unlock(mlc.mlc_lock);
 		D_ASSERT(mlc.mlc_inflights == 0);
 	}
 	ABT_cond_free(&mlc.mlc_cond);


### PR DESCRIPTION
ABT_cond_wait() requires the caller to hold the mutex lock.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
