### PR TITLE
DAOS-17107 debug: Dump group contents on update

### DIFF
--- a/src/mgmt/srv_util.c
+++ b/src/mgmt/srv_util.c
@@ -59,6 +59,11 @@ ds_mgmt_group_update(struct server_entry *servers, int nservers, uint32_t versio
 	for (i = 0; i < nservers; i++)
 		uris[i] = servers[i].se_uri;
 
+	for (i = 0; i < nservers; i++) {
+		D_INFO("rank: %d [incarnation: %ld] uri: '%s'\n",
+			ranks->rl_ranks[i], incarnations[i], uris[i]);
+	}
+
 	rc = crt_group_primary_modify(NULL /* grp */, &info->dmi_ctx, 1 /* num_ctxs */, ranks,
 				      incarnations, uris, CRT_GROUP_MOD_OP_REPLACE, version);
 	if (rc != 0) {


### PR DESCRIPTION
- Dump rank/incarnation/uri info on group update.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
