### PR TITLE
DAOS-17786 metrics: fix daos_metrics help

### DIFF
--- a/src/utils/daos_metrics/daos_metrics.c
+++ b/src/utils/daos_metrics/daos_metrics.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2021-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -35,6 +36,8 @@ print_usage(const char *prog_name)
 	       "\tDisplay data in CSV format\n"
 	       "--meta, -M\n"
 	       "\tDisplay associated metric metadata\n"
+	       "--meminfo, -m\n"
+	       "\tDisplay memory allocation metrics\n"
 	       "--type, -T\n"
 	       "\tDisplay metric type\n"
 	       "--help, -h\n"


### PR DESCRIPTION
Add the missing meminfo option in the daos_metric application help message.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
