### PR TITLE
DAOS-17748 control: Add verification to raft-db Add/Remove wrappers (…

### DIFF
--- a/src/control/go.mod
+++ b/src/control/go.mod
@@ -5,7 +5,6 @@ module github.com/daos-stack/daos/src/control
 // - debian packaging version checks: debian/control
 // Scons uses this file to extract the minimum version.
 go 1.21
-toolchain go1.23.0
 
 require (
 	github.com/Jille/raft-grpc-transport v1.2.0

--- a/src/control/go.mod
+++ b/src/control/go.mod
@@ -5,6 +5,7 @@ module github.com/daos-stack/daos/src/control
 // - debian packaging version checks: debian/control
 // Scons uses this file to extract the minimum version.
 go 1.21
+toolchain go1.23.0
 
 require (
 	github.com/Jille/raft-grpc-transport v1.2.0

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -204,8 +204,8 @@ func (m *Membership) joinReplace(req *JoinRequest) (*JoinResponse, error) {
 	memberToReplace := &Member{}
 	*memberToReplace = *cm
 
-	m.log.Debugf("replace-rank: updating member with UUID %s->%s", memberToReplace.UUID,
-		req.UUID)
+	m.log.Debugf("replace-rank: updating member with UUID %s->%s, Addr %s",
+		memberToReplace.UUID, req.UUID, memberToReplace.Addr)
 
 	if err := m.db.RemoveMember(cm); err != nil {
 		return nil, errors.Wrap(err, "removing old member in replace-rank join request")

--- a/src/control/system/raft/database_members_test.go
+++ b/src/control/system/raft/database_members_test.go
@@ -9,10 +9,10 @@ package raft
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 
-	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
@@ -79,7 +79,10 @@ func TestRaft_MemberAddrMap_removeMember(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tc.addrMap.removeMember(tc.toRemove)
 
-			test.CmpAny(t, "MemberAddrMap", tc.expMap, tc.addrMap, cmpopts.IgnoreFields(system.Member{}, "LastUpdate"))
+			cmpOpt := cmpopts.IgnoreFields(system.Member{}, "LastUpdate")
+			if diff := cmp.Diff(tc.expMap, tc.addrMap, cmpOpt); diff != "" {
+				t.Fatalf("unexpected MemberAddrMap (-want, +got):\n%s\n", diff)
+			}
 		})
 	}
 }

--- a/src/control/system/raft/database_members_test.go
+++ b/src/control/system/raft/database_members_test.go
@@ -1,0 +1,85 @@
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package raft
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/system"
+)
+
+func TestRaft_MemberAddrMap_removeMember(t *testing.T) {
+	makeMap := func(t *testing.T, members ...*system.Member) MemberAddrMap {
+		mam := make(MemberAddrMap)
+		for _, m := range members {
+			mam[m.Addr.String()] = append(mam[m.Addr.String()], m)
+		}
+		return mam
+	}
+
+	testMember := func(t *testing.T, idx int) *system.Member {
+		return system.MockMember(t, uint32(idx), system.MemberStateJoined)
+	}
+
+	members := func(t *testing.T, n int) []*system.Member {
+		members := []*system.Member{}
+		for i := 0; i < n; i++ {
+			members = append(members, testMember(t, i))
+		}
+		return members
+	}
+
+	for name, tc := range map[string]struct {
+		addrMap  MemberAddrMap
+		toRemove *system.Member
+		expMap   MemberAddrMap
+	}{
+		"empty": {
+			addrMap: make(MemberAddrMap),
+			toRemove: &system.Member{
+				Addr: system.MockControlAddr(t, 1),
+				UUID: uuid.New(),
+			},
+			expMap: make(MemberAddrMap),
+		},
+		"only one member": {
+			addrMap:  makeMap(t, members(t, 1)...),
+			toRemove: testMember(t, 0),
+			expMap:   make(MemberAddrMap),
+		},
+		"first member": {
+			addrMap:  makeMap(t, members(t, 3)...),
+			toRemove: testMember(t, 0),
+			expMap:   makeMap(t, testMember(t, 1), testMember(t, 2)),
+		},
+		"last member": {
+			addrMap:  makeMap(t, members(t, 3)...),
+			toRemove: testMember(t, 2),
+			expMap:   makeMap(t, testMember(t, 0), testMember(t, 1)),
+		},
+		"middle member": {
+			addrMap:  makeMap(t, members(t, 3)...),
+			toRemove: testMember(t, 1),
+			expMap:   makeMap(t, testMember(t, 0), testMember(t, 2)),
+		},
+		"not found": {
+			addrMap:  makeMap(t, members(t, 3)...),
+			toRemove: testMember(t, 6),
+			expMap:   makeMap(t, members(t, 3)...),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tc.addrMap.removeMember(tc.toRemove)
+
+			test.CmpAny(t, "MemberAddrMap", tc.expMap, tc.addrMap, cmpopts.IgnoreFields(system.Member{}, "LastUpdate"))
+		})
+	}
+}

