### PR TITLE
DAOS-17656 object: several fix for EC object fetch processing

### DIFF
--- a/src/object/cli_csum.c
+++ b/src/object/cli_csum.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -286,6 +287,19 @@ dc_rw_cb_csum_verify(struct dc_csum_veriry_args *args)
 
 		if (!csum_iod_is_supported(iod))
 			continue;
+
+		/* For EC single value degraded fetch, if need data recovery the data is not
+		 * transferred back so need not csum verify. Data will be transferred back and
+		 * do csum verify at following EC data recovery phase.
+		 */
+		if (iod->iod_type == DAOS_IOD_SINGLE && args->ec_deg_fetch &&
+		    args->recov_list != NULL && args->recov_list[i].re_nr > 0) {
+			D_DEBUG(DB_CSUM,
+				DF_C_UOID_DKEY " SKIP [%d] iod single value csum verify "
+					       "for EC degraded fetch\n",
+				DP_C_UOID_DKEY(args->oid, args->dkey), i);
+			continue;
+		}
 
 		shard_iod.iod_size = args->sizes[i];
 		if (iod->iod_type == DAOS_IOD_ARRAY && args->oiods != NULL) {

--- a/src/object/cli_csum.h
+++ b/src/object/cli_csum.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -51,6 +52,9 @@ struct dc_csum_veriry_args {
 	d_iov_t                 *iov_csum;
 	uint32_t                 shard;
 	uint32_t                 shard_idx;
+
+	struct daos_recx_ep_list *recov_list;
+	bool                      ec_deg_fetch;
 };
 
 int

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1302,10 +1303,10 @@ obj_ec_recx_reasb(struct dc_object *obj, daos_iod_t *iod, d_sg_list_t *sgl,
 		siod->siod_tgt_idx = obj_ec_shard_idx(obj, dkey_hash, i);
 		siod->siod_idx = tgt_recx_idxs[i];
 		siod->siod_nr = tgt_recx_nrs[i];
-		EC_TRACE("i %d tgt %u idx %u nr %u, start "DF_U64
-			" tgt_recx %u/%u\n", i, siod->siod_tgt_idx, siod->siod_idx,
-			siod->siod_nr, obj_ec_shard_idx(obj, dkey_hash, 0),
-			tgt_recx_idxs[i], tgt_recx_nrs[i]);
+		EC_TRACE("i %d tgt %u idx %u nr %u, start %d,"
+			 " tgt_recx %u/%u\n",
+			 i, siod->siod_tgt_idx, siod->siod_idx, siod->siod_nr,
+			 obj_ec_shard_idx(obj, dkey_hash, 0), tgt_recx_idxs[i], tgt_recx_nrs[i]);
 		siod->siod_off = rec_nr * iod_size;
 		for (idx = last; idx < tgt_recx_idxs[i] + tgt_recx_nrs[i]; idx++)
 			rec_nr += riod->iod_recxs[idx].rx_nr;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1956,10 +1956,6 @@ obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 		 fail_info->efi_recov_tasks != NULL);
 	for (i = 0; i < fail_info->efi_recov_ntasks; i++) {
 		recov_task = &fail_info->efi_recov_tasks[i];
-		/* Set client hlc as recovery epoch only for the case that
-		 * singv recovery without fetch from server ahead - when
-		 * some targets un-available.
-		 */
 		D_ASSERTF(recov_task->ert_epoch != DAOS_EPOCH_MAX && recov_task->ert_epoch != 0,
 			  "bad ert_epoch " DF_X64 "\n", recov_task->ert_epoch);
 		dc_cont2hdl_noref(obj->cob_co, &coh);
@@ -5748,9 +5744,8 @@ obj_ec_fetch_shards_get(struct dc_object *obj, daos_obj_fetch_t *args, unsigned 
 			continue;
 
 		if (obj_auxi->ec_in_recov) {
-			D_DEBUG(DB_IO, DF_OID" shard %d failed recovery(%d) or singv fetch(%d).\n",
-				DP_OID(obj->cob_md.omd_id), grp_start + tgt_idx,
-				obj_auxi->ec_in_recov, obj_auxi->reasb_req.orr_singv_only);
+			D_DEBUG(DB_IO, DF_OID " shard %d failed recovery.\n",
+				DP_OID(obj->cob_md.omd_id), grp_start + tgt_idx);
 			D_GOTO(out, rc = -DER_TGT_RETRY);
 		}
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1,5 +1,6 @@
 /*
  *  (C) Copyright 2016-2024 Intel Corporation.
+ *  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -519,8 +520,8 @@ dc_shard_update_size(struct rw_cb_args *rw_args, int fetch_rc)
 		struct shard_fetch_stat	*fetch_stat;
 		bool			conflict = false;
 
-		D_DEBUG(DB_IO, DF_UOID" size "DF_U64" eph "DF_U64"\n", DP_UOID(orw->orw_oid),
-			sizes[i], orw->orw_epoch);
+		D_DEBUG(DB_IO, DF_UOID " size[%d] " DF_U64 " eph " DF_U64 "\n",
+			DP_UOID(orw->orw_oid), i, sizes[i], orw->orw_epoch);
 
 		if (!is_ec_obj) {
 			iods[i].iod_size = sizes[i];

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -130,35 +130,38 @@ rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 	bool			 is_ec_obj;
 	struct dc_object	*obj = rw_args->shard_args->auxi.obj_auxi->obj;
 	struct dc_csum_veriry_args csum_verify_args = {
-	    .csummer    = rw_args->co->dc_csummer,
-	    .sgls       = rw_args->rwaa_sgls,
-	    .iods       = orw->orw_iod_array.oia_iods,
-	    .iods_csums = orwo->orw_iod_csums.ca_arrays,
-	    .maps       = orwo->orw_maps.ca_arrays,
-	    .dkey       = &orw->orw_dkey,
-	    .sizes      = orwo->orw_iod_sizes.ca_arrays,
-	    .oid        = orw->orw_oid,
-	    .iod_nr     = orw->orw_iod_array.oia_iod_nr,
-	    .maps_nr    = orwo->orw_maps.ca_count,
-	    .oiods      = rw_args->shard_args->oiods,
-	    .reasb_req  = rw_args->shard_args->reasb_req,
-	    .obj        = obj,
-	    .dkey_hash  = rw_args->shard_args->auxi.obj_auxi->dkey_hash,
-	    .shard_offs = rw_args->shard_args->offs,
-	    .oc_attr    = &obj->cob_oca,
-	    .iov_csum   = rw_args2csum_iov(rw_args->shard_args),
-	    .shard      = rw_args->shard_args->auxi.shard,
+	    .csummer      = rw_args->co->dc_csummer,
+	    .sgls         = rw_args->rwaa_sgls,
+	    .iods         = orw->orw_iod_array.oia_iods,
+	    .iods_csums   = orwo->orw_iod_csums.ca_arrays,
+	    .maps         = orwo->orw_maps.ca_arrays,
+	    .dkey         = &orw->orw_dkey,
+	    .sizes        = orwo->orw_iod_sizes.ca_arrays,
+	    .oid          = orw->orw_oid,
+	    .iod_nr       = orw->orw_iod_array.oia_iod_nr,
+	    .maps_nr      = orwo->orw_maps.ca_count,
+	    .oiods        = rw_args->shard_args->oiods,
+	    .reasb_req    = rw_args->shard_args->reasb_req,
+	    .obj          = obj,
+	    .dkey_hash    = rw_args->shard_args->auxi.obj_auxi->dkey_hash,
+	    .shard_offs   = rw_args->shard_args->offs,
+	    .oc_attr      = &obj->cob_oca,
+	    .iov_csum     = rw_args2csum_iov(rw_args->shard_args),
+	    .shard        = rw_args->shard_args->auxi.shard,
+	    .recov_list   = orwo->orw_rels.ca_arrays,
+	    .ec_deg_fetch = false,
 	};
 
-	if (obj_is_ec(obj))
+	if (obj_is_ec(obj)) {
 		csum_verify_args.shard_idx =
 		    obj_ec_shard_off(obj,
 				     rw_args->shard_args->auxi.obj_auxi->dkey_hash,
 				     orw->orw_oid.id_shard);
-	else
+		csum_verify_args.ec_deg_fetch = orw->orw_flags & ORF_EC_DEGRADED;
+	} else {
 		csum_verify_args.shard_idx = orw->orw_oid.id_shard %
 					     daos_oclass_grp_size(&obj->cob_oca);
-
+	}
 
 	rc = dc_rw_cb_csum_verify(&csum_verify_args);
 

--- a/src/object/tests/cli_checksum_tests.c
+++ b/src/object/tests/cli_checksum_tests.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -66,18 +67,19 @@ static void
 timiing_obj_csums_verify(void **state)
 {
 	struct cli_checksum_test_state	*st = *state;
-	struct dc_csum_veriry_args	 args = {
-		 .csummer    = st->csummer,
-		 .iods       = st->td.td_iods,
-		 .iod_nr     = 1,
-		 .sgls       = st->td.td_sgls,
-		 .dkey       = &st->td.dkey,
-		 .maps       = st->td.td_maps,
-		 .maps_nr    = 1,
-		 .iods_csums = NULL,
-		 .dkey_hash  = 1,
-		 .sizes      = st->td.td_sizes,
-	};
+	struct dc_csum_veriry_args       args = {
+		  .csummer      = st->csummer,
+		  .iods         = st->td.td_iods,
+		  .iod_nr       = 1,
+		  .sgls         = st->td.td_sgls,
+		  .dkey         = &st->td.dkey,
+		  .maps         = st->td.td_maps,
+		  .maps_nr      = 1,
+		  .iods_csums   = NULL,
+		  .dkey_hash    = 1,
+		  .sizes        = st->td.td_sizes,
+		  .ec_deg_fetch = false,
+        };
 
 	/* Calculate the checksums that will be verified. In production, these would
 	 * come from the server

--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1694,15 +1695,19 @@ ec_cond_fetch(void **state)
 	daos_handle_t	 oh;
 	d_iov_t		 dkey;
 	d_iov_t		 non_exist_dkey;
-	d_sg_list_t	 sgl[2];
-	d_iov_t		 sg_iov[2];
-	daos_iod_t	 iod[2];
-	daos_recx_t	 recx[2];
-	char		*buf[2];
-	char		*akey[2];
+	d_sg_list_t      sgl[3];
+	d_iov_t          sg_iov[3];
+	daos_iod_t       iod[3];
+	daos_recx_t      recx[3];
+	char            *buf[3];
+	char            *akey[3];
 	const char	*akey_fmt = "akey%d";
 	int		 i, rc;
 	daos_size_t	 size = 8192;
+	daos_size_t      stripe_size;
+	uint16_t         fail_shards[2];
+	uint64_t         fail_val;
+	bool             degraded_test = false;
 
 	if (!test_runable(arg, 6))
 		return;
@@ -1716,17 +1721,24 @@ ec_cond_fetch(void **state)
 	d_iov_set(&dkey, "dkey", strlen("dkey"));
 	d_iov_set(&non_exist_dkey, "non_dkey", strlen("non_dkey"));
 
-	for (i = 0; i < 2; i++) {
+	stripe_size = ec_data_nr_get(oid) * (daos_size_t)ec_cell_size;
+	for (i = 0; i < 3; i++) {
 		D_ALLOC(akey[i], strlen(akey_fmt) + 1);
 		sprintf(akey[i], akey_fmt, i);
 
-		D_ALLOC(buf[i], size);
-		assert_non_null(buf[i]);
-
-		dts_buf_render(buf[i], size);
+		if (i == 2) {
+			D_ALLOC(buf[i], stripe_size);
+			assert_non_null(buf[i]);
+			dts_buf_render(buf[i], stripe_size);
+			d_iov_set(&sg_iov[i], buf[i], stripe_size);
+		} else {
+			D_ALLOC(buf[i], size);
+			assert_non_null(buf[i]);
+			dts_buf_render(buf[i], size);
+			d_iov_set(&sg_iov[i], buf[i], size);
+		}
 
 		/** init scatter/gather */
-		d_iov_set(&sg_iov[i], buf[i], size);
 		sgl[i].sg_nr		= 1;
 		sgl[i].sg_nr_out	= 0;
 		sgl[i].sg_iovs		= &sg_iov[i];
@@ -1740,16 +1752,26 @@ ec_cond_fetch(void **state)
 		if (i == 0) {
 			recx[i].rx_idx		= 0;
 			recx[i].rx_nr		= size;
-		} else {
+		} else if (i == 1) {
 			recx[i].rx_idx		= ec_cell_size;
 			recx[i].rx_nr		= size;
+		} else {
+			recx[i].rx_idx = 0;
+			recx[i].rx_nr  = stripe_size;
 		}
 	}
 
 	/** update record */
-	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 2, iod, sgl,
-			     NULL);
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 3, iod, sgl, NULL);
 	assert_rc_equal(rc, 0);
