### PR TITLE
DAOS-16823 client: Allow client metrics dump to container

### DIFF
--- a/src/client/README.md
+++ b/src/client/README.md
@@ -5,3 +5,6 @@
 - <a href="https://github.com/daos-stack/go-daos">Go bindings</a> and <a href="https://godoc.org/github.com/daos-stack/go-daos/pkg/daos">API documentation</a>
 - <a href="dfs/README.md">POSIX File & Directory Emulation (libdfs)</a>
 - <a href="ds3/README.md">S3 Emulation (libds3)</a>
+
+# Other Documentation
+- <a href="telemetry.md">DAOS Client Telemetry</a>

--- a/src/client/api/job.c
+++ b/src/client/api/job.c
@@ -10,8 +10,9 @@
 #include <daos/common.h>
 #include <daos/job.h>
 
-char *dc_jobid_env;
-char *dc_jobid;
+char        *dc_jobid_env;
+char        *dc_jobid;
+static char *default_jobid;
 
 static int
 craft_default_jobid(char **jobid)
@@ -56,11 +57,17 @@ get_jobid_env_var(char **jobid_env)
 }
 
 int
-dc_set_default_jobid(const char *default_jobid)
+dc_set_default_jobid(const char *jobid)
 {
 	char *jobid_env = NULL;
-	char *jobid     = NULL;
+	char *env_jobid = NULL;
 	int   rc        = 0;
+
+	if (jobid == NULL)
+		return -DER_INVAL;
+
+	if (default_jobid != NULL)
+		return -DER_ALREADY;
 
 	/* first, determine which environment variable to check/set */
 	rc = get_jobid_env_var(&jobid_env);
@@ -68,17 +75,31 @@ dc_set_default_jobid(const char *default_jobid)
 		D_GOTO(out, rc);
 
 	/* next, check to see if a jobid has already been set in the environment */
-	d_agetenv_str(&jobid, jobid_env);
-	if (jobid != NULL) {
-		d_freeenv_str(&jobid);
+	d_agetenv_str(&env_jobid, jobid_env);
+	if (env_jobid != NULL) {
+		d_freeenv_str(&env_jobid);
 		goto out;
 	}
 
-	/* set it to the default value since it wasn't already set */
-	d_setenv(jobid_env, default_jobid, 0);
+	D_STRNDUP(default_jobid, jobid, MAX_JOBID_LEN);
+	if (default_jobid == NULL)
+		D_GOTO(out, -DER_NOMEM);
+
 out:
 	D_FREE(jobid_env);
 	return rc;
+}
+
+bool
+dc_jobid_is_default(const char *jobid)
+{
+	if (jobid == NULL)
+		return false;
+
+	if (jobid == default_jobid || strcmp(jobid, default_jobid) == 0)
+		return true;
+
+	return false;
 }
 
 int
@@ -87,22 +108,26 @@ dc_job_init(void)
 	char *jobid;
 	int   err = 0;
 
+	if (default_jobid == NULL) {
+		err = craft_default_jobid(&default_jobid);
+		if (err)
+			D_GOTO(out_env, err);
+	}
+
 	err = get_jobid_env_var(&dc_jobid_env);
 	if (err)
 		D_GOTO(out_err, err);
 
 	d_agetenv_str(&jobid, dc_jobid_env);
 	if (jobid == NULL) {
-		err = craft_default_jobid(&jobid);
-		if (err)
-			D_GOTO(out_env, err);
+		jobid = default_jobid;
 	} else {
 		char *tmp_jobid = jobid;
 
 		D_STRNDUP(jobid, tmp_jobid, MAX_JOBID_LEN);
 		d_freeenv_str(&tmp_jobid);
 		if (jobid == NULL)
-			D_GOTO(out_env, err = -DER_NOMEM);
+			D_GOTO(out_def, err = -DER_NOMEM);
 	}
 
 	dc_jobid = jobid;
@@ -111,6 +136,8 @@ dc_job_init(void)
 	D_INFO("Using JOBID %s\n", dc_jobid);
 	return 0;
 
+out_def:
+	D_FREE(default_jobid);
 out_env:
 	D_FREE(dc_jobid_env);
 out_err:
@@ -122,4 +149,5 @@ dc_job_fini()
 {
 	D_FREE(dc_jobid);
 	D_FREE(dc_jobid_env);
+	D_FREE(default_jobid);
 }

--- a/src/client/dfs/SConscript
+++ b/src/client/dfs/SConscript
@@ -33,7 +33,7 @@ def configure_lustre(denv):
 
 def scons():
     """Execute build"""
-    Import('env')
+    Import('env', 'prereqs')
 
     env.d_add_build_rpath()
 
@@ -54,6 +54,9 @@ def scons():
 
     duns = denv.d_library('duns', 'duns.c', LIBS=libraries)
     denv.Install('$PREFIX/lib64/', duns)
+
+    if prereqs.test_requested():
+        SConscript('tests/SConscript', exports='denv')
 
 
 if __name__ == "SCons.Script":

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -429,4 +430,10 @@ update_stbuf_times(struct dfs_entry entry, daos_epoch_t max_epoch, struct stat *
 int
 lookup_rel_path(dfs_t *dfs, dfs_obj_t *root, const char *path, int flags, dfs_obj_t **_obj,
 		mode_t *mode, struct stat *stbuf, size_t depth);
+
+int
+csv_file_path(pid_t pid, const char *root_dir, char **file_dir, char **file_name);
+int
+write_tm_csv(const char *tm_pool, const char *tm_cont, const char *csv_file_dir,
+	     const char *csv_file_name, const char *csv_buf, size_t csv_buf_sz);
 #endif /* __DFS_INTERNAL_H__ */

--- a/src/client/dfs/metrics.c
+++ b/src/client/dfs/metrics.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -7,6 +8,7 @@
 
 #include <uuid/uuid.h>
 #include <fcntl.h>
+#include <sys/utsname.h>
 
 #include <daos.h>
 #include <daos_fs.h>
@@ -23,11 +25,12 @@
 #include "metrics.h"
 #include "dfs_internal.h"
 
-#define DFS_METRICS_ROOT  "dfs"
+#define DFS_METRICS_ROOT    "dfs"
+#define DFS_DUMPTIME_METRIC "dump_time"
 
-#define STAT_METRICS_SIZE (D_TM_METRIC_SIZE * DOS_LIMIT)
-#define FILE_METRICS_SIZE (((D_TM_METRIC_SIZE * NR_SIZE_BUCKETS) * 2) + D_TM_METRIC_SIZE * 2)
-#define DFS_METRICS_SIZE  (STAT_METRICS_SIZE + FILE_METRICS_SIZE)
+#define STAT_METRICS_SIZE   (D_TM_METRIC_SIZE * DOS_LIMIT)
+#define FILE_METRICS_SIZE   (((D_TM_METRIC_SIZE * NR_SIZE_BUCKETS) * 2) + D_TM_METRIC_SIZE * 2)
+#define DFS_METRICS_SIZE    (STAT_METRICS_SIZE + FILE_METRICS_SIZE)
 
 #define SPRINTF_TM_PATH(buf, pool_uuid, cont_uuid, path)                                           \
 	snprintf(buf, sizeof(buf), "pool/" DF_UUIDF "/container/" DF_UUIDF "/%s",                  \
@@ -39,11 +42,11 @@
 			     "calls", tmp_path);                                                   \
 	if (rc != 0) {                                                                             \
 		DL_ERROR(rc, "failed to create " #name " counter");                                \
-		return;                                                                            \
+		return rc;                                                                         \
 	}                                                                                          \
 	i++;
 
-static void
+static int
 op_stats_init(struct dfs_metrics *metrics, uuid_t pool_uuid, uuid_t cont_uuid)
 {
 	char tmp_path[D_TM_MAX_NAME_LEN] = {0};
@@ -51,35 +54,47 @@ op_stats_init(struct dfs_metrics *metrics, uuid_t pool_uuid, uuid_t cont_uuid)
 	int  rc;
 
 	if (metrics == NULL)
-		return;
+		return 0;
 
 	D_FOREACH_DFS_OP_STAT(ADD_STAT_METRIC);
+	return 0;
 }
 
-static void
+static int
 cont_stats_init(struct dfs_metrics *metrics, uuid_t pool_uuid, uuid_t cont_uuid)
 {
 	char tmp_path[D_TM_MAX_NAME_LEN] = {0};
 	int  rc                          = 0;
 
 	if (metrics == NULL)
-		return;
+		return 0;
 
 	SPRINTF_TM_PATH(tmp_path, pool_uuid, cont_uuid, "mount_time");
 	rc = d_tm_add_metric(&metrics->dm_mount_time, D_TM_TIMESTAMP, "container mount time", NULL,
 			     tmp_path);
-	if (rc != 0)
+	if (rc != 0) {
 		DL_ERROR(rc, "failed to create mount_time timestamp");
+		return rc;
+	}
+
+	SPRINTF_TM_PATH(tmp_path, pool_uuid, cont_uuid, DFS_DUMPTIME_METRIC);
+	rc = d_tm_add_metric(&metrics->dm_dump_time, D_TM_TIMESTAMP, "container dump time", NULL,
+			     tmp_path);
+	if (rc != 0) {
+		DL_ERROR(rc, "failed to create dump_time timestamp");
+		return rc;
+	}
+	return 0;
 }
 
-static void
+static int
 file_stats_init(struct dfs_metrics *metrics, uuid_t pool_uuid, uuid_t cont_uuid)
 {
 	char tmp_path[D_TM_MAX_NAME_LEN] = {0};
 	int  rc                          = 0;
 
 	if (metrics == NULL)
-		return;
+		return 0;
 
 	SPRINTF_TM_PATH(tmp_path, pool_uuid, cont_uuid, DFS_METRICS_ROOT "/read_bytes");
 	rc = d_tm_add_metric(&metrics->dm_read_bytes, D_TM_STATS_GAUGE, "dfs read bytes", "bytes",
@@ -88,8 +103,10 @@ file_stats_init(struct dfs_metrics *metrics, uuid_t pool_uuid, uuid_t cont_uuid)
 		DL_ERROR(rc, "failed to create dfs read_bytes counter");
 	rc =
 	    d_tm_init_histogram(metrics->dm_read_bytes, tmp_path, NR_SIZE_BUCKETS, 256, 2, "bytes");
-	if (rc)
+	if (rc) {
 		DL_ERROR(rc, "Failed to init dfs read size histogram");
+		return rc;
+	}
 
 	SPRINTF_TM_PATH(tmp_path, pool_uuid, cont_uuid, DFS_METRICS_ROOT "/write_bytes");
 	rc = d_tm_add_metric(&metrics->dm_write_bytes, D_TM_STATS_GAUGE, "dfs write bytes", "bytes",
@@ -98,15 +115,11 @@ file_stats_init(struct dfs_metrics *metrics, uuid_t pool_uuid, uuid_t cont_uuid)
 		DL_ERROR(rc, "failed to create dfs write_bytes counter");
 	rc = d_tm_init_histogram(metrics->dm_write_bytes, tmp_path, NR_SIZE_BUCKETS, 256, 2,
 				 "bytes");
-	if (rc)
+	if (rc) {
 		DL_ERROR(rc, "Failed to init dfs write size histogram");
-}
-
-bool
-dfs_metrics_enabled()
-{
-	/* set in client/api/metrics.c */
-	return daos_client_metric;
+		return rc;
+	}
+	return 0;
 }
 
 void
@@ -117,6 +130,7 @@ dfs_metrics_init(dfs_t *dfs)
 	char   root_name[D_TM_MAX_NAME_LEN];
 	pid_t  pid       = getpid();
 	size_t root_size = DFS_METRICS_SIZE + (D_TM_METRIC_SIZE * 3);
+	int    tm_flags  = (D_TM_OPEN_OR_CREATE | D_TM_NO_SHMEM);
 	int    rc;
 
 	if (dfs == NULL)
@@ -136,7 +150,7 @@ dfs_metrics_init(dfs_t *dfs)
 
 	snprintf(root_name, sizeof(root_name), "%d", pid);
 	/* if only container-level metrics are enabled; this will init a root for them */
-	rc = d_tm_init_with_name(d_tm_cli_pid_key(pid), root_size, D_TM_OPEN_OR_CREATE, root_name);
+	rc = d_tm_init_with_name(d_tm_cli_pid_key(pid), root_size, tm_flags, root_name);
 	if (rc != 0 && rc != -DER_ALREADY) {
 		DL_ERROR(rc, "failed to init DFS metrics");
 		goto error;
@@ -145,6 +159,7 @@ dfs_metrics_init(dfs_t *dfs)
 	D_ALLOC_PTR(dfs->metrics);
 	if (dfs->metrics == NULL) {
 		D_ERROR("failed to alloc DFS metrics");
+		rc = -DER_NOMEM;
 		goto error;
 	}
 
@@ -155,20 +170,405 @@ dfs_metrics_init(dfs_t *dfs)
 		goto error;
 	}
 
-	cont_stats_init(dfs->metrics, pool_uuid, cont_uuid);
-	op_stats_init(dfs->metrics, pool_uuid, cont_uuid);
-	file_stats_init(dfs->metrics, pool_uuid, cont_uuid);
+	rc = cont_stats_init(dfs->metrics, pool_uuid, cont_uuid);
+	if (rc != 0)
+		goto error;
+	rc = op_stats_init(dfs->metrics, pool_uuid, cont_uuid);
+	if (rc != 0)
+		goto error;
+	rc = file_stats_init(dfs->metrics, pool_uuid, cont_uuid);
+	if (rc != 0)
+		goto error;
 
 	d_tm_record_timestamp(dfs->metrics->dm_mount_time);
 	return;
 
 error:
-	if (dfs->metrics != NULL)
-		D_FREE(dfs->metrics);
+	DL_ERROR(rc, "failed to init DFS metrics");
+	D_FREE(dfs->metrics);
+	dfs->metrics = NULL;
 }
+
+static void
+iter_dump(struct d_tm_context *ctx, struct d_tm_node_t *node, int level, char *path, int format,
+	  int opt_fields, void *arg)
+{
+	if (strncmp(d_tm_get_name(ctx, node), DFS_DUMPTIME_METRIC, D_TM_MAX_NAME_LEN) == 0)
+		d_tm_record_timestamp(node);
+	d_tm_print_node(ctx, node, level, path, format, opt_fields, (FILE *)arg);
+}
+
+static const char *
+get_process_name(void)
+{
+#if defined(_GNU_SOURCE)
+	return program_invocation_name;
+#else
+	return "unknown";
+#endif
+}
+
+int
+csv_file_path(pid_t pid, const char *root_dir, char **file_dir, char **file_name)
+{
+	struct utsname name          = {0};
+	time_t         now           = time(NULL);
+	struct tm     *gm_now        = gmtime(&now);
+	char           time_str[16]  = {0};
+	char           dt_prefix[16] = {0};
+	const char    *path_prefix;
+	const char    *path_sep;
+	char          *tmp_dir       = NULL;
+	char          *tmp_name      = NULL;
+	int            rc            = 0;
+
+	if (file_dir == NULL || file_name == NULL)
+		return -DER_INVAL;
+
+	if (root_dir != NULL && root_dir[0] != '\0') {
+		path_prefix = root_dir;
+		path_sep    = (root_dir[strlen(root_dir) - 1] == '/') ? "" : "/";
+	} else {
+		path_prefix = "";
+		path_sep    = "/";
+	}
+
+	/*
+	 * NB: Default dc_jobid is $hostname-$pid, which is not very useful
+	 * as an organizational scheme.
+	 *
+	 * If the jobid is not default, then the path should look like:
+	 *	$root_dir/$yyyy/$mm/$dd/$hh/job/$jobid/$procname/$now-$hostname-$pid.csv
+	 * If the jobid is default, then the path should look like:
+	 * 	$root_dir/$yyyy/$mm/$dd/$hh/proc/$procname/$now-$hostname-$pid.csv
+	 */
+
+	if (uname(&name) != 0) {
+		D_ERROR("unable to get uname: %s\n", strerror(errno));
+		return -DER_MISC;
+	}
+
+	if (gm_now != NULL) {
+		if (!strftime(dt_prefix, sizeof(dt_prefix), "%Y/%m/%d/%H/", gm_now))
+			return -DER_MISC;
+	} else {
+		dt_prefix[0] = '\0';
+	}
+
+	if (dc_jobid_is_default(dc_jobid))
+		D_ASPRINTF(tmp_dir, "%s%s%sproc/%s", path_prefix, path_sep, dt_prefix,
+			   get_process_name());
+	else
+		D_ASPRINTF(tmp_dir, "%s%s%sjob/%s/%s", path_prefix, path_sep, dt_prefix, dc_jobid,
+			   get_process_name());
+
+	if (tmp_dir == NULL) {
+		D_ERROR("failed to allocate memory for file dir\n");
+		return -DER_NOMEM;
+	}
+
+	snprintf(time_str, sizeof(time_str), "%lu", now);
+	D_ASPRINTF(tmp_name, "%s-%s-%d.csv", time_str, name.nodename, pid);
+	if (tmp_name == NULL) {
+		D_ERROR("failed to allocate memory for file name\n");
+		D_GOTO(err_free, rc = -DER_NOMEM);
+	}
+
+	/* Check that the full path will not exceed system limits. +1 for the '/' separator. */
+	if (strlen(tmp_dir) + 1 + strlen(tmp_name) >= PATH_MAX) {
+		D_ERROR("csv file path too long\n");
+		D_GOTO(err_free, rc = -DER_INVAL);
+	}
+
+	*file_dir  = tmp_dir;
+	*file_name = tmp_name;
+	return 0;
+
+err_free:
+	D_FREE(tmp_dir);
+	D_FREE(tmp_name);
+	return rc;
+}
+
+static int
+get_metrics_csv(pid_t pid, char **dump_buf, size_t *dump_buf_sz)
+{
+	struct d_tm_context *ctx = NULL;
+	struct d_tm_node_t  *root;
+	FILE                *dump_file;
+	uint32_t             filter;
+	int                  rc = 0;
+
+	ctx = d_tm_open(d_tm_cli_pid_key(pid));
+	if (ctx == NULL) {
+		D_ERROR("failed to connect to telemetry segment for pid %d\n", pid);
+		return -DER_MISC;
+	}
+
+	root = d_tm_get_root(ctx);
+	if (root == NULL) {
+		D_ERROR("No metrics found for dump.\n");
+		D_GOTO(close_ctx, rc = -DER_NONEXIST);
+	}
+
+	dump_file = open_memstream(dump_buf, dump_buf_sz);
+	if (dump_file == NULL)
+		D_GOTO(close_ctx, rc = -DER_NOMEM);
+
+	filter = D_TM_COUNTER | D_TM_DURATION | D_TM_TIMESTAMP | D_TM_MEMINFO |
+		 D_TM_TIMER_SNAPSHOT | D_TM_GAUGE | D_TM_STATS_GAUGE;
+
+	d_tm_print_field_descriptors(0, dump_file);
+	d_tm_iterate(ctx, root, 0, filter, NULL, D_TM_CSV, 0, iter_dump, dump_file);
+
+	fclose(dump_file);
+
+close_ctx:
+	d_tm_close(&ctx);
+	return rc;
+}
+
+int
+write_tm_csv(const char *tm_pool, const char *tm_cont, const char *csv_file_dir,
+	     const char *csv_file_name, const char *csv_buf, size_t csv_buf_sz)
+{
+	dfs_sys_t *dfs_sys = NULL;
+	dfs_obj_t *obj;
+	char      *full_path = NULL;
+	int        rc;
+
+	rc = dfs_init();
+	if (rc != 0)
+		return rc;
+
+	rc = dfs_sys_connect(tm_pool, NULL, tm_cont, O_RDWR, 0, NULL, &dfs_sys);
+	if (rc != 0) {
+		D_ERROR("failed to connect to metrics container %s/%s", tm_pool, tm_cont);
+		D_GOTO(out_fini, rc);
+	}
+
+	D_INFO("dumping telemetry to %s:%s%s/%s\n", tm_pool, tm_cont, csv_file_dir, csv_file_name);
+
+	rc = dfs_sys_mkdir_p(dfs_sys, csv_file_dir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH, 0);
+	if (rc != 0) {
+		DL_ERROR(rc, "failed to mkdir_p %s", csv_file_dir);
+		D_GOTO(out_disconnect, rc);
+	}
+
+	D_ASPRINTF(full_path, "%s/%s", csv_file_dir, csv_file_name);
+	if (full_path == NULL)
+		D_GOTO(out_disconnect, rc = -DER_NOMEM);
+
+	rc = dfs_sys_open(dfs_sys, full_path, S_IFREG | S_IWUSR | S_IRUSR,
+			  O_RDWR | O_CREAT | O_EXCL, 0, 0, NULL, &obj);
+	if (rc != 0) {
+		DL_ERROR(rc, "failed to open %s", full_path);
+		D_GOTO(out_path, rc);
+	}
+
+	rc = dfs_sys_write(dfs_sys, obj, csv_buf, 0, &csv_buf_sz, NULL);
+	if (rc != 0)
+		DL_ERROR(rc, "failed to write to %s", full_path);
+
+	int close_rc = dfs_sys_close(obj);
+	if (close_rc != 0) {
+		DL_ERROR(close_rc, "failed to close %s", full_path);
+		if (rc == 0)
+			rc = close_rc;
+	}
+
+out_path:
+	D_FREE(full_path);
+out_disconnect:
+	dfs_sys_disconnect(dfs_sys);
+out_fini:
+	dfs_fini();
+	return rc;
+}
+
+static int
+dump_tm_container(const char *tm_pool, const char *tm_cont, const char *tm_root_dir)
+{
+	pid_t  pid           = getpid();
+	char  *csv_file_dir  = NULL;
+	char  *csv_file_name = NULL;
+	char  *csv_buf       = NULL;
+	size_t csv_buf_sz    = 0;
+	int    rc;
+
+	if (tm_pool == NULL || tm_cont == NULL)
+		return -DER_INVAL;
+
+	rc = get_metrics_csv(pid, &csv_buf, &csv_buf_sz);
+	if (rc != 0)
+		return rc;
+
+	rc = csv_file_path(pid, tm_root_dir, &csv_file_dir, &csv_file_name);
+	if (rc != 0 || csv_file_dir == NULL || csv_file_name == NULL) {
+		D_ERROR("failed to get csv file path\n");
+		D_GOTO(out_free, rc);
+	}
+
+	rc = write_tm_csv(tm_pool, tm_cont, csv_file_dir, csv_file_name, csv_buf, csv_buf_sz);
+
+out_free:
+	free(csv_buf);
+	D_FREE(csv_file_dir);
+	D_FREE(csv_file_name);
+
+	return rc;
+}
+
+#define DUMP_ATTR_COUNT     3
+#define DUMP_ATTR_VALUE_LEN PATH_MAX
+
+char const *const dump_attr_names[DUMP_ATTR_COUNT] = {DAOS_CLIENT_METRICS_DUMP_POOL_ATTR,
+						      DAOS_CLIENT_METRICS_DUMP_CONT_ATTR,
+						      DAOS_CLIENT_METRICS_DUMP_DIR_ATTR};
+
+#define DUMP_ATTR_POOL 0
+#define DUMP_ATTR_CONT 1
+#define DUMP_ATTR_DIR  2
+
+static int
+read_tm_dump_attrs(dfs_t *dfs, char **pool, char **cont, char **dir)
+{
+	size_t value_sizes[DUMP_ATTR_COUNT] = {0};
+	size_t capacity[DUMP_ATTR_COUNT]    = {0};
+	void  *buff_addrs[DUMP_ATTR_COUNT]  = {NULL};
+	char  *tmp_pool                     = NULL;
+	char  *tmp_cont                     = NULL;
+	char  *tmp_dir                      = NULL;
+	int    rc                           = 0;
+
+	if (dfs == NULL || pool == NULL || cont == NULL)
+		return -DER_INVAL;
+
+	/* Pass 1: Query the sizes of the attributes first. */
+	rc =
+	    daos_cont_get_attr(dfs->coh, DUMP_ATTR_COUNT, dump_attr_names, NULL, value_sizes, NULL);
+	if (rc == -DER_NONEXIST) {
+		/* Not an error, just means the attributes are not set. */
+		return 0;
+	} else if (rc != 0) {
+		DL_ERROR(rc, "Failed to query container metric attribute sizes");
+		return rc;
+	}
+
+	/* Pass 2: Allocate buffers of the exact required size. */
+	if (value_sizes[DUMP_ATTR_POOL] > 0) {
+		D_ALLOC(tmp_pool, value_sizes[DUMP_ATTR_POOL] + 1);
+		if (tmp_pool == NULL)
+			D_GOTO(err, rc = -DER_NOMEM);
+		buff_addrs[DUMP_ATTR_POOL] = tmp_pool;
+		capacity[DUMP_ATTR_POOL]   = value_sizes[DUMP_ATTR_POOL] + 1;
+	}
+	if (value_sizes[DUMP_ATTR_CONT] > 0) {
+		D_ALLOC(tmp_cont, value_sizes[DUMP_ATTR_CONT] + 1);
+		if (tmp_cont == NULL)
+			D_GOTO(err, rc = -DER_NOMEM);
+		buff_addrs[DUMP_ATTR_CONT] = tmp_cont;
+		capacity[DUMP_ATTR_CONT]   = value_sizes[DUMP_ATTR_CONT] + 1;
+	}
+	if (value_sizes[DUMP_ATTR_DIR] > 0) {
+		D_ALLOC(tmp_dir, value_sizes[DUMP_ATTR_DIR] + 1);
+		if (tmp_dir == NULL)
+			D_GOTO(err, rc = -DER_NOMEM);
+		buff_addrs[DUMP_ATTR_DIR] = tmp_dir;
+		capacity[DUMP_ATTR_DIR]   = value_sizes[DUMP_ATTR_DIR] + 1;
+	}
+
+	/* Pass 2: Actually get the attribute data into the new buffers. */
+	rc = daos_cont_get_attr(dfs->coh, DUMP_ATTR_COUNT, dump_attr_names, buff_addrs, capacity,
+				NULL);
+	if (rc != 0) {
+		DL_ERROR(rc, "Failed to read container metric attributes");
+		D_GOTO(err, rc);
+	}
+
+	*pool = tmp_pool;
+	*cont = tmp_cont;
+	*dir  = tmp_dir;
+	return 0;
+
+err:
+	D_FREE(tmp_pool);
+	D_FREE(tmp_cont);
+	D_FREE(tmp_dir);
+	return rc;
+}
+
+#define DEFAULT_DIR "/"
 
 void
 dfs_metrics_fini(dfs_t *dfs)
 {
+	char *tm_pool = NULL;
+	char *tm_cont = NULL;
+	char *tm_dir  = NULL;
+	int   rc;
+
+	if (dfs == NULL || dfs->metrics == NULL)
+		return;
+
+	rc = read_tm_dump_attrs(dfs, &tm_pool, &tm_cont, &tm_dir);
+	if (rc != 0)
+		goto out;
+
+	if (tm_pool == NULL || tm_cont == NULL)
+		goto out;
+
+	if (tm_dir == NULL) {
+		D_STRNDUP_S(tm_dir, DEFAULT_DIR);
+		if (tm_dir == NULL)
+			goto out;
+	}
+
+	rc = dump_tm_container(tm_pool, tm_cont, tm_dir);
+	if (rc != 0)
+		D_ERROR("failed to dump DFS metrics to %s/%s:%s", tm_pool, tm_cont, tm_dir);
+
+out:
+	D_FREE(tm_pool);
+	D_FREE(tm_cont);
+	D_FREE(tm_dir);
 	D_FREE(dfs->metrics);
+}
+
+static bool
+cont_attrs_set(dfs_t *dfs)
+{
+	char *tm_pool   = NULL;
+	char *tm_cont   = NULL;
+	char *tm_dir    = NULL;
+	bool  attrs_set = false;
+	int   rc;
+
+	if (dfs == NULL)
+		return false;
+
+	rc = read_tm_dump_attrs(dfs, &tm_pool, &tm_cont, &tm_dir);
+	if (rc != 0) {
+		return false;
+	}
+
+	if (tm_pool != NULL && tm_cont != NULL)
+		attrs_set = true;
+
+	D_FREE(tm_pool);
+	D_FREE(tm_cont);
+	D_FREE(tm_dir);
+	return attrs_set;
+}
+
+bool
+dfs_metrics_should_init(dfs_t *dfs)
+{
+	return (daos_client_metric || cont_attrs_set(dfs));
+}
+
+bool
+dfs_metrics_enabled(dfs_t *dfs)
+{
+	return dfs->metrics != NULL;
 }

--- a/src/client/dfs/metrics.h
+++ b/src/client/dfs/metrics.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -65,15 +66,10 @@ struct dfs_metrics {
 	struct d_tm_node_t *dm_read_bytes;
 	struct d_tm_node_t *dm_write_bytes;
 	struct d_tm_node_t *dm_mount_time;
+	struct d_tm_node_t *dm_dump_time;
 };
 
 bool
-dfs_metrics_enabled();
-
-void
-dfs_metrics_init(dfs_t *dfs);
-
-void
-dfs_metrics_fini(dfs_t *dfs);
+dfs_metrics_should_init(dfs_t *dfs);
 
 #endif /* __DFS_METRICS_H__ */

--- a/src/client/dfs/mnt.c
+++ b/src/client/dfs/mnt.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -729,7 +730,7 @@ dfs_mount_int(daos_handle_t poh, daos_handle_t coh, int flags, daos_epoch_t epoc
 		daos_obj_oid_cycle(&dfs->oid);
 	}
 
-	if (dfs_metrics_enabled())
+	if (dfs_metrics_should_init(dfs))
 		dfs_metrics_init(dfs);
 
 	dfs->mounted = DFS_MOUNT;

--- a/src/client/dfs/tests/SConscript
+++ b/src/client/dfs/tests/SConscript
@@ -1,0 +1,16 @@
+"""Build DFS tests"""
+
+
+def scons():
+    """Execute build"""
+    Import('denv')
+
+    metrics_tests = denv.d_test_program('metrics_tests', 'metrics_tests.c',
+                                        LIBS=['daos', 'daos_common', 'gurt', 'cart', 'dfs',
+                                              'pthread', 'cmocka', 'uuid'])
+
+    denv.Install('$PREFIX/bin/', [metrics_tests])
+
+
+if __name__ == "SCons.Script":
+    scons()

--- a/src/client/dfs/tests/metrics_tests.c
+++ b/src/client/dfs/tests/metrics_tests.c
@@ -1,0 +1,611 @@
+/*
+ * (C) Copyright 2025 Google LLC
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <daos/tests_lib.h>
+#include <daos_fs.h>
+#include <daos/metrics.h>
+#include <daos/job.h>
+#include <gurt/telemetry_common.h>
+#include <gurt/telemetry_producer.h>
+#include <sys/utsname.h>
+#include <uuid/uuid.h>
+#include "../dfs_internal.h"
+
+/* Global variable used to toggle client metrics. */
+bool daos_client_metric;
+/* Global variable for process name */
+#define TEST_PROC_NAME "test_proc"
+char *program_invocation_name = TEST_PROC_NAME;
+/* Global variable for job id */
+char *dc_jobid;
+
+/* System mocks */
+#define TEST_PID 1234
+pid_t
+getpid(void)
+{
+	return TEST_PID;
+}
+
+#define TEST_TIME 1234567890
+time_t
+time(time_t *t)
+{
+	if (t != NULL)
+		*t = TEST_TIME;
+	return TEST_TIME;
+}
+
+struct tm *
+gmtime(const time_t *timer)
+{
+	static struct tm mock_tm;
+
+	/* For failure case */
+	if (mock_type(int) == 1)
+		return NULL;
+
+	/* For success case */
+	mock_tm.tm_year = 109; /* 2009 - 1900 */
+	mock_tm.tm_mon  = 1;   /* February */
+	mock_tm.tm_mday = 13;
+	mock_tm.tm_hour = 23;
+	return &mock_tm;
+}
+
+#define TEST_HOSTNAME "test-hostname"
+int
+uname(struct utsname *buf)
+{
+	strncpy(buf->nodename, TEST_HOSTNAME, _UTSNAME_NODENAME_LENGTH);
+	/* Ensure null termination */
+	buf->nodename[_UTSNAME_NODENAME_LENGTH - 1] = '\0';
+
+	return 0;
+}
+
+/* Mock for dc_pool_hdl2uuid() */
+int
+dc_pool_hdl2uuid(daos_handle_t poh, uuid_t *hdl_uuid, uuid_t *pool_uuid)
+{
+	if (pool_uuid != NULL)
+		uuid_generate(*pool_uuid);
+	return mock_type(int);
+}
+
+/* Mock for dc_cont_hdl2uuid() */
+int
+dc_cont_hdl2uuid(daos_handle_t coh, uuid_t *hdl_uuid, uuid_t *cont_uuid)
+{
+	if (cont_uuid != NULL)
+		uuid_generate(*cont_uuid);
+	return mock_type(int);
+}
+
+/* Mock for dc_jobid_is_default() */
+bool
+dc_jobid_is_default(const char *jobid)
+{
+	return mock_type(bool);
+}
+
+/* from daos/job.c, simplified */
+int
+dc_set_default_jobid(const char *jobid)
+{
+	D_FREE(dc_jobid);
+	D_ASPRINTF(dc_jobid, "%s", jobid);
+	if (dc_jobid == NULL)
+		return -DER_NOMEM;
+
+	return 0;
+}
+
+/* Mocks for telemetry functions */
+int
+write_tm_csv(const char *tm_pool, const char *tm_cont, const char *csv_file_dir,
+	     const char *csv_file_name, const char *csv_buf, size_t csv_buf_sz)
+{
+	check_expected(tm_pool);
+	check_expected(tm_cont);
+
+	return mock_type(int);
+}
+
+/* Flexible mock for daos_cont_get_attr() */
+int
+daos_cont_get_attr(daos_handle_t coh, int n, const char *const names[], void *const buffs[],
+		   size_t sizes[], daos_event_t *ev)
+{
+	const char *pool_val = mock_ptr_type(const char *);
+	const char *cont_val = mock_ptr_type(const char *);
+	int         rc       = mock_type(int);
+
+	if (rc != 0)
+		return rc;
+
+	for (int i = 0; i < n; i++) {
+		if (strcmp(names[i], DAOS_CLIENT_METRICS_DUMP_POOL_ATTR) == 0) {
+			if (buffs == NULL) { /* Size query */
+				sizes[i] = (pool_val == NULL) ? 0 : strlen(pool_val);
+			} else if (pool_val != NULL) { /* Value query */
+				strncpy(buffs[i], pool_val, sizes[i]);
+			}
+		} else if (strcmp(names[i], DAOS_CLIENT_METRICS_DUMP_CONT_ATTR) == 0) {
+			if (buffs == NULL) { /* Size query */
+				sizes[i] = (cont_val == NULL) ? 0 : strlen(cont_val);
+			} else if (cont_val != NULL) { /* Value query */
+				strncpy(buffs[i], cont_val, sizes[i]);
+			}
+		} else if (strcmp(names[i], DAOS_CLIENT_METRICS_DUMP_DIR_ATTR) == 0) {
+			/* For now, we don't test the dir attribute */
+			if (buffs == NULL)
+				sizes[i] = 0;
+		}
+	}
+	return 0;
+}
+
+/*
+ * ======================================================================
+ * Test State and Setup/Teardown
+ * ======================================================================
+ */
+
+struct test_state {
+	dfs_t *dfs;
+};
+
+static int
+setup(void **state)
+{
+	struct test_state *ts;
+
+	D_ALLOC_PTR(ts);
+	if (ts == NULL)
+		return -1;
+
+	D_ALLOC_PTR(ts->dfs);
+	if (ts->dfs == NULL) {
+		D_FREE(ts);
+		return -1;
+	}
+
+	*state = ts;
+	return 0;
+}
+
+static int
+teardown(void **state)
+{
+	struct test_state *ts = *state;
+
+	d_tm_fini();
+	D_FREE(ts->dfs->metrics);
+	D_FREE(ts->dfs);
+	D_FREE(ts);
+	D_FREE(dc_jobid);
+	*state = NULL;
+	return 0;
+}
+
+/*
+ * ======================================================================
+ * Test Cases
+ * ======================================================================
+ */
+
+static void
+test_metrics_enabled(void **state)
+{
+	struct test_state *ts = *state;
+
+	/* Not enabled if metrics struct is NULL */
+	ts->dfs->metrics = NULL;
+	assert_false(dfs_metrics_enabled(ts->dfs));
+
+	/* Enabled if metrics struct is allocated */
+	D_ALLOC_PTR(ts->dfs->metrics);
+	assert_non_null(ts->dfs->metrics);
+	assert_true(dfs_metrics_enabled(ts->dfs));
+}
+
+static void
+test_should_init_global_flag(void **state)
+{
+	struct test_state *ts = *state;
+
+	/* Should init if the global flag is set */
+	daos_client_metric = true;
+	assert_true(dfs_metrics_should_init(ts->dfs));
+	daos_client_metric = false;
+}
+
+static void
+test_should_init_cont_attrs(void **state)
+{
+	struct test_state *ts = *state;
+
+	daos_client_metric = false;
+
+	/* Mock daos_cont_get_attr to return attributes (size query) */
+	will_return(daos_cont_get_attr, "pool-label");
+	will_return(daos_cont_get_attr, "cont-label");
+	will_return(daos_cont_get_attr, 0);
+	/* Mock daos_cont_get_attr to return attributes (value query) */
+	will_return(daos_cont_get_attr, "pool-label");
+	will_return(daos_cont_get_attr, "cont-label");
+	will_return(daos_cont_get_attr, 0);
+
+	assert_true(dfs_metrics_should_init(ts->dfs));
+}
+
+static void
+test_should_not_init(void **state)
+{
+	struct test_state *ts = *state;
+
+	daos_client_metric = false;
+
+	/* Mock daos_cont_get_attr to return no attributes */
+	will_return(daos_cont_get_attr, NULL);
+	will_return(daos_cont_get_attr, NULL);
+	will_return(daos_cont_get_attr, -DER_NONEXIST);
+
+	assert_false(dfs_metrics_should_init(ts->dfs));
+}
+
+static void
+test_init_success(void **state)
+{
+	struct test_state *ts = *state;
+
+	will_return(dc_pool_hdl2uuid, 0);
+	will_return(dc_cont_hdl2uuid, 0);
+
+	dfs_metrics_init(ts->dfs);
+
+	assert_non_null(ts->dfs->metrics);
+}
+
+static void
+test_init_pool_uuid_fails(void **state)
+{
+	struct test_state *ts = *state;
+
+	will_return(dc_pool_hdl2uuid, -DER_INVAL);
+
+	dfs_metrics_init(ts->dfs);
+
+	assert_null(ts->dfs->metrics);
+}
+
+static void
+test_init_cont_uuid_fails(void **state)
+{
+	struct test_state *ts = *state;
+
+	will_return(dc_pool_hdl2uuid, 0);
+	will_return(dc_cont_hdl2uuid, -DER_INVAL);
+
+	dfs_metrics_init(ts->dfs);
+
+	assert_null(ts->dfs->metrics);
+}
+
+static void
+test_fini_no_metrics(void **state)
+{
+	struct test_state *ts = *state;
+
+	ts->dfs->metrics = NULL;
+	/* Should not crash and do nothing */
+	dfs_metrics_fini(ts->dfs);
+}
+
+static void
+test_fini_no_dump_attrs(void **state)
+{
+	struct test_state *ts = *state;
+
+	D_ALLOC_PTR(ts->dfs->metrics);
+	assert_non_null(ts->dfs->metrics);
+
+	/* Mock daos_cont_get_attr to return no attributes */
+	will_return(daos_cont_get_attr, NULL);
+	will_return(daos_cont_get_attr, NULL);
+	will_return(daos_cont_get_attr, -DER_NONEXIST);
+
+	/* dump_tm_container should NOT be called */
+	dfs_metrics_fini(ts->dfs);
+
+	/* The metrics struct should be freed */
+	assert_null(ts->dfs->metrics);
+}
+
+#define TEST_POOL "pool1"
+#define TEST_CONT "cont1"
+
+static void
+test_fini_with_dump_attrs_success(void **state)
+{
+	struct test_state *ts = *state;
+
+	will_return(dc_pool_hdl2uuid, 0);
+	will_return(dc_cont_hdl2uuid, 0);
+
+	/* Mock daos_cont_get_attr to return attributes (size query) */
+	will_return(daos_cont_get_attr, TEST_POOL);
+	will_return(daos_cont_get_attr, TEST_CONT);
+	will_return(daos_cont_get_attr, 0);
+	/* Mock daos_cont_get_attr to return attributes (value query) */
+	will_return(daos_cont_get_attr, TEST_POOL);
+	will_return(daos_cont_get_attr, TEST_CONT);
+	will_return(daos_cont_get_attr, 0);
+
+	will_return(dc_jobid_is_default, true);
+	will_return(gmtime, 0);
+
+	expect_string(write_tm_csv, tm_pool, "pool1");
+	expect_string(write_tm_csv, tm_cont, "cont1");
+	will_return(write_tm_csv, 0);
+
+	dfs_metrics_init(ts->dfs);
+	assert_non_null(ts->dfs->metrics);
+
+	dfs_metrics_fini(ts->dfs);
+
+	assert_null(ts->dfs->metrics);
+}
+
+static void
+test_fini_with_dump_attrs_fail_dump(void **state)
+{
+	struct test_state *ts = *state;
+
+	will_return(dc_pool_hdl2uuid, 0);
+	will_return(dc_cont_hdl2uuid, 0);
+
+	/* Mock daos_cont_get_attr to return attributes (size query) */
+	will_return(daos_cont_get_attr, TEST_POOL);
+	will_return(daos_cont_get_attr, TEST_CONT);
+	will_return(daos_cont_get_attr, 0);
+	/* Mock daos_cont_get_attr to return attributes (value query) */
+	will_return(daos_cont_get_attr, TEST_POOL);
+	will_return(daos_cont_get_attr, TEST_CONT);
+	will_return(daos_cont_get_attr, 0);
+
+	will_return(dc_jobid_is_default, true);
+	will_return(gmtime, 0);
+
+	expect_string(write_tm_csv, tm_pool, "pool1");
+	expect_string(write_tm_csv, tm_cont, "cont1");
+	will_return(write_tm_csv, -DER_MISC);
+
+	dfs_metrics_init(ts->dfs);
+	assert_non_null(ts->dfs->metrics);
+	dfs_metrics_fini(ts->dfs);
+
+	assert_null(ts->dfs->metrics);
+}
+
+static void
+test_fini_read_attrs_fails(void **state)
+{
+	struct test_state *ts = *state;
+
+	D_ALLOC_PTR(ts->dfs->metrics);
+	assert_non_null(ts->dfs->metrics);
+
+	/* Mock daos_cont_get_attr to return an error */
+	will_return(daos_cont_get_attr, NULL);
+	will_return(daos_cont_get_attr, NULL);
+	will_return(daos_cont_get_attr, -DER_INVAL);
+
+	dfs_metrics_fini(ts->dfs);
+
+	assert_null(ts->dfs->metrics);
+}
+
+/*
+ * ======================================================================
+ * csv_file_path tests
+ * ======================================================================
+ */
+
+static void
+test_csv_file_path_default_jobid(void **state)
+{
+	char *file_dir  = NULL;
+	char *file_name = NULL;
+	char  expected_dir[PATH_MAX];
+	char  expected_name[PATH_MAX];
+	int   rc;
+
+	/* Mock dc_jobid_is_default to return true */
+	will_return(dc_jobid_is_default, true);
+	will_return(gmtime, 0);
+
+	rc = csv_file_path(TEST_PID, NULL, &file_dir, &file_name);
+	assert_int_equal(rc, 0);
+	assert_non_null(file_dir);
+	assert_non_null(file_name);
+
+	snprintf(expected_dir, sizeof(expected_dir), "/2009/02/13/23/proc/%s",
+		 program_invocation_name);
+	snprintf(expected_name, sizeof(expected_name), "%ld-%s-%d.csv", (long)TEST_TIME,
+		 TEST_HOSTNAME, TEST_PID);
+
+	assert_string_equal(file_dir, expected_dir);
+	assert_string_equal(file_name, expected_name);
+
+	D_FREE(file_dir);
+	D_FREE(file_name);
+}
+
+static void
+test_csv_file_path_custom_jobid_with_root(void **state)
+{
+	char       *file_dir  = NULL;
+	char       *file_name = NULL;
+	char        expected_dir[PATH_MAX];
+	char        expected_name[PATH_MAX];
+	const char *root_dir     = "/tmp/metrics";
+	const char *custom_jobid = "my-custom-job";
+	int         rc;
+
+	/* Set custom job id */
+	dc_set_default_jobid(custom_jobid);
+
+	/* Mock dc_jobid_is_default to return false */
+	will_return(dc_jobid_is_default, false);
+	will_return(gmtime, 0);
+
+	rc = csv_file_path(TEST_PID, root_dir, &file_dir, &file_name);
+	assert_int_equal(rc, 0);
+	assert_non_null(file_dir);
+	assert_non_null(file_name);
+
+	snprintf(expected_dir, sizeof(expected_dir), "%s/2009/02/13/23/job/%s/%s", root_dir,
+		 custom_jobid, program_invocation_name);
+	snprintf(expected_name, sizeof(expected_name), "%ld-%s-%d.csv", (long)TEST_TIME,
+		 TEST_HOSTNAME, TEST_PID);
+
+	assert_string_equal(file_dir, expected_dir);
+	assert_string_equal(file_name, expected_name);
+
+	D_FREE(file_dir);
+	D_FREE(file_name);
+}
+
+static void
+test_csv_file_path_root_with_slash(void **state)
+{
+	char       *file_dir  = NULL;
+	char       *file_name = NULL;
+	char        expected_dir[PATH_MAX];
+	const char *root_dir     = "/tmp/metrics/";
+	const char *custom_jobid = "my-custom-job";
+	int         rc;
+
+	/* Set custom job id */
+	dc_set_default_jobid(custom_jobid);
+
+	/* Mock dc_jobid_is_default to return false */
+	will_return(dc_jobid_is_default, false);
+	will_return(gmtime, 0);
+
+	rc = csv_file_path(TEST_PID, root_dir, &file_dir, &file_name);
+	assert_int_equal(rc, 0);
+	assert_non_null(file_dir);
+	assert_non_null(file_name);
+
+	/* Note: no extra slash after root_dir */
+	snprintf(expected_dir, sizeof(expected_dir), "%s2009/02/13/23/job/%s/%s", root_dir,
+		 custom_jobid, program_invocation_name);
+
+	assert_string_equal(file_dir, expected_dir);
+
+	D_FREE(file_dir);
+	D_FREE(file_name);
+}
+
+static void
+test_csv_file_path_null_params(void **state)
+{
+	char *file_dir  = NULL;
+	char *file_name = NULL;
+	int   rc;
+
+	will_return(gmtime, 0);
+	will_return(gmtime, 0);
+
+	rc = csv_file_path(TEST_PID, NULL, NULL, &file_name);
+	assert_int_equal(rc, -DER_INVAL);
+
+	rc = csv_file_path(TEST_PID, NULL, &file_dir, NULL);
+	assert_int_equal(rc, -DER_INVAL);
+}
+
+static void
+test_csv_file_path_path_too_long(void **state)
+{
+	char *file_dir  = NULL;
+	char *file_name = NULL;
+	char *long_root;
+	int   rc;
+
+	D_ALLOC(long_root, PATH_MAX);
+	assert_non_null(long_root);
+	memset(long_root, 'a', PATH_MAX - 1);
+	long_root[PATH_MAX - 1] = '\0';
+
+	will_return(dc_jobid_is_default, true);
+	will_return(gmtime, 0);
+
+	rc = csv_file_path(TEST_PID, long_root, &file_dir, &file_name);
+	assert_int_equal(rc, -DER_INVAL);
+	assert_null(file_dir);
+	assert_null(file_name);
+
+	D_FREE(long_root);
+}
+
+static void
+test_csv_file_path_gmtime_fails(void **state)
+{
+	char *file_dir  = NULL;
+	char *file_name = NULL;
+	char  expected_dir[PATH_MAX];
+	int   rc;
+
+	will_return(dc_jobid_is_default, true);
+	will_return(gmtime, 1); /* fail */
+
+	rc = csv_file_path(TEST_PID, NULL, &file_dir, &file_name);
+	assert_int_equal(rc, 0);
+
+	snprintf(expected_dir, sizeof(expected_dir), "/proc/%s", program_invocation_name);
+	assert_string_equal(file_dir, expected_dir);
+
+	D_FREE(file_dir);
+	D_FREE(file_name);
+}
+
+int
+main(void)
+{
+	const struct CMUnitTest tests[] = {
+	    cmocka_unit_test_setup_teardown(test_metrics_enabled, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_should_init_global_flag, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_should_init_cont_attrs, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_should_not_init, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_init_success, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_init_pool_uuid_fails, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_init_cont_uuid_fails, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_fini_no_metrics, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_fini_no_dump_attrs, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_fini_with_dump_attrs_success, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_fini_with_dump_attrs_fail_dump, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_fini_read_attrs_fails, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_csv_file_path_default_jobid, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_csv_file_path_custom_jobid_with_root, setup,
+					    teardown),
+	    cmocka_unit_test_setup_teardown(test_csv_file_path_root_with_slash, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_csv_file_path_null_params, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_csv_file_path_path_too_long, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_csv_file_path_gmtime_fails, setup, teardown),
+	};
+
+	d_register_alt_assert(mock_assert);
+
+	return cmocka_run_group_tests_name("dfs_metrics_public", tests, NULL, NULL);
+}

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -542,6 +542,9 @@ struct dfuse_cont {
 
 	/* Set to true if the inode was allocated to this structure, so should be kept on close*/
 	bool                    dfc_save_ino;
+
+	/* Toggle metrics enablement for IL clients using this container */
+	ATOMIC bool                   dfc_metrics_enabled;
 };
 
 #define dfs_entry core.dfcc_entry
@@ -920,6 +923,17 @@ dfuse_loop(struct dfuse_info *dfuse_info);
 	} while (0)
 
 #define DFUSE_REPLY_IOCTL(desc, req, arg) DFUSE_REPLY_IOCTL_SIZE(desc, req, &(arg), sizeof(arg))
+
+#define DFUSE_REPLY_OK(_oh, req)                                                                   \
+	do {                                                                                       \
+		int __rc;                                                                          \
+		DFUSE_TRA_DEBUG(_oh, "Returning OK to complete ioctl");                            \
+		_Static_assert(IS_OH(_oh), "Param is not open handle");                            \
+		(_oh) = NULL;                                                                      \
+		__rc  = fuse_reply_ioctl(req, 0, NULL, 0);                                         \
+		if (__rc != 0)                                                                     \
+			DS_ERROR(-__rc, "fuse_reply_ioctl() error");                               \
+	} while (0)
 
 /**
  * Inode handle.

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -966,6 +966,13 @@ dfuse_cont_open(struct dfuse_info *dfuse_info, struct dfuse_pool *dfp, const cha
 		DFUSE_TRA_DEBUG(dfc, "Returning dfs for " DF_UUID " ref %d", DP_UUID(dfc->dfc_uuid),
 				dfc->dfs_ref);
 	}
+
+	/* If DFS metrics are enabled via container attributes, then enable them
+	 * for IL clients. Can also be toggled via ioctl at runtime.
+	 */
+	if (dfs_metrics_enabled(dfc->dfs_ns))
+		atomic_store_relaxed(&dfc->dfc_metrics_enabled, true);
+
 	*_dfc = dfc;
 
 	return rc;

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -133,6 +134,9 @@ ioil_shrink_cont(struct ioil_cont *cont, bool shrink_pool, bool force)
 		return 0;
 
 	if (cont->ioc_dfs != NULL) {
+		if (cont->ioc_metrics_enabled)
+			dfs_metrics_fini(cont->ioc_dfs);
+
 		DFUSE_TRA_DOWN(cont->ioc_dfs);
 		rc = dfs_umount(cont->ioc_dfs);
 		if (rc != 0) {
@@ -715,6 +719,11 @@ ioil_fetch_cont_handles(int fd, struct ioil_cont *cont)
 		DFUSE_LOG_WARNING("Failed to use dfs handle: %d (%s)", rc, strerror(rc));
 		D_FREE(iov.iov_buf);
 		return rc;
+	}
+
+	if ((hs_reply.fsr_flags & DFUSE_IOCTL_FLAGS_METRICS) != 0) {
+		cont->ioc_metrics_enabled = true;
+		dfs_metrics_init(cont->ioc_dfs);
 	}
 
 	DFUSE_TRA_UP(cont->ioc_dfs, &ioil_iog, "dfs");

--- a/src/client/dfuse/il/ioil.h
+++ b/src/client/dfuse/il/ioil.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2023 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -26,6 +27,8 @@ struct ioil_cont {
 	d_list_t          ioc_containers;
 	/* Number of files open in container */
 	int               ioc_open_count;
+	/* Metrics enabled for this container? */
+	bool              ioc_metrics_enabled;
 };
 
 struct fd_entry {

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -915,6 +916,11 @@ retrieve_handles_from_fuse(int idx)
 			"daos_pool_global2local(): %d (%s)\n",
 			errno_saved, strerror(errno_saved));
 		goto err;
+	}
+
+	if ((hs_reply.fsr_flags & DFUSE_IOCTL_FLAGS_METRICS) != 0) {
+		dfs_list[idx].metrics_enabled = true;
+		dfs_metrics_init(dfs_list[idx].dfs);
 	}
 
 	D_FREE(buff);
@@ -7391,6 +7397,9 @@ finalize_dfs(void)
 			D_FREE(dfs_list[i].cont);
 			continue;
 		}
+
+		if (dfs_list[i].metrics_enabled)
+			dfs_metrics_fini(dfs_list[i].dfs);
 
 		rc = dcache_destroy(dfs_list[i].dcache);
 		if (rc != 0) {

--- a/src/client/dfuse/pil4dfs/pil4dfs_int.h
+++ b/src/client/dfuse/pil4dfs/pil4dfs_int.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -90,6 +91,7 @@ struct dfs_mt {
 	_Atomic uint32_t inited;
 	char            *pool, *cont;
 	char            *fs_root;
+	bool             metrics_enabled;
 };
 
 #endif

--- a/src/client/telemetry.md
+++ b/src/client/telemetry.md
@@ -1,0 +1,3028 @@
+# DAOS Client Telemetry
+
+The DAOS client library (libdaos) includes performance monitoring and workload characterization
+capabilities provided via the <a href="/src/gurt/telemetry.md">DAOS telemetry library</a>. This
+document was written to describe those capabilities and provide a starting point for site-specific
+integration possibilities.
+
+## Unmanaged Use Cases
+
+The simplest scenarios supported by client telemetry allow a developer or advanced user to dump a
+final snapshot of the client telemetry at process exit. These modes do not require any special
+configuration of the DAOS agent or external monitoring infrastructure. The tradeoff for simplicity
+is the loss of information about how the metric values changed over time. Some complex metric types
+(stats gauges and histograms) do provide extra information derived over time, but the final dump
+still only contains a single datapoint for those extra metric values.
+
+### Manual Metrics Dump via Environment Variable
+
+The header file <a href="/src/include/daos/metrics.h">&lt;daos/metrics.h&gt;</a> defines a number of
+environment variables that may be set in the client process environment to control the client
+telemetry library. The only one directly relevant to this use case, however, is
+`DAOS_CLIENT_METRICS_DUMP_DIR`, which may be set to a local or shared directory. When the client
+process exits, it will write out a
+<a href="https://en.wikipedia.org/wiki/Comma-separated_values">CSV</a>-formatted file that contains
+one line for each metric. See the <a href="#client-telemetry-examples">Examples</a> section below for more
+information. Note that in this mode, the client telemetry is recorded in non-shared memory segments,
+so it is not possible to both dump to CSV and sample the telemetry periodically during the client
+process run time. The telemetry recorded in this mode also contains the full set of client metrics,
+as the library is initialized via the client invocation of `daos_init()`.
+
+### Automatic Metrics Dump per Container
+
+This mode allows a user with write access to a container to enable metrics dump for any libdaos
+client that accesses the container. In addition to the previously-described mode where the CSV
+files are written out to a directory on a local or shared filesystem, this mode also provides a
+capability to specify that the CSVs should be written to a DAOS container. Using a DAOS container
+for the metrics storage simplifies use cases where metrics may be collected for many processes
+distributed over a large set of client machines. In this mode, a client process will dump metrics
+directly to the metrics container using the DFS API, without any need to set up a mountpoint
+for the container.
+
+Enabling this mode requires use of the `daos` tool to set the relevant parameters for a container.
+In its simplest form, the only required parameters are the source pool/container, and the destination
+container in the same pool. The source pool/container may be obtained from a dfuse mountpoint via the
+`--path` parameter, or may be specified as positional parameters.
+
+> **_NOTE:_** The destination container must exist, must use the POSIX layout option, and must be
+writable by the user under which the client process is running. Future updates may allow the
+destination container to be created automatically.
+
+> **_NOTE:_** If telemetry is to be enabled for Interception Library (IL) clients _after_ dfuse has
+been started, then the `--path` parameter must be used in order to toggle the setting in the
+running dfuse process.
+Due to limitations of the current implementation, the command needs to be run on all client machines
+running a `dfuse` process. This limitation may be avoided by enabling telemetry for a container
+_before_ starting any dfuse clients.
+
+```shell
+# Dump metrics to a container in the same pool as the source container:
+$ daos container telemetry enable poolA contA --dump-cont=contB
+
+# Dump metrics to a container in a different pool:
+$ daos container telemetry enable poolA contA --dump-pool=poolB --dump-cont=contB
+
+# Obtain the source pool/cont from a dfuse mountpoint:
+$ daos container telemetry enable --path=/mnt/daos --dump-cont=contB
+```
+
+To disable telemetry for a container, use the disable command (**NB**: the same
+consideration for a running dfuse process applies):
+
+```shell
+# Disable telemetry for a container without running dfuse clients:
+$ daos container telemetry disable poolA contA
+
+# Disable telemetry for a container backing a running dfuse client:
+$ daos container telemetry disable --path=/mnt/daos
+```
+
+> **_NOTE:_** The CSV files for clients configured to dump their telemetry using this
+method may only contain a subset of available client metrics. The difference in
+behavior depends on whether or not client telemetry has been enabled via `daos_agent`
+configuration. In cases where client telemetry is _only_ enabled via container
+parameters, the set of client metrics will be restricted to the DFS-layer metrics for
+the container where telemetry is enabled.
+
+## Managed Use Cases
+
+In addition to the user-driven use cases, the client telemetry feature provides capabilities
+for integration with a site-provided telemetry solution. For a full description of the
+Prometheus integration, refer to the <a href="/src/gurt/telemetry.md">DAOS telemetry library</a> documentation.
+
+### Enabling Client Telemetry for All libdaos Clients
+
+In this mode, libdaos clients will record telemetry in shared memory segments so that the
+`daos_agent` process can export the metrics via the configured Prometheus endpoint. By default,
+these shared memory segments are cleaned up immediately after the client process exits, but
+the agent may be configured to retain the segments for some period of time after client exit.
+
+The minimal <a href="/utils/config/daos_agent.yml">daos_agent.yml</a> configuration required to
+enable client telemetry would look something like the following:
+
+```yaml
+telemetry_port: 9192 # set to a port that will otherwise be unused on the client machine(s)
+telemetry_enabled: true
+```
+
+If it is desirable to retain the client telemetry segments for a period of time after client exit,
+use the `telemetry_retain:` parameter to set a duration value (e.g. 30s, 1m). This parameter may
+be used to allow the monitoring infrastructure time to capture a final sample. Future updates to
+the implementation may provide other retention options, e.g. "retain until read".
+
+### Enabling Client Telemetry for Selected libdaos Clients
+
+In scenarios where some clients should use shared memory for sampled telemetry and other clients
+should be controlled by user-initiated action, it is possible to configure the agent such that
+it only enables telemetry for a subset of clients. One such example of this scenario might be an
+environment where long-running `dfuse` clients are monitored via telemetry infrastructure, and
+other ephemeral clients are optionally configured to dump telemetry on exit for post-workload
+analysis.
+
+The `daos_agent.yml` configuration parameters controlling this feature would look something like
+the following (**NB**: These parameters are mutually exclusive):
+
+```yaml
+telemetry_enabled_procs: <regex> # only clients matching this regex will have telemetry enabled
+telemetry_disabled_procs: <regex> # clients matching this regex will not have telemetry disabled
+```
+
+### Developer Access
+
+When shared telemetry has been enabled for a client process, the typical use case for it is to
+be exported via `daos_agent`. It is, however, possible for a user to access the shared telemetry
+via the `daos_metrics` tool. This tool was created primarily to enable lightweight developer
+access to the server and client telemetry via shared memory on the same host as the
+telemetry producer process.
+
+Running the tool requires read permissions on the shared memory segments exposed by the client
+and knowledge of the client process PID, e.g. `daos_metrics --cli_pid=<pid>`
+
+# Client Telemetry Examples
+
+The following section contains examples of DAOS client telemetry dumped at process exit and
+sampled during runtime. Note that these are only provided as examples and are not intended to
+be canonical references for the entire set of available metrics, which may change from release
+to release.
+
+## CSV Dump Files
+
+When the `DAOS_CLIENT_METRICS_DUMP_DIR` environment variable is set, the dump path will be whatever
+was set, and the filename will follow the pattern `<dc_jobid>-<pid>.csv`. The value of `<dc_jobid>`
+is defined in <a href="/src/client/api/job.c">job.c</a>. If the `DAOS_JOBID` environment
+variable has been set, then that value will be used. Otherwise the default (`<hostname>-<pid>`) will
+be used.
+
+When the metrics container dump method is enabled, the path to each client CSV is generated following
+a pattern that is designed to reduce storage "hot spots" and allow for easy time-based cleanup of
+client CSVs. The generated paths differ slightly depending on whether or not a custom `DAOS_JOBID`
+value has been set:
+
+```
+# DAOS_JOBID=foo
+-> <root>/<yyyy>/<mm>/<dd>/<hh>/job/foo/<proc_name>/<epoch>-<hostname>-<pid>.csv
+```
+
+```
+# DAOS_JOBID unset
+-> <root>/<yyyy>/<mm>/<dd>/<hh>/proc/<proc_name>/<epoch>-<hostname>-<pid>.csv
+```
+
+Note that the time-based components of the path are always in GMT. Future updates may allow
+for more configurability of the path pattern.
+
+### CSV Dump File Example
+
+```
+$ cat /mnt/daos/metrics/2025/04/30/18/proc/rsync/1746038198-testhost-2687361.csv
+name,value,min,max,mean,sample_size,sum,std_dev
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/CHMOD,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/CHOWN,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/CREATE,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/GETSIZE,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/GETXATTR,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/LSXATTR,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/MKDIR,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/OPEN,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/OPENDIR,15
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/READ,34
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/READDIR,15
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/READLINK,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/RENAME,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/RMXATTR,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/SETATTR,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/SETXATTR,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/STAT,83
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/SYMLINK,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/SYNC,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/TRUNCATE,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/UNLINK,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/ops/WRITE,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes,39534,3426,39534,13925.411765,34,473464,7312.911418
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/0_255_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/256_511_bytes,3
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/512_1023_bytes,27
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/1024_2047_bytes,2
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/2048_4095_bytes,1
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/4096_8191_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/8192_16383_bytes,1
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/16384_32767_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/32768_65535_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/65536_131071_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/131072_262143_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/262144_524287_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/524288_1048575_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/1048576_2097151_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/2097152_4194303_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/read_bytes/4194304_inf_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/0_255_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/256_511_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/512_1023_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/1024_2047_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/2048_4095_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/4096_8191_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/8192_16383_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/16384_32767_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/32768_65535_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/65536_131071_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/131072_262143_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/262144_524287_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/524288_1048575_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/1048576_2097151_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/2097152_4194303_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dfs/write_bytes/4194304_inf_bytes,0
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/mount_time,Wed Apr 30 18:36:36 2025
+2687361/pool/fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd/container/1a6fef2b-0cbc-4e11-9edd-6abb252e93c8/dump_time,Wed Apr 30 18:36:38 2025
+```
+
+## Prometheus Export Example
+
+The `dmg` tool includes a subcommand for displaying telemetry exposed via Prometheus endpoint. When
+the `daos_agent` process has been configured to export client telemetry, the `dmg` tool may be used
+to inspect the metrics. The metrics returned from a `dmg` invocation are from a single sample of
+all available metrics at that time.
+
+In this example, the output is from querying an agent that is managing telemetry for a single
+`dfuse` process:
+
+```
+$ dmg telemetry metrics query -p 9292 --hostname localhost
+connecting to localhost:9292...
+- Metric Set: client_dfs_ops_chmod (Type: Counter)
+  Count of CHMOD calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_chown (Type: Counter)
+  Count of CHOWN calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_create (Type: Counter)
+  Count of CREATE calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_getsize (Type: Counter)
+  Count of GETSIZE calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_getxattr (Type: Counter)
+  Count of GETXATTR calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_lsxattr (Type: Counter)
+  Count of LSXATTR calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_mkdir (Type: Counter)
+  Count of MKDIR calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_open (Type: Counter)
+  Count of OPEN calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_opendir (Type: Counter)
+  Count of OPENDIR calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_read (Type: Counter)
+  Count of READ calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_readdir (Type: Counter)
+  Count of READDIR calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_readlink (Type: Counter)
+  Count of READLINK calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_rename (Type: Counter)
+  Count of RENAME calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_rmxattr (Type: Counter)
+  Count of RMXATTR calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_setattr (Type: Counter)
+  Count of SETATTR calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_setxattr (Type: Counter)
+  Count of SETXATTR calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_stat (Type: Counter)
+  Count of STAT calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_symlink (Type: Counter)
+  Count of SYMLINK calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_sync (Type: Counter)
+  Count of SYNC calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_truncate (Type: Counter)
+  Count of TRUNCATE calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_unlink (Type: Counter)
+  Count of UNLINK calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_ops_write (Type: Counter)
+  Count of WRITE calls
+    Metric  Labels                                                                                                                Value 
+    ------  ------                                                                                                                ----- 
+    Counter (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_dfs_read_bytes (Type: Histogram)
+  dfs read bytes
+    Metric                      Labels                                                                                                                Value        
+    ------                      ------                                                                                                                -----        
+    Sample Count                (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Sample Sum                  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(0) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 255          
+    Bucket(0) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(1) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 511          
+    Bucket(1) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(2) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 1023         
+    Bucket(2) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(3) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 2047         
+    Bucket(3) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(4) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 4095         
+    Bucket(4) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(5) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 8191         
+    Bucket(5) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(6) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 16383        
+    Bucket(6) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(7) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 32767        
+    Bucket(7) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(8) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 65535        
+    Bucket(8) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(9) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 131071       
+    Bucket(9) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(10) Upper Bound      (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 262143       
+    Bucket(10) Cumulative Count (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(11) Upper Bound      (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 524287       
+    Bucket(11) Cumulative Count (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(12) Upper Bound      (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 1.048575e+06 
+    Bucket(12) Cumulative Count (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(13) Upper Bound      (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 2.097151e+06 
+    Bucket(13) Cumulative Count (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(14) Upper Bound      (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 4.194303e+06 
+    Bucket(14) Cumulative Count (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(15) Upper Bound      (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) +Inf         
+    Bucket(15) Cumulative Count (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+
+- Metric Set: client_dfs_write_bytes (Type: Histogram)
+  dfs write bytes
+    Metric                      Labels                                                                                                                Value        
+    ------                      ------                                                                                                                -----        
+    Sample Count                (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Sample Sum                  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(0) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 255          
+    Bucket(0) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(1) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 511          
+    Bucket(1) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(2) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 1023         
+    Bucket(2) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(3) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 2047         
+    Bucket(3) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(4) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 4095         
+    Bucket(4) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(5) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 8191         
+    Bucket(5) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(6) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 16383        
+    Bucket(6) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(7) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 32767        
+    Bucket(7) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(8) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 65535        
+    Bucket(8) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(9) Upper Bound       (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 131071       
+    Bucket(9) Cumulative Count  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(10) Upper Bound      (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 262143       
+    Bucket(10) Cumulative Count (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(11) Upper Bound      (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 524287       
+    Bucket(11) Cumulative Count (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(12) Upper Bound      (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 1.048575e+06 
+    Bucket(12) Cumulative Count (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(13) Upper Bound      (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 2.097151e+06 
+    Bucket(13) Cumulative Count (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(14) Upper Bound      (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 4.194303e+06 
+    Bucket(14) Cumulative Count (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+    Bucket(15) Upper Bound      (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) +Inf         
+    Bucket(15) Cumulative Count (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0            
+
+- Metric Set: client_io_latency_fetch (Type: Gauge)
+  fetch RPC processing time
+    Metric Labels                                                      Value 
+    ------ ------                                                      ----- 
+    Gauge  (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  3060  
+    Gauge  (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_latency_fetch_max (Type: Gauge)
+  fetch RPC processing time (max value)
+    Metric Labels                                                      Value 
+    ------ ------                                                      ----- 
+    Gauge  (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  3227  
+    Gauge  (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_latency_fetch_mean (Type: Gauge)
+  fetch RPC processing time (mean)
+    Metric Labels                                                      Value 
+    ------ ------                                                      ----- 
+    Gauge  (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  2121  
+    Gauge  (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_latency_fetch_min (Type: Gauge)
+  fetch RPC processing time (min value)
+    Metric Labels                                                      Value 
+    ------ ------                                                      ----- 
+    Gauge  (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  76    
+    Gauge  (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_latency_fetch_samples (Type: Counter)
+  fetch RPC processing time (samples)
+    Metric  Labels                                                      Value 
+    ------  ------                                                      ----- 
+    Counter (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  3     
+    Counter (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_latency_fetch_stddev (Type: Gauge)
+  fetch RPC processing time (std dev)
+    Metric Labels                                                      Value              
+    ------ ------                                                      -----              
+    Gauge  (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  1772.9892836675579 
+    Gauge  (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0                  
+    Gauge  (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0                  
+
+- Metric Set: client_io_latency_fetch_sum (Type: Counter)
+  fetch RPC processing time (sum)
+    Metric  Labels                                                      Value 
+    ------  ------                                                      ----- 
+    Counter (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  6363  
+    Counter (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_latency_fetch_sumsquares (Type: Counter)
+  fetch RPC processing time (sum of squares)
+    Metric  Labels                                                      Value         
+    ------  ------                                                      -----         
+    Counter (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0             
+    Counter (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0             
+    Counter (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0             
+    Counter (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0             
+    Counter (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0             
+    Counter (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0             
+    Counter (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0             
+    Counter (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0             
+    Counter (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0             
+    Counter (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0             
+    Counter (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0             
+    Counter (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  1.9782905e+07 
+    Counter (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0             
+    Counter (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0             
+    Counter (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0             
+    Counter (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0             
+
+- Metric Set: client_io_latency_update (Type: Gauge)
+  update RPC processing time
+    Metric Labels                                                      Value 
+    ------ ------                                                      ----- 
+    Gauge  (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_latency_update_max (Type: Gauge)
+  update RPC processing time (max value)
+    Metric Labels                                                      Value 
+    ------ ------                                                      ----- 
+    Gauge  (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_latency_update_mean (Type: Gauge)
+  update RPC processing time (mean)
+    Metric Labels                                                      Value 
+    ------ ------                                                      ----- 
+    Gauge  (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_latency_update_min (Type: Gauge)
+  update RPC processing time (min value)
+    Metric Labels                                                      Value 
+    ------ ------                                                      ----- 
+    Gauge  (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_latency_update_samples (Type: Counter)
+  update RPC processing time (samples)
+    Metric  Labels                                                      Value 
+    ------  ------                                                      ----- 
+    Counter (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_latency_update_stddev (Type: Gauge)
+  update RPC processing time (std dev)
+    Metric Labels                                                      Value 
+    ------ ------                                                      ----- 
+    Gauge  (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Gauge  (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Gauge  (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Gauge  (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_latency_update_sum (Type: Counter)
+  update RPC processing time (sum)
+    Metric  Labels                                                      Value 
+    ------  ------                                                      ----- 
+    Counter (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_latency_update_sumsquares (Type: Counter)
+  update RPC processing time (sum of squares)
+    Metric  Labels                                                      Value 
+    ------  ------                                                      ----- 
+    Counter (jobid=dfuse, pid=2688260, size=128KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=16KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=1KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=1MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=256B, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=256KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=2KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=2MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=32KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=4KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=4MB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=512B, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=512KB, tid=140048582007104) 0     
+    Counter (jobid=dfuse, pid=2688260, size=64KB, tid=140048582007104)  0     
+    Counter (jobid=dfuse, pid=2688260, size=8KB, tid=140048582007104)   0     
+    Counter (jobid=dfuse, pid=2688260, size=GT4MB, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_enum_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_akey_punch_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_compound_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_enum_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_dkey_punch_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_agg_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_ec_rep_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_fetch_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_fetch_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 1     
+
+- Metric Set: client_io_ops_fetch_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0.5   
+
+- Metric Set: client_io_ops_fetch_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_fetch_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 6     
+
+- Metric Set: client_io_ops_fetch_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value              
+    ------ ------                                          -----              
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0.5477225575051661 
+
+- Metric Set: client_io_ops_fetch_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 3     
+
+- Metric Set: client_io_ops_fetch_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 3     
+
+- Metric Set: client_io_ops_key2anchor_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key2anchor_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key_query_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key_query_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 1     
+
+- Metric Set: client_io_ops_key_query_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0.5   
+
+- Metric Set: client_io_ops_key_query_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key_query_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 2     
+
+- Metric Set: client_io_ops_key_query_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value              
+    ------ ------                                          -----              
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0.7071067811865476 
+
+- Metric Set: client_io_ops_key_query_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 1     
+
+- Metric Set: client_io_ops_key_query_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 1     
+
+- Metric Set: client_io_ops_key_query_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 252   
+
+- Metric Set: client_io_ops_key_query_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 252   
+
+- Metric Set: client_io_ops_key_query_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 252   
+
+- Metric Set: client_io_ops_key_query_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 252   
+
+- Metric Set: client_io_ops_key_query_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 1     
+
+- Metric Set: client_io_ops_key_query_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_key_query_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 252   
+
+- Metric Set: client_io_ops_key_query_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 63504 
+
+- Metric Set: client_io_ops_migrate_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_migrate_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_punch_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_coll_query_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_enum_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_punch_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_obj_sync_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_recx_enum_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_akey_punch_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_dkey_punch_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_latency (Type: Gauge)
+  object RPC processing time
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_latency_max (Type: Gauge)
+  object RPC processing time (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_latency_mean (Type: Gauge)
+  object RPC processing time (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_latency_min (Type: Gauge)
+  object RPC processing time (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_latency_samples (Type: Counter)
+  object RPC processing time (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_latency_stddev (Type: Gauge)
+  object RPC processing time (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_latency_sum (Type: Counter)
+  object RPC processing time (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_punch_latency_sumsquares (Type: Counter)
+  object RPC processing time (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_update_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_update_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_update_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_update_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_update_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_update_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_update_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_tgt_update_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_update_active (Type: Gauge)
+  number of active object RPCs
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_update_active_max (Type: Gauge)
+  number of active object RPCs (max value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_update_active_mean (Type: Gauge)
+  number of active object RPCs (mean)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_update_active_min (Type: Gauge)
+  number of active object RPCs (min value)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_update_active_samples (Type: Counter)
+  number of active object RPCs (samples)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_update_active_stddev (Type: Gauge)
+  number of active object RPCs (std dev)
+    Metric Labels                                          Value 
+    ------ ------                                          ----- 
+    Gauge  (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_update_active_sum (Type: Counter)
+  number of active object RPCs (sum)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_io_ops_update_active_sumsquares (Type: Counter)
+  number of active object RPCs (sum of squares)
+    Metric  Labels                                          Value 
+    ------  ------                                          ----- 
+    Counter (jobid=dfuse, pid=2688260, tid=140048582007104) 0     
+
+- Metric Set: client_net_hg_active_rpcs (Type: Gauge)
+  Mercury-layer count of active RPCs
+    Metric Labels                                                  Value 
+    ------ ------                                                  ----- 
+    Gauge  (context=0, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+    Gauge  (context=1, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+
+- Metric Set: client_net_hg_bulks (Type: Counter)
+  Mercury-layer count of bulk transfers
+    Metric  Labels                                                  Value 
+    ------  ------                                                  ----- 
+    Counter (context=0, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+    Counter (context=1, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+
+- Metric Set: client_net_hg_extra_bulk_req (Type: Counter)
+  Mercury-layer count of RPCs with extra bulk request
+    Metric  Labels                                                  Value 
+    ------  ------                                                  ----- 
+    Counter (context=0, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+    Counter (context=1, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+
+- Metric Set: client_net_hg_extra_bulk_resp (Type: Counter)
+  Mercury-layer count of RPCs with extra bulk response
+    Metric  Labels                                                  Value 
+    ------  ------                                                  ----- 
+    Counter (context=0, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+    Counter (context=1, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+
+- Metric Set: client_net_hg_mr_copies (Type: Counter)
+  Mercury-layer count of multi-recv RPC requests requiring a copy
+    Metric  Labels                                                  Value 
+    ------  ------                                                  ----- 
+    Counter (context=0, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+    Counter (context=1, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+
+- Metric Set: client_net_hg_req_recv (Type: Counter)
+  Mercury-layer count of RPC requests received
+    Metric  Labels                                                  Value 
+    ------  ------                                                  ----- 
+    Counter (context=0, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+    Counter (context=1, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+
+- Metric Set: client_net_hg_req_sent (Type: Counter)
+  Mercury-layer count of RPC requests sent
+    Metric  Labels                                                  Value 
+    ------  ------                                                  ----- 
+    Counter (context=0, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+    Counter (context=1, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+
+- Metric Set: client_net_hg_resp_recv (Type: Counter)
+  Mercury-layer count of RPC responses received
+    Metric  Labels                                                  Value 
+    ------  ------                                                  ----- 
+    Counter (context=0, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+    Counter (context=1, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+
+- Metric Set: client_net_hg_resp_sent (Type: Counter)
+  Mercury-layer count of RPC responses sent
+    Metric  Labels                                                  Value 
+    ------  ------                                                  ----- 
+    Counter (context=0, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+    Counter (context=1, jobid=dfuse, pid=2688260, provider=ofi+tcp) 0     
+
+- Metric Set: client_pool_dump_time (Type: Gauge)
+  container dump time
+    Metric Labels                                                                                                                Value 
+    ------ ------                                                                                                                ----- 
+    Gauge  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ec_agg_blocked (Type: Counter)
+  total number of EC agg pauses due to VOS discard or agg
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ec_update_full_stripe (Type: Counter)
+  total number of EC full-stripe updates
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ec_update_partial (Type: Counter)
+  total number of EC partial updates
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_mount_time (Type: Gauge)
+  container mount time
+    Metric Labels                                                                                                                Value           
+    ------ ------                                                                                                                -----           
+    Gauge  (container=1a6fef2b-0cbc-4e11-9edd-6abb252e93c8, jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 1.746038345e+09 
+
+- Metric Set: client_pool_ops_akey_enum (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_akey_punch (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_compound (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_dkey_enum (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_dkey_punch (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_ec_agg (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_ec_rep (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_fetch (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_key2anchor (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_key_query (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_migrate (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_obj_coll_punch (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_obj_coll_query (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_obj_enum (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_obj_punch (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_obj_sync (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_recx_enum (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_tgt_akey_punch (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_tgt_dkey_punch (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_tgt_punch (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_tgt_update (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_ops_update (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_resent (Type: Counter)
+  total number of resent update RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_restarted (Type: Counter)
+  total number of restarted update ops
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_retry (Type: Counter)
+  total number of retried update RPCs
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_pool_xferred_fetch (Type: Counter)
+  total number of bytes fetched/read
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 956   
+
+- Metric Set: client_pool_xferred_update (Type: Counter)
+  total number of bytes updated/written
+    Metric  Labels                                                                Value 
+    ------  ------                                                                ----- 
+    Counter (jobid=dfuse, pid=2688260, pool=fd69d9b8-c863-4bd8-8fc2-59db53ad8cdd) 0     
+
+- Metric Set: client_started_at (Type: Gauge)
+  Timestamp of client startup
+    Metric Labels                     Value           
+    ------ ------                     -----           
+    Gauge  (jobid=dfuse, pid=2688260) 1.746038345e+09 
+
+(Not shown: Go runtime metrics)
+```

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -62,6 +62,8 @@ type containerCmd struct {
 	DestroySnapshot containerSnapDestroyCmd      `command:"destroy-snap" description:"destroy container snapshot"`
 	ListSnapshots   containerSnapListCmd         `command:"list-snap" alias:"list-snaps" description:"list container snapshots"`
 	Rollback        containerSnapshotRollbackCmd `command:"rollback" description:"roll back container to specified snapshot"`
+
+	Telemetry containerTelemetryCmd `command:"telemetry" description:"container telemetry commands"`
 }
 
 type containerBaseCmd struct {

--- a/src/control/cmd/daos/telemetry.go
+++ b/src/control/cmd/daos/telemetry.go
@@ -1,0 +1,81 @@
+//
+// (C) Copyright 2025 Google LLC.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+import (
+	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/daos/api"
+)
+
+type containerTelemetryCmd struct {
+	Enable  containerEnableTelemetryCmd  `command:"enable" description:"enable container telemetry"`
+	Disable containerDisableTelemetryCmd `command:"disable" description:"disable container telemetry"`
+}
+
+type containerEnableTelemetryCmd struct {
+	existingContainerCmd
+
+	DumpPool PoolID      `long:"dump-pool" short:"P" description:"Pool hosting the telemetry dump container (default: this pool)"`
+	DumpCont ContainerID `long:"dump-cont" short:"C" description:"Container hosting the telemetry dump"`
+	DumpDir  string      `long:"dump-dir" short:"D" description:"Root directory (local or in dump container) for telemetry dump"`
+}
+
+func (cmd *containerEnableTelemetryCmd) Execute(_ []string) error {
+	ap, deallocCmdArgs, err := allocCmdArgs(cmd.Logger)
+	if err != nil {
+		return err
+	}
+	defer deallocCmdArgs()
+
+	cleanup, err := cmd.resolveAndOpen(daos.ContainerOpenFlagReadWrite, ap)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	req := api.ContainerTelemetryRequest{
+		DumpPoolID:      cmd.DumpPool.String(),
+		DumpContainerID: cmd.DumpCont.String(),
+		DumpPathRoot:    cmd.DumpDir,
+		DfuseMountPath:  cmd.Path,
+	}
+	if req.DumpPoolID == "" {
+		req.DumpPoolID = cmd.pool.ID()
+	}
+
+	if err := cmd.container.EnableTelemetry(cmd.MustLogCtx(), req); err != nil {
+		return err
+	}
+
+	cmd.Infof("Container telemetry enabled (dumping to %s:%s%s)", req.DumpPoolID, req.DumpContainerID, req.DumpPathRoot)
+	return nil
+}
+
+type containerDisableTelemetryCmd struct {
+	existingContainerCmd
+}
+
+func (cmd *containerDisableTelemetryCmd) Execute(_ []string) error {
+	ap, deallocCmdArgs, err := allocCmdArgs(cmd.Logger)
+	if err != nil {
+		return err
+	}
+	defer deallocCmdArgs()
+
+	cleanup, err := cmd.resolveAndOpen(daos.ContainerOpenFlagReadWrite, ap)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if err := cmd.container.DisableTelemetry(cmd.MustLogCtx(), &cmd.Path); err != nil {
+		return err
+	}
+
+	cmd.Info("Container telemetry disabled")
+	return nil
+}

--- a/src/control/cmd/daos/telemetry_test.go
+++ b/src/control/cmd/daos/telemetry_test.go
@@ -1,0 +1,113 @@
+//
+// (C) Copyright 2025 Google LLC
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/lib/daos/api"
+	"github.com/daos-stack/daos/src/control/lib/ui"
+)
+
+func TestDaos_containerEnableTelemetryCmd(t *testing.T) {
+	baseArgs := test.JoinArgs(nil, "container", "telemetry", "enable")
+	fullArgs := test.JoinArgs(baseArgs, defaultPoolInfo.Label, defaultContInfo.ContainerLabel)
+
+	for name, tc := range map[string]struct {
+		args    []string
+		expErr  error
+		expArgs containerEnableTelemetryCmd
+		setup   func(t *testing.T)
+	}{
+		"invalid flag": {
+			args:   test.JoinArgs(fullArgs, "--bad"),
+			expErr: errors.New("unknown flag"),
+		},
+		"open fails": {
+			args:   test.JoinArgs(fullArgs, "-C", "dump"),
+			expErr: errors.New("whoops"),
+			setup: func(t *testing.T) {
+				prevErr := contOpenErr
+				t.Cleanup(func() {
+					contOpenErr = prevErr
+				})
+				contOpenErr = errors.New("whoops")
+			},
+		},
+		"missing source container": {
+			args:   test.JoinArgs(baseArgs, defaultPoolInfo.Label, "-C", "dump"),
+			expErr: errors.New("no container"),
+		},
+		"missing required arguments": {
+			args:   fullArgs,
+			expErr: errors.New("DumpContainerID must be set if DumpPoolID is set"),
+		},
+		"success": {
+			args: test.JoinArgs(fullArgs, "-C", "dump"),
+			expArgs: containerEnableTelemetryCmd{
+				DumpCont: ContainerID{argOrID: argOrID{LabelOrUUIDFlag: ui.LabelOrUUIDFlag{Label: "dump"}}},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Cleanup(api.ResetTestStubs)
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+
+			runCmdTest(t, tc.args, tc.expArgs, tc.expErr, "Container.Telemetry.Enable")
+		})
+	}
+}
+
+func TestDaos_containerDisableTelemetryCmd(t *testing.T) {
+	baseArgs := test.JoinArgs(nil, "container", "telemetry", "disable")
+	fullArgs := test.JoinArgs(baseArgs, defaultPoolInfo.Label, defaultContInfo.ContainerLabel)
+
+	for name, tc := range map[string]struct {
+		args    []string
+		expErr  error
+		expArgs containerDisableTelemetryCmd
+		setup   func(t *testing.T)
+	}{
+		"invalid flag": {
+			args:   test.JoinArgs(fullArgs, "--bad"),
+			expErr: errors.New("unknown flag"),
+		},
+		"open fails": {
+			args:   fullArgs,
+			expErr: errors.New("whoops"),
+			setup: func(t *testing.T) {
+				prevErr := contOpenErr
+				t.Cleanup(func() {
+					contOpenErr = prevErr
+				})
+				contOpenErr = errors.New("whoops")
+			},
+		},
+		"missing source container": {
+			args:   test.JoinArgs(baseArgs, defaultPoolInfo.Label),
+			expErr: errors.New("no container"),
+		},
+		"success": {
+			args:    fullArgs,
+			expArgs: containerDisableTelemetryCmd{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Cleanup(api.ResetTestStubs)
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+
+			runCmdTest(t, tc.args, tc.expArgs, tc.expErr, "Container.Telemetry.Disable")
+		})
+	}
+}

--- a/src/control/cmd/daos/util_test.go
+++ b/src/control/cmd/daos/util_test.go
@@ -66,6 +66,12 @@ func runCmdTest(t *testing.T, args []string, expCmd any, expErr error, cmdPath s
 		cmp.Comparer(func(a, b ui.ByteSizeFlag) bool {
 			return a.String() == b.String()
 		}),
+		cmp.Comparer(func(a, b PoolID) bool {
+			return a.String() == b.String()
+		}),
+		cmp.Comparer(func(a, b ContainerID) bool {
+			return a.String() == b.String()
+		}),
 	}...)
 	test.CmpAny(t, fmt.Sprintf("%s args", cmdPath), expCmd, testCmd.Interface(), cmpOpts...)
 }

