### PR TITLE
DAOS-17659 control: Enable setting property value with multiple strings

### DIFF
--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -820,6 +820,34 @@ func TestPoolCommands(t *testing.T) {
 			nil,
 		},
 		{
+			"Set pool properties with double-quoted comma-separated value",
+			`pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb self_heal:"exclude,rebuild",space_rb:42`,
+			strings.Join([]string{
+				printRequest(t, &control.PoolSetPropReq{
+					ID: "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
+					Properties: []*daos.PoolProperty{
+						propWithVal("self_heal", "exclude,rebuild"),
+						propWithVal("space_rb", "42"),
+					},
+				}),
+			}, " "),
+			nil,
+		},
+		{
+			"Set pool properties with single-quoted comma-separated value",
+			`pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb self_heal:'exclude,rebuild',space_rb:42`,
+			strings.Join([]string{
+				printRequest(t, &control.PoolSetPropReq{
+					ID: "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
+					Properties: []*daos.PoolProperty{
+						propWithVal("self_heal", "exclude,rebuild"),
+						propWithVal("space_rb", "42"),
+					},
+				}),
+			}, " "),
+			nil,
+		},
+		{
 			"Set pool properties with pool flag",
 			"pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb label:foo,space_rb:42",
 			strings.Join([]string{

--- a/src/control/lib/ui/prop_flags.go
+++ b/src/control/lib/ui/prop_flags.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2023 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -159,6 +160,8 @@ func (f *SetPropertiesFlag) UnmarshalFlag(fv string) error {
 			return propError("value must not be empty")
 		}
 
+		value = strings.Trim(value, "\"")
+		value = strings.Trim(value, "'")
 		f.ParsedProps[key] = value
 	}
 

--- a/src/control/lib/ui/prop_flags_test.go
+++ b/src/control/lib/ui/prop_flags_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2023 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -105,7 +106,6 @@ func TestUI_SetPropertiesFlag_UnmarshalFlag(t *testing.T) {
 
 }
 
-/* NB: Doesn't work with go < 1.18
 func FuzzUI_SetPropertiesFlag_UnmarshalFlag(f *testing.F) {
 	f.Fuzz(func(t *testing.T, fv string) {
 		f := ui.SetPropertiesFlag{}
@@ -118,7 +118,6 @@ func FuzzUI_SetPropertiesFlag_UnmarshalFlag(f *testing.F) {
 		}
 	})
 }
-*/
 
 func TestUI_SetPropertiesFlag_Complete(t *testing.T) {
 	comps := ui.CompletionMap{


### PR DESCRIPTION
Features: control

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
