### PR TITLE
DAOS-17442 engine: Improve start issue handling (#16376)

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -385,6 +385,7 @@ struct bio_xs_context {
 	struct bio_xs_blobstore	*bxc_xs_blobstores[SMD_DEV_TYPE_MAX];
 	struct bio_dma_buffer	*bxc_dma_buf;
 	unsigned int		 bxc_self_polling:1;	/* for standalone VOS */
+	unsigned int             bxc_skip_draining : 1;
 };
 
 /* Per VOS instance I/O context */

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -1501,6 +1501,8 @@ bio_xsctxt_free(struct bio_xs_context *ctxt)
 			rc = xs_poll_completion(ctxt, &cp_arg.cca_inflights,
 						bio_spdk_subsys_timeout);
 			DL_CDEBUG(rc == 0, DB_MGMT, DLOG_ERR, rc, "SPDK subsystems finalized");
+			if (rc != 0)
+				ctxt->bxc_skip_draining = 1;
 
 			nvme_glb.bd_init_thread = NULL;
 
@@ -1512,18 +1514,21 @@ bio_xsctxt_free(struct bio_xs_context *ctxt)
 	ABT_mutex_unlock(nvme_glb.bd_mutex);
 
 	if (ctxt->bxc_thread != NULL) {
-		D_DEBUG(DB_MGMT, "Finalizing SPDK thread, tgt_id:%d",
-			ctxt->bxc_tgt_id);
+		D_DEBUG(DB_MGMT, "Finalizing SPDK thread, tgt_id:%d, skip_draining:%u",
+			ctxt->bxc_tgt_id, ctxt->bxc_skip_draining);
 
-		/* Don't drain events if spdk_subsystem_fini() timeout */
-		while (rc == 0 && !spdk_thread_is_idle(ctxt->bxc_thread))
+		/*
+		 * Don't drain events if we are asked to skip this (usually
+		 * due to an earlier error).
+		 */
+		while (!ctxt->bxc_skip_draining && !spdk_thread_is_idle(ctxt->bxc_thread))
 			spdk_thread_poll(ctxt->bxc_thread, 0, 0);
 
 		D_DEBUG(DB_MGMT, "SPDK thread finalized, tgt_id:%d",
 			ctxt->bxc_tgt_id);
 
 		spdk_thread_exit(ctxt->bxc_thread);
-		while (rc == 0 && !spdk_thread_is_exited(ctxt->bxc_thread))
+		while (!ctxt->bxc_skip_draining && !spdk_thread_is_exited(ctxt->bxc_thread))
 			spdk_thread_poll(ctxt->bxc_thread, 0, 0);
 		spdk_thread_destroy(ctxt->bxc_thread);
 		ctxt->bxc_thread = NULL;
@@ -1609,7 +1614,12 @@ bio_xsctxt_alloc(struct bio_xs_context **pctxt, int tgt_id, bool self_polling)
 
 		if (cp_arg.cca_rc != 0) {
 			rc = cp_arg.cca_rc;
-			D_ERROR("failed to init bdevs, rc:%d\n", rc);
+			DL_ERROR(rc, "failed to init bdevs");
+			/*
+			 * We're afraid that draining the thread might never
+			 * complete (DAOS-17442).
+			 */
+			ctxt->bxc_skip_draining = 1;
 			goto out;
 		}
 

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -696,10 +697,6 @@ dss_crt_hlc_error_cb(void *arg)
 static void
 server_id_cb(uint32_t *tid, uint64_t *uid)
 {
-
-	if (server_init_state != DSS_INIT_STATE_SET_UP)
-		return;
-
 	if (uid != NULL && dss_abt_init) {
 		ABT_unit_type type = ABT_UNIT_TYPE_EXT;
 		int rc;

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -571,8 +571,10 @@ dss_srv_handler(void *arg)
 			}
 		}
 
-		if (dss_xstream_exiting(dx))
+		if (dss_xstream_exiting(dx)) {
+			rc = 0;
 			break;
+		}
 
 		ABT_thread_yield();
 	}
@@ -609,6 +611,7 @@ signal:
 		ABT_cond_signal(xstream_data.xd_ult_init);
 		ABT_mutex_unlock(xstream_data.xd_mutex);
 	}
+	DL_CDEBUG(rc == 0, DLOG_INFO, DLOG_ERR, rc, "stopping");
 }
 
 static inline struct dss_xstream *
@@ -1067,8 +1070,10 @@ dss_start_xs_id(int tag, int xs_id)
 	}
 
 	rc = dss_start_one_xstream(obj->cpuset, tag, xs_id);
-	if (rc)
+	if (rc != 0) {
+		DL_ERROR(rc, "failed to start one xstream: tag=%x xs_id=%d", tag, xs_id);
 		return rc;
+	}
 
 	return 0;
 }

--- a/src/include/daos_srv/ras.h
+++ b/src/include/daos_srv/ras.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2020-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -49,6 +50,7 @@
 	X(RAS_POOL_REPS_UPDATE, "pool_replicas_updated")                                           \
 	X(RAS_POOL_DF_INCOMPAT, "pool_durable_format_incompatible")                                \
 	X(RAS_POOL_DEFER_DESTROY, "pool_destroy_deferred")                                         \