+
+deg_test:
+	if (degraded_test) {
+		fail_shards[0] = 0;
+		fail_val       = daos_shard_fail_value(fail_shards, 1);
+		daos_fail_value_set(fail_val);
+		daos_fail_loc_set(DAOS_FAIL_SHARD_OPEN | DAOS_FAIL_ALWAYS);
+	}
 
 	/** fetch with NULL sgl but iod_size is non-zero */
 	print_message("negative test - fetch with non-zero iod_size and NULL sgl\n");
@@ -1757,15 +1779,12 @@ ec_cond_fetch(void **state)
 			    NULL, NULL);
 	assert_rc_equal(rc, -DER_INVAL);
 
-	/** normal fetch */
-	for (i = 0; i < 2; i++)
-		iod[i].iod_size	= DAOS_REC_ANY;
-
 	print_message("normal fetch\n");
-	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 2, iod, NULL,
-			    NULL, NULL);
+	for (i = 0; i < 3; i++)
+		iod[i].iod_size = DAOS_REC_ANY;
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 3, iod, NULL, NULL, NULL);
 	assert_rc_equal(rc, 0);
-	for (i = 0; i < 2; i++)
+	for (i = 0; i < 3; i++)
 		assert_int_equal(iod[i].iod_size, 1);
 
 	for (i = 0; i < 2; i++)
