### PR TITLE
DAOS-17822 chk: filter out repeated pools in the check list

### DIFF
--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -332,20 +333,15 @@ chk_ranks_dump(uint32_t rank_nr, d_rank_t *ranks)
 	D_INFO("Ranks List:\n");
 
 	while (rank_nr >= 8) {
-		D_INFO("%8u %8u %8u %8u %8u %8u %8u %8u\n",
-		       ranks[0], ranks[1], ranks[2], ranks[3],
+		D_INFO("%8u%8u%8u%8u%8u%8u%8u%8u\n", ranks[0], ranks[1], ranks[2], ranks[3],
 		       ranks[4], ranks[5], ranks[6], ranks[7]);
 		rank_nr -= 8;
 		ranks += 8;
 	}
 
 	if (rank_nr > 0) {
-		rc = snprintf(ptr, 79, "%8u", ranks[0]);
-		D_ASSERT(rc > 0);
-		ptr += rc;
-
-		for (i = 1; i < rank_nr; i++) {
-			rc = snprintf(ptr, 79 - 8 * i, " %8u", ranks[i]);
+		for (i = 0; i < rank_nr; i++) {
+			rc = snprintf(ptr, 79 - 8 * i, "%8u", ranks[i]);
 			D_ASSERT(rc > 0);
 			ptr += rc;
 		}
@@ -610,6 +606,8 @@ chk_pools_load_list(struct chk_instance *ins, uint64_t gen, uint32_t flags,
 	struct chk_bookmark	cbk;
 	char			uuid_str[DAOS_UUID_STR_SIZE];
 	d_rank_t		myrank = dss_self_rank();
+	d_iov_t                 kiov;
+	d_iov_t                 riov;
 	int			i;
 	int			rc = 0;
 
@@ -658,6 +656,16 @@ chk_pools_load_list(struct chk_instance *ins, uint64_t gen, uint32_t flags,
 
 		if (rc == 0 && cbk.cb_phase == CHK__CHECK_SCAN_PHASE__CSP_DONE && ins->ci_is_leader)
 			continue;
+
+		/* There may be repeated pool(s) in the list, filter out. */
+		d_iov_set(&kiov, pools[i], sizeof(uuid_t));
+		d_iov_set(&riov, NULL, 0);
+		rc = dbtree_lookup(ins->ci_pool_hdl, &kiov, &riov);
+		if (unlikely(rc == 0))
+			continue;
+
+		if (unlikely(rc != -DER_NONEXIST))
+			break;
 
 		/*
 		 * Here, we only update the pool bookmark in DRAM, the caller will store the update


### PR DESCRIPTION
The user/admin may specify repeated pool(s) in the check list via 'dmg check' command. The logic needs to handle such case to avoid invalid assertion.

The patch also fixes chk dump logic to avoid out-of-boundary DRAM accessing.

Test-tag: cat_recov

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
