### PR TITLE
DAOS-17656 object: several fix for EC object fetch processing

### DIFF
--- a/src/object/cli_csum.c
+++ b/src/object/cli_csum.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -286,6 +287,19 @@ dc_rw_cb_csum_verify(struct dc_csum_veriry_args *args)
 
 		if (!csum_iod_is_supported(iod))
 			continue;
+
+		/* For EC single value degraded fetch, if need data recovery the data is not
+		 * transferred back so need not csum verify. Data will be transferred back and
+		 * do csum verify at following EC data recovery phase.
+		 */
+		if (iod->iod_type == DAOS_IOD_SINGLE && args->ec_deg_fetch &&
+		    args->recov_list != NULL && args->recov_list[i].re_nr > 0) {
+			D_DEBUG(DB_CSUM,
+				DF_C_UOID_DKEY " SKIP [%d] iod single value csum verify "
+					       "for EC degraded fetch\n",
+				DP_C_UOID_DKEY(args->oid, args->dkey), i);
+			continue;
+		}
 
 		shard_iod.iod_size = args->sizes[i];
 		if (iod->iod_type == DAOS_IOD_ARRAY && args->oiods != NULL) {

--- a/src/object/cli_csum.h
+++ b/src/object/cli_csum.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -51,6 +52,9 @@ struct dc_csum_veriry_args {
 	d_iov_t                 *iov_csum;
 	uint32_t                 shard;
 	uint32_t                 shard_idx;
+
+	struct daos_recx_ep_list *recov_list;
+	bool                      ec_deg_fetch;
 };
 
 int

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1302,10 +1303,10 @@ obj_ec_recx_reasb(struct dc_object *obj, daos_iod_t *iod, d_sg_list_t *sgl,
 		siod->siod_tgt_idx = obj_ec_shard_idx(obj, dkey_hash, i);
 		siod->siod_idx = tgt_recx_idxs[i];
 		siod->siod_nr = tgt_recx_nrs[i];
-		EC_TRACE("i %d tgt %u idx %u nr %u, start "DF_U64
-			" tgt_recx %u/%u\n", i, siod->siod_tgt_idx, siod->siod_idx,
-			siod->siod_nr, obj_ec_shard_idx(obj, dkey_hash, 0),
-			tgt_recx_idxs[i], tgt_recx_nrs[i]);
+		EC_TRACE("i %d tgt %u idx %u nr %u, start %d,"
+			 " tgt_recx %u/%u\n",
+			 i, siod->siod_tgt_idx, siod->siod_idx, siod->siod_nr,
+			 obj_ec_shard_idx(obj, dkey_hash, 0), tgt_recx_idxs[i], tgt_recx_nrs[i]);
 		siod->siod_off = rec_nr * iod_size;
 		for (idx = last; idx < tgt_recx_idxs[i] + tgt_recx_nrs[i]; idx++)
 			rec_nr += riod->iod_recxs[idx].rx_nr;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -58,7 +58,7 @@ open_retry:
 		D_GOTO(unlock, rc = -DER_NONEXIST);
 	}
 
-	D_DEBUG(DB_TRACE, "Open object shard %d\n", shard);
+	D_DEBUG(DB_TRACE, "Open object shard %d, lock_upgraded %d\n", shard, lock_upgraded);
 
 	if (obj_shard->do_obj == NULL) {
 		daos_unit_oid_t	 oid;
@@ -1089,7 +1089,7 @@ obj_shard_tgts_query(struct dc_object *obj, uint32_t map_ver, uint32_t shard,
 			  grp_idx * daos_oclass_grp_size(obj_get_oca(obj_auxi->obj));
 
 		if (isclr(bitmap, tgt_idx)) {
-			D_DEBUG(DB_TRACE, DF_OID" shard %u is not in bitmap\n",
+			D_DEBUG(DB_IO, DF_OID " shard %u is not in bitmap\n",
 				DP_OID(obj->cob_md.omd_id), obj_shard->do_id.id_shard);
 			D_GOTO(close, rc = -DER_NONEXIST);
 		}
@@ -1963,8 +1963,8 @@ obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 		 * singv recovery without fetch from server ahead - when
 		 * some targets un-available.
 		 */
-		if (recov_task->ert_epoch == DAOS_EPOCH_MAX)
-			recov_task->ert_epoch = d_hlc_get();
+		D_ASSERTF(recov_task->ert_epoch != DAOS_EPOCH_MAX && recov_task->ert_epoch != 0,
+			  "bad ert_epoch " DF_X64 "\n", recov_task->ert_epoch);
 		dc_cont2hdl_noref(obj->cob_co, &coh);
 		rc = dc_tx_local_open(coh, recov_task->ert_epoch, 0, &th);
 		if (rc) {
@@ -2283,7 +2283,7 @@ obj_iod_sgl_valid(daos_obj_id_t oid, unsigned int nr, daos_iod_t *iods,
 				if ((iods[i].iod_size == DAOS_REC_ANY) ||
 				    (!update && check_exist))
 					continue;
-				D_ERROR("invalid req with NULL sgl\n");
+				D_ERROR("iods[%d] invalid req with NULL sgl\n", i);
 				return -DER_INVAL;
 			}
 			if (!size_fetch &&
@@ -5750,8 +5750,7 @@ obj_ec_fetch_shards_get(struct dc_object *obj, daos_obj_fetch_t *args, unsigned 
 		if (likely(ec_deg_tgt == tgt_idx))
 			continue;
 
-		if (obj_auxi->ec_in_recov ||
-		    (obj_auxi->reasb_req.orr_singv_only && !obj_auxi->reasb_req.orr_size_fetch)) {
+		if (obj_auxi->ec_in_recov) {
 			D_DEBUG(DB_IO, DF_OID" shard %d failed recovery(%d) or singv fetch(%d).\n",
 				DP_OID(obj->cob_md.omd_id), grp_start + tgt_idx,
 				obj_auxi->ec_in_recov, obj_auxi->reasb_req.orr_singv_only);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1959,10 +1959,6 @@ obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 		 fail_info->efi_recov_tasks != NULL);
 	for (i = 0; i < fail_info->efi_recov_ntasks; i++) {
 		recov_task = &fail_info->efi_recov_tasks[i];
-		/* Set client hlc as recovery epoch only for the case that
-		 * singv recovery without fetch from server ahead - when
-		 * some targets un-available.
-		 */
 		D_ASSERTF(recov_task->ert_epoch != DAOS_EPOCH_MAX && recov_task->ert_epoch != 0,
 			  "bad ert_epoch " DF_X64 "\n", recov_task->ert_epoch);
 		dc_cont2hdl_noref(obj->cob_co, &coh);
@@ -5751,9 +5747,8 @@ obj_ec_fetch_shards_get(struct dc_object *obj, daos_obj_fetch_t *args, unsigned 
 			continue;
 
 		if (obj_auxi->ec_in_recov) {
-			D_DEBUG(DB_IO, DF_OID" shard %d failed recovery(%d) or singv fetch(%d).\n",
-				DP_OID(obj->cob_md.omd_id), grp_start + tgt_idx,
-				obj_auxi->ec_in_recov, obj_auxi->reasb_req.orr_singv_only);
+			D_DEBUG(DB_IO, DF_OID " shard %d failed recovery.\n",
+				DP_OID(obj->cob_md.omd_id), grp_start + tgt_idx);
 			D_GOTO(out, rc = -DER_TGT_RETRY);
 		}
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1,5 +1,6 @@
 /*
  *  (C) Copyright 2016-2024 Intel Corporation.
+ *  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -519,8 +520,8 @@ dc_shard_update_size(struct rw_cb_args *rw_args, int fetch_rc)
 		struct shard_fetch_stat	*fetch_stat;
 		bool			conflict = false;
 
-		D_DEBUG(DB_IO, DF_UOID" size "DF_U64" eph "DF_U64"\n", DP_UOID(orw->orw_oid),
-			sizes[i], orw->orw_epoch);
+		D_DEBUG(DB_IO, DF_UOID " size[%d] " DF_U64 " eph " DF_U64 "\n",
+			DP_UOID(orw->orw_oid), i, sizes[i], orw->orw_epoch);
 
 		if (!is_ec_obj) {
 			iods[i].iod_size = sizes[i];

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -130,35 +130,38 @@ rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 	bool			 is_ec_obj;
 	struct dc_object	*obj = rw_args->shard_args->auxi.obj_auxi->obj;
 	struct dc_csum_veriry_args csum_verify_args = {
-	    .csummer    = rw_args->co->dc_csummer,
-	    .sgls       = rw_args->rwaa_sgls,
-	    .iods       = orw->orw_iod_array.oia_iods,
-	    .iods_csums = orwo->orw_iod_csums.ca_arrays,
-	    .maps       = orwo->orw_maps.ca_arrays,
-	    .dkey       = &orw->orw_dkey,
-	    .sizes      = orwo->orw_iod_sizes.ca_arrays,
-	    .oid        = orw->orw_oid,
-	    .iod_nr     = orw->orw_iod_array.oia_iod_nr,
-	    .maps_nr    = orwo->orw_maps.ca_count,
-	    .oiods      = rw_args->shard_args->oiods,
-	    .reasb_req  = rw_args->shard_args->reasb_req,
-	    .obj        = obj,
-	    .dkey_hash  = rw_args->shard_args->auxi.obj_auxi->dkey_hash,
-	    .shard_offs = rw_args->shard_args->offs,
-	    .oc_attr    = &obj->cob_oca,
-	    .iov_csum   = rw_args2csum_iov(rw_args->shard_args),
-	    .shard      = rw_args->shard_args->auxi.shard,
+	    .csummer      = rw_args->co->dc_csummer,
+	    .sgls         = rw_args->rwaa_sgls,
+	    .iods         = orw->orw_iod_array.oia_iods,
+	    .iods_csums   = orwo->orw_iod_csums.ca_arrays,
+	    .maps         = orwo->orw_maps.ca_arrays,
+	    .dkey         = &orw->orw_dkey,
+	    .sizes        = orwo->orw_iod_sizes.ca_arrays,
+	    .oid          = orw->orw_oid,
+	    .iod_nr       = orw->orw_iod_array.oia_iod_nr,
+	    .maps_nr      = orwo->orw_maps.ca_count,
+	    .oiods        = rw_args->shard_args->oiods,
+	    .reasb_req    = rw_args->shard_args->reasb_req,
+	    .obj          = obj,
+	    .dkey_hash    = rw_args->shard_args->auxi.obj_auxi->dkey_hash,
+	    .shard_offs   = rw_args->shard_args->offs,
+	    .oc_attr      = &obj->cob_oca,
+	    .iov_csum     = rw_args2csum_iov(rw_args->shard_args),
+	    .shard        = rw_args->shard_args->auxi.shard,
+	    .recov_list   = orwo->orw_rels.ca_arrays,
+	    .ec_deg_fetch = false,
 	};
 
-	if (obj_is_ec(obj))
+	if (obj_is_ec(obj)) {
 		csum_verify_args.shard_idx =
 		    obj_ec_shard_off(obj,
 				     rw_args->shard_args->auxi.obj_auxi->dkey_hash,
 				     orw->orw_oid.id_shard);
-	else
+		csum_verify_args.ec_deg_fetch = orw->orw_flags & ORF_EC_DEGRADED;
+	} else {
 		csum_verify_args.shard_idx = orw->orw_oid.id_shard %
 					     daos_oclass_grp_size(&obj->cob_oca);
-
+	}
 
 	rc = dc_rw_cb_csum_verify(&csum_verify_args);
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -517,6 +517,9 @@ again:
 	return rc;
 }
 
+/* bypass bulk rma for single value's degraded fetch */
+#define OBJ_BULK_OFFSET_SKIP ((uint64_t)-1)
+
 int
 obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind, crt_bulk_t *remote_bulks,
 		  uint64_t *remote_offs, uint8_t *skips, daos_handle_t ioh, d_sg_list_t **sgls,
@@ -597,9 +600,14 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind, crt_bul
 				break;
 		}
 
-		rc = bulk_transfer_sgl(ioh, rpc, remote_bulks[i + skip_nr],
-				       remote_offs ? remote_offs[i] : 0,
-				       bulk_op, bulk_bind, sgl, i, p_arg);
+		/* OBJ_BULK_OFFSET_SKIP is for the case of EC single value degraded fetch,
+		 * unnecessary to bulk transfer here, the data will be transferred back when
+		 * data recovery (ORF_EC_RECOV).
+		 */
+		if (remote_offs == NULL || remote_offs[i] != OBJ_BULK_OFFSET_SKIP)
+			rc = bulk_transfer_sgl(ioh, rpc, remote_bulks[i + skip_nr],
+					       remote_offs ? remote_offs[i] : 0, bulk_op, bulk_bind,
+					       sgl, i, p_arg);
 		if (sgls == NULL)
 			d_sgl_fini(sgl, false);
 		if (rc) {
@@ -1058,6 +1066,7 @@ obj_singv_ec_rw_filter(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
 		} else if (deg_fetch) {
 			rc = obj_singv_ec_add_recov(nr, i, iod->iod_size,
 						    epoch, recov_lists_ptr);
+			offs[i] = OBJ_BULK_OFFSET_SKIP;
 		}
 	}
 
@@ -1448,6 +1457,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc, daos_iod_t *io
 		bool				ec_deg_fetch;
 		bool				ec_recov;
 		bool				is_parity_shard;
+		bool                             size_only = false;
 		struct daos_recx_ep_list	*shadows = NULL;
 
 		bulk_op = CRT_BULK_PUT;
@@ -1455,8 +1465,10 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc, daos_iod_t *io
 			fetch_flags = VOS_OF_FETCH_CHECK_EXISTENCE;
 		if (!rma && orw->orw_sgls.ca_arrays == NULL) {
 			spec_fetch = true;
-			if (!(orw->orw_flags & ORF_CHECK_EXISTENCE))
+			if (!(orw->orw_flags & ORF_CHECK_EXISTENCE)) {
 				fetch_flags = VOS_OF_FETCH_SIZE_ONLY;
+				size_only   = true;
+			}
 		}
 
 		ec_deg_fetch = orw->orw_flags & ORF_EC_DEGRADED;
@@ -1483,7 +1495,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc, daos_iod_t *io
 				ioc->ioc_coc->sc_ec_agg_eph_boundary, DP_RC(rc));
 			goto out;
 		}
-		if (ec_deg_fetch && !spec_fetch) {
+		if (ec_deg_fetch && (size_only || !spec_fetch)) {
 			if (orwo->orw_rels.ca_arrays != NULL) {
 				/* Re-entry case */
 				daos_recx_ep_list_free(orwo->orw_rels.ca_arrays,
@@ -1589,24 +1601,27 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc, daos_iod_t *io
 			daos_epoch_t	recov_epoch = 0;
 			bool		recov_snap = false;
 
-			/* If fetch from snapshot, and snapshot epoch lower than
-			 * vos agg epoch boundary, recovery from snapshot epoch.
-			 * Or, will recovery from max{parity_epoch, vos_epoch_
-			 * boundary}.
-			 */
-			vos_agg_epoch = ioc->ioc_coc->sc_ec_agg_eph_boundary;
-			if (ioc->ioc_fetch_snap &&
-			    orw->orw_epoch < vos_agg_epoch) {
-				recov_epoch = orw->orw_epoch;
-				recov_snap =  true;
+			if (size_only) {
+				daos_recx_ep_list_free(recov_lists, iods_nr);
 			} else {
-				recov_epoch = vos_agg_epoch;
+				/* If fetch from snapshot, and snapshot epoch lower than
+				 * vos agg epoch boundary, recovery from snapshot epoch.
+				 * Or, will recovery from max{parity_epoch, vos_epoch_
+				 * boundary}.
+				 */
+				vos_agg_epoch = ioc->ioc_coc->sc_ec_agg_eph_boundary;
+				if (ioc->ioc_fetch_snap && orw->orw_epoch < vos_agg_epoch) {
+					recov_epoch = orw->orw_epoch;
+					recov_snap  = true;
+				} else {
+					recov_epoch = vos_agg_epoch;
+				}
+				daos_recx_ep_list_set(recov_lists, iods_nr, recov_epoch,
+						      recov_snap);
+				daos_recx_ep_list_merge(recov_lists, iods_nr);
+				orwo->orw_rels.ca_arrays = recov_lists;
+				orwo->orw_rels.ca_count  = iods_nr;
 			}
-			daos_recx_ep_list_set(recov_lists, iods_nr,
-					      recov_epoch, recov_snap);
-			daos_recx_ep_list_merge(recov_lists, iods_nr);
-			orwo->orw_rels.ca_arrays = recov_lists;
-			orwo->orw_rels.ca_count = iods_nr;
 		}
 	}
 

--- a/src/object/tests/cli_checksum_tests.c
+++ b/src/object/tests/cli_checksum_tests.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -66,18 +67,19 @@ static void
 timiing_obj_csums_verify(void **state)
 {
 	struct cli_checksum_test_state	*st = *state;
-	struct dc_csum_veriry_args	 args = {
-		 .csummer    = st->csummer,
-		 .iods       = st->td.td_iods,
-		 .iod_nr     = 1,
-		 .sgls       = st->td.td_sgls,
-		 .dkey       = &st->td.dkey,
-		 .maps       = st->td.td_maps,
-		 .maps_nr    = 1,
-		 .iods_csums = NULL,
-		 .dkey_hash  = 1,
-		 .sizes      = st->td.td_sizes,
-	};
+	struct dc_csum_veriry_args       args = {
+		  .csummer      = st->csummer,
+		  .iods         = st->td.td_iods,
+		  .iod_nr       = 1,
+		  .sgls         = st->td.td_sgls,
+		  .dkey         = &st->td.dkey,
+		  .maps         = st->td.td_maps,
+		  .maps_nr      = 1,
+		  .iods_csums   = NULL,
+		  .dkey_hash    = 1,
+		  .sizes        = st->td.td_sizes,
+		  .ec_deg_fetch = false,
+        };
 
 	/* Calculate the checksums that will be verified. In production, these would
 	 * come from the server

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -286,6 +286,9 @@ async_enable(void **state)
 
 	arg->overlap = 0;
 	arg->async   = true;
+	/* reset fail injection to avoid the case of previously failed test case affect next one */
+	daos_fail_value_set(0);
+	daos_fail_loc_set(0);
 	return 0;
 }
 
@@ -296,6 +299,9 @@ async_disable(void **state)
 
 	arg->overlap = 0;
 	arg->async   = false;
+	/* reset fail injection to avoid the case of previously failed test case affect next one */
+	daos_fail_value_set(0);
+	daos_fail_loc_set(0);
 	return 0;
 }
 


### PR DESCRIPTION
1) For EC singv degraded fetch, don't directly start EC data recovery
   from client side, because cannot directly use any hlc from client.
   Instead it will do a degraded fetch from parity shard to get back
   the valid epoch for EC data recovery first.
2) For EC singv degraded fetch server handling, need not bulk
   transferring back the data, instead only need to do the bulk for
   data recovery.
3) For EC array size query, for the degraded fetch also need to convert
   the recx vos index to replica offset.

test code change - add degraded test for EC 18, and reset fail injection when init each test case.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
