### PR TITLE
SRE-3149 test: Skip gpg check for lua-lmod install

### DIFF
--- a/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
+++ b/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
@@ -9,7 +9,7 @@ bootstrap_dnf() {
     rm -rf "$REPOS_DIR"
     ln -s ../zypp/repos.d "$REPOS_DIR"
     dnf -y remove lua-lmod
-    dnf -y install lua-lmod '--repo=*lua*' --repo '*network-cluster*'
+    dnf -y --nogpgcheck install lua-lmod '--repo=*lua*' --repo '*network-cluster*'
 }
 
 group_repo_post() {


### PR DESCRIPTION
Temporarily skip the GPG check for the lua-lmod install in post provisioning for Leap 15.6.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-test-el8: true
Skip-func-test-el9: true
Skip-func-test-leap15: false
Skip-func-hw-test: true
Test-tag: test_always_passes

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
