### PR TITLE
DAOS-17356 rebuild: POOL_REBUILD_STOP/START RPC handlers

### DIFF
--- a/src/pool/rpc.c
+++ b/src/pool/rpc.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -198,6 +199,8 @@ CRT_RPC_DEFINE(pool_query_info_v6, DAOS_ISEQ_POOL_QUERY_INFO, DAOS_OSEQ_POOL_QUE
 CRT_RPC_DEFINE(pool_query_info, DAOS_ISEQ_POOL_QUERY_INFO, DAOS_OSEQ_POOL_QUERY_INFO)
 CRT_RPC_DEFINE(pool_tgt_query_map, DAOS_ISEQ_POOL_TGT_QUERY_MAP, DAOS_OSEQ_POOL_TGT_QUERY_MAP)
 CRT_RPC_DEFINE(pool_tgt_discard, DAOS_ISEQ_POOL_TGT_DISCARD, DAOS_OSEQ_POOL_TGT_DISCARD)
+CRT_RPC_DEFINE(pool_rebuild_stop, DAOS_ISEQ_POOL_REBUILD_STOP, DAOS_OSEQ_POOL_REBUILD_STOP)
+CRT_RPC_DEFINE(pool_rebuild_start, DAOS_ISEQ_POOL_REBUILD_START, DAOS_OSEQ_POOL_REBUILD_START)
 CRT_RPC_DEFINE(pool_tgt_warmup, DAOS_ISEQ_POOL_TGT_WARMUP, DAOS_OSEQ_POOL_TGT_WARMUP)
 
 /* Define for cont_rpcs[] array population below.

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -77,7 +77,9 @@
 	X(POOL_ACL_DELETE, 0, &CQF_pool_acl_delete, ds_pool_acl_delete_handler, NULL)              \
 	X(POOL_RANKS_GET, 0, &CQF_pool_ranks_get, ds_pool_ranks_get_handler, NULL)                 \
 	X(POOL_UPGRADE, 0, &CQF_pool_upgrade, ds_pool_upgrade_handler, NULL)                       \
-	X(POOL_TGT_DISCARD, 0, &CQF_pool_tgt_discard, ds_pool_tgt_discard_handler, NULL)
+	X(POOL_TGT_DISCARD, 0, &CQF_pool_tgt_discard, ds_pool_tgt_discard_handler, NULL)           \
+	X(POOL_REBUILD_STOP, 0, &CQF_pool_rebuild_stop, ds_pool_rebuild_stop_handler, NULL)        \
+	X(POOL_REBUILD_START, 0, &CQF_pool_rebuild_start, ds_pool_rebuild_start_handler, NULL)
 
 #define POOL_PROTO_RPC_LIST                                                                        \
 	POOL_PROTO_CLI_RPC_LIST(DAOS_POOL_VERSION)                                                 \
@@ -901,6 +903,22 @@ CRT_RPC_DECLARE(pool_tgt_query_map, DAOS_ISEQ_POOL_TGT_QUERY_MAP, DAOS_OSEQ_POOL
 	((int32_t)			(ptdo_rc)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_tgt_discard, DAOS_ISEQ_POOL_TGT_DISCARD, DAOS_OSEQ_POOL_TGT_DISCARD)
+
+#define DAOS_ISEQ_POOL_REBUILD_STOP	/* input fields */       \
+	((struct pool_op_in)		(rstpi_op)		CRT_VAR)
+
+#define DAOS_OSEQ_POOL_REBUILD_STOP	/* output fields */      \
+	((struct pool_op_out)		(rstpo_op)		CRT_VAR)
+
+CRT_RPC_DECLARE(pool_rebuild_stop, DAOS_ISEQ_POOL_REBUILD_STOP, DAOS_OSEQ_POOL_REBUILD_STOP)
+
+#define DAOS_ISEQ_POOL_REBUILD_START	/* input fields */   \
+	((struct pool_op_in)		(rstai_op)		CRT_VAR)
+
+#define DAOS_OSEQ_POOL_REBUILD_START	/* output fields */  \
+	((struct pool_op_out)		(rstao_op)		CRT_VAR)
+
+CRT_RPC_DECLARE(pool_rebuild_start, DAOS_ISEQ_POOL_REBUILD_START, DAOS_OSEQ_POOL_REBUILD_START)
 
 /* clang-format on */
 

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -225,6 +225,10 @@ int ds_pool_tgt_connect(struct ds_pool *pool, struct pool_iv_conn *pic);
 void ds_pool_tgt_query_map_handler(crt_rpc_t *rpc);
 void ds_pool_tgt_discard_handler(crt_rpc_t *rpc);
 void
+ds_pool_rebuild_stop_handler(crt_rpc_t *rpc);
+void
+ds_pool_rebuild_start_handler(crt_rpc_t *rpc);
+void
 ds_pool_tgt_warmup_handler(crt_rpc_t *rpc);
 int
 ds_pool_lookup_map_bc(struct ds_pool *pool, crt_context_t ctx, struct ds_pool_map_bc **map_bc_out,

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -8234,7 +8234,24 @@ ds_pool_svc_stop_handler(crt_rpc_t *rpc)
 	pool_svc_stop_handler(rpc, DAOS_POOL_VERSION);
 }
 
-/* TODO: make a real RPC handler ds_pool_rebuild_stop_handler(crt_rpc *rpc) to call this. */
+/* Administrator (via dmg command) asks to stop currently-running rebuild for a pool. */
+void
+ds_pool_rebuild_stop_handler(crt_rpc_t *rpc)
+{
+	struct pool_rebuild_stop_in  *in  = crt_req_get(rpc);
+	struct pool_rebuild_stop_out *out = crt_reply_get(rpc);
+	int                           rc;
+
+	D_DEBUG(DB_MD, DF_UUID ": processing rpc: %p\n", DP_UUID(in->rstpi_op.pi_uuid), rpc);
+
+	rc = ds_pool_rebuild_stop(in->rstpi_op.pi_uuid, &out->rstpo_op.po_hint);
+
+	out->rstpo_op.po_rc = rc;
+	D_DEBUG(DB_MD, DF_UUID ": replying rpc: %p " DF_RC "\n", DP_UUID(in->rstpi_op.pi_uuid), rpc,
+		DP_RC(rc));
+	crt_reply_send(rpc);
+}
+
 int
 ds_pool_rebuild_stop(uuid_t pool_uuid, struct rsvc_hint *hint)
 {
@@ -8247,15 +8264,32 @@ ds_pool_rebuild_stop(uuid_t pool_uuid, struct rsvc_hint *hint)
 
 	rc = ds_rebuild_admin_stop(svc->ps_pool);
 
-	/* TODO: ds_rsvc_set_hint(&svc->ps_rsvc, &out->hint); */
+	if (hint != NULL)
+		ds_rsvc_set_hint(&svc->ps_rsvc, hint);
 	pool_svc_put_leader(svc);
 	return rc;
 }
 
 /* administrator (via dmg command) asks to resume normal rebuild behavior for pool
  * (if it has not already happened due to another automatic or manual rebuild in the meantime).
- * TODO: make a real RPC handler ds_pool_rebuild_start_handler(crt_rpc *rpc) to call this.
  */
+void
+ds_pool_rebuild_start_handler(crt_rpc_t *rpc)
+{
+	struct pool_rebuild_start_in  *in  = crt_req_get(rpc);
+	struct pool_rebuild_start_out *out = crt_reply_get(rpc);
+	int                            rc;
+
+	D_DEBUG(DB_MD, DF_UUID ": processing rpc: %p\n", DP_UUID(in->rstai_op.pi_uuid), rpc);
+
+	rc = ds_pool_rebuild_start(in->rstai_op.pi_uuid, &out->rstao_op.po_hint);
+
+	out->rstao_op.po_rc = rc;
+	D_DEBUG(DB_MD, DF_UUID ": replying rpc: %p " DF_RC "\n", DP_UUID(in->rstai_op.pi_uuid), rpc,
+		DP_RC(rc));
+	crt_reply_send(rpc);
+}
+
 int
 ds_pool_rebuild_start(uuid_t pool_uuid, struct rsvc_hint *hint)
 {
@@ -8268,7 +8302,8 @@ ds_pool_rebuild_start(uuid_t pool_uuid, struct rsvc_hint *hint)
 
 	rc = ds_rebuild_admin_start(svc->ps_pool);
 
-	/* TODO: ds_rsvc_set_hint(&svc->ps_rsvc, &out->hint); */
+	if (hint != NULL)
+		ds_rsvc_set_hint(&svc->ps_rsvc, hint);
 	pool_svc_put_leader(svc);
 	return rc;
 }


### PR DESCRIPTION
prepare RPC handlers to integrate with forthcoming control plane dmg command (and MS engine dRPC handler) implementation.

Allow-unstable: true
Test-tag: pr test_daos_rebuild_simple_interactive
Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
