### PR TITLE
DAOS-17821 test: Remove curl command from dfuse/bash.py

### DIFF
--- a/src/tests/ftest/dfuse/bash.py
+++ b/src/tests/ftest/dfuse/bash.py
@@ -140,14 +140,6 @@ class DfuseBashCmd(TestWithServers):
             f'{fuse_root_dir}/ --bs=1M --numjobs="1" --ioengine=libaio --iodepth=16'
             '--group_reporting --exitall_on_error --continue_on_error=none',
         ]
-        # If set, use the HTTPS_PROXY for curl command
-        https_proxy = os.environ.get('HTTPS_PROXY')
-        if https_proxy:
-            proxy_option = f'--proxy "{https_proxy}"'
-        else:
-            proxy_option = ''
-        cmd = f'curl "https://www.google.com" -o {fuse_root_dir}/download.html {proxy_option}'
-        commands.append(cmd)
 
         for cmd in commands:
             self.log_step(f'Running command: {cmd}')


### PR DESCRIPTION
dfuse/bash.py calls many Linux commands in dfuse mounted container to test its IO. One of the commands is curl to google.com and download the content to the container. However, accessing an external website isn't a good idea because there are many parts that could go wrong (lab connection issue, proxy config change, etc). There are already many commands that test IO. The networking part of curl isn't quite relevant to container IO, so it adds risks without much benefits. Thus, we'll remove the curl command from the test.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: DfuseBashCmd

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
