### PR TITLE
DAOS-17818 test: CR Automate Test - dmg check start --failout

### DIFF
--- a/src/tests/ftest/recovery/check_start_options.py
+++ b/src/tests/ftest/recovery/check_start_options.py
@@ -68,21 +68,7 @@ class DMGCheckStartOptionsTest(RecoveryTestBase):
 
         # 4. Verify that the orphan pool is detected.
         self.log_step("Verify that the orphan pool is detected.")
-        repair_reports = None
-        for _ in range(8):
-            check_query_out = dmg_command.check_query()
-            if check_query_out["response"]["status"] == "RUNNING":
-                repair_reports = check_query_out["response"]["reports"]
-                break
-            time.sleep(5)
-        if not repair_reports:
-            self.fail("Checker didn't detect any inconsistency!")
-        fault_msg = repair_reports[0]["msg"]
-        orphan_pool = "orphan pool"
-        if orphan_pool not in fault_msg:
-            msg = (f"Checker didn't detect the {orphan_pool} (1)! Fault msg = "
-                   f"{fault_msg}")
-            self.fail(msg)
+        self.query_detect(fault="orphan pool")
 
         # 5. Stop the checker.
         self.log_step("Stop the checker.")
@@ -115,12 +101,13 @@ class DMGCheckStartOptionsTest(RecoveryTestBase):
         self.log_step("Verify that the action entry is still there.")
         # At this point, the status is STOPPED (it will not turn to RUNNING), so just
         # check whether msg contains "orphan pool".
-        check_query_out = self.get_dmg_command().check_query()
-        if not repair_reports:
+        check_query_out = dmg_command.check_query()
+        query_reports = check_query_out["response"]["reports"]
+        if not query_reports:
             self.fail("Checker didn't detect any inconsistency!")