@@ -1826,11 +1845,20 @@ ec_cond_fetch(void **state)
 	rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_PER_AKEY, &dkey, 2, iod, sgl, NULL, NULL);
 	assert_rc_equal(rc, 0);
 
+	if (!degraded_test) {
+		degraded_test = true;
+		print_message("run same tests in degraded mode ...\n");
+		goto deg_test;
+	}
+
 	/** close object */
 	rc = daos_obj_close(oh, NULL);
 	assert_rc_equal(rc, 0);
 
-	for (i = 0; i < 2; i++) {
+	daos_fail_value_set(0);
+	daos_fail_loc_set(0);
+
+	for (i = 0; i < 3; i++) {
 		D_FREE(akey[i]);
 		D_FREE(buf[i]);
 	}

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -281,6 +281,9 @@ async_enable(void **state)
 
 	arg->overlap = 0;
 	arg->async   = true;
+	/* reset fail injection to avoid the case of previously failed test case affect next one */
+	daos_fail_value_set(0);
+	daos_fail_loc_set(0);
 	return 0;
 }
 
@@ -291,6 +294,9 @@ async_disable(void **state)
 
 	arg->overlap = 0;
 	arg->async   = false;
+	/* reset fail injection to avoid the case of previously failed test case affect next one */
+	daos_fail_value_set(0);
+	daos_fail_loc_set(0);
 	return 0;
 }
 


### PR DESCRIPTION
1) For EC singv degraded fetch, don't directly start EC data recovery
   from client side, because cannot directly use any hlc from client.
   Instead it will do a degraded fetch from parity shard to get back
   the valid epoch for EC data recovery first.
2) For EC singv degraded fetch server handling, need not bulk
   transferring back the data, instead only need to do the bulk for
   data recovery.
3) For EC array size query, for the degraded fetch also need to convert
   the recx vos index to replica offset.

test code change - add degraded test for EC 18, and reset fail injection when init each test case.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
