### PR TITLE
DAOS-17737 dtx: handle race between DTX refresh and DTX abort

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -1363,59 +1363,16 @@ dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont)
 	if (DAOS_FAIL_CHECK(DAOS_DTX_NO_RETRY))
 		return -DER_IO;
 
-	rc = dtx_refresh_internal(cont, &dth->dth_share_tbd_count,
-				  &dth->dth_share_tbd_list,
-				  &dth->dth_share_cmt_list,
-				  &dth->dth_share_abt_list,
+	rc = dtx_refresh_internal(cont, &dth->dth_share_tbd_count, &dth->dth_share_tbd_list,
+				  &dth->dth_share_cmt_list, &dth->dth_share_abt_list,
 				  &dth->dth_share_act_list, true);
-
-	/* If we can resolve the DTX status, then return -DER_AGAIN
-	 * to the caller that will retry related operation locally.
-	 */
 	if (rc == 0) {
 		D_ASSERT(dth->dth_share_tbd_count == 0);
 
-		if (dth->dth_need_validation) {
-			rc = vos_dtx_validation(dth);
-			switch (rc) {
-			case DTX_ST_INITED:
-				if (!dth->dth_aborted)
-					break;
-				/* Fall through */
-			case DTX_ST_PREPARED:
-			case DTX_ST_PREPARING:
-				/* The DTX has been ever aborted and related resent RPC
-				 * is in processing. Return -DER_AGAIN to make this ULT
-				 * to retry sometime later without dtx_abort().
-				 */
-				rc = -DER_AGAIN;
-				break;
-			case DTX_ST_ABORTED:
-				D_ASSERT(dth->dth_ent == NULL);
-				/* Aborted, return -DER_INPROGRESS for client retry.
-				 *
-				 * Fall through.
-				 */
-			case DTX_ST_ABORTING:
-				rc = -DER_INPROGRESS;
-				break;
-			case DTX_ST_COMMITTED:
-			case DTX_ST_COMMITTING:
-			case DTX_ST_COMMITTABLE:
-				/* Aborted then prepared/committed by race.
-				 * Return -DER_ALREADY to avoid repeated modification.
-				 */
-				dth->dth_already = 1;
-				rc = -DER_ALREADY;
-				break;
-			default:
-				D_ASSERTF(0, "Unexpected DTX "DF_DTI" status %d\n",
-					  DP_DTI(&dth->dth_xid), rc);
-			}
-		} else {
+		rc = vos_dtx_validation(dth);
+		if (rc == 0) {
 			vos_dtx_cleanup(dth, false);
-			dtx_handle_reinit(dth);
-			rc = -DER_AGAIN;
+			rc = dtx_handle_reinit(dth);
 		}
 	}
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1758,26 +1758,7 @@ out:
 	 * Let's check resent again before further process.
 	 */
 	if (rc == 0 && obj_rpc_is_update(rpc) && sched_cur_seq() != sched_seq) {
-		if (dth->dth_need_validation) {
-			daos_epoch_t	epoch = 0;
-			int		rc1;
-
-			rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &orw->orw_dti, &epoch, NULL);
-			switch (rc1) {
-			case 0:
-				orw->orw_epoch = epoch;
-				/* Fall through */
-			case -DER_ALREADY:
-				rc = -DER_ALREADY;
-				break;
-			case -DER_NONEXIST:
-			case -DER_EP_OLD:
-				break;
-			default:
-				rc = rc1;
-				break;
-			}
-		}
+		rc = vos_dtx_validation(dth);
 
 		/* For solo update, it will be handled via one-phase transaction.
 		 * If there is CPU yield after its epoch generated, we will renew
@@ -1803,7 +1784,7 @@ out:
 	}
 
 	/* re-generate the recx_list if some akeys skipped */
-	if (skips != NULL && orwo->orw_rels.ca_arrays != NULL && orw->orw_nr != iods_nr)
+	if (rc == 0 && skips != NULL && orwo->orw_rels.ca_arrays != NULL && orw->orw_nr != iods_nr)
 		rc = obj_rw_recx_list_post(orw, orwo, skips, rc);
 
 	rc = obj_rw_complete(rpc, ioc, ioh, rc, dth);
@@ -1818,7 +1799,7 @@ out:
 	}
 	if (iods_dup != NULL)
 		daos_iod_recx_free(iods_dup, iods_nr);
-	return unlikely(rc == -DER_ALREADY) ? 0 : rc;
+	return rc;
 }
 
 /* Extract local iods/offs/csums by orw_oid.id_shard from @orw */