-        fault_msg = repair_reports[0]["msg"]
-        if orphan_pool not in fault_msg:
-            msg = (f"Checker didn't detect the {orphan_pool} (2)! Fault msg = "
+        fault_msg = query_reports[0]["msg"]
+        if "orphan pool" not in fault_msg:
+            msg = (f"Checker didn't detect the orphan pool (2)! Fault msg = "
                    f"{fault_msg}")
             dmg_command.check_disable()
             self.fail(msg)
@@ -151,6 +138,96 @@ class DMGCheckStartOptionsTest(RecoveryTestBase):
         if repair_reports:
             msg = f"Status is COMPLETED, but repair reports isn't empty! {repair_reports}"
             self.fail(msg)
+
+        # Disable the checker to prepare for the tearDown.
+        dmg_command.check_disable()
+        # The pool is orphan pool, so skip the cleanup.
+        pool.skip_cleanup()
+
+    def test_check_start_failout(self):
+        """Test dmg check start --failout=[on|off].
+
+        See the state diagram attached to the ticket.
+
+        1. Create a pool.
+        2. Inject orphan pool fault.
+        3. Enable checker and set policy to --all-interactive.
+        4. Start the checker with --failout=on.
+        5. Query and check that it detected the orphan pool.
+        6. Remove the pool directory from the mount point.
+        7. Repair the pool.
+        8. Query and verify that Current status is FAILED. i.e., State is failed.
+
+        Jira ID: DAOS-17818
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=recovery,cat_recov
+        :avocado: tags=DMGCheckStartOptionsTest,test_check_start_failout
+        """
+        # 1. Create a pool.
+        self.log_step("Create a pool")
+        pool = self.get_pool(connect=False)
+
+        # 2. Inject orphan pool fault.
+        self.log_step("Inject orphan pool fault")
+        dmg_command = self.get_dmg_command()
+        dmg_command.faults_mgmt_svc_pool(
+            pool=pool.identifier, checker_report_class="CIC_POOL_NONEXIST_ON_MS")
+
+        # 3. Enable checker and set policy to --all-interactive.
+        self.log_step("Enable checker and set policy to --all-interactive.")
+        dmg_command.check_enable()
+        dmg_command.check_set_policy(all_interactive=True)
+
+        # 4. Start the checker with --failout=on.
+        self.log_step("Start the checker with --failout=on.")
+        dmg_command.check_start(failout="on")
+
+        # 5. Query and check that it detected the orphan pool.
+        self.log_step("Query and check that it detected the orphan pool.")
+        query_reports = self.query_detect(fault="orphan pool")
+
+        # 6. Remove the pool directory from the mount point.
+        self.log_step("Remove the pool directory from the mount point.")
+        scm_mount = self.server_managers[0].get_config_value("scm_mount")
+        pool_path = f"{scm_mount}/{pool.uuid.lower()}"
+        pool_out = check_file_exists(
+            hosts=self.hostlist_servers, filename=pool_path, sudo=True)
+        if not pool_out[0]:
+            msg = ("MD-on-SSD cluster. Contents under mount point are removed by control "
+                   "plane after system stop.")
+            self.log.info(msg)
+            dmg_command.system_start()
+            # return results in PASS.
+            return
+        command = f"sudo rm -rf {pool_path}"
+        remove_result = run_remote(
+            log=self.log, hosts=self.hostlist_servers, command=command)
+        if not remove_result.passed:
+            self.fail(f"Failed to remove {pool_path} from {self.hostlist_servers}")
+        success_nodes = remove_result.passed_hosts
+        if self.hostlist_servers != success_nodes:
+            msg = (f"Failed to remove pool directory! All = {self.hostlist_servers}, "
+                   f"Success = {success_nodes}")
+            self.fail(msg)
+
+        # 7. Repair the pool.
+        self.log_step("Repair the pool.")
+        seq_num = str(query_reports[0]["seq"])
+        dmg_command.check_repair(seq_num=seq_num, action="0")
+
+        # 8. Query and verify that Current status is FAILED.
+        self.log_step("Query and verify that Current status is FAILED.")
+        status_failed = False
+        for _ in range(8):
+            check_query_out = dmg_command.check_query()
+            if check_query_out["response"]["status"] == "FAILED":
+                status_failed = True
+                break
+            time.sleep(5)
+        if not status_failed:
+            self.fail("Current status isn't FAILED!")
 
         # Disable the checker to prepare for the tearDown.
         dmg_command.check_disable()

--- a/src/tests/ftest/recovery/check_start_options.py
+++ b/src/tests/ftest/recovery/check_start_options.py
@@ -145,7 +145,7 @@ class DMGCheckStartOptionsTest(RecoveryTestBase):
         pool.skip_cleanup()
 
     def test_check_start_failout(self):
-        """Test dmg check start --failout=[on|off].
+        """Test dmg check start --failout=on.
 
         See the state diagram attached to the ticket.
 

--- a/src/tests/ftest/recovery/check_start_options.py
+++ b/src/tests/ftest/recovery/check_start_options.py
@@ -7,7 +7,7 @@ import time
 
 from general_utils import check_file_exists
 from recovery_test_base import RecoveryTestBase
-from run_utils import run_remote
+from run_utils import command_as_user, run_remote
 
 
 class DMGCheckStartOptionsTest(RecoveryTestBase):
@@ -201,11 +201,11 @@ class DMGCheckStartOptionsTest(RecoveryTestBase):
             dmg_command.system_start()
             # return results in PASS.
             return
-        command = f"sudo rm -rf {pool_path}"
+        command = command_as_user(command=f"rm -rf {pool_path}", user="root")
         remove_result = run_remote(
             log=self.log, hosts=self.hostlist_servers, command=command)
         if not remove_result.passed:
-            self.fail(f"Failed to remove {pool_path} from {self.hostlist_servers}")
+            self.fail(f"Failed to remove {pool_path} from {remove_result.failed_hosts}")
         success_nodes = remove_result.passed_hosts
         if self.hostlist_servers != success_nodes:
             msg = (f"Failed to remove pool directory! All = {self.hostlist_servers}, "

--- a/src/tests/ftest/recovery/check_start_options.yaml
+++ b/src/tests/ftest/recovery/check_start_options.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 1
+  test_clients: 1
 
 timeout: 180
 
@@ -14,3 +15,6 @@ server_config:
 
 pool:
   size: 5G
+
+container:
+  control_method: daos

--- a/src/tests/ftest/util/recovery_test_base.py
+++ b/src/tests/ftest/util/recovery_test_base.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/ftest/util/recovery_test_base.py
+++ b/src/tests/ftest/util/recovery_test_base.py
@@ -69,3 +69,29 @@ class RecoveryTestBase(TestWithServers):
             self.fail("Checker didn't detect or repair any inconsistency!")
 
         return repair_reports
+
+    def query_detect(self, fault):
+        """Query until status becomes RUNNING and check if given fault is found.
+
+        Args:
+            fault (str): Fault string to search in the query report.
+
+        Returns:
+            list: List of query reports.
+
+        """
+        for _ in range(8):
+            check_query_out = self.get_dmg_command().check_query()
+            if check_query_out["response"]["status"] == "RUNNING":
+                query_reports = check_query_out["response"]["reports"]
+                break
+            time.sleep(5)
+
+        if not query_reports:
+            self.fail("Checker didn't detect any inconsistency!")
+
+        fault_msg = query_reports[0]["msg"]
+        if fault not in fault_msg:
+            self.fail(f"Checker didn't detect {fault}! Fault msg = {fault_msg}")
+
+        return query_reports


### PR DESCRIPTION
Test steps:
1. Create a pool.
2. Inject orphan pool fault.
3. Enable checker and set policy to --all-interactive.
4. Start the checker with --failout=on.
5. Query and check that it detected the orphan pool.
6. Remove the pool directory from the mount point.
7. Repair the pool.
8. Query and verify that Current status is FAILED. i.e., State is failed.

Added query_detect in recovery_test_base.py that's used in this new test and test_check_start_reset.

Fixed test_check_start_reset.

Added container in the test yaml.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_check_start_reset test_check_start_failout

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