--- a/src/control/lib/daos/api/ioctl.go
+++ b/src/control/lib/daos/api/ioctl.go
@@ -1,0 +1,52 @@
+//
+// (C) Copyright 2025 Google LLC
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//go:build !test_stubs
+// +build !test_stubs
+
+package api
+
+/*
+#include <fcntl.h>
+#include <sys/ioctl.h>
+
+#include <dfuse_ioctl.h>
+
+static int
+call_dfuse_telemetry_ioctl(char *path, bool enabled)
+{
+	int fd;
+	int rc;
+
+	fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+	if (fd < 0)
+		return errno;
+
+	errno = 0;
+	rc = ioctl(fd, DFUSE_IOCTL_METRICS_TOGGLE, &enabled);
+	if (rc != 0) {
+		int err = errno;
+
+		close(fd);
+		return err;
+	}
+	close(fd);
+
+	return 0;
+}
+*/
+import "C"
+
+func call_dfuse_telemetry_ioctl(path string, enabled bool) error {
+	cPath := C.CString(path)
+	defer freeString(cPath)
+
+	_, err := C.call_dfuse_telemetry_ioctl(cPath, C.bool(enabled))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/src/control/lib/daos/api/ioctl_stubs.go
+++ b/src/control/lib/daos/api/ioctl_stubs.go
@@ -1,0 +1,32 @@
+//
+// (C) Copyright 2025 Google LLC
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//go:build test_stubs
+// +build test_stubs
+
+package api
+
+func reset_ioctl_stubs() {
+	reset_call_dfuse_telemetry_ioctl()
+}
+
+var (
+	call_dfuse_telemetry_ioctl_Error   error
+	call_dfuse_telemetry_ioctl_Enabled bool
+)
+
+func reset_call_dfuse_telemetry_ioctl() {
+	call_dfuse_telemetry_ioctl_Error = nil
+	call_dfuse_telemetry_ioctl_Enabled = false
+}
+
+func call_dfuse_telemetry_ioctl(_ string, enabled bool) error {
+	if call_dfuse_telemetry_ioctl_Error != nil {
+		return call_dfuse_telemetry_ioctl_Error
+	}
+
+	call_dfuse_telemetry_ioctl_Enabled = enabled
+	return nil
+}

--- a/src/control/lib/daos/api/pool_test.go
+++ b/src/control/lib/daos/api/pool_test.go
@@ -811,6 +811,7 @@ func TestAPI_PoolHandleMethods(t *testing.T) {
 		method := thType.Method(i)
 		methArgs := make([]reflect.Value, 0)
 		var expResults int
+		defaultContLabel := daos_default_ContainerInfo.ContainerLabel
 
 		switch method.Name {
 		case "Disconnect":
@@ -836,13 +837,13 @@ func TestAPI_PoolHandleMethods(t *testing.T) {
 			methArgs = append(methArgs, reflect.ValueOf(true))
 			expResults = 2
 		case "DestroyContainer":
-			methArgs = append(methArgs, reflect.ValueOf("foo"), reflect.ValueOf(true))
+			methArgs = append(methArgs, reflect.ValueOf(defaultContLabel), reflect.ValueOf(true))
 			expResults = 1
 		case "QueryContainer":
-			methArgs = append(methArgs, reflect.ValueOf("foo"))
+			methArgs = append(methArgs, reflect.ValueOf(defaultContLabel))
 			expResults = 2
 		case "OpenContainer":
-			methArgs = append(methArgs, reflect.ValueOf(ContainerOpenReq{ID: "foo"}))
+			methArgs = append(methArgs, reflect.ValueOf(ContainerOpenReq{ID: defaultContLabel}))
 			expResults = 2
 		case "FillHandle", "IsValid", "String", "UUID", "ID":
 			// No tests for these. The main point of this suite is to ensure that the

--- a/src/control/lib/daos/api/test_stubs.go
+++ b/src/control/lib/daos/api/test_stubs.go
@@ -33,4 +33,5 @@ func ResetTestStubs() {
 	reset_daos_pool_stubs()
 	reset_daos_cont_stubs()
 	reset_dfs_stubs()
+	reset_ioctl_stubs()
 }

--- a/src/control/lib/daos/constants.go
+++ b/src/control/lib/daos/constants.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2022 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -8,6 +9,7 @@ package daos
 
 /*
 #include <daos_types.h>
+#include <daos/metrics.h>
 */
 import "C"
 
@@ -19,4 +21,13 @@ const (
 
 	// MaxAttributeNameLength defines the maximum length of an attribute name.
 	MaxAttributeNameLength = C.DAOS_ATTR_NAME_MAX
+
+	// ClientMetricsDumpPoolAttr defines the attribute name for the pool hosting the telemetry dumps.
+	ClientMetricsDumpPoolAttr = C.DAOS_CLIENT_METRICS_DUMP_POOL_ATTR
+
+	// ClientMetricsDumpContAttr defines the attribute name for the container hosting the telemetry dumps.
+	ClientMetricsDumpContAttr = C.DAOS_CLIENT_METRICS_DUMP_CONT_ATTR
+
+	// ClientMetricsDumpDirAttr defines the attribute name for the directory hosting the telemetry dumps.
+	ClientMetricsDumpDirAttr = C.DAOS_CLIENT_METRICS_DUMP_DIR_ATTR
 )

--- a/src/control/lib/telemetry/promexp/README.md
+++ b/src/control/lib/telemetry/promexp/README.md
@@ -1,0 +1,129 @@
+# Prometheus Exporter for DAOS
+
+This package implements the
+<a href="https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md">Prometheus exposition format</a> 
+for DAOS telemetry. It includes a minimal httpd implementation that serves a `/metrics` endpoint which contains
+metrics for the `daos_server` or `daos_agent` process hosting the endpoint.
+
+## Client Metrics
+
+Refer to the <a href="/src/client/telemetry.md">Client Telemetry documentation</a> for a full description
+of the available options and configuration possibilities.
+
+## Server Metrics
+
+To enable export of server metrics, add the `telemetry_port: <port>` parameter to the `daos_server`
+<a href="/utils/config/daos_server.yml">configuration file</a>. The port chosen should not conflict
+with other services on the host. The `dmg` tool provided as part of the DAOS admin installation will
+default to port 9191 if no port is specified, so this is a good choice if it's available.
+
+## Metric Naming and Labels
+
+The Prometheus exposition format specifies conventions and rules for how metrics are named and
+labeled. In the <a href="/src/gurt/telemetry.md">DAOS Telemetry Library</a>, metrics are named
+based on their position in the telemetry tree. These names must be flattened and adjusted to
+conform to Prometheus standards, however.
+
+For example, the following DAOS metrics track the count of Update (Write) operations
+received by targets in a given pool on a single engine (as shown via `daos_metrics --csv`):
+```
+ID: 0/pool/8d69add3-0e79-4cdd-8663-e32c6ae5fbdb/ops/update/tgt_7,40
+ID: 0/pool/8d69add3-0e79-4cdd-8663-e32c6ae5fbdb/ops/update/tgt_0,48
+ID: 0/pool/8d69add3-0e79-4cdd-8663-e32c6ae5fbdb/ops/update/tgt_5,36
+ID: 0/pool/8d69add3-0e79-4cdd-8663-e32c6ae5fbdb/ops/update/tgt_6,40
+ID: 0/pool/8d69add3-0e79-4cdd-8663-e32c6ae5fbdb/ops/update/tgt_4,50
+ID: 0/pool/8d69add3-0e79-4cdd-8663-e32c6ae5fbdb/ops/update/tgt_2,54
+ID: 0/pool/8d69add3-0e79-4cdd-8663-e32c6ae5fbdb/ops/update/tgt_1,41
+ID: 0/pool/8d69add3-0e79-4cdd-8663-e32c6ae5fbdb/ops/update/tgt_3,44
+```
+
+The tree is rooted at the engine index (0), and follows a path down the branches to each
+`tgt_N` leaf metric node. Each metric has a unique name based on its full path from the root.
+
+This same set of metrics expressed in Prometheus format looks like the
+following:
+```
+- Metric Set: engine_pool_ops_update (Type: Counter)
+  total number of processed object RPCs
+    Metric  Labels                                                        Value
+    ------  ------                                                        -----
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=0, target=0) 48
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=0, target=1) 41
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=0, target=2) 54
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=0, target=3) 44
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=0, target=4) 50
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=0, target=5) 36
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=0, target=6) 40
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=0, target=7) 40
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=1, target=0) 44
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=1, target=1) 45
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=1, target=2) 39
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=1, target=3) 34
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=1, target=4) 54
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=1, target=5) 35
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=1, target=6) 45
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=1, target=7) 37
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=2, target=0) 39
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=2, target=1) 45
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=2, target=2) 45
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=2, target=3) 34
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=2, target=4) 41
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=2, target=5) 57
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=2, target=6) 46
+    Counter (pool=8d69add3-0e79-4cdd-8663-e32c6ae5fbdb, rank=2, target=7) 34
+```
+
+This server hosts 3 engines (ranks), hence the increased number of datapoints. Note that
+there is now a single metric name: `engine_pool_ops_update`. This name is derived from the path
+according to rules defined in the <a href="/src/control/lib/telemetry/promexp/engine.go">engine collector</a>.
+The individual datapoints are _labeled_ as characteristics that may be used to refine queries of
+the entity being measured (in this case, the number of update operations seen across all pools,
+ranks, and targets).
+
+## Basic Prometheus and Grafana Configuration
+
+As the technologies related to metrics collection and analysis are constantly changing and
+evolving, an attempt to document a complete solution for DAOS monitoring would be outdated
+almost as soon as that document is saved. This section aims to provide a starting point
+for readers who have minimal experience with metrics monitoring infrastructure.
+
+Each invocation of `daos_metrics` or `dmg telemetry ...` yields a set of metric
+datapoints for a single point in time. This may be useful for simple spot checks
+or development tasks, but does not provide much in the way of insights about how
+the system is performing _over time_. For that capability, we need something to
+periodically collect those datapoints and store them in a way that datapoints
+may be compared to each other across time. The technology category for this task
+is generally referred to as a Time Series Database (TSDB), and conceptually can be thought
+of as a columnar database, where points in time are the columns, and the measurements
+taken at those times are stored in the rows.
+
+### Install A Prometheus Server
+
+One of the first examples of a modern Open Source TSDB was <a href="https://prometheus.io/">Prometheus</a>.
+We'll use it in this example because it's mature and easy to set up. Follow the
+<a href="https://prometheus.io/docs/prometheus/latest/getting_started/">Getting Started</a> guide
+to install a Prometheus server. Once you have that running, edit the configuration file
+to add a scrape configuration for your DAOS servers:
+
+```
+scrape_configs:
+- job_name: daos
+  scrape_interval: 30s
+  static_configs:
+  - targets:
+    - serverA:9191
+    - serverB:9191
+    - serverC:9191
+```
+
+Then (re)start your Prometheus server to verify that it is collecting metrics. The Prometheus web UI
+provides basic querying and graphing capabilities, but should normally be paired with a dashboard
+system (e.g. Grafana) to provide a more complete monitoring solution.
+
+Refer to the
+<a href="https://prometheus.io/docs/prometheus/latest/configuration/configuration/">Prometheus documentation</a>
+for more details on advanced configuration directives.
+
+### Set Up Grafana
+
+Refer to the <a href="/utils/grafana/README.md">README</a> for the DAOS Grafana dashboards.

--- a/src/control/lib/telemetry/promexp/client.go
+++ b/src/control/lib/telemetry/promexp/client.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //

--- a/src/control/lib/telemetry/promexp/engine.go
+++ b/src/control/lib/telemetry/promexp/engine.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //

--- a/src/gurt/telemetry.md
+++ b/src/gurt/telemetry.md
@@ -1,0 +1,258 @@
+# DAOS Telemetry Library
+
+DAOS includes a library for instrumentation of the I/O servers (engines) and clients. On the
+server side, the telemetry is always enabled. Client telemetry may be optionally enabled and
+is described in a <a href="/src/client/telemetry.md">separate document</a>.
+
+Before moving on, a quick point of clarification: In the context of these documents, the term
+"telemetry" refers exclusively to metrics that have been predefined in DAOS to measure certain
+characteristics of the system. Examples of these metrics might include bytes read, counts
+of operations by type, counts of errors, etc. This documentation does not cover logging or
+log analysis. External integrations may define additional metrics based on log analysis, but
+that topic is not covered here.
+
+## Unmanaged Use Cases
+
+On the server side, the only use cases that don't involve some metrics infrastructure are
+primarily aimed at DAOS developers who need an easy way to spot-check metrics values while
+debugging or working on a new feature. The tools described in this section are not recommended
+for production uses, as there are better solutions available.
+
+### Local Metrics Dump via daos_metrics
+
+The `daos_metrics` utility is typically provided as part of a DAOS server installation and may
+be used to directly access the shared memory segments exposed by the `daos_engine` process(es)
+running on a server. The user running `daos_metrics` must have read permission to the shared
+memory exposed by the engine. In most cases, this will just be the same user used by the
+server processes.
+
+With no arguments, `daos_server` will attempt to traverse and pretty-print the telemetry tree
+rooted at engine index 0, which is associated with the first engine started by the `daos_server`
+control process. If the tool should traverse a different engine's telemetry, specify the index
+with the `--srv_idx, -S` option.
+
+By default, the tool will pretty-print the metrics in a format that is easy for humans to read
+but takes up a lot of screen real estate. An example of the first few metrics printed looks
+like the following:
+```
+ID: 0
+    started_at: Thu May  1 20:13:26 2025
+    servicing_at: Thu May  1 20:13:29 2025
+    rank: 0
+    events
+        dead_ranks: 0 events
+        last_event_ts: Thu Jan  1 00:00:00 1970
+    net
+        uri
+            lookup_self: 0
+            lookup_other: 0
+```
+
+Another output option is to print the metrics in 
+<a href="https://en.wikipedia.org/wiki/Comma-separated_values">CSV</a> format, where each
+metric is represented in a single spreadsheet row. This format is a bit easier to sift through,
+but requires some more understanding of the metrics to make sense of them. Running the same
+command with the `--csv, -C` option produces output like the following:
+```
+name,value,min,max,mean,sample_size,sum,std_dev
+ID: 0/started_at,Thu May  1 20:13:26 2025
+ID: 0/servicing_at,Thu May  1 20:13:29 2025
+ID: 0/rank,0
+ID: 0/events/dead_ranks,0
+ID: 0/events/last_event_ts,Thu Jan  1 00:00:00 1970
+ID: 0/net/uri/lookup_self,0
+ID: 0/net/uri/lookup_other,0
+```
+
+Refer to the output of `daos_metrics --help` for a full list of options.
+
+### Remote Metrics Dump via dmg
+
+If the `daos_server` configuration specifies a `telemetry_port: <port>` parameter, then each
+`daos_server` process will start a HTTP server with a special `/metrics` endpoint that exposes
+the engine metrics in the 
+<a href="https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md">Prometheus exposition format</a>. The `dmg` tool provided as part of the DAOS admin installation
+includes a `telemetry` subcommand that can be used to list or query the metrics on a server. Note
+that this tool only supports interaction with a single server at a time -- it is not intended to
+provide aggregate metrics across a cluster of servers.
+
+An example of the query output for the same server used in the previous examples looks like the
+following (note that port may be omitted if the server is running on port 9191):
+```
+$ dmg telemetry metrics query -l localhost -m engine_started_at
+connecting to localhost:9191...
+- Metric Set: engine_started_at (Type: Gauge)
+  Timestamp of last engine startup
+    Metric Labels   Value
+    ------ ------   -----
+    Gauge  (rank=0) 1.746130406e+09
+    Gauge  (rank=1) 1.746130404e+09
+    Gauge  (rank=2) 1.746130405e+09
+```
+
+For completeness, we can see that curl may also be used, in a pinch:
+```
+$ curl -s http://localhost:9191/metrics | grep engine_started_at
+# HELP engine_started_at Timestamp of last engine startup
+# TYPE engine_started_at gauge
+engine_started_at{rank="0"} 1.746130406e+09
+engine_started_at{rank="1"} 1.746130404e+09
+engine_started_at{rank="2"} 1.746130405e+09
+```
+
+Note that the metric has the `engine_` prefix in its name and follows the Prometheus conventions
+for naming and labeling.
+
+## Managed Use Cases
+
+For the purposes of this document, a full discussion of how to set up a monitoring solution for
+DAOS is out of scope. The details and technologies are a constantly-moving target, and most sites
+already have existing infrastructure into which DAOS monitoring should be integrated. Instead of
+going to that level of detail, this section will describe some high-level concepts and offer
+guidance on various integration strategies.
+
+### The Prometheus Exporter
+
+As documented in <a href="/src/control/lib/telemetry/promexp/README.md">telemetry/promexp</a>,
+the `daos_server` and `daos_agent` processes may be configured to start a HTTP server with a
+`/metrics` endpoint that exposes telemetry for engine processes hosted on that server. The
+simplest way to use this endpoint is to install a single
+<a href="https://prometheus.io/docs/prometheus/latest/getting_started/">Prometheus Server</a>
+instance that is configured to periodically "scrape" the metrics endpoints on all of the
+`daos_server` and/or `daos_agent` processes in the cluster. The metrics are then efficiently
+stored in its time series database for later query and analysis (e.g. with a
+<a href="https://grafana.com/">Grafana</a> dashboard that is based on the
+<a href="/utils/grafana/README.md">example</a> provided with DAOS).
+
+Aside from Prometheus itself, the <a href="https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md">Prometheus exposition format</a> is legible to most
+modern time series data ingestion and storage solutions. Prominent examples of these include:
+  * <a href="https://www.timescale.com/">TimescaleDB</a>
+  * <a href="https://www.influxdata.com/">InfluxDB</a>
+  * <a href="https://victoriametrics.com/">VictoriaMetrics</a>
+
+The specifics of how these solutions would collect metrics (e.g. pull from a central server vs.
+push from local agents) are outside the scope of this document.
+
+### Custom Exporter
+
+The Prometheus Exporter provides a solution that requires minimal understanding of and
+integration with the DAOS telemetry library. The tradeoff for this simplicity is that
+the metrics must be converted into an intermediate format and then converted into the final
+storage format. At small scales, these inefficiencies may be of little concern, but for larger
+scales, it may be desirable to implement a custom solution for reading the metrics directly
+out of shared memory and converting them into an efficient wire format.
+
+One existing example of this approach is the <a href="https://github.com/ovis-hpc/ldms/tree/main/ldms/src/contrib/sampler/daos">LDMS sampler for DAOS</a>.
+
+# Developer Guide
+
+This section is intended to provide an overview of the telemetry library for DAOS developers who
+are interested in adding new instrumentation to the client and/or server implementations.
+
+## Orientation
+
+The library is defined in three header files, 
+<a href="/src/include/gurt/telemetry_common.h">&lt;gurt/telemetry_common.h&gt;</a>,
+<a href="/src/include/gurt/telemetry_consumer.h">&lt;gurt/telemetry_consumer.h&gt;</a>, and
+<a href="/src/include/gurt/telemetry_producer.h">&lt;gurt/telemetry_producer.h&gt;</a>. It is
+implemented in a single C file: <a href="/src/gurt/telemetry.c">src/gurt/telemetry.c</a>, and
+cmocka unit tests for the library may be found in
+<a href="/src/gurt/tests/test_gurt_telem_producer.c">src/gurt/tests/test_gurt_telem_producer.c</a>.
+
+The original design and implementation of the library was based on server-only use cases that
+rely on use of shared memory to allow realtime sampling of the metric values from outside of the
+engine processes. In the years since that original implementation was completed, the library has
+been updated to support client-side use cases, some of which do not need shared memory and instead
+use regular memory allocations for metrics.
+
+In all cases, the metrics are managed as nodes in a rooted tree that allows for efficient traversal
+and dynamic addition and removal of branches (e.g. for pools).
+
+## Metric Types
+
+Within the library, the smallest unit of organization is a tree node (`struct d_tm_node_t`). Each
+node has a type, and depending on the type will have different uses of the fields within the struct.
+
+The full set of supported node types is defined in 
+<a href="/src/include/gurt/telemetry_common.h">&lt;gurt/telemetry_common.h&gt;</a>, and
+the following list describes the most commonly used types:
+
+  * DIRECTORY: Not a metric per se, but a special node type with a name, a potential child, a
+    potential neighbor, and possibly an associated memory region if it is the root of a dynamic branch.
+  * TIMESTAMP: Used to record timestamps for events, e.g. engine start time, 
+    container mount time, etc.
+  * DURATION: Measures the duration of time between recorded start and end times.
+  * COUNTER: Used to maintain a uint64 count of something (e.g. bytes read, RPCs sent, etc.).
+    Should never be decremented. Consumers must handle wraparound (i.e. reset to zero). When sampled
+    over time, may be used to calculate rates of change in a value. Think of this type like the
+    odometer in a car. It always goes up, never backwards (unless it wraps around).
+  * GAUGE: Simple float64 gauge that records an instantaneous measurement. May be
+    incremented, decremented, or reset to zero. Think of this type like a thermometer or
+    speedometer in a car. It provides a reading at a point in time and can fluctuate.
+  * STATS_GAUGE: Complex gauge that includes an instantaneous measurement along with
+    associated statistics (min/max/sum/avg/std_dev/sum_sq/count).
+
+In addition to these core metric types, the DURATION and GAUGE metrics may optionally be associated
+with a set of histogram buckets containing counters that correspond to bucketed values set on
+the base metric.
+
+## Adding A New Metric
+
+For an exhaustive reference and set of examples, see the
+<a href="/src/gurt/examples/telem_producer_example.c">producer</a> and
+<a href="/src/gurt/examples/telem_consumer_example.c">consumer</a> examples.
+
+This section will provide a simple(?) example of adding a new counter metric to the engine, with
+some commentary and context that may not be readily apparent from reading the code directly.
+
+Let's assume that we have identified a need to count the number of RAS events sent from
+the engine up to its local control plane server. The first order of business is to find a
+central location through which all RAS events pass in order to count them. Looking at the
+engine code, it seems like `send_event()` in <a href="/src/engine/drpc_ras.c">drpc_ras.c</a>
+might be a good place to start. There's a problem, though: We need some place to store the
+metric, and this function doesn't have access to anything other than the event itself. In
+fact, this whole file seems to consist of various wrappers around `dss_drpc_call()` in
+<a href="/src/engine/drpc_client.c">drpc_client.c</a>. OK, so let's look there.
+
+Looking in `dss_drpc_call()`, we can see that the function is responsible for sending the
+dRPC request immediately if it doesn't need a response, or scheduling it to run on a new
+thread if it does. Either way, we still don't have something to "hang" the new metric on.
+
+What now? This has gotten complicated in a hurry. Rummaging around a bit in the engine
+directory, we can see that there's a <a href="/src/engine/srv_metrics.c">srv_metrics.c</a>
+file. Looks like there's a global `struct engine_metrics` instance which is defined in
+<a href="/src/engine/srv_internal.h">srv_internal.h</a>. Putting aside the question of
+whether or not it's a good idea to be using a global variable for this kind of thing, let's
+just add our new metric there and call it a day.
+
+First, we need to add a new `struct d_tm_node_t` pointer field to `struct engine_metrics`.
+Let's name it `drpc_ras_events`. Next, we need to initialize it, which takes care of
+allocating telemetry memory and adding the node to the tree. Going back to
+`srv_metrics.c`, we can see that there's a `dss_engine_metrics_init()` function that looks
+like a good spot to do this. Following the examples set by the existing metrics, we add
+some new code that looks like the following:
+```C
+rc = d_tm_add_metric(&dss_engine_metrics.drpc_ras_events,
+                     D_TM_COUNTER,
+                     "Number of engine RAS events reported", "events",
+                     "events/ras");
+```
+
+Of note, we're using the `COUNTER` type, because the value of this metric will always
+be incremented, never decremented. If we were adding a metric to measure the current
+value of _outstanding_ (i.e. not handled yet) RAS events, then a `GAUGE` would be more
+appropriate. But we're not doing that. The other things to consider here are the
+help string which is visible to telemetry consumers, the unit, and the path in the
+telemetry tree to the metric. If the return code is zero, then we know that the metric
+was successfully initialized and added to the tree and is ready to be used.
+
+Going back to `send_event()` in <a href="/src/engine/drpc_ras.c">drpc_ras.c</a>, we can
+now add some code to increment our new counter. Keeping it simple, we can just
+increment the counter for every successful event sent. That means putting code like
+the following right above the first exit handler:
+```C
+d_tm_inc_counter(&dss_engine_metrics.drpc_ras_events);
+```
+
+And that's it. Recompile and restart your server, and you should now see a counter that
+is incremented for every RAS event sent.

--- a/src/include/daos/job.h
+++ b/src/include/daos/job.h
@@ -45,6 +45,16 @@ extern char *dc_jobid;
 int
 dc_set_default_jobid(const char *default_jobid);
 
+/**
+ * Check if the provided jobid string matches the default jobid.
+ *
+ * \param[in]	jobid	The job ID string to check.
+ *
+ * \return		true if the jobid matches the default.
+ */
+bool
+dc_jobid_is_default(const char *jobid);
+
 /*
  * The answer of what the max length of envvar name is very tricky. Arguments
  * and environment variable share the same memory space so to make things easy

--- a/src/include/daos/metrics.h
+++ b/src/include/daos/metrics.h
@@ -27,6 +27,11 @@
 extern bool daos_client_metric;
 extern bool daos_client_metric_retain;
 
+/* Container attributes used to control metrics dump behavior */
+#define DAOS_CLIENT_METRICS_DUMP_POOL_ATTR "client-metrics-dump-pool"
+#define DAOS_CLIENT_METRICS_DUMP_CONT_ATTR "client-metrics-dump-container"
+#define DAOS_CLIENT_METRICS_DUMP_DIR_ATTR  "client-metrics-dump-directory"
+
 struct daos_module_metrics {
 	/* Indicate where the keys should be instantiated */
 	enum daos_module_tag dmm_tags;

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -1371,6 +1372,32 @@ dfs_readdir_with_filter(dfs_t *dfs, dfs_obj_t *obj, dfs_pipeline_t *dpipe, daos_
  */
 int
 dfs_cont_scan(daos_handle_t poh, const char *cont, uint64_t flags, const char *name);
+
+/**
+ * Enable metrics for the DFS namespace.
+ *
+ * \param[in]	dfs	Pointer to the mounted file system.
+ */
+void
+dfs_metrics_init(dfs_t *dfs);
+
+/**
+ * Check to see if metrics are enabled for the DFS namespace.
+ *
+ * \param[in]	dfs	Pointer to the mounted file system.
+ *
+ * \return		true if metrics are enabled, false otherwise.
+ */
+bool
+dfs_metrics_enabled(dfs_t *dfs);
+
+/**
+ * Finalize metrics for the DFS namespace.
+ *
+ * \param[in]	dfs	Pointer to the mounted file system.
+ */
+void
+dfs_metrics_fini(dfs_t *dfs);
 
 #if defined(__cplusplus)
 }

--- a/src/include/dfuse_ioctl.h
+++ b/src/include/dfuse_ioctl.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2023 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -29,9 +30,12 @@
 #define DFUSE_COUNT_QUERY_CMD    (DFUSE_IOCTL_REPLY_BASE + 10)
 #define DFUSE_IOCTL_EVICT_NR     (DFUSE_IOCTL_REPLY_BASE + 11)
 #define DFUSE_IOCTL_STAT_NR      (DFUSE_IOCTL_REPLY_BASE + 12)
+#define DFUSE_IOCTL_METRICS_NR    (DFUSE_IOCTL_REPLY_BASE + 13)
 
 /** Metadada caching is enabled for this file */
 #define DFUSE_IOCTL_FLAGS_MCACHE (0x1)
+/** Client metrics are enabled */
+#define DFUSE_IOCTL_FLAGS_METRICS (0x2)
 
 /* Core IOCTL reply */
 struct dfuse_il_reply {
@@ -44,10 +48,11 @@ struct dfuse_il_reply {
 
 /* Query for global pool/container handle sizes */
 struct dfuse_hs_reply {
-	int    fsr_version;
-	size_t fsr_pool_size;
-	size_t fsr_cont_size;
-	size_t fsr_dfs_size;
+	int      fsr_version;
+	size_t   fsr_pool_size;
+	size_t   fsr_cont_size;
+	size_t   fsr_dfs_size;
+	uint64_t fsr_flags;
 };
 
 /* Query for global dfs/object handle sizes */
@@ -97,5 +102,8 @@ struct dfuse_stat {
 
 #define DFUSE_IOCTL_DFUSE_EVICT                                                                    \
 	((int)_IOR(DFUSE_IOCTL_TYPE, DFUSE_IOCTL_EVICT_NR, struct dfuse_mem_query))
+
+/* Toggle metrics on/off for this container */
+#define DFUSE_IOCTL_METRICS_TOGGLE ((int)_IOW(DFUSE_IOCTL_TYPE, DFUSE_IOCTL_METRICS_NR, bool))
 
 #endif /* __DFUSE_IOCTL_H__ */

--- a/utils/cq/check_update_copyright.sh
+++ b/utils/cq/check_update_copyright.sh
@@ -56,7 +56,6 @@ targets=(
     '*LICENSE*'
     '*NOTICE*'
     '*.txt'
-    '*.md'
     # Entries without a wildcard
     'Makefile'
     'Jenkinsfile'


### PR DESCRIPTION
Enable DFS-layer metrics dump to a POSIX-layout container.
Metric collection and dump may be toggled on a per-container
basis using the `daos container telemetry (enable|disable)`
commands. When telemetry is enabled for a POSIX container,
DFS clients will begin recording telemetry on container open,
and then dump that telemetry on container close.

Change-Id: I29ed830675ebdcf3459cdf64d6c7f8d3bc70ea36
Signed-off-by: Michael MacDonald <mjmac@google.com>
