### PR TITLE
DAOS-17591 object: refresh DTX MBS for case being changed

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -164,6 +164,23 @@ vos_dtx_load_mbs(daos_handle_t coh, struct dtx_id *dti, daos_unit_oid_t *oid,
 		 struct dtx_memberships **mbs);
 
 /**
+ * Refresh participants information and pool map version for the given DTX.
+ *
+ * \param coh		[IN]	Container open handle.
+ * \param dti		[IN]	Pointer to the DTX identifier.
+ * \param mbs		[IN]	Pointer to the DTX participants information.
+ * \param pm_ver	[IN]	Pool map version for the new DTX participants information.
+ * \param leader	[IN]	Is DTX leader or not.
+ *
+ * \return		Zero on success.
+ *			Positive if changed nothing.
+ *			Negative value if error.
+ */
+int
+vos_dtx_refresh_mbs(daos_handle_t coh, struct dtx_id *dti, struct dtx_memberships *mbs,
+		    uint32_t pm_ver, bool leader);
+
+/**
  * Commit the specified DTXs.
  *
  * \param coh	[IN]	Container open handle.

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2635,6 +2635,81 @@ out:
 	obj_ioc_end(&ioc, rc);
 }
 
+static int
+obj_handle_resend(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch, uint32_t *pm_ver,
+		  uint32_t *flags, struct dtx_memberships *mbs, bool leader, bool dist)
+{
+	daos_epoch_t e;
+	uint32_t     ver = *pm_ver;
+	int          rc;
+
+	if (!leader || dist || (flags != NULL && *flags & ORF_RESEND))
+		e = *epoch;
+	else
+		e = 0;
+
+	rc = dtx_handle_resend(coh, dti, &e, &ver);
+	switch (rc) {
+	case -DER_ALREADY:
+		/* Do nothing if 'committed' or 'committable'. */
+		D_GOTO(out, rc = 1);
+	case 0:
+		/* For 'prepared' DTX, if pool map has been changed, then DTX membership maybe
+		 * changed also. Let's refresh it if necessary.
+		 */
+		if (ver < *pm_ver) {
+			rc = vos_dtx_refresh_mbs(coh, dti, mbs, *pm_ver, leader);
+			if (rc < 0)
+				goto out;
+
+			if (rc > 0)
+				rc = 0;
+
+			if (leader && !dist)
+				*pm_ver = ver;
+		}
+
+		if (flags != NULL) {
+			*flags |= ORF_RESEND;
+			*epoch = e;
+		}
+
+		break;
+	case -DER_MISMATCH:
+		if (dist)
+			/* NOTE: For distributed transaction, there is race between the client DTX
+			 *	 commit with restart and the DTX recovery on the new leader. It is
+			 *	 possible that the new DTX leader is waiting for others reply for
+			 *	 related DTX recovery, or the DTX recovery ULT is not started yet.
+			 *
+			 *	 But we do not know whether the old DTX leader has ever committed
+			 *	 related DTX before its corruption or not. If yes, then abort DTX
+			 *	 with old epoch will break the semantics.
+			 *
+			 *	 So here we need to wait the new DTX leader to recover such DTX:
+			 *	 either commit or abort. Let's return '-DER_INPROGRESS' to ask the
+			 *	 client to retry sometime later.
+			 */
+			D_GOTO(out, rc = -DER_INPROGRESS);
+
+		/* Abort it if exist but with different epoch, then re-execute with new epoch. */
+		rc = vos_dtx_abort(coh, dti, e);
+		if (rc < 0 && rc != -DER_NONEXIST)
+			D_GOTO(out, rc);
+		/* Fall through */
+	case -DER_NONEXIST:
+		if (flags != NULL)
+			*flags = 0;
+		rc = 0;
+		break;
+	default:
+		break;
+	}
+
+out:
+	return rc;
+}
+
 void
 ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 {
@@ -2675,26 +2750,18 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 		dss_get_module_info()->dmi_xs_id, orw->orw_epoch,
 		orw->orw_map_ver, ioc.ioc_map_ver, DP_DTI(&orw->orw_dti));
 
