### PR TITLE
DAOS-17731 test: erasurecode/online_rebuild_mdtest.py - wait_for_rebu…

### DIFF
--- a/src/tests/ftest/erasurecode/online_rebuild_mdtest.py
+++ b/src/tests/ftest/erasurecode/online_rebuild_mdtest.py
@@ -20,6 +20,7 @@ class EcodOnlineRebuildMdtest(ErasureCodeMdtest):
 
         Test Description:
             Test EC object class with MDtest for on-line rebuild.
+
         Use Cases:
             Create the pool and run MDtest with EC object class.
             While MDtest is running kill single server.
@@ -34,3 +35,4 @@ class EcodOnlineRebuildMdtest(ErasureCodeMdtest):
         # Stop one random rank while mdtest is running
         ranks_to_stop = self.random.sample(list(self.server_managers[0].ranks), k=1)
         self.start_online_mdtest(ranks_to_stop)
+        self.pool.wait_for_rebuild_to_end()


### PR DESCRIPTION
…… (#16542)

The test runs MDTest and it stops a random rank halfway. Then it checks that the MDTest ends without failure. However, stopping a rank causes rebuild and if the rebuild doesn't finish by the end of the test, the pool destroy in tearDown may time out.
Thus, add wait_for_rebuild_to_end() at the end of the test before entering tearDown.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_ec_online_rebuild_mdtest
Test-repeat: 3

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
