### PR TITLE
DAOS-17738 client: reset DTX base UUID after fork - b26

### DIFF
--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -104,6 +104,9 @@ daos_eq_lib_init(crt_init_options_t *crt_info)
 
 unlock:
 	D_MUTEX_UNLOCK(&daos_eq_lock);
+	if (rc == 0)
+		daos_dti_reset();
+
 	return rc;
 crt:
 	crt_finalize();

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -805,7 +806,6 @@ child_hdlr(void)
 	rc = daos_eq_lib_reset_after_fork();
 	if (rc)
 		DL_WARN(rc, "daos_eq_lib_init() failed in child process");
-	daos_dti_reset();
 	ioil_eqh = ioil_iog.iog_main_eqh = DAOS_HDL_INVAL;
 	rc = daos_eq_create(&ioil_eqh);
 	if (rc)

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -946,7 +946,6 @@ child_hdlr(void)
 	rc = daos_eq_lib_reset_after_fork();
 	if (rc)
 		DL_WARN(rc, "daos_eq_lib_init() failed in child process");
-	daos_dti_reset();
 	td_eqh = main_eqh = DAOS_HDL_INVAL;
 	context_reset = true;
 	d_eq_count    = 0;

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -659,7 +660,16 @@ daos_crt_init_opt_get(bool server, int ctx_nr)
 	return &daos_crt_init_opt;
 }
 
-static __thread uuid_t dti_uuid;
+/* For new created thread (via pthread_create), the pre-thread variable \@dti_uuid will be
+ * automatically reset as zero, then subsequent daos_dti_gen() will generate new UUID for
+ * the transactions sponsored by current thread.
+ *
+ * For new created process (via fork), the pre-thread variable \@dti_uuid will be reset as
+ * zero via daos_dti_reset(). The process owner needs to explicitly call it or in-directly
+ * trigger it (such as via daos_eq_lib_init) to guarantee that new process will not reuse
+ * parent's UUID for the transactions sponsored by current process.
+ */
+static __thread uuid_t dti_uuid = {0};
 
 void
 daos_dti_gen_unique(struct dtx_id *dti)


### PR DESCRIPTION
To avoid parent and child processes generating the same DTX ID.

It also changes vos_dtx logic to avoid assertion when client
reuses some DTX ID.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