+	tgts    = orw->orw_shard_tgts.ca_arrays;
+	tgt_cnt = orw->orw_shard_tgts.ca_count;
+	rc      = obj_gen_dtx_mbs(orw->orw_flags, &tgt_cnt, &tgts, &mbs);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
 	/* Handle resend. */
 	if (orw->orw_flags & ORF_RESEND) {
-		daos_epoch_t	e = orw->orw_epoch;
-
-		rc = dtx_handle_resend(ioc.ioc_vos_coh, &orw->orw_dti, &e, NULL);
-		/* Do nothing if 'prepared' or 'committed'. */
-		if (rc == -DER_ALREADY || rc == 0)
-			D_GOTO(out, rc = 0);
-
-		/* Abort it firstly if exist but with different epoch,
-		 * then re-execute with new epoch.
-		 */
-		if (rc == -DER_MISMATCH)
-			/* Abort it by force with MAX epoch to guarantee
-			 * that it can be aborted.
-			 */
-			rc = vos_dtx_abort(ioc.ioc_vos_coh, &orw->orw_dti, e);
-
-		if (rc < 0 && rc != -DER_NONEXIST)
-			D_GOTO(out, rc);
+		rc = obj_handle_resend(ioc.ioc_vos_coh, &orw->orw_dti, &orw->orw_epoch,
+				       &orw->orw_map_ver, NULL, mbs, false, false);
+		if (rc != 0)
+			D_GOTO(out, rc = (rc > 0 ? 0 : rc));
 	}
 
 	/* Inject failure for test to simulate the case of lost some
@@ -2716,13 +2783,6 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 		}
 		D_GOTO(out, rc = 0);
 	}
-
-	tgts = orw->orw_shard_tgts.ca_arrays;
-	tgt_cnt = orw->orw_shard_tgts.ca_count;
-
-	rc = obj_gen_dtx_mbs(orw->orw_flags, &tgt_cnt, &tgts, &mbs);
-	if (rc != 0)
-		D_GOTO(out, rc);
 
 	epoch.oe_value = orw->orw_epoch;
 	epoch.oe_first = orw->orw_epoch_first;
@@ -2998,36 +3058,14 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 	/* Handle resend. */
 	if (orw->orw_flags & ORF_RESEND) {
-		daos_epoch_t		 e;
-
 		d_tm_inc_counter(opm->opm_update_resent, 1);
 
 again:
-		if (flags & ORF_RESEND)
-			e = orw->orw_epoch;
-		else
-			e = 0;
 		version = orw->orw_map_ver;
-		rc      = dtx_handle_resend(ioc.ioc_vos_coh, &orw->orw_dti, &e, &version);
-		switch (rc) {
-		case -DER_ALREADY:
-			D_GOTO(out, rc = 0);
-		case 0:
-			flags |= ORF_RESEND;
-			orw->orw_epoch = e;
-			/* TODO: Also recover the epoch uncertainty. */
-			break;
-		case -DER_MISMATCH:
-			rc = vos_dtx_abort(ioc.ioc_vos_coh, &orw->orw_dti, e);
-			if (rc < 0 && rc != -DER_NONEXIST)
-				D_GOTO(out, rc);
-			/* Fall through */
-		case -DER_NONEXIST:
-			flags = 0;
-			break;
-		default:
-			D_GOTO(out, rc);
-		}
+		rc = obj_handle_resend(ioc.ioc_vos_coh, &orw->orw_dti, &orw->orw_epoch, &version,
+				       &flags, mbs, true, false);
+		if (rc != 0)
+			D_GOTO(out, rc = (rc > 0 ? 0 : rc));
 	} else if (DAOS_FAIL_CHECK(DAOS_DTX_LOST_RPC_REQUEST)) {
 		ioc.ioc_lost_reply = 1;
 		D_GOTO(out, rc);
@@ -3641,10 +3679,9 @@ obj_tgt_punch(struct obj_tgt_punch_args *otpa, uint32_t *shards, uint32_t count)
 	struct obj_io_context	*p_ioc = otpa->sponsor_ioc;
 	struct dtx_handle	*dth = otpa->sponsor_dth;
 	struct obj_punch_in	*opi = otpa->opi;
-	struct dtx_epoch	 epoch;
-	daos_epoch_t		 tmp;
-	uint32_t		 dtx_flags = 0;
-	int			 rc = 0;
+	struct dtx_epoch         epoch;
+	uint32_t                 dtx_flags = 0;
+	int                      rc        = 0;
 
 	if (p_ioc == NULL) {
 		p_ioc = &ioc;
@@ -3663,21 +3700,10 @@ obj_tgt_punch(struct obj_tgt_punch_args *otpa, uint32_t *shards, uint32_t count)
 	}
 
 	if (opi->opi_flags & ORF_RESEND) {
-		tmp = opi->opi_epoch;
-		rc = dtx_handle_resend(p_ioc->ioc_vos_coh, &opi->opi_dti, &tmp, NULL);
-		/* Do nothing if 'prepared' or 'committed'. */
-		if (rc == -DER_ALREADY || rc == 0)
-			D_GOTO(out, rc = 0);
-
-		/* Abort old one with different epoch, then re-execute with new epoch. */
-		if (rc == -DER_MISMATCH)
-			/* Abort it by force with MAX epoch to guarantee
-			 * that it can be aborted.
-			 */
-			rc = vos_dtx_abort(p_ioc->ioc_vos_coh, &opi->opi_dti, tmp);
-
-		if (rc < 0 && rc != -DER_NONEXIST)
-			D_GOTO(out, rc);
+		rc = obj_handle_resend(p_ioc->ioc_vos_coh, &opi->opi_dti, &opi->opi_epoch,
+				       &opi->opi_map_ver, NULL, otpa->mbs, false, false);
+		if (rc != 0)
+			D_GOTO(out, rc = (rc > 0 ? 0 : rc));
 	}
 
 	epoch.oe_value = opi->opi_epoch;
@@ -3903,34 +3929,12 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 
 	/* Handle resend. */
 	if (opi->opi_flags & ORF_RESEND) {
-		daos_epoch_t	e;
-
 again:
-		if (flags & ORF_RESEND)
-			e = opi->opi_epoch;
-		else
-			e = 0;
 		version = opi->opi_map_ver;
-		rc      = dtx_handle_resend(ioc.ioc_vos_coh, &opi->opi_dti, &e, &version);
-		switch (rc) {
-		case -DER_ALREADY:
-			D_GOTO(out, rc = 0);
-		case 0:
-			opi->opi_epoch = e;
-			flags |= ORF_RESEND;
-			/* TODO: Also recovery the epoch uncertainty. */
-			break;
-		case -DER_MISMATCH:
-			rc = vos_dtx_abort(ioc.ioc_vos_coh, &opi->opi_dti, e);
-			if (rc < 0 && rc != -DER_NONEXIST)
-				D_GOTO(out, rc);
-			/* Fall through */
-		case -DER_NONEXIST:
-			flags = 0;
-			break;
-		default:
-			D_GOTO(out, rc);
-		}
+		rc = obj_handle_resend(ioc.ioc_vos_coh, &opi->opi_dti, &opi->opi_epoch, &version,
+				       &flags, mbs, true, false);
+		if (rc != 0)
+			D_GOTO(out, rc = (rc > 0 ? 0 : rc));
 	} else if (DAOS_FAIL_CHECK(DAOS_DTX_LOST_RPC_REQUEST) ||
 		   DAOS_FAIL_CHECK(DAOS_DTX_LONG_TIME_RESEND)) {
 		goto cleanup;
@@ -4969,32 +4973,30 @@ again:
 static int
 ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 {
-	struct dtx_handle		*dth = NULL;
-	struct obj_cpd_in		*oci = crt_req_get(rpc);
-	struct daos_cpd_sub_head	*dcsh = ds_obj_cpd_get_head(rpc, 0);
-	struct daos_cpd_disp_ent	*dcde = ds_obj_cpd_get_ents(rpc, 0, -1);
-	struct daos_cpd_sub_req		*dcsr = ds_obj_cpd_get_reqs(rpc, 0);
-	daos_epoch_t			 e = dcsh->dcsh_epoch.oe_value;
-	uint32_t			 dtx_flags = DTX_DIST;
-	int				 rc = 0;
-	int				 rc1 = 0;
+	struct dtx_handle        *dth       = NULL;
+	struct obj_cpd_in        *oci       = crt_req_get(rpc);
+	struct daos_cpd_sub_head *dcsh      = ds_obj_cpd_get_head(rpc, 0);
+	struct daos_cpd_disp_ent *dcde      = ds_obj_cpd_get_ents(rpc, 0, -1);
+	struct daos_cpd_sub_req  *dcsr      = ds_obj_cpd_get_reqs(rpc, 0);
+	daos_epoch_t              epoch     = dcsh->dcsh_epoch.oe_value;
+	uint32_t                  dtx_flags = DTX_DIST;
+	int                       rc        = 0;
 
 	D_DEBUG(DB_IO, "Handling DTX "DF_DTI" on non-leader\n",
 		DP_DTI(&dcsh->dcsh_xid));
 
-	D_ASSERT(dcsh->dcsh_epoch.oe_value != 0);
-	D_ASSERT(dcsh->dcsh_epoch.oe_value != DAOS_EPOCH_MAX);
+	D_ASSERT(epoch != 0);
+	D_ASSERT(epoch != DAOS_EPOCH_MAX);
 
 	if (oci->oci_flags & ORF_RESEND) {
-		rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &dcsh->dcsh_xid, &e, NULL);
-		/* Do nothing if 'prepared' or 'committed'. */
-		if (rc1 == -DER_ALREADY || rc1 == 0)
-			D_GOTO(out, rc = 0);
+		rc = obj_handle_resend(ioc->ioc_vos_coh, &dcsh->dcsh_xid, &epoch, &oci->oci_map_ver,
+				       NULL, dcsh->dcsh_mbs, false, true);
+		if (rc != 0)
+			D_GOTO(out, rc = (rc > 0 ? 0 : rc));
 	}
 
 	/* Refuse any modification with old epoch. */
-	if (dcde->dcde_write_cnt != 0 &&
-	    dcsh->dcsh_epoch.oe_value < dss_get_start_epoch())
+	if (dcde->dcde_write_cnt != 0 && epoch < dss_get_start_epoch())
 		D_GOTO(out, rc = -DER_TX_RESTART);
 
 	/* The check for read capa has been done before handling the CPD RPC.
@@ -5004,23 +5006,6 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 		rc = obj_capa_check(ioc->ioc_coh, true, false);
 		if (rc != 0)
 			goto out;
-	}
-
-	switch (rc1) {
-	case -DER_NONEXIST:
-	case 0:
-		break;
-	case -DER_MISMATCH:
-		/* For resent RPC, abort it firstly if exist but with different
-		 * (old) epoch, then re-execute with new epoch.
-		 */
-		rc = vos_dtx_abort(ioc->ioc_vos_coh, &dcsh->dcsh_xid, e);
-		if (rc < 0 && rc != -DER_NONEXIST)
-			D_GOTO(out, rc);
-		break;
-	default:
-		D_ASSERTF(rc1 < 0, "Resend check result: %d\n", rc1);
-		D_GOTO(out, rc = rc1);
 	}
 
 	if (oci->oci_flags & ORF_DTX_SYNC)
@@ -5135,41 +5120,11 @@ again:
 		/* For distributed transaction, the 'ORF_RESEND' may means
 		 * that the DTX has been restarted with newer epoch.
 		 */
-		rc = dtx_handle_resend(dca->dca_ioc->ioc_vos_coh,
-				       &dcsh->dcsh_xid,
-				       &dcsh->dcsh_epoch.oe_value, NULL);
-		switch (rc) {
-		case -DER_ALREADY:
-			/* Do nothing if 'committed'. */
-			D_GOTO(out, rc = 0);
-		case 0:
-			/* For 'prepared' case, still need to dispatch. */
-			flags = ORF_RESEND;
-			break;
-		case -DER_MISMATCH:
-			/* XXX: For distributed transaction, there is race
-			 *	between the client DTX commit with restart
-			 *	and the DTX recovery on the new leader. It
-			 *	is possible that the new leader is waiting
-			 *	for others reply for related DTX recovery,
-			 *	or the DTX recovery ULT is not started yet.
-			 *
-			 *	But we do not know whether the old leader
-			 *	has ever committed related DTX before its
-			 *	corruption or not. If yes, then abort DTX
-			 *	with old epoch will break the semantics.
-			 *
-			 *	So here we need to wait the new leader to
-			 *	recover such DTX: either commit or abort.
-			 *	Let's return '-DER_INPROGRESS' to ask the
-			 *	client to retry sometime later.
-			 */
-			D_GOTO(out, rc = -DER_INPROGRESS);
-		default:
-			if (rc < 0 && rc != -DER_NONEXIST)
-				D_GOTO(out, rc);
-			break;
-		}
+		rc = obj_handle_resend(dca->dca_ioc->ioc_vos_coh, &dcsh->dcsh_xid,
+				       &dcsh->dcsh_epoch.oe_value, &oci->oci_map_ver, &flags,
+				       dcsh->dcsh_mbs, true, true);
+		if (rc != 0)
+			D_GOTO(out, rc = (rc > 0 ? 0 : rc));
 	} else if (DAOS_FAIL_CHECK(DAOS_DTX_LOST_RPC_REQUEST)) {
 		D_GOTO(out, rc = 0);
 	}