--- a/src/control/system/raft/database_test.go
+++ b/src/control/system/raft/database_test.go
@@ -432,6 +432,51 @@ func ignoreFaultDomainIDOption() cmp.Option {
 		}, cmp.Ignore())
 }
 
+func checkMemberDB(t *testing.T, mdb *MemberDatabase, expMember *Member, opts ...cmp.Option) {
+	t.Helper()
+
+	cmpOpts := []cmp.Option{
+		cmp.AllowUnexported(Member{}),
+	}
+	for _, o := range opts {
+		cmpOpts = append(cmpOpts, o)
+	}
+
+	uuidM, ok := mdb.Uuids[expMember.UUID]
+	if !ok {
+		t.Errorf("member not found for UUID %s", expMember.UUID)
+	}
+	if diff := cmp.Diff(expMember, uuidM, cmpOpts...); diff != "" {
+		t.Fatalf("member wrong in UUID DB (-want, +got):\n%s\n", diff)
+	}
+
+	rankM, ok := mdb.Ranks[expMember.Rank]
+	if !ok {
+		t.Errorf("member not found for rank %d", expMember.Rank)
+	}
+	if diff := cmp.Diff(expMember, rankM, cmpOpts...); diff != "" {
+		t.Fatalf("member wrong in rank DB (-want, +got):\n%s\n", diff)
+	}
+
+	addrMs, ok := mdb.Addrs[expMember.Addr.String()]
+	if !ok {
+		t.Errorf("slice not found for addr %s", expMember.Addr.String())
+	}
+
+	found := false
+	for _, am := range addrMs {
+		if am.Rank == expMember.Rank {
+			found = true
+			if diff := cmp.Diff(expMember, am, cmpOpts...); diff != "" {
+				t.Fatalf("member wrong in addr DB (-want, +got):\n%s\n", diff)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected member %+v not found for addr %s", expMember, expMember.Addr.String())
+	}
+}
+
 func TestSystem_Database_memberRaftOps(t *testing.T) {
 	ctx := test.Context(t)
 
@@ -453,10 +498,6 @@ func TestSystem_Database_memberRaftOps(t *testing.T) {
 		Addr:        testMembers[1].Addr,
 		State:       testMembers[1].State,
 		FaultDomain: MustCreateFaultDomainFromString("/rack1"),
-	}
-
-	cmpOpts := []cmp.Option{
-		cmp.AllowUnexported(Member{}),
 	}
 
 	for name, tc := range map[string]struct {
@@ -546,43 +587,21 @@ func TestSystem_Database_memberRaftOps(t *testing.T) {
 
 			// Check member DB was updated
 			for _, expMember := range tc.expMembers {
-				uuidM, ok := db.data.Members.Uuids[expMember.UUID]
-				if !ok {
-					t.Errorf("member not found for UUID %s", expMember.UUID)
-				}
-				if diff := cmp.Diff(expMember, uuidM, cmpOpts...); diff != "" {
-					t.Fatalf("member wrong in UUID DB (-want, +got):\n%s\n", diff)
-				}
-
-				rankM, ok := db.data.Members.Ranks[expMember.Rank]
-				if !ok {
-					t.Errorf("member not found for rank %d", expMember.Rank)
-				}
-				if diff := cmp.Diff(expMember, rankM, cmpOpts...); diff != "" {
-					t.Fatalf("member wrong in rank DB (-want, +got):\n%s\n", diff)
-				}
-
-				addrMs, ok := db.data.Members.Addrs[expMember.Addr.String()]
-				if !ok {
-					t.Errorf("slice not found for addr %s", expMember.Addr.String())
-				}
-
-				found := false
-				for _, am := range addrMs {
-					if am.Rank == expMember.Rank {
-						found = true
-						if diff := cmp.Diff(expMember, am, cmpOpts...); diff != "" {
-							t.Fatalf("member wrong in addr DB (-want, +got):\n%s\n", diff)
-						}
-					}
-				}
-				if !found {
-					t.Fatalf("expected member %+v not found for addr %s", expMember, expMember.Addr.String())
-				}
-
+				checkMemberDB(t, db.data.Members, expMember)
 			}
 			if len(db.data.Members.Uuids) != len(tc.expMembers) {
-				t.Fatalf("expected %d members, got %d", len(tc.expMembers), len(db.data.Members.Uuids))
+				t.Fatalf("expected %d member UUIDs, got %d: %+v", len(tc.expMembers), len(db.data.Members.Uuids), db.data.Members.Uuids)
+			}
+			if len(db.data.Members.Ranks) != len(tc.expMembers) {
+				t.Fatalf("expected %d member ranks, got %d: %+v", len(tc.expMembers), len(db.data.Members.Ranks), db.data.Members.Ranks)
+			}
+
+			totalMemberAddrs := 0
+			for _, members := range db.data.Members.Addrs {
+				totalMemberAddrs += len(members)
+			}
+			if totalMemberAddrs != len(tc.expMembers) {
+				t.Fatalf("expected %d members in address table, got %d: %+v", len(tc.expMembers), totalMemberAddrs, db.data.Members.Addrs)
 			}
 
 			if diff := cmp.Diff(tc.expFDTree, db.data.Members.FaultDomains, ignoreFaultDomainIDOption()); diff != "" {
@@ -820,7 +839,7 @@ func TestSystem_Database_OnEvent(t *testing.T) {
 	}
 }
 
-func TestSystemDatabase_PoolServiceList(t *testing.T) {
+func TestSystem_Database_PoolServiceList(t *testing.T) {
 	ready := &PoolService{
 		PoolUUID:   uuid.New(),
 		PoolLabel:  "pool0001",
@@ -1062,7 +1081,7 @@ func TestSystem_Database_GroupMap(t *testing.T) {
 	}
 }
 
-func Test_Database_ResignLeadership(t *testing.T) {
+func TestSystem_Database_ResignLeadership(t *testing.T) {
 	for name, tc := range map[string]struct {
 		cause     error
 		expErr    error
@@ -1117,7 +1136,7 @@ func Test_Database_ResignLeadership(t *testing.T) {
 	}
 }
 
-func TestDatabase_TakePoolLock(t *testing.T) {
+func TestSystem_Database_TakePoolLock(t *testing.T) {
 	mockUUID := uuid.MustParse(test.MockUUID(1))
 	parentLock := makeLock(1, 1, 1)
 	wrongIdLock := makeLock(1, 2, 1)

--- a/src/control/system/raft/raft.go
+++ b/src/control/system/raft/raft.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -454,7 +455,8 @@ func (db *Database) submitMemberUpdate(op raftOp, m *memberUpdate) error {
 	if err != nil {
 		return err
 	}
-	db.log.Debugf("member %d:%x updated @ %s", m.Member.Rank, m.Member.Incarnation, common.FormatTime(m.Member.LastUpdate))
+	db.log.Debugf("member %d:%x %s @ %s", m.Member.Rank, m.Member.Incarnation, op,
+		common.FormatTime(m.Member.LastUpdate))
 	return db.submitRaftUpdate(data)
 }
 


### PR DESCRIPTION
…#16557)

Address issue where snapshot load fails because of inconsistency with Member address-to-uuid map. Avoid duplicate UUID member entries by fixing removeMember function.

Priority: 2
Features: control

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
