### PR TITLE
DAOS-17443 gurt: Always retain first .old log file (#16314)

### DIFF
--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -377,6 +378,13 @@ log_rotate(void)
 	int rc = 0;
 
 	if (!mst.log_old) {
+		rc = asprintf(&mst.log_old, "%s.first", mst.log_file);
+		if (rc < 0) {
+			dlog_print_err(errno, "failed to alloc name\n");
+			return -1;
+		}
+	} else {
+		free(mst.log_old);
 		rc = asprintf(&mst.log_old, "%s.old", mst.log_file);
 		if (rc < 0) {
 			dlog_print_err(errno, "failed to alloc name\n");


### PR DESCRIPTION
Upon log rotation, the very first '.old' file is saved now as '.first'

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
