### PR TITLE
DAOS-17305 mgmt: Skip pools during engine start (#16452)

### DIFF
--- a/src/include/daos_srv/daos_mgmt_srv.h
+++ b/src/include/daos_srv/daos_mgmt_srv.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -39,5 +40,7 @@ int
 ds_mgmt_tgt_pool_destroy_ranks(uuid_t pool_uuid, d_rank_list_t *ranks);
 int
 ds_mgmt_tgt_pool_shard_destroy(uuid_t pool_uuid, int shard_idx, d_rank_t rank);
+bool
+ds_mgmt_pbl_has_pool(uuid_t uuid);
 
 #endif /* __MGMT_SRV_H__ */

--- a/src/mgmt/srv.c
+++ b/src/mgmt/srv.c
@@ -585,6 +585,12 @@ ds_mgmt_init()
 	if (rc != 0)
 		return rc;
 
+	rc = ds_mgmt_pbl_create();
+	if (rc != 0) {
+		ds_mgmt_system_module_fini();
+		return rc;
+	}
+
 	D_DEBUG(DB_MGMT, "successful init call\n");
 	return 0;
 }
@@ -592,8 +598,8 @@ ds_mgmt_init()
 static int
 ds_mgmt_fini()
 {
+	ds_mgmt_pbl_destroy();
 	ds_mgmt_system_module_fini();
-
 	D_DEBUG(DB_MGMT, "successful fini call\n");
 	return 0;
 }

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -180,5 +180,9 @@ void ds_mgmt_tgt_mark_hdlr(crt_rpc_t *rpc);
 /** srv_util.c */
 int ds_mgmt_group_update(struct server_entry *servers, int nservers, uint32_t version);
 void ds_mgmt_kill_rank(bool force);
+int
+ds_mgmt_pbl_create(void);
+void
+ds_mgmt_pbl_destroy(void);
 
 #endif /* __SRV_MGMT_INTERNAL_H__ */

--- a/src/mgmt/srv_util.c
+++ b/src/mgmt/srv_util.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -75,4 +76,83 @@ out:
 	if (ranks != NULL)
 		d_rank_list_free(ranks);
 	return rc;
+}
+
+static struct d_uuid *pool_blacklist;
+static int            pool_blacklist_len;
+
+static int
+pbl_append(char *uuid_str)
+{
+	uuid_t         uuid;
+	struct d_uuid *p;
+	int            rc;
+
+	rc = uuid_parse(uuid_str, uuid);
+	if (rc != 0)
+		return -DER_INVAL;
+
+	/* Grow pool_blacklist by one element. */
+	D_REALLOC_ARRAY(p, pool_blacklist, pool_blacklist_len, pool_blacklist_len + 1);
+	if (p == NULL)
+		return -DER_NOMEM;
+	pool_blacklist = p;
+
+	uuid_copy(pool_blacklist[pool_blacklist_len].uuid, uuid);
+	pool_blacklist_len++;
+	return 0;
+}
+
+/**
+ * Create the (global) pool blacklist, a list of UUIDs of pools that shall be
+ * skipped during the engine setup process, based on the environment variable
+ * DAOS_POOL_BLACKLIST.
+ */
+int
+ds_mgmt_pbl_create(void)
+{
+	char *name = "DAOS_POOL_BLACKLIST";
+	char *value;
+	char *sep = ",";
+	char *uuid_str;
+	char *c;
+	int   rc;
+
+	rc = d_agetenv_str(&value, name);
+	if (rc == -DER_NONEXIST)
+		return 0;
+	else if (rc != 0)
+		return rc;
+
+	for (uuid_str = strtok_r(value, sep, &c); uuid_str != NULL;
+	     uuid_str = strtok_r(NULL, sep, &c)) {
+		rc = pbl_append(uuid_str);
+		if (rc != 0) {
+			DL_ERROR(rc, "failed to parse pool UUID in %s: '%s'", name, uuid_str);
+			D_FREE(pool_blacklist);
+			pool_blacklist_len = 0;
+			break;
+		}
+	}
+
+	d_freeenv_str(&value);
+	return rc;
+}
+
+bool
+ds_mgmt_pbl_has_pool(uuid_t uuid)
+{
+	int i;
+
+	for (i = 0; i < pool_blacklist_len; i++)
+		if (uuid_compare(pool_blacklist[i].uuid, uuid) == 0)
+			return true;
+	return false;
+}
+
+void
+ds_mgmt_pbl_destroy(void)
+{
+	D_FREE(pool_blacklist);
+	pool_blacklist_len = 0;
 }

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2686,6 +2686,12 @@ start_one(uuid_t uuid, void *varg)
 	bool			 immutable;
 	int			 rc;
 
+	if (ds_mgmt_pbl_has_pool(uuid)) {
+		D_INFO(DF_UUID ": not starting: in pool blacklist\n", DP_UUID(uuid));
+		ds_pool_failed_add(uuid, -DER_NO_SERVICE);
+		return 0;
+	}
+
 	if (psa != NULL) {
 		aft_chk = psa->psa_aft_chk;
 		immutable = psa->psa_immutable;


### PR DESCRIPTION
Add an "internal" environment variable, DAOS_POOL_BLACKLIST, for skipping problematic pools in emergency situations.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
