### PR TITLE
DAOS-17550 object: fix a bug of key comparison in merge_key()

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3574,7 +3574,7 @@ merge_key(struct dc_object *obj, d_list_t *head, char *key, int key_size)
 
 	d_list_for_each_entry(key_one, head, key_list) {
 		if (key_size == key_one->key.iov_len &&
-		    strncmp(key_one->key.iov_buf, key, key_size) == 0) {
+		    memcmp(key_one->key.iov_buf, key, key_size) == 0) {
 			return 0;
 		}
 	}


### PR DESCRIPTION
should use memcmp instead of strncmp.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
