### PR TITLE
DAOS-17790 test: Fix MSMembership ramdisk size check

### DIFF
--- a/src/tests/ftest/recovery/ms_membership.yaml
+++ b/src/tests/ftest/recovery/ms_membership.yaml
@@ -10,4 +10,3 @@ server_config:
     0:
       targets: 1
       storage: auto
-  system_ram_reserved: 1


### PR DESCRIPTION
Update system_ram_reserved setting for the recovery/ms_membership.py test.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: MSMembershipTest

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
