### PR TITLE
DAOS-17772 rebuild: fix a race in rebuild status checker

### DIFF
--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -79,6 +79,10 @@ struct migrate_pool_tls {
 	ATOMIC uint32_t		*mpt_obj_ult_cnts;
 	ATOMIC uint32_t		*mpt_dkey_ult_cnts;
 
+	/* ULTs waiting for scheduling */
+	ATOMIC uint32_t		 mpt_obj_ult_waiters;
+	ATOMIC uint32_t		 mpt_dkey_ult_waiters;
+
 	/* reference count for the structure */
 	uint64_t		mpt_refcount;
 


### PR DESCRIPTION
daos rebuild checker may report rebuild completion when some pulling ULT are still waiting

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
