### PR TITLE
DAOS-17111 swim: Parse untrustable updates about self

### DIFF
--- a/src/cart/swim/swim.c
+++ b/src/cart/swim/swim.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2016 UChicago Argonne, LLC
  * (C) Copyright 2018-2024 Intel Corporation.
  * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */


### PR DESCRIPTION
When an engine starts up, after it gets its rank, but before it gets the latest system map, the engine skips parsing any incoming swim updates, because the current swim code considers all others untrustable. This makes the engine unusually vulnerable to transient suspicions:

    swim_dump_updates() 2 <= 1: {2 S 2241541897092071424} {1 A
      2241415852910968832}
    swim_updates_parse() 2: skip untrustable update from 1, rc = -1005

Hence, this patch lets swim parse the "untrustable" updates, react to SUSPECT and DEAD updates about the self member, but skip those about other members.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
