### PR TITLE
SRE-3194 build: Remove redhat-lsb-core from Dockerfile.mockbuild

### DIFF
--- a/utils/rpms/packaging/Dockerfile.mockbuild
+++ b/utils/rpms/packaging/Dockerfile.mockbuild
@@ -30,7 +30,7 @@ RUN chmod +x /tmp/repo-helper.sh &&                 \
 # This needs to be moved to a shell script like above in the future to
 # properly only remove the proxy variables only when they need to be removed
 RUN dnf -y install mock make                                        \
-                   rpm-build createrepo rpmlint redhat-lsb-core git \
+                   rpm-build createrepo rpmlint git                 \
                    python-srpm-macros rpmdevtools &&                \
     dnf -y clean all
 


### PR DESCRIPTION
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