+	X(RAS_POOL_START_FAILED, "pool_start_failed")                                              \
 	X(RAS_CONT_DF_INCOMPAT, "container_durable_format_incompatible")                           \
 	X(RAS_RDB_DF_INCOMPAT, "rdb_durable_format_incompatible")                                  \
 	X(RAS_SWIM_RANK_ALIVE, "swim_rank_alive")                                                  \

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1273,6 +1274,7 @@ tgt_destroy_cleanup(void *arg)
 
 	/** make sure the rename is persistent */
 	(void)dir_fsync(zombie);
+	D_INFO(DF_UUID ": moved %s to %s\n", DP_UUID(tda->tda_id.uuid), tda->tda_path, zombie);
 
 	/**
 	 * once successfully moved to the ZOMBIES directory, the target will
@@ -1282,6 +1284,7 @@ tgt_destroy_cleanup(void *arg)
 	if (tda->tda_rc == 0) {
 		(void)subtree_destroy(zombie);
 		(void)rmdir(zombie);
+		D_INFO(DF_UUID ": removed %s\n", DP_UUID(tda->tda_id.uuid), zombie);
 	} else {
 		D_INFO("Defer cleanup for lingering pool:"DF_UUID"\n",
 		       DP_UUID(tda->tda_id.uuid));

--- a/src/pool/srv.c
+++ b/src/pool/srv.c
@@ -118,7 +118,7 @@ setup(void)
 	bool start = true;
 
 	if (!engine_in_check()) {
-		d_getenv_bool("DAOS_START_POOL_SVC", &start);
+		d_getenv_bool("DAOS_START_POOLS", &start);
 		if (start)
 			return ds_pool_start_all();
 	}

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2699,9 +2699,17 @@ start_one(uuid_t uuid, void *varg)
 
 	rc = ds_pool_start(uuid, aft_chk, immutable);
 	if (rc != 0) {
+		uuid_t uuid_tmp;
+
 		DL_ERROR(rc, DF_UUID ": failed to start pool, aft_chk %s, immutable %s",
 			 DP_UUID(uuid), aft_chk ? "yes" : "no", immutable ? "yes" : "no");
 		ds_pool_failed_add(uuid, rc);
+		uuid_copy(uuid_tmp, uuid);
+		ds_notify_ras_eventf(RAS_POOL_START_FAILED, RAS_TYPE_INFO, RAS_SEV_ERROR,
+				     NULL /* hwid */, NULL /* rank */, NULL /* inc */,
+				     NULL /* jobid */, &uuid_tmp, NULL /* cont */, NULL /* objid */,
+				     NULL /* ctlop */, NULL /* data */,
+				     "failed to start pool: " DF_RC, DP_RC(rc));
 	}
 
 	return 0;
@@ -2712,11 +2720,10 @@ pool_start_all(void *arg)
 {
 	int rc;
 
-	/* Scan the storage and start all pool services. */
+	/* Scan the storage and start all pools. */
 	rc = ds_mgmt_tgt_pool_iterate(start_one, NULL /* arg */);
 	if (rc != 0)
-		D_ERROR("failed to scan all pool services: "DF_RC"\n",
-			DP_RC(rc));
+		DL_ERROR(rc, "failed to scan pools");
 }
 
 bool

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -460,7 +460,6 @@ out:
 
 }
 
-
 static int
 pool_child_start(struct ds_pool_child *child, bool recreate)
 {
@@ -490,14 +489,14 @@ pool_child_start(struct ds_pool_child *child, bool recreate)
 	D_FREE(path);
 
 	if (rc != 0) {
-		if (rc != -DER_NONEXIST) {
+		if (!engine_in_check() || rc != -DER_NONEXIST) {
 			DL_CDEBUG(rc == -DER_NVME_IO, DB_MGMT, DLOG_ERR, rc,
 				  DF_UUID": Open VOS pool failed.", DP_UUID(child->spc_uuid));
 			goto out;
 		}
 
-		D_WARN("Lost pool "DF_UUIDF" shard %u on rank %u.\n",
-		       DP_UUID(child->spc_uuid), info->dmi_tgt_id, dss_self_rank());
+		D_WARN(DF_UUID ": Lost pool shard %u on rank %u.\n", DP_UUID(child->spc_uuid),
+		       info->dmi_tgt_id, dss_self_rank());
 		/*
 		 * Ignore the failure to allow subsequent logic (such as DAOS check)
 		 * to handle the trouble.


### PR DESCRIPTION
We infer from the available log messages that bio_xsctxt_alloc might get stuck after "failed to init bdevs: -1003" for some unknown reason related to SPDK. This patch skips two while statements in bio_xsctxt_free that might be where we got stuck.

When not in the CR mode, a pool ignores nonexistent children, leading to states that the current code cannot handle well (yet). This patch restricts this CR behavior to the CR mode. (Ideally, we shall allow the healthy children to start and automatically exclude the nonexistent children in the future.)

To make pool start failures easier to spot, this patch adds a RAS event that is raised when we fail to start a pool.

Also, this patch

  - fixes "-1" xstream IDs in messages logged during engine setup,
  - fixes a few places where we should write "pool" instead of "pool service", including the name of an internal environment variable, and
  - adds some infrequent log messages to help future debugging of engine start issues.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