@@ -2056,7 +2037,7 @@ again:
 	if (dth != NULL && obj_dtx_need_refresh(dth, rc)) {
 		if (++retry < 3) {
 			rc = dtx_refresh(dth, ioc->ioc_coc);
-			if (rc == -DER_AGAIN)
+			if (rc == 0)
 				goto again;
 		} else if (orw->orw_flags & ORF_MAYBE_STARVE) {
 			dsp = d_list_entry(dth->dth_share_tbd_list.next, struct dtx_share_peer,
@@ -2769,7 +2750,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	rc = obj_local_rw(rpc, &ioc, dth);
 	if (rc != 0)
 		DL_CDEBUG(
-		    rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
+		    rc == -DER_INPROGRESS || rc == -DER_TX_RESTART || rc == -DER_ALREADY ||
 			(rc == -DER_EXIST &&
 			 (orw->orw_api_flags & (DAOS_COND_DKEY_INSERT | DAOS_COND_AKEY_INSERT))) ||
 			(rc == -DER_NONEXIST &&
@@ -3284,7 +3265,7 @@ re_pack:
 	if (obj_dtx_need_refresh(dth, rc)) {
 		rc = dtx_refresh(dth, ioc->ioc_coc);
 		/* After DTX refresh, re_pack will resume from the position at \@anchors. */
-		if (rc == -DER_AGAIN)
+		if (rc == 0)
 			goto re_pack;
 	}
 
@@ -3592,44 +3573,15 @@ again:
 		}
 
 		rc = dtx_refresh(dth, ioc->ioc_coc);
-		if (rc != -DER_AGAIN)
+		if (rc != 0)
 			goto out;
-
-		if (unlikely(sched_cur_seq() == sched_seq))
-			goto again;
-
-		/*
-		 * There is CPU yield after DTX start, and the resent RPC may be handled
-		 * during that. Let's check resent again before further process.
-		 */
-
-		if (dth->dth_need_validation) {
-			daos_epoch_t	epoch = 0;
-			int		rc1;
-
-			rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &opi->opi_dti, &epoch, NULL);
-			switch (rc1) {
-			case 0:
-				opi->opi_epoch = epoch;
-				/* Fall through */
-			case -DER_ALREADY:
-				rc = -DER_ALREADY;
-				break;
-			case -DER_NONEXIST:
-			case -DER_EP_OLD:
-				break;
-			default:
-				rc = rc1;
-				break;
-			}
-		}
 
 		/*
 		 * For solo punch, it will be handled via one-phase transaction. If there is CPU
 		 * yield after its epoch generated, we will renew the epoch, then we can use the
 		 * epoch to sort related solo DTXs based on their epochs.
 		 */
-		if (rc == -DER_AGAIN && dth->dth_solo) {
+		if (dth->dth_solo && sched_cur_seq() != sched_seq) {
 			struct dtx_epoch	epoch;
 
 			epoch.oe_value = d_hlc_get();
@@ -3721,8 +3673,8 @@ obj_tgt_punch(struct obj_tgt_punch_args *otpa, uint32_t *shards, uint32_t count)
 exec:
 	rc = obj_local_punch(opi, otpa->opc, count, shards, p_ioc, dth);
 	if (rc != 0)
-		DL_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
-			  (rc == -DER_NONEXIST && (opi->opi_api_flags & DAOS_COND_PUNCH)),
+		DL_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART || rc == -DER_ALREADY ||
+			      (rc == -DER_NONEXIST && (opi->opi_api_flags & DAOS_COND_PUNCH)),
 			  DB_IO, DLOG_ERR, rc, DF_UOID, DP_UOID(opi->opi_oid));
 
 out:
@@ -4141,7 +4093,7 @@ again:
 				       p_recx, p_epoch, cell_size, stripe_size, dth);
 		if (obj_dtx_need_refresh(dth, rc)) {
 			rc = dtx_refresh(dth, ioc->ioc_coc);
-			if (rc == -DER_AGAIN)
+			if (rc == 0)
 				goto again;
 		}
 
@@ -4798,24 +4750,11 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh, struct daos_cp
 	 * Let's check resent again before further process.
 	 */
 	if (rc == 0 && dth->dth_modification_cnt > 0 && sched_cur_seq() != sched_seq) {
-		if (dth->dth_need_validation) {
-			daos_epoch_t	epoch = 0;
-			int		rc1;
+		rc = vos_dtx_validation(dth);
+		if (rc != 0)
+			goto out;
 
-			rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &dcsh->dcsh_xid, &epoch, NULL);
-			switch (rc1) {
-			case 0:
-			case -DER_ALREADY:
-				D_GOTO(out, rc = -DER_ALREADY);
-			case -DER_NONEXIST:
-			case -DER_EP_OLD:
-				break;
-			default:
-				D_GOTO(out, rc = rc1);
-			}
-		}
-
-		if (rc == 0 && dth->dth_solo) {
+		if (dth->dth_solo) {
 			daos_epoch_t	epoch = dcsh->dcsh_epoch.oe_value;
 
 			D_ASSERT(dcde->dcde_read_cnt == 0);
@@ -4983,7 +4922,7 @@ again:
 	if (obj_dtx_need_refresh(dth, rc)) {
 		if (++retry < 3) {
 			rc = dtx_refresh(dth, ioc->ioc_coc);
-			if (rc == -DER_AGAIN)
+			if (rc == 0)
 				goto again;
 		} else if (oci->oci_flags & ORF_MAYBE_STARVE) {
 			dsp = d_list_entry(dth->dth_share_tbd_list.next,

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1533,7 +1533,8 @@ vos_dtx_validation(struct dtx_handle *dth)
 	d_iov_t			 riov;
 	int			 rc = 0;
 
-	D_ASSERT(dtx_is_valid_handle(dth));
+	if (!dtx_is_valid_handle(dth) || dth->dth_need_validation == 0)
+		return 0;
 
 	dae = dth->dth_ent;
 
@@ -1549,7 +1550,7 @@ vos_dtx_validation(struct dtx_handle *dth)
 	 * (or different) DTX LRU array slot.
 	 */
 
-	if (unlikely(dth->dth_aborted)) {
+	if (dth->dth_aborted) {
 		D_ASSERT(dae == NULL);
 		cont = vos_hdl2cont(dth->dth_coh);
 		D_ASSERT(cont != NULL);
@@ -1580,7 +1581,22 @@ vos_dtx_validation(struct dtx_handle *dth)
 
 out:
 	dth->dth_need_validation = 0;
-	return rc;
+
+	/* It is aborted, then resent, prepared and committed by race. Return -DER_ALREADY to avoid
+	 * repeated modification.
+	 */
+	if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTING || rc == DTX_ST_COMMITTABLE) {
+		dth->dth_already = 1;
+		return -DER_ALREADY;
+	}
+
+	/* The DTX has been ever aborted. Return -DER_AGAIN to make related client to retry sometime
+	 * later without triggering dtx_abort().
+	 */
+	if (dth->dth_aborted || rc == DTX_ST_ABORTED || rc == DTX_ST_ABORTING)
+		return -DER_AGAIN;
+
+	return rc > 0 ? 0 : rc;
 }
 
 /* The caller has started local transaction. */
@@ -1601,40 +1617,10 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 	 * Check whether someone touched the DTX before we registering modification
 	 * for the first time (during the prepare, such as bulk data transferring).
 	 */
-	if (unlikely(dth->dth_need_validation && !dth->dth_active)) {
+	if (!dth->dth_active) {
 		rc = vos_dtx_validation(dth);
-		switch (rc) {
-		case DTX_ST_INITED:
-			if (!dth->dth_aborted)
-				break;
-			/* Fall through */
-		case DTX_ST_PREPARED:
-		case DTX_ST_PREPARING:
-			/* The DTX has been ever aborted and related resent RPC
-			 * is in processing. Return -DER_AGAIN to make this ULT
-			 * to retry sometime later without dtx_abort().
-			 */
-			D_GOTO(out, rc = -DER_AGAIN);
-		case DTX_ST_COMMITTED:
-		case DTX_ST_COMMITTING:
-		case DTX_ST_COMMITTABLE:
-			/* Aborted then prepared/committed by race.
-			 * Return -DER_ALREADY to avoid repeated modification.
-			 */
-			dth->dth_already = 1;
-			D_GOTO(out, rc = -DER_ALREADY);
-		case DTX_ST_ABORTED:
-			D_ASSERT(dth->dth_ent == NULL);
-			/* Aborted, return -DER_INPROGRESS for client retry.
-			 *
-			 * Fall through.
-			 */
-		case DTX_ST_ABORTING:
-			D_GOTO(out, rc = -DER_INPROGRESS);
-		default:
-			D_ASSERTF(0, "Unexpected DTX "DF_DTI" status %d\n",
-				  DP_DTI(&dth->dth_xid), rc);
-		}
+		if (rc != 0)
+			goto out;
 	}
 
 	dae = dth->dth_ent;


### PR DESCRIPTION
If current transaction is aborted during dtx_refresh() yield by race, then return non-zero value to the sponsor to trigger client side RPC retry. That will make related transaction's status to be more clean.

More check after dtx_refresh() to avoid re-initializing aborted DTX.

The patch also cleanup the usage for vos_dtx_validation() to handle kinds of DTX abort (and maybe resent after that) cases.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