@@ -5695,21 +5650,25 @@ ds_obj_coll_punch_handler(crt_rpc_t *rpc)
 	uint32_t			 dtx_flags = DTX_TGT_COLL;
 	uint32_t			 version = 0;
 	uint32_t			 max_ver = 0;
-	struct dtx_epoch		 epoch;
-	daos_epoch_t			 tmp;
+	struct dtx_epoch                 epoch;
 	int				 rc;
 	int				 rc1;
 	int				 i;
 	bool				 need_abort = false;
+	bool                             leader;
 
-	D_DEBUG(DB_IO, "(%s) handling collective punch RPC %p for obj "
-		DF_UOID" on XS %u/%u epc "DF_X64" pmv %u, with dti "
-		DF_DTI", forward width %u, forward depth %u, flags %x\n",
-		(ocpi->ocpi_flags & ORF_LEADER) ? "leader" :
-		(ocpi->ocpi_tgts.ca_count == 1 ? "non-leader" : "relay-engine"),
-		rpc, DP_UOID(ocpi->ocpi_oid), dmi->dmi_xs_id, dmi->dmi_tgt_id,
-		ocpi->ocpi_epoch, ocpi->ocpi_map_ver, DP_DTI(&ocpi->ocpi_xid),
-		ocpi->ocpi_disp_width, ocpi->ocpi_disp_depth, ocpi->ocpi_flags);
+	if (ocpi->ocpi_flags & ORF_LEADER)
+		leader = true;
+	else
+		leader = false;
+
+	D_DEBUG(DB_IO,
+		"(%s) handling collective punch RPC %p for obj " DF_UOID " on XS %u/%u epc " DF_X64
+		" pmv %u, with dti " DF_DTI ", forward width %u, forward depth %u, flags %x\n",
+		leader ? "leader" : (ocpi->ocpi_tgts.ca_count == 1 ? "non-leader" : "relay-engine"),
+		rpc, DP_UOID(ocpi->ocpi_oid), dmi->dmi_xs_id, dmi->dmi_tgt_id, ocpi->ocpi_epoch,
+		ocpi->ocpi_map_ver, DP_DTI(&ocpi->ocpi_xid), ocpi->ocpi_disp_width,
+		ocpi->ocpi_disp_depth, ocpi->ocpi_flags);
 
 	D_ASSERT(dmi->dmi_xs_id != 0);
 
