### PR TITLE
DAOS-16887 dfuse: use the inode instead of open handle in pre-read (#15630)

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -206,8 +206,6 @@ struct dfuse_obj_hdl {
 	bool                      doh_kreaddir_finished;
 
 	bool                      doh_evict_on_close;
-	/* the handle is doing readhead for the moment */
-	bool                      doh_readahead_inflight;
 };
 
 /* Readdir support.
@@ -1033,6 +1031,9 @@ struct dfuse_inode_entry {
 
 	/* Entry on the evict list */
 	d_list_t                  ie_evict_entry;
+
+	/* the inode is doing readhead for the moment */
+	bool                      ie_readahead_inflight;
 };
 
 struct active_inode {
@@ -1220,14 +1221,14 @@ bool
 dfuse_dcache_get_valid(struct dfuse_inode_entry *ie, double max_age);
 
 void
-dfuse_pre_read(struct dfuse_info *dfuse_info, struct dfuse_obj_hdl *oh, struct dfuse_event *ev);
+dfuse_pre_read(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie, struct dfuse_event *ev);
 
 int
 dfuse_pre_read_init(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie,
 		    struct dfuse_event **evp);
 
 void
-dfuse_pre_read_abort(struct dfuse_info *dfuse_info, struct dfuse_obj_hdl *oh,
+dfuse_pre_read_abort(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie,
 		     struct dfuse_event *ev, int rc);
 
 int


### PR DESCRIPTION
The file open handle can be freed from under the pre-read. The inode should be used instead.

NB: This is a backport of the patch from master to the google/2.6 branch, and
some necessary adjustments were made to fit into the different codebase.

Co-authored-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>
Change-Id: I449057fbff3104f865a70ce34963c554af3bd64a
Signed-off-by: Michael MacDonald <mjmac@google.com>
