### PR TITLE
DAOS-17534 dtx: race between DTX aggregation and container close

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -118,45 +118,14 @@ dtx_free_dbca(struct dtx_batched_cont_args *dbca)
 	D_ASSERT(d_list_empty(&cont->sc_dtx_cos_list));
 	D_ASSERT(d_list_empty(&cont->sc_dtx_coll_list));
 
-	/* Even if the container is reopened during current deregister, the
-	 * reopen will use new dbca, so current dbca needs to be cleanup.
-	 */
+	if (dbca->dbca_cleanup_req != NULL)
+		sched_req_abort(dbca->dbca_cleanup_req);
 
-	if (dbca->dbca_cleanup_req != NULL) {
-		if (!dbca->dbca_cleanup_done)
-			sched_req_wait(dbca->dbca_cleanup_req, true);
-		/* dtx_batched_commit might put it while we were waiting. */
-		if (dbca->dbca_cleanup_req != NULL) {
-			D_ASSERT(dbca->dbca_cleanup_done);
-			sched_req_put(dbca->dbca_cleanup_req);
-			dbca->dbca_cleanup_req = NULL;
-			dbca->dbca_cleanup_done = 0;
-		}
-	}
+	if (dbca->dbca_commit_req != NULL)
+		sched_req_abort(dbca->dbca_commit_req);
 
-	if (dbca->dbca_commit_req != NULL) {
-		if (!dbca->dbca_commit_done)
-			sched_req_wait(dbca->dbca_commit_req, true);
-		/* dtx_batched_commit might put it while we were waiting. */
-		if (dbca->dbca_commit_req != NULL) {
-			D_ASSERT(dbca->dbca_commit_done);
-			sched_req_put(dbca->dbca_commit_req);
-			dbca->dbca_commit_req = NULL;
-			dbca->dbca_commit_done = 0;
-		}
-	}
-
-	if (dbca->dbca_agg_req != NULL) {
-		if (!dbca->dbca_agg_done)
-			sched_req_wait(dbca->dbca_agg_req, true);
-		/* Just to be safe... */
-		if (dbca->dbca_agg_req != NULL) {
-			D_ASSERT(dbca->dbca_agg_done);
-			sched_req_put(dbca->dbca_agg_req);
-			dbca->dbca_agg_req = NULL;
-			dbca->dbca_agg_done = 0;
-		}
-	}
+	if (dbca->dbca_agg_req != NULL)
+		sched_req_abort(dbca->dbca_agg_req);
 
 	/* batched_commit/aggreagtion ULT may hold reference on the dbca. */
 	while (dbca->dbca_refs > 0) {
@@ -168,6 +137,15 @@ dtx_free_dbca(struct dtx_batched_cont_args *dbca)
 		d_list_del(&dbpa->dbpa_sys_link);
 		D_FREE(dbpa);
 	}
+
+	if (dbca->dbca_cleanup_req != NULL)
+		sched_req_put(dbca->dbca_cleanup_req);
+
+	if (dbca->dbca_commit_req != NULL)
+		sched_req_put(dbca->dbca_commit_req);
+
+	if (dbca->dbca_agg_req != NULL)
+		sched_req_put(dbca->dbca_agg_req);
 
 	D_FREE(dbca);
 	cont->sc_dtx_registered = 0;
@@ -482,6 +460,7 @@ dtx_aggregation_pool(struct dss_module_info *dmi, struct dtx_batched_pool_args *
 				    dbca_pool_link);
 		D_ASSERT(!dbca->dbca_deregister);
 
