### PR TITLE
DAOS-17365 common: Phase-2 allocator pre-enabler for md-blob resize

### DIFF
--- a/src/common/dav_v2/dav_iface.c
+++ b/src/common/dav_v2/dav_iface.c
@@ -61,6 +61,84 @@ dav_uc_callback(int evt_type, void *arg, uint32_t zid)
 	return 0;
 }
 
+static int
+dav_setup_zinfo_alloc_class(dav_obj_t *hdl, uint64_t *alloc_size, int *class_id)
+{
+	struct dav_alloc_class_desc p;
+	int                         rc;
+	uint64_t                    size, capacity;
+
+	heap_zinfo_get_size(&size, &capacity);
+	p.unit_size       = size;
+	p.alignment       = 0;
+	p.units_per_block = 1;
+	p.header_type     = DAV_HEADER_NONE;
+	p.class_id        = 0;
+	rc                = dav_class_register_v2(hdl, &p);
+	if (rc) {
+		D_ERROR("unable to register allocation class for zinfo, err %d\n", rc);
+		return rc;
+	}
+	if (class_id)
+		*class_id = p.class_id;
+	if (alloc_size)
+		*alloc_size = size;
+	return 0;
+}
+
+static int
+dav_setup_zone0(dav_obj_t *hdl)
+{
+	int          rc;
+	int          zinfo_class_id = 0;
+	struct zone *z0;
+	uint64_t     alloc_size;
+
+	rc = lw_tx_begin(hdl);
+	if (rc) {
+		D_ERROR("lw_tx_begin failed with err %d\n", rc);
+		rc = ENOMEM;
+		goto out;
+	}
+	rc = heap_ensure_zone0_initialized(hdl->do_heap);
+	if (rc) {
+		lw_tx_end(hdl, NULL);
+		D_ERROR("Failed to initialize zone0, rc = %d", daos_errno2der(rc));
+		goto out;
+	}
+	lw_tx_end(hdl, NULL);
+
+	rc = dav_setup_zinfo_alloc_class(hdl, &alloc_size, &zinfo_class_id);
+	if (rc)
+		goto out;
+
+	rc = lw_tx_begin(hdl);
+	if (rc) {
+		D_ERROR("lw_tx_begin failed with err %d\n", rc);
+		goto out;
+	}
+	z0 = ZID_TO_ZONE(&hdl->do_heap->layout_info, 0);
+	rc = obj_realloc(hdl, &z0->header.zone0_zinfo_off, &z0->header.zone0_zinfo_size, alloc_size,
+			 zinfo_class_id);
+	lw_tx_end(hdl, NULL);
+	if (rc) {
+		D_ERROR("Failed to allocate zinfo array, rc = %d", daos_errno2der(rc));
+		goto out;
+	}
+
+	rc = lw_tx_begin(hdl);
+	if (rc) {
+		D_ERROR("lw_tx_begin failed with err %d\n", rc);
+		goto out;
+	}
+	heap_zinfo_init(hdl->do_heap, true);
+	lw_tx_end(hdl, NULL);
+
+	return 0;
+out:
+	return rc;
+}
+
 static dav_obj_t *
 dav_obj_open_internal(int fd, int flags, size_t scm_sz, const char *path, struct umem_store *store)
 {
@@ -69,12 +147,21 @@ dav_obj_open_internal(int fd, int flags, size_t scm_sz, const char *path, struct
 	int                     err = 0;
 	int                     rc;
 	struct heap_zone_limits hzl;
-	struct zone            *z0;
+	uint64_t                alloc_size, max_zones = 0;
+
+	heap_zinfo_get_size(&alloc_size, &max_zones);
 
 	hzl = heap_get_zone_limits(store->stor_size, scm_sz, 100);
 
 	if (hzl.nzones_heap == 0) {
 		ERR("Insufficient heap size.");
+		errno = EINVAL;
+		return NULL;
+	}
+
+	if (hzl.nzones_heap > max_zones) {
+		ERR("heap size %lu greater than max size %lu supported", store->stor_size,
+		    max_zones * ZONE_MAX_SIZE);
 		errno = EINVAL;
 		return NULL;
 	}
@@ -156,82 +243,67 @@ dav_obj_open_internal(int fd, int flags, size_t scm_sz, const char *path, struct
 		goto out3;
 	}
 
-	if (!(flags & DAV_HEAP_INIT)) {
-		rc = heap_zone_load(hdl->do_heap, 0);
-		if (rc) {
-			err = rc;
-			goto out4;
-		}
-		D_ASSERT(store != NULL);
-		rc = hdl->do_store->stor_ops->so_wal_replay(hdl->do_store, dav_wal_replay_cb, hdl);
-		if (rc) {
-			err = daos_der2errno(rc);
-			goto out4;
-		}
-	}
-
 	rc = dav_create_clogs(hdl);
 	if (rc) {
 		err = rc;
 		goto out4;
 	}
 
-	rc = lw_tx_begin(hdl);
-	if (rc) {
-		D_ERROR("lw_tx_begin failed with err %d\n", rc);
-		err = ENOMEM;
-		goto out5;
-	}
-	rc = heap_ensure_zone0_initialized(hdl->do_heap);
-	if (rc) {
-		lw_tx_end(hdl, NULL);
-		D_ERROR("Failed to initialize zone0, rc = %d", daos_errno2der(rc));
-		err = rc;
-		goto out5;
-	}
-	lw_tx_end(hdl, NULL);
-
-	z0 = ZID_TO_ZONE(&hdl->do_heap->layout_info, 0);
-	if (z0->header.zone0_zinfo_off) {
-		D_ASSERT(z0->header.zone0_zinfo_size);
-		D_ASSERT(OFFSET_TO_ZID(z0->header.zone0_zinfo_off) == 0);
-
-		rc = heap_update_mbrt_zinfo(hdl->do_heap, false);
+	if (flags & DAV_HEAP_INIT) {
+		rc = dav_setup_zone0(hdl);
 		if (rc) {
-			D_ERROR("Failed to update mbrt with zinfo errno = %d", rc);
-			err = rc;
-			goto out5;
-		}
-
-		rc = heap_load_nonevictable_zones(hdl->do_heap);
-		if (rc) {
-			D_ERROR("Failed to load required zones during boot, errno= %d", rc);
 			err = rc;
 			goto out5;
 		}
 	} else {
-		D_ASSERT(z0->header.zone0_zinfo_size == 0);
+		rc = dav_setup_zinfo_alloc_class(hdl, NULL, NULL);
+		if (rc) {
+			err = rc;
+			goto out5;
+		}
+		rc = heap_zone_load(hdl->do_heap, 0);
+		if (rc) {
+			err = rc;
+			goto out5;
+		}
+		D_ASSERT(store != NULL);
+		rc = hdl->do_store->stor_ops->so_wal_replay(hdl->do_store, dav_wal_replay_cb, hdl);
+		if (rc) {
+			err = daos_der2errno(rc);
+			goto out5;
+		}
+
 		rc = lw_tx_begin(hdl);
 		if (rc) {
 			D_ERROR("lw_tx_begin failed with err %d\n", rc);
 			err = ENOMEM;
 			goto out5;
 		}
-		rc = obj_realloc(hdl, &z0->header.zone0_zinfo_off, &z0->header.zone0_zinfo_size,
-				 heap_zinfo_get_size(hzl.nzones_heap));
-		if (rc != 0) {
-			lw_tx_end(hdl, NULL);
-			D_ERROR("Failed to setup zinfo");
-			goto out5;
-		}
-		rc = heap_update_mbrt_zinfo(hdl->do_heap, true);
+		rc = heap_ensure_zone0_initialized(hdl->do_heap);
 		if (rc) {
-			D_ERROR("Failed to update mbrt with zinfo errno = %d", rc);
+			lw_tx_end(hdl, NULL);
+			D_ERROR("Failed to initialize zone0, rc = %d", daos_errno2der(rc));
 			err = rc;
 			goto out5;
 		}
+		heap_zinfo_init(hdl->do_heap, false);
 		lw_tx_end(hdl, NULL);
+
+		rc = heap_update_mbrt_zinfo(hdl->do_heap);
+		if (rc) {
+			D_ERROR("Failed to update mbrt with zinfo, rc = %d", daos_errno2der(rc));
+			err = rc;
+			goto out5;
+		}
+		rc = heap_load_nonevictable_zones(hdl->do_heap);
+		if (rc) {
+			D_ERROR("Failed to load required zones during boot, rc = %d",
+				daos_errno2der(rc));
+			err = rc;
+			goto out5;
+		}
 	}
+
 	umem_cache_post_replay(hdl->do_store);
 
 #if VG_MEMCHECK_ENABLED

--- a/src/common/dav_v2/heap.c
+++ b/src/common/dav_v2/heap.c
@@ -34,6 +34,7 @@
 #define MAX_RUN_LOCKS_VG MAX_CHUNK /* avoid perf issues /w drd */
 
 #define ZINFO_VERSION    0x1
+#define ZINFO_CAPACITY            262144
 
 struct zinfo_element {
 	unsigned char z_allotted   : 1;
@@ -42,9 +43,11 @@ struct zinfo_element {
 };
 
 struct zinfo_vec {
-	uint32_t             version;
-	uint32_t             num_elems;
-	struct zinfo_element z[];
+	uint32_t             zv_version;
+	uint32_t             zv_capacity;
+	uint32_t             zv_inuse;
+	uint64_t             zv_next_off;
+	struct zinfo_element zv_elems[];
 };
 
 TAILQ_HEAD(mbrt_q, mbrt);
@@ -138,7 +141,7 @@ heap_zinfo_set(struct palloc_heap *heap, uint32_t zid, bool allotted, bool evict
 	struct zinfo_element *ze;
 
 	if (heap->rt->zinfo_vec) {
-		ze                  = heap->rt->zinfo_vec->z;
+		ze                  = heap->rt->zinfo_vec->zv_elems;
 		ze[zid].z_allotted  = allotted;
 		ze[zid].z_evictable = evictable;
 		mo_wal_persist(&heap->p_ops, &ze[zid], sizeof(ze[zid]));
@@ -152,7 +155,7 @@ heap_zinfo_get(struct palloc_heap *heap, uint32_t zid, bool *allotted, bool *evi
 	struct zinfo_element *ze;
 
 	if (heap->rt->zinfo_vec) {
-		ze         = heap->rt->zinfo_vec->z;
+		ze         = heap->rt->zinfo_vec->zv_elems;
 		*allotted  = ze[zid].z_allotted;
 		*evictable = ze[zid].z_evictable;
 	} else {
@@ -165,7 +168,7 @@ heap_zinfo_get(struct palloc_heap *heap, uint32_t zid, bool *allotted, bool *evi
 static inline void
 heap_zinfo_set_usage(struct palloc_heap *heap, uint32_t zid, enum mb_usage_hint val)
 {
-	struct zinfo_element *ze = heap->rt->zinfo_vec->z;
+	struct zinfo_element *ze = heap->rt->zinfo_vec->zv_elems;
 
 	D_ASSERT(heap->rt->zinfo_vec && ze[zid].z_allotted && val < MB_UMAX_HINT);
 	ze[zid].z_usage_hint = val;
@@ -175,31 +178,51 @@ heap_zinfo_set_usage(struct palloc_heap *heap, uint32_t zid, enum mb_usage_hint 
 static inline void
 heap_zinfo_get_usage(struct palloc_heap *heap, uint32_t zid, enum mb_usage_hint *val)
 {
-	struct zinfo_element *ze = heap->rt->zinfo_vec->z;
+	struct zinfo_element *ze = heap->rt->zinfo_vec->zv_elems;
 
 	D_ASSERT(heap->rt->zinfo_vec && ze[zid].z_allotted && ze[zid].z_evictable &&
 		 ze[zid].z_usage_hint < MB_UMAX_HINT);
 	*val = ze[zid].z_usage_hint;
 }
 
-size_t
-heap_zinfo_get_size(uint32_t nzones)
+void
+heap_zinfo_get_size(uint64_t *alloc_size, uint64_t *capacity)
 {
-	return (sizeof(struct zinfo_vec) + sizeof(struct zinfo_element) * nzones);
+	*alloc_size = (sizeof(struct zinfo_vec) + sizeof(struct zinfo_element) * ZINFO_CAPACITY);
+	*capacity   = ZINFO_CAPACITY;
 }
 
-static inline void
-heap_zinfo_init(struct palloc_heap *heap)
+void
+heap_zinfo_init(struct palloc_heap *heap, bool is_create)
 {
-	struct zinfo_vec *z = heap->rt->zinfo_vec;
+	struct zinfo_vec *zv;
+	struct zone      *z0 = heap->layout_info.zone0;
+	uint64_t          alloc_size, capacity;
 
-	D_ASSERT(heap->layout_info.zone0->header.zone0_zinfo_size >=
-		 heap_zinfo_get_size(heap->rt->nzones));
+	heap_zinfo_get_size(&alloc_size, &capacity);
+	D_ASSERT(z0->header.zone0_zinfo_size == alloc_size);
 
-	z->version   = ZINFO_VERSION;
-	z->num_elems = heap->rt->nzones;
-	mo_wal_persist(&heap->p_ops, z, sizeof(*z));
-	heap_zinfo_set(heap, 0, 1, false);
+	heap->rt->zinfo_vec      = HEAP_OFF_TO_PTR(heap, z0->header.zone0_zinfo_off);
+	heap->rt->zinfo_vec_size = z0->header.zone0_zinfo_size;
+
+	zv = heap->rt->zinfo_vec;
+
+	if (is_create) {
+		zv->zv_version  = ZINFO_VERSION;
+		zv->zv_capacity = capacity;
+		zv->zv_inuse    = heap->rt->nzones;
+		mo_wal_persist(&heap->p_ops, zv, sizeof(*zv));
+		heap_zinfo_set(heap, 0, 1, false);
+	} else {
+		D_ASSERT(zv->zv_inuse <= heap->rt->nzones);
+		if (zv->zv_inuse < heap->rt->nzones) {
+			zv->zv_inuse = heap->rt->nzones;
+			mo_wal_persist(&heap->p_ops, &zv->zv_inuse, sizeof(zv->zv_inuse));
+		}
+	}
+	heap->rt->zones_exhausted    = 1;
+	heap->rt->zones_exhausted_ne = 1;
+	heap->rt->zones_exhausted_e  = 0;
 }
 
 static void
@@ -2352,26 +2375,17 @@ heap_off2mbid(struct palloc_heap *heap, uint64_t offset)
 }
 
 int
-heap_update_mbrt_zinfo(struct palloc_heap *heap, bool init)
+heap_update_mbrt_zinfo(struct palloc_heap *heap)
 {
 	bool               allotted, evictable;
-	struct zone       *z0       = heap->layout_info.zone0;
 	int                nemb_cnt = 1, emb_cnt = 0, i;
 	struct mbrt       *mb;
 	struct zone       *z;
 	enum mb_usage_hint usage_hint;
 	int                last_allocated = 0;
 
-	heap->rt->zinfo_vec      = HEAP_OFF_TO_PTR(heap, z0->header.zone0_zinfo_off);
-	heap->rt->zinfo_vec_size = z0->header.zone0_zinfo_size;
-
-	if (init)
-		heap_zinfo_init(heap);
-	else {
-		D_ASSERT(heap->rt->zinfo_vec->num_elems == heap->rt->nzones);
-		heap_zinfo_get(heap, 0, &allotted, &evictable);
-		D_ASSERT((evictable == false) && (allotted == true));
-	}
+	heap_zinfo_get(heap, 0, &allotted, &evictable);
+	D_ASSERT((evictable == false) && (allotted == true));
 
 	for (i = 1; i < heap->rt->nzones; i++) {
 		heap_zinfo_get(heap, i, &allotted, &evictable);
@@ -2400,6 +2414,7 @@ heap_update_mbrt_zinfo(struct palloc_heap *heap, bool init)
 		}
 		last_allocated = i;
 	}
+
 	heap->rt->zones_exhausted    = last_allocated + 1;
 	heap->rt->zones_exhausted_ne = nemb_cnt;
 	heap->rt->zones_exhausted_e  = emb_cnt;

--- a/src/common/dav_v2/heap.h
+++ b/src/common/dav_v2/heap.h
@@ -66,9 +66,11 @@ heap_zone_load(struct palloc_heap *heap, uint32_t zid);
 int
 heap_load_nonevictable_zones(struct palloc_heap *heap);
 int
-heap_update_mbrt_zinfo(struct palloc_heap *heap, bool init);
-size_t
-heap_zinfo_get_size(uint32_t nzones);
+heap_update_mbrt_zinfo(struct palloc_heap *heap);
+void
+heap_zinfo_get_size(uint64_t *alloc_size, uint64_t *capacity);
+void
+heap_zinfo_init(struct palloc_heap *heap, bool is_create);
 
 struct alloc_class *
 heap_get_best_class(struct palloc_heap *heap, size_t size);

--- a/src/common/dav_v2/tx.c
+++ b/src/common/dav_v2/tx.c
@@ -1868,7 +1868,7 @@ dav_allot_mb_evictable_v2(dav_obj_t *pop, int flags)
  * obj_realloc -- (internal) reallocate zinfo object
  */
 int
-obj_realloc(dav_obj_t *pop, uint64_t *offp, size_t *sizep, size_t size)
+obj_realloc(dav_obj_t *pop, uint64_t *offp, size_t *sizep, size_t size, uint16_t class_id)
 {
 	struct operation_context *ctx;
 	struct carg_realloc       carg;
@@ -1890,7 +1890,7 @@ obj_realloc(dav_obj_t *pop, uint64_t *offp, size_t *sizep, size_t size)
 	operation_add_entry(ctx, sizep, size, ULOG_OPERATION_SET);
 
 	ret = palloc_operation(pop->do_heap, *offp, offp, size, constructor_zrealloc_root, &carg, 0,
-			       0, 0, 0, ctx);
+			       0, class_id, 0, ctx);
 
 	return ret;
 }

--- a/src/common/dav_v2/tx.h
+++ b/src/common/dav_v2/tx.h
@@ -20,6 +20,6 @@ struct mo_ops;
 int tx_create_wal_entry(struct ulog_entry_base *e, void *arg, const struct mo_ops *p_ops);
 
 int
-obj_realloc(dav_obj_t *pop, uint64_t *offp, size_t *sizep, size_t size);
+obj_realloc(dav_obj_t *pop, uint64_t *offp, size_t *sizep, size_t size, uint16_t class_id);
 
 #endif

--- a/src/common/tests/umem_test_bmem.c
+++ b/src/common/tests/umem_test_bmem.c
@@ -2342,6 +2342,17 @@ test_umempobj_create_smallsize(void **state)
 	unlink(name);
 	D_FREE(name);
 
+	/* umempobj_create with metablob size greater than 4TB */
+	D_ASPRINTF(name, "/mnt/daos/umem-test-tmp-%d", num++);
+	assert_true(name != NULL);
+	ustore_tmp.stor_size = (4ul * 1024 * 1024 * 1024 * 1024) + (1024 * 1024);
+	uma.uma_pool = umempobj_create(name, "invalid_pool", UMEMPOBJ_ENABLE_STATS, POOL_SIZE, 0666,
+				       &ustore_tmp);
+	assert_ptr_equal(uma.uma_pool, NULL);
+	ustore_tmp.stor_size = POOL_SIZE;
+	unlink(name);
+	D_FREE(name);
+
 	/* umempobj_create with scm size less than 32MB */
 	D_ASPRINTF(name, "/mnt/daos/umem-test-tmp-%d", num++);
 	assert_true(name != NULL);
@@ -2519,7 +2530,7 @@ test_umempobj_heap_mb_stats(void **state)
 	/* Create a heap and cache of size 256MB and 128MB (16 & 8 zones) respectively */
 	D_ASPRINTF(name, "/mnt/daos/umem-test-tmp-%d", 0);
 	assert_true(name != NULL);
-	uma.uma_pool = umempobj_create(name, "invalid_pool", UMEMPOBJ_ENABLE_STATS, scm_size, 0666,
+	uma.uma_pool = umempobj_create(name, "heap_mb_stats", UMEMPOBJ_ENABLE_STATS, scm_size, 0666,
 				       &ustore_tmp);
 	assert_ptr_not_equal(uma.uma_pool, NULL);
 	maxsz_exp   = (uint64_t)(scm_size / MB_SIZE * NEMB_RATIO) * MB_SIZE;
@@ -2553,6 +2564,7 @@ test_umempobj_heap_mb_stats(void **state)
 	assert_int_equal(rc, 0);
 	assert_true(allocated1 * 100 / maxsz_alloc >= 99);
 	assert_int_equal(maxsz, maxsz_exp);
+	allocated1 -= allocated0;
 
 	for (count = num; count > num / 2; count--) {
 		umoff = *ptr;
@@ -2565,6 +2577,7 @@ test_umempobj_heap_mb_stats(void **state)
 	rc = umempobj_get_mbusage(umm.umm_pool, 0, &allocated, &maxsz);
 	print_message("NE usage max_size = %lu allocated = %lu\n", maxsz, allocated);
 	assert_int_equal(rc, 0);
+	allocated -= allocated0;
 	assert_true(allocated < ((allocated1 / 2) + alloc_size));
 	assert_true((allocated + alloc_size) > (allocated1 / 2));
 	assert_int_equal(maxsz, maxsz_exp);


### PR DESCRIPTION
This commit adds pre-reserved space in the persistent heap (md-blob) to enable future resizing. The space is tied to the zone info vector, which tracks allocator-managed zones/buckets.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
