### PR TITLE
DAOS-17772 rebuild: fix a race condition between fetch and aggregation

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -628,29 +628,31 @@ dc_obj_shard2anchor(daos_anchor_t *anchor, uint32_t shard)
 
 enum daos_io_flags {
 	/* The RPC will be sent to leader replica. */
-	DIOF_TO_LEADER		= 0x1,
+	DIOF_TO_LEADER = 0x1,
 	/* The RPC will be sent to specified replica. */
-	DIOF_TO_SPEC_SHARD	= 0x2,
+	DIOF_TO_SPEC_SHARD = 0x2,
 	/* The operation (enumeration) has specified epoch. */
-	DIOF_WITH_SPEC_EPOCH	= 0x4,
+	DIOF_WITH_SPEC_EPOCH = 0x4,
 	/* The operation is for EC recovering. */
-	DIOF_EC_RECOV		= 0x8,
+	DIOF_EC_RECOV = 0x8,
 	/* The key existence. */
-	DIOF_CHECK_EXISTENCE	= 0x10,
+	DIOF_CHECK_EXISTENCE = 0x10,
 	/* The RPC will be sent to specified redundancy group. */
-	DIOF_TO_SPEC_GROUP	= 0x20,
+	DIOF_TO_SPEC_GROUP = 0x20,
 	/* For data migration. */
-	DIOF_FOR_MIGRATION	= 0x40,
+	DIOF_FOR_MIGRATION = 0x40,
 	/* For EC aggregation. */
-	DIOF_FOR_EC_AGG		= 0x80,
+	DIOF_FOR_EC_AGG = 0x80,
 	/* The operation is for EC snapshot recovering */
-	DIOF_EC_RECOV_SNAP	= 0x100,
+	DIOF_EC_RECOV_SNAP = 0x100,
 	/* Only recover from parity */
 	DIOF_EC_RECOV_FROM_PARITY = 0x200,
 	/* Force fetch/list to do degraded enumeration/fetch */
 	DIOF_FOR_FORCE_DEGRADE = 0x400,
 	/* reverse enumeration for recx */
 	DIOF_RECX_REVERSE = 0x800,
+	/* Use for rebuild fetch epoch selection */
+	DIOF_FETCH_EPOCH_EC_AGG_BOUNDARY = 0x1000,
 };
 
 /**

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5999,6 +5999,8 @@ dc_obj_fetch_task(tse_task_t *task)
 
 	if (args->extra_flags & DIOF_EC_RECOV_FROM_PARITY)
 		obj_auxi->flags |= ORF_EC_RECOV_FROM_PARITY;
+	if (args->extra_flags & DIOF_FETCH_EPOCH_EC_AGG_BOUNDARY)
+		obj_auxi->flags |= ORF_FETCH_EPOCH_EC_AGG_BOUNDARY;
 
 	if (args->extra_flags & DIOF_FOR_FORCE_DEGRADE ||
 	    DAOS_FAIL_CHECK(DAOS_OBJ_FORCE_DEGRADE))

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1180,6 +1180,16 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	orw->orw_api_flags = api_args->flags;
 	orw->orw_epoch = auxi->epoch.oe_value;
 	orw->orw_epoch_first = auxi->epoch.oe_first;
+	if (orw->orw_flags & ORF_FETCH_EPOCH_EC_AGG_BOUNDARY) {
+		D_ASSERTF(auxi->epoch.oe_value == auxi->epoch.oe_first,
+			  "bad epoch.oe_value " DF_X64 ", epoch.oe_first " DF_X64 "\n",
+			  auxi->epoch.oe_value, auxi->epoch.oe_first);
+		D_ASSERT(api_args->extra_arg != NULL);
+		orw->orw_epoch_first = (uintptr_t)api_args->extra_arg;
+		D_ASSERTF(orw->orw_epoch <= orw->orw_epoch_first,
+			  "bad orw_epoch " DF_X64 ", orw_epoch_first " DF_X64 "\n", orw->orw_epoch,
+			  orw->orw_epoch_first);
+	}
 	orw->orw_dkey_hash = auxi->obj_auxi->dkey_hash;
 	orw->orw_nr = nr;
 	orw->orw_dkey = *dkey;

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -191,6 +191,8 @@ enum obj_rpc_flags {
 	ORF_EMPTY_SGL		= (1 << 24),
 	/* The CPD RPC only contains read-only transaction. */
 	ORF_CPD_RDONLY		= (1 << 25),
+	/* Use for rebuild fetch epoch selection */
+	ORF_FETCH_EPOCH_EC_AGG_BOUNDARY = (1 << 26),
 };
 /* clang-format on */
 


### PR DESCRIPTION
Add ORF_FETCH_EPOCH_EC_AGG_BOUNDARY flag for rebuild fetch. The container's sc_ec_agg_eph_boundary possibly be different on the initiator and target engines of the rebuild fetch, initiator selected fetch epoch possibly lower than readable epoch at target engine side if vos aggregation merged adjacent extents to higher epoch. For this case increase the fetch epoch to sc_ec_agg_eph_boundary.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