+		dtx_get_dbca(dbca);
 		if (dbca->dbca_agg_req != NULL && dbca->dbca_agg_done) {
 			sched_req_put(dbca->dbca_agg_req);
 			dbca->dbca_agg_req = NULL;
@@ -489,36 +468,41 @@ dtx_aggregation_pool(struct dss_module_info *dmi, struct dtx_batched_pool_args *
 		}
 
 		/* Finish this cycle scan. */
-		if (dbca->dbca_agg_gen == tls->dt_agg_gen)
+		if (dbca->dbca_agg_gen == tls->dt_agg_gen) {
+			dtx_put_dbca(dbca);
 			break;
+		}
+
+		if (unlikely(dbca->dbca_deregister)) {
+			/* Someone is stopping current container. */
+			D_ASSERT(d_list_empty(&dbca->dbca_pool_link));
+			goto next;
+		}
 
 		dbca->dbca_agg_gen = tls->dt_agg_gen;
 		d_list_move_tail(&dbca->dbca_pool_link, &dbpa->dbpa_cont_list);
 
 		if (dbca->dbca_agg_req != NULL)
-			continue;
+			goto next;
 
 		cont = dbca->dbca_cont;
 		dtx_stat(cont, &stat);
-		if (stat.dtx_cont_cmt_count == 0 ||
-		    stat.dtx_first_cmt_blob_time_lo == 0)
-			continue;
+		if (stat.dtx_cont_cmt_count == 0 || stat.dtx_first_cmt_blob_time_lo == 0)
+			goto next;
 
 		if (dtx_sec2age(stat.dtx_first_cmt_blob_time_lo) <= DTX_AGG_AGE_PRESERVE)
-			continue;
+			goto next;
 
 		if (stat.dtx_cont_cmt_count >= dtx_agg_thd_cnt_up ||
 		    ((stat.dtx_cont_cmt_count > dtx_agg_thd_cnt_lo ||
 		      stat.dtx_pool_cmt_count >= dtx_agg_thd_cnt_up) &&
 		     (dtx_sec2age(stat.dtx_first_cmt_blob_time_lo) >= dtx_agg_thd_age_up))) {
 			D_ASSERT(!dbca->dbca_agg_done);
-			dtx_get_dbca(dbca);
 			dbca->dbca_agg_req = sched_create_ult(&attr, dtx_aggregate, dbca, 0);
 			if (dbca->dbca_agg_req == NULL) {
 				D_WARN("Fail to start DTX agg ULT (1) for "DF_UUID"\n",
 				       DP_UUID(cont->sc_uuid));
-				dtx_put_dbca(dbca);
-				continue;
+				goto next;
 			}
 
 			dbpa->dbpa_aggregating++;
@@ -532,9 +516,15 @@ dtx_aggregation_pool(struct dss_module_info *dmi, struct dtx_batched_pool_args *
 		    (victim_stat.dtx_first_cmt_blob_time_lo == stat.dtx_first_cmt_blob_time_lo &&
 		     victim_stat.dtx_first_cmt_blob_time_up == stat.dtx_first_cmt_blob_time_up &&
 		     victim_stat.dtx_cont_cmt_count < stat.dtx_cont_cmt_count)) {
+			if (victim_dbca != NULL)
+				dtx_put_dbca(victim_dbca);
+			dtx_get_dbca(dbca);
 			victim_stat = stat;
 			victim_dbca = dbca;
 		}
+
+next:
+		dtx_put_dbca(dbca);
 	}
 
 	/* No single container exceeds DTX thresholds, but the whole pool does,
@@ -545,16 +535,18 @@ dtx_aggregation_pool(struct dss_module_info *dmi, struct dtx_batched_pool_args *
 	    victim_dbca != NULL && victim_stat.dtx_pool_cmt_count >= dtx_agg_thd_cnt_up) {
 		D_ASSERT(victim_dbca->dbca_agg_req == NULL && !victim_dbca->dbca_agg_done);
 
-		dtx_get_dbca(victim_dbca);
 		victim_dbca->dbca_agg_req = sched_create_ult(&attr, dtx_aggregate, victim_dbca, 0);
 		if (victim_dbca->dbca_agg_req == NULL) {
-			D_WARN("Fail to start DTX agg ULT (2) for "DF_UUID"\n",
-				DP_UUID(victim_dbca->dbca_cont->sc_uuid));
-			dtx_put_dbca(victim_dbca);
+			D_WARN("Fail to start DTX agg ULT (2) for " DF_UUID "\n",
+			       DP_UUID(victim_dbca->dbca_cont->sc_uuid));
 		} else {
 			dbpa->dbpa_aggregating++;
+			victim_dbca = NULL;
 		}
 	}
+
+	if (victim_dbca != NULL)
+		dtx_put_dbca(victim_dbca);
 }
 
 void

--- a/src/dtx/tests/sched_mock.c
+++ b/src/dtx/tests/sched_mock.c
@@ -22,6 +22,12 @@ sched_req_wakeup(struct sched_request *req)
 	assert_true(false);
 }
 
+void
+sched_req_abort(struct sched_request *req)
+{
+	assert_true(false);
+}
+
 struct sched_request *
 sched_req_get(struct sched_req_attr *attr, ABT_thread ult)
 {

--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -1542,15 +1542,21 @@ sched_req_wakeup(struct sched_request *req)
 }
 
 void
+sched_req_abort(struct sched_request *req)
+{
+	req->sr_abort = 1;
+	sched_req_wakeup(req);
+}
+
+void
 sched_req_wait(struct sched_request *req, bool abort)
 {
 	int	rc;
 
 	D_ASSERT(req != NULL);
-	if (abort) {
-		req->sr_abort = 1;
-		sched_req_wakeup(req);
-	}
+	if (abort)
+		sched_req_abort(req);
+
 	D_ASSERT(req->sr_ult != ABT_THREAD_NULL);
 	rc = ABT_thread_join(req->sr_ult);
 	D_ASSERTF(rc == ABT_SUCCESS, "ABT_thread_join: %d\n", rc);

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -237,6 +237,17 @@ void sched_req_sleep(struct sched_request *req, uint32_t msec);
  */
 void sched_req_wakeup(struct sched_request *req);
 
+/* clang-format off */
+/**
+ * Abort a sched request attached ULT (without waiting).
+ *
+ * \param[in] req	Sched request.
+ *
+ * \retval		N/A
+ */
+void sched_req_abort(struct sched_request *req);
+/* clang-format on */
+
 /**
  * Wakeup a sched request attached ULT terminated. The associated ULT of \a req
  * must not an unnamed ULT.


### PR DESCRIPTION
dtx_aggregation_pool() logic may yield because of sched_req_put(). Then someone may close related container during the yield. If DTX aggregation logic does not check the race with close before adding the container back to the DTX aggregation list (per pool), then it may trigger assertion of "D_ASSERT(!dbca->dbca_deregister)" during subsequent DTX batched commit or DTX aggregation process.

On the other hand, DTX aggregation logic needs to hold reference on the dbca structure to avoid being freed during DTX aggregation.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