@@ -5718,7 +5677,7 @@ ds_obj_coll_punch_handler(crt_rpc_t *rpc)
 	if (rc != 0)
 		goto out;
 
-	if (ocpi->ocpi_flags & ORF_LEADER && ocpi->ocpi_bulk_tgt_sz > 0) {
+	if (leader && ocpi->ocpi_bulk_tgt_sz > 0) {
 		rc = obj_coll_punch_bulk(rpc, &iov, &proc, &dcts, &dct_nr);
 		if (rc != 0)
 			goto out;
@@ -5731,7 +5690,7 @@ ds_obj_coll_punch_handler(crt_rpc_t *rpc)
 	if (rc != 0)
 		goto out;
 
-	if (ocpi->ocpi_flags & ORF_LEADER) {
+	if (leader) {
 		rc = process_epoch(&ocpi->ocpi_epoch, NULL /* epoch_first */, &ocpi->ocpi_flags);
 		if (rc == PE_OK_LOCAL) {
 			ocpi->ocpi_flags &= ~ORF_EPOCH_UNCERTAIN;
@@ -5749,37 +5708,16 @@ ds_obj_coll_punch_handler(crt_rpc_t *rpc)
 	if (ocpi->ocpi_flags & ORF_DTX_SYNC)
 		dtx_flags |= DTX_SYNC;
 
-	if (!(ocpi->ocpi_flags & ORF_LEADER))
+	if (!leader)
 		dtx_flags |= DTX_RELAY;
 
 	if (ocpi->ocpi_flags & ORF_RESEND) {
-
 again:
-		if (!(ocpi->ocpi_flags & ORF_LEADER) || (flags & ORF_RESEND))
-			tmp = ocpi->ocpi_epoch;
-		else
-			tmp = 0;
 		version = ocpi->ocpi_map_ver;
-		rc      = dtx_handle_resend(ioc.ioc_vos_coh, &ocpi->ocpi_xid, &tmp, &version);
-		switch (rc) {
-		case -DER_ALREADY:
-			D_GOTO(out, rc = 0);
-		case 0:
-			ocpi->ocpi_epoch = tmp;
-			flags |= ORF_RESEND;
-			/* TODO: Also recovery the epoch uncertainty. */
-			break;
-		case -DER_MISMATCH:
-			rc = vos_dtx_abort(ioc.ioc_vos_coh, &ocpi->ocpi_xid, tmp);
-			if (rc < 0 && rc != -DER_NONEXIST)
-				D_GOTO(out, rc);
-			/* Fall through */
-		case -DER_NONEXIST:
-			flags = 0;
-			break;
-		default:
-			D_GOTO(out, rc);
-		}
+		rc      = obj_handle_resend(ioc.ioc_vos_coh, &ocpi->ocpi_xid, &ocpi->ocpi_epoch,
+					    &version, &flags, odm->odm_mbs, leader, false);
+		if (rc != 0)
+			D_GOTO(out, rc = (rc > 0 ? 0 : rc));
 
 		dce->dce_ver = version;
 	}

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2123,6 +2123,123 @@ vos_dtx_load_mbs(daos_handle_t coh, struct dtx_id *dti, daos_unit_oid_t *oid,
 }
 
 int
+vos_dtx_refresh_mbs(daos_handle_t coh, struct dtx_id *dti, struct dtx_memberships *mbs,
+		    uint32_t pm_ver, bool leader)
+{
+	struct vos_container      *cont;
+	struct umem_instance      *umm;
+	d_iov_t                    kiov;
+	d_iov_t                    riov;
+	struct vos_dtx_act_ent    *dae     = NULL;
+	struct vos_dtx_act_ent_df *dae_df  = NULL;
+	uint32_t                   saved   = 0;
+	int                        rc      = 0;
+	bool                       started = false;
+	bool                       old_inline;
+	bool                       new_inline;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = vos_cont2umm(cont);
+	d_iov_set(&kiov, dti, sizeof(*dti));
+	d_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc != 0)
+		goto out;
+
+	dae = riov.iov_buf;
+
+	/* Only 'prepared' but not committed/committable DTX can be refreshed MBS. */
+	if (unlikely(dae->dae_prepared == 0))
+		D_GOTO(out, rc = -DER_NO_PERM);
+
+	if (DAE_MBS_DSIZE(dae) != mbs->dm_data_size) {
+		if (DAE_MBS_DSIZE(dae) <= sizeof(DAE_MBS_INLINE(dae)))
+			old_inline = true;
+		else
+			old_inline = false;
+		if (mbs->dm_data_size <= sizeof(DAE_MBS_INLINE(dae)))
+			new_inline = true;
+		else
+			new_inline = false;
+	} else {
+		if (mbs->dm_data_size <= sizeof(DAE_MBS_INLINE(dae))) {
+			if (memcmp(DAE_MBS_INLINE(dae), mbs->dm_data, mbs->dm_data_size) == 0)
+				D_GOTO(out, rc = 1);
+
+			old_inline = true;
+			new_inline = true;
+		} else {
+			if (memcmp(umem_off2ptr(umm, DAE_MBS_OFF(dae)), mbs->dm_data,
+				   mbs->dm_data_size) == 0)
+				D_GOTO(out, rc = 1);
+
+			old_inline = false;
+			new_inline = false;
+		}
+	}
+
+	rc = umem_tx_begin(umm, NULL);
+	if (rc != 0)
+		goto out;
+
+	started = true;
+	dae_df  = umem_off2ptr(umm, dae->dae_df_off);
+	rc      = umem_tx_add_ptr(umm, dae_df, sizeof(*dae_df));
+	if (rc != 0)
+		goto out;
+
+	if (!old_inline) {
+		D_ASSERT(!UMOFF_IS_NULL(dae_df->dae_mbs_off));
+
+		rc = umem_free(umm, dae_df->dae_mbs_off);
+		if (rc != 0)
+			goto out;
+
+		dae_df->dae_mbs_off = UMOFF_NULL;
+	}
+
+	if (new_inline) {
+		memcpy(dae_df->dae_mbs_inline, mbs->dm_data, mbs->dm_data_size);
+	} else {
+		dae_df->dae_mbs_off = umem_zalloc(umm, mbs->dm_data_size);
+		if (UMOFF_IS_NULL(dae_df->dae_mbs_off))
+			D_GOTO(out, rc = -DER_NOSPACE);
+
+		memcpy(umem_off2ptr(umm, dae_df->dae_mbs_off), mbs->dm_data, mbs->dm_data_size);
+	}
+
+	dae_df->dae_mbs_dsize = mbs->dm_data_size;
+	dae_df->dae_tgt_cnt   = mbs->dm_tgt_cnt;
+	saved                 = dae_df->dae_ver;
+	dae_df->dae_ver       = pm_ver;
+	if (leader)
+		dae_df->dae_flags |= DTE_LEADER;
+
+out:
+	if (started) {
+		if (rc == 0) {
+			rc = umem_tx_commit(umm);
+			D_ASSERTF(rc == 0, "local TX commit failure: %d\n", rc);
+
+			memcpy(&dae->dae_base, dae_df, sizeof(*dae_df));
+		} else {
+			rc = umem_tx_abort(umm, rc);
+		}
+	}
+
+	if (rc < 0)
+		D_ERROR("Failed to refresh MBS for DTX " DF_DTI " with version %u: " DF_RC "\n",
+			DP_DTI(dti), pm_ver, DP_RC(rc));
+	else if (rc == 0)
+		D_DEBUG(DB_IO, "Refresh MBS for DTX " DF_DTI " from version %u to %u\n",
+			DP_DTI(dti), saved, pm_ver);
+
+	return rc;
+}
+
+int
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id dtis[],
 			int count, daos_epoch_t epoch, bool keep_act, bool rm_cos[],
 			struct vos_dtx_act_ent **daes, struct vos_dtx_cmt_ent **dces)


### PR DESCRIPTION
During DTX preparing, if some related target is evicted for some reason, then the in processing DTX maybe failed and related client will resend the RPC with new DTX MBS (participants) information based on new pool map. On the other hand, the DTX on other healthy targets may has been prepared with old MBS information. Under such case, related RPC handler on server needs to process the resent RPC and refresh related DTX's MBS information (and the pool map version, flags if DTX leader is switched). Then the subsequent DTX RPC (such as commit, abort, check and refresh) can be sent to the right targets/participants.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
