### PR TITLE
DAOS-9217 pool: allow rd_fac to be modified (#16289)

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -809,9 +809,6 @@ func (cmd *poolSetPropCmd) Execute(_ []string) error {
 		if prop.Name == "perf_domain" {
 			return errors.New("can't set perf_domain on existing pool.")
 		}
-		if prop.Name == "rd_fac" {
-			return errors.New("can't set redundancy factor on existing pool.")
-		}
 		if prop.Name == "ec_pda" {
 			return errors.New("can't set EC performance domain affinity on existing pool.")
 		}

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -748,6 +748,19 @@ func TestPoolCommands(t *testing.T) {
 			nil,
 		},
 		{
+			"Set pool rd_fac property",
+			"pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb rd_fac:1",
+			strings.Join([]string{
+				printRequest(t, &control.PoolSetPropReq{
+					ID: "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
+					Properties: []*daos.PoolProperty{
+						propWithVal("rd_fac", "1"),
+					},
+				}),
+			}, " "),
+			nil,
+		},
+		{
 			"Set pool property invalid property",
 			"pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb whoops:foo",
 			"",
@@ -770,18 +783,6 @@ func TestPoolCommands(t *testing.T) {
 			"pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb perf_domain:root",
 			"",
 			errors.New("can't set perf_domain on existing pool."),
-		},
-		{
-			"Set pool rd_fac property is not allowed",
-			"pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb rd_fac:1",
-			"",
-			errors.New("can't set redundancy factor on existing pool."),
-		},
-		{
-			"Set pool rf property is not allowed",
-			"pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb rf:1",
-			"",
-			errors.New("can't set redundancy factor on existing pool."),
 		},
 		{
 			"Set pool ec_pda property is not allowed",

--- a/src/pool/srv_cli.c
+++ b/src/pool/srv_cli.c
@@ -849,11 +849,6 @@ dsc_pool_svc_set_prop(uuid_t pool_uuid, d_rank_list_t *ranks, uint64_t deadline,
 		return -DER_NO_PERM;
 	}
 
-	if (daos_prop_entry_get(prop, DAOS_PROP_PO_REDUN_FAC)) {
-		D_ERROR("Can't set set redundancy factor on existing pool.\n");
-		return -DER_NO_PERM;
-	}
-
 	if (daos_prop_entry_get(prop, DAOS_PROP_PO_EC_PDA)) {
 		D_ERROR("Can't set EC performance domain affinity on existing pool\n");
 		return -DER_NO_PERM;


### PR DESCRIPTION
Allow the pool's rd_fac to be modified on existing pools.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
