### PR TITLE
DAOS-17770 test: erasurecode/online_rebuild_mdtest.py:EcodOnlineRebui…

### DIFF
--- a/src/tests/ftest/erasurecode/online_rebuild_mdtest.py
+++ b/src/tests/ftest/erasurecode/online_rebuild_mdtest.py
@@ -34,5 +34,7 @@ class EcodOnlineRebuildMdtest(ErasureCodeMdtest):
         """
         # Stop one random rank while mdtest is running
         ranks_to_stop = self.random.sample(list(self.server_managers[0].ranks), k=1)
+        self.log_step("Starting mdtest")
         self.start_online_mdtest(ranks_to_stop)
+        self.log_step("Waiting for rebuild completion")
         self.pool.wait_for_rebuild_to_end()

--- a/src/tests/ftest/erasurecode/online_rebuild_mdtest.yaml
+++ b/src/tests/ftest/erasurecode/online_rebuild_mdtest.yaml
@@ -42,7 +42,7 @@ mdtest:
     np: 4
   api: DFS
   test_dir: /
-  dfs_destroy: True
+  dfs_destroy: False
   manager: MPICH
   flags: "-u -F -C"
   write_bytes: 524288


### PR DESCRIPTION
…ldMdtest.test_ec_online_rebuild_mdtest

Script with step log and test yaml update.

Test-tag: test_ec_online_rebuild_mdtest
Test-repeat: 10

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
