### PR TITLE
DAOS-17803 cq: Automate Jira ticket for dependabot

### DIFF
--- a/.github/workflows/dependabot2jira.yml
+++ b/.github/workflows/dependabot2jira.yml
@@ -1,0 +1,53 @@
+name: Dependabot Jira ticket
+# This workflow is triggered to create a Jira ticket for every new dependabot PR
+
+permissions: {}
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  run-if-dependabot:
+    if: github.actor == 'dependabot'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Create a new Jira ticket
+        env:
+          JIRA_PROJECT_KEY: "DAOS"
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          new_title=$(echo "$PR_TITLE" | sed 's/^Doc-only: true //')
+          jira_response=$(curl -u "${{ secrets.JIRA_EMAIL }}:${{ secrets.JIRA_API_TOKEN }}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            --data "$(jq -n --arg title "$new_title" \
+                           --arg body "$PR_BODY" \
+                           --arg project_key "$JIRA_PROJECT_KEY" \
+                           '{
+                              fields: {
+                                project: { key: $project_key },
+                                summary: $title,
+                                description: $body,
+                                issuetype: { name: "Story" }
+                              }
+                            }')" ${{ secrets.JIRA_BASE_URL }}
+           )
+
+          jira_ticket_key=$(echo $jira_response | jq -r .key)
+          echo "PR_NEW_TITLE=$jira_ticket_key cq: $new_title" >> $GITHUB_ENV
+
+      - name: Update the PR title with a prefix based on the Jira ticket key
+        env:
+          PR_URL: "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" # yamllint disable-line
+        run: |
+          curl -X PATCH -sS -o /dev/null \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data "$(jq -n --arg title "$PR_NEW_TITLE" \
+                           '{
+                              title: $title,
+                            }' )" $PR_URL


### PR DESCRIPTION
Automate Jira ticket create for dependabot's PRs
- create a new Jira ticket in the DAOS project for every new PR created by the dependabot based on PR title and PR description
- remove `Doc-only: true` prefix from PR title
- Add `DAOS-... cq:` prefix to PR title.

An example of working workflow can be find here:
https://github.com/grom72/daos/actions/runs/16288506266/job/45992625398
with related ticket in the DAOS-PMDK project: https://daosio.atlassian.net/browse/PMDK-654
and PR itself with an updated title: https://github.com/grom72/daos/pull/129

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
