### PR TITLE
DAOS-16170 control: Ignore EngineDied event for old incarnation

### DIFF
--- a/src/control/events/engine.go
+++ b/src/control/events/engine.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -58,15 +59,16 @@ func EngineStateInfoToProto(rsi *EngineStateInfo) (*sharedpb.RASEvent_EngineStat
 }
 
 // NewEngineDiedEvent creates a specific EngineDied event from given inputs.
-func NewEngineDiedEvent(hostname string, instanceIdx uint32, rank uint32, exitErr common.ExitStatus, exPid int) *RASEvent {
+func NewEngineDiedEvent(hostname string, instanceIdx uint32, rank uint32, incarnation uint64, exitErr common.ExitStatus, exPid int) *RASEvent {
 	return fill(&RASEvent{
-		Msg:      fmt.Sprintf("DAOS engine %d exited unexpectedly: %s", instanceIdx, exitErr),
-		ID:       RASEngineDied,
-		Hostname: hostname,
-		Rank:     rank,
-		Type:     RASTypeStateChange,
-		Severity: RASSeverityError,
-		ProcID:   exPid, // pid of exited engine
+		Msg:         fmt.Sprintf("DAOS engine %d exited unexpectedly: %s", instanceIdx, exitErr),
+		ID:          RASEngineDied,
+		Hostname:    hostname,
+		Rank:        rank,
+		Incarnation: incarnation,
+		Type:        RASTypeStateChange,
+		Severity:    RASSeverityError,
+		ProcID:      exPid, // pid of exited engine
 		ExtendedInfo: &EngineStateInfo{
 			InstanceIdx: instanceIdx,
 			ExitErr:     exitErr,
@@ -89,12 +91,13 @@ func NewEngineFormatRequiredEvent(hostname string, instanceIdx uint32, formatTyp
 }
 
 // NewEngineJoinFailedEvent creates an EngineJoinFailed event from the given inputs.
-func NewEngineJoinFailedEvent(hostname string, instanceIdx uint32, rank uint32, reason string) *RASEvent {
+func NewEngineJoinFailedEvent(hostname string, instanceIdx uint32, rank uint32, incarnation uint64, reason string) *RASEvent {
 	return fill(&RASEvent{
 		Msg:          fmt.Sprintf("DAOS engine %d (rank %d) was not allowed to join the system", instanceIdx, rank),
 		ID:           RASEngineJoinFailed,
 		Hostname:     hostname,
 		Rank:         rank,
+		Incarnation:  incarnation,
 		Type:         RASTypeInfoOnly,
 		Severity:     RASSeverityError,
 		ExtendedInfo: NewStrInfo(reason),

--- a/src/control/events/engine_test.go
+++ b/src/control/events/engine_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -12,14 +13,17 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/common/test"
 )
 
 const (
 	tHost        = "foo"
-	tInstanceIdx = 1
-	tRank        = 1
+	tInstanceIdx = uint32(1)
+	tRank        = uint32(1)
 	tPid         = 1234
 	tFmtType     = "Metadata"
+	tIncarnation = uint64(456)
+	tReason      = "test reason"
 )
 
 var (
@@ -28,12 +32,56 @@ var (
 
 func mockEvtDied(t *testing.T) *RASEvent {
 	t.Helper()
-	return NewEngineDiedEvent(tHost, tInstanceIdx, tRank, tExitErr, tPid)
+	return NewEngineDiedEvent(tHost, tInstanceIdx, tRank, tIncarnation, tExitErr, tPid)
 }
 
 func mockEvtFmtReq(t *testing.T) *RASEvent {
 	t.Helper()
 	return NewEngineFormatRequiredEvent(tHost, tInstanceIdx, tFmtType)
+}
+
+func TestEvents_NewEngineDiedEvent(t *testing.T) {
+	evt := NewEngineDiedEvent(tHost, tInstanceIdx, tRank, tIncarnation, tExitErr, tPid)
+
+	test.AssertEqual(t, RASEngineDied, evt.ID, "")
+	test.AssertEqual(t, RASTypeStateChange, evt.Type, "")
+	test.AssertEqual(t, RASSeverityError, evt.Severity, "")
+
+	test.AssertEqual(t, "DAOS engine 1 exited unexpectedly: test", evt.Msg, "")
+
+	test.AssertEqual(t, tHost, evt.Hostname, "")
+	test.AssertEqual(t, tRank, evt.Rank, "")
+	test.AssertEqual(t, tIncarnation, evt.Incarnation, "")
+	test.AssertEqual(t, tPid, evt.ProcID, "")
+
+	extInfo, ok := evt.ExtendedInfo.(*EngineStateInfo)
+	if !ok {
+		t.Fatalf("extended info is wrong type %t", evt.ExtendedInfo)
+	}
+
+	test.AssertEqual(t, tInstanceIdx, extInfo.InstanceIdx, "")
+	test.CmpErr(t, tExitErr, extInfo.ExitErr)
+}
+
+func TestEvents_NewEngineJoinFailedEvent(t *testing.T) {
+	evt := NewEngineJoinFailedEvent(tHost, tInstanceIdx, tRank, tIncarnation, tReason)
+
+	test.AssertEqual(t, RASEngineJoinFailed, evt.ID, "")
+	test.AssertEqual(t, RASTypeInfoOnly, evt.Type, "")
+	test.AssertEqual(t, RASSeverityError, evt.Severity, "")
+
+	test.AssertEqual(t, "DAOS engine 1 (rank 1) was not allowed to join the system", evt.Msg, "")
+
+	test.AssertEqual(t, tHost, evt.Hostname, "")
+	test.AssertEqual(t, tRank, evt.Rank, "")
+	test.AssertEqual(t, tIncarnation, evt.Incarnation, "")
+
+	extInfo, ok := evt.ExtendedInfo.(*StrInfo)
+	if !ok {
+		t.Fatalf("extended info is wrong type %t", evt.ExtendedInfo)
+	}
+
+	test.AssertEqual(t, tReason, string(*extInfo), "")
 }
 
 func TestEvents_ConvertEngineDied(t *testing.T) {

--- a/src/control/events/ras.go
+++ b/src/control/events/ras.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -343,6 +344,9 @@ func (evt *RASEvent) PrintRAS() string {
 	}
 	if evt.Rank != C.CRT_NO_RANK {
 		fmt.Fprintf(&b, " rank: [%d]", evt.Rank)
+	}
+	if evt.Incarnation != 0 {
+		fmt.Fprintf(&b, " incarnation: [%d]", evt.Incarnation)
 	}
 	if evt.JobID != "" {
 		fmt.Fprintf(&b, " jobid: [%s]", evt.JobID)

--- a/src/control/lib/control/event_test.go
+++ b/src/control/lib/control/event_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -26,7 +27,7 @@ import (
 
 func mockEvtEngineDied(t *testing.T) *events.RASEvent {
 	t.Helper()
-	return events.NewEngineDiedEvent("foo", 0, 0, common.NormalExit, 1234)
+	return events.NewEngineDiedEvent("foo", 0, 0, 123, common.NormalExit, 1234)
 }
 
 func TestControl_eventNotify(t *testing.T) {
@@ -194,7 +195,7 @@ func TestControl_EventLogger_OnEvent(t *testing.T) {
 			expShouldLog:       false,
 			expShouldLogSyslog: true,
 			expSyslogOut: `
-prio27 id: [engine_died] ts: [%s] host: [foo] type: [STATE_CHANGE] sev: [ERROR] msg: [DAOS engine 0 exited unexpectedly: process exited with 0] pid: [1234] rank: [0]
+prio27 id: [engine_died] ts: [%s] host: [foo] type: [STATE_CHANGE] sev: [ERROR] msg: [DAOS engine 0 exited unexpectedly: process exited with 0] pid: [1234] rank: [0] incarnation: [123]
 `,
 		},
 	} {

--- a/src/control/server/ctl_ranks_rpc_test.go
+++ b/src/control/server/ctl_ranks_rpc_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -48,7 +49,7 @@ var (
 
 func mockEvtEngineDied(t *testing.T) *events.RASEvent {
 	t.Helper()
-	return events.NewEngineDiedEvent("foo", 0, 0, common.NormalExit, 1234)
+	return events.NewEngineDiedEvent("foo", 0, 0, 0, common.NormalExit, 1234)
 }
 
 // checkUnorderedRankResults fails if results slices contain any differing results,
@@ -378,7 +379,7 @@ func TestServer_CtlSvc_StopRanks(t *testing.T) {
 				*ei._superblock.Rank = ranklist.Rank(i + 1)
 
 				ei.OnInstanceExit(
-					func(_ context.Context, _ uint32, _ ranklist.Rank, _ error, _ int) error {
+					func(_ context.Context, _ uint32, _ ranklist.Rank, _ uint64, _ error, _ int) error {
 						svc.events.Publish(mockEvtEngineDied(t))
 						return nil
 					})

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -34,7 +34,7 @@ type (
 	onAwaitFormatFn  func(context.Context, uint32, string) error
 	onStorageReadyFn func(context.Context) error
 	onReadyFn        func(context.Context) error
-	onInstanceExitFn func(context.Context, uint32, ranklist.Rank, error, int) error
+	onInstanceExitFn func(context.Context, uint32, ranklist.Rank, uint64, error, int) error
 )
 
 // EngineInstance encapsulates control-plane specific configuration
@@ -49,6 +49,7 @@ type EngineInstance struct {
 
 	log             logging.Logger
 	runner          EngineRunner
+	incarnation     uint64
 	storage         *storage.Provider
 	waitFormat      atm.Bool
 	storageReady    chan bool
@@ -291,6 +292,9 @@ func (ei *EngineInstance) handleReady(ctx context.Context, ready *srvpb.NotifyRe
 	if err != nil {
 		return err
 	}
+
+	ei.incarnation = ready.Incarnation
+	ei.log.Debugf("engine idx=%d joined with rank=%d, incarnation=%d", ei.Index(), r, ei.incarnation)
 
 	// If the join was already processed because it ran on the same server,
 	// skip the rest of these steps.

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -412,7 +412,7 @@ func (svc *mgmtSvc) checkReqFabricProvider(req *mgmtpb.JoinReq, peerAddr *net.TC
 }
 
 func publishJoinFailedEvent(req *mgmtpb.JoinReq, peerAddr *net.TCPAddr, publisher events.Publisher, msg string) {
-	publisher.Publish(events.NewEngineJoinFailedEvent(peerAddr.String(), req.Idx, req.Rank, msg))
+	publisher.Publish(events.NewEngineJoinFailedEvent(peerAddr.String(), req.Idx, req.Rank, req.Incarnation, msg))
 }
 
 func getProviderFromURI(uri string) (string, error) {

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -562,7 +563,7 @@ func registerEngineEventCallbacks(srv *server, engine *EngineInstance, allStarte
 	// Register callback to publish engine process exit events.
 	engine.OnInstanceExit(createPublishInstanceExitFunc(srv.pubSub.Publish, srv.hostname))
 
-	engine.OnInstanceExit(func(_ context.Context, _ uint32, _ ranklist.Rank, _ error, _ int) error {
+	engine.OnInstanceExit(func(_ context.Context, _ uint32, _ ranklist.Rank, _ uint64, _ error, _ int) error {
 		if engine.storage.BdevRoleMetaConfigured() {
 			return engine.storage.UnmountTmpfs()
 		}

--- a/src/control/server/telemetry.go
+++ b/src/control/server/telemetry.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2018-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -41,8 +42,8 @@ func regPromEngineSources(ctx context.Context, log logging.Logger, engines []Eng
 		}
 	}
 
-	delFn := func(idx uint32) func(context.Context, uint32, ranklist.Rank, error, int) error {
-		return func(_ context.Context, _ uint32, rank ranklist.Rank, _ error, _ int) error {
+	delFn := func(idx uint32) onInstanceExitFn {
+		return func(_ context.Context, _ uint32, rank ranklist.Rank, _ uint64, _ error, _ int) error {
 			log.Debugf("Tearing down metrics collection for engine %d (rank %s)", idx, rank.String())
 			c.RemoveSource(idx)
 			return nil

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -711,6 +711,11 @@ func (m *Membership) handleEngineFailure(evt *events.RASEvent) {
 		return
 	}
 
+	if evt.Incarnation < member.Incarnation {
+		m.log.Debugf("skipping event for incarnation = %d, current member incarnation = %d: %s", evt.Incarnation, member.Incarnation, evt.String())
+		return
+	}
+
 	// TODO DAOS-7261: sanity check that the correct member is being
 	//                 updated by performing lookup on provided hostname
 	//                 and matching returned addresses with the address

--- a/src/control/system/mocks.go
+++ b/src/control/system/mocks.go
@@ -67,6 +67,15 @@ func MockMember(t *testing.T, idx uint32, state MemberState, info ...string) *Me
 	return m
 }
 
+// MockMemberWithIncarnation creates a system member with an incarnation set.
+func MockMemberWithIncarnation(t *testing.T, idx uint32, state MemberState, incarnation uint64) *Member {
+	t.Helper()
+
+	m := MockMember(t, idx, state)
+	m.Incarnation = incarnation
+	return m
+}
+
 // MockMemberResult return a result from an action on a system member.
 func MockMemberResult(rank Rank, action string, err error, state MemberState) *MemberResult {
 	result := NewMemberResult(rank, err, state)


### PR DESCRIPTION
It is possible to be forwarded an EngineDied event late, after the engine has re-joined. This can incorrectly re-mark the rank as Errored.

- Include incarnation in engine-related events.
- Print incarnation in logs if provided.
- Do not update member if engine died event is for old incarnation.

Features: control

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
