### PR TITLE
Merge release/2.6 into google/2.6

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -71,6 +71,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f  # v3.28.18
+        uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858  # v3.29.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
 
       - name: Run Trivy vulnerability scanner in filesystem mode (table format)
-        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5  # 0.30.0
+        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37  # 0.31.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -51,14 +51,14 @@ jobs:
           sed -i 's/format: template/format: sarif/g' utils/trivy/trivy.yaml
 
       - name: Run Trivy vulnerability scanner in filesystem mode (sarif format)
-        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5  # 0.30.0
+        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37  # 0.31.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
           trivy-config: 'utils/trivy/trivy.yaml'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f  # v3.28.18
+        uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858  # v3.29.0
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -69,7 +69,7 @@ jobs:
           sed -i 's/exit-code: 0/exit-code: 1/g' utils/trivy/trivy.yaml
 
       - name: Run Trivy vulnerability scanner in filesystem mode (human readable format)
-        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5  # 0.30.0
+        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37  # 0.31.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/src/cart/utils/memcheck-cart.supp
+++ b/src/cart/utils/memcheck-cart.supp
@@ -710,7 +710,7 @@
    fun:crt_context_provider_create
    fun:daos_eq_lib_init
    fun:daos_init
-   fun:_cgo_b590e4e2531a_Cfunc_daos_init
+   ...
    fun:runtime.asmcgocall.abi0
 }
 {

--- a/src/cart/utils/memcheck-cart.supp
+++ b/src/cart/utils/memcheck-cart.supp
@@ -565,7 +565,7 @@
    DAOS-15159
    Memcheck:Param
    write(buf)
-   fun:runtime/internal/syscall.Syscall6
+   fun:internal/runtime/syscall.Syscall6
 }
 {
    DAOS-15548
@@ -660,7 +660,7 @@
    Syscall6 param
    Memcheck:Param
    read(buf)
-   fun:runtime/internal/syscall.Syscall6
+   fun:internal/runtime/syscall.Syscall6
 }
 {
    __tsan_go_atomic32_load


### PR DESCRIPTION
- **DAOS-17664 cq: update gha versions (#16490) (#16489)**
- **DAOS-17432 test: Update suppressions for Go runtime (#16310) (#16507)**
- **DAOS-17705 cq: Bump github/codeql-action from 3.28.19 to 3.29.0 (#16513) (#16512)**
