### PR TITLE
DAOS-17203 build: Build DAOS RPMs with Leap 15.6

### DIFF
--- a/ci/parse_ci_envs.sh
+++ b/ci/parse_ci_envs.sh
@@ -23,7 +23,7 @@ if [ -n "${STAGE_NAME:?}" ]; then
       : "${REPO_SPEC:=el-9}"
       ;;
     *Leap\ 15.6*|*leap15.6*|*opensuse15.6*|*sles15.6*)
-      : "${CHROOT_NAME:=opensuse-leap-15.5-x86_64}"
+      : "${CHROOT_NAME:=opensuse-leap-15.6-x86_64}"
       : "${TARGET:=leap15.6}"
       ;;
     *Leap\ 15.5*|*leap15.5*|*opensuse15.5*|*sles15.5*)
@@ -39,7 +39,7 @@ if [ -n "${STAGE_NAME:?}" ]; then
       : "${TARGET:=leap15.3}"
       ;;
     *Leap\ 15*|*leap15*|*opensuse15*|*sles15*)
-      : "${CHROOT_NAME:=opensuse-leap-15.5-x86_64}"
+      : "${CHROOT_NAME:=opensuse-leap-15.6-x86_64}"
       : "${TARGET:=leap15}"
       : "${REPO_SPEC:=sl-15}"
       ;;

--- a/utils/scripts/install-leap15.sh
+++ b/utils/scripts/install-leap15.sh
@@ -75,6 +75,10 @@ dnf --nodocs install ${dnf_install_args} \
     which \
     yasm
 
+# Make sure we have lua-lmod > 8.7.34
+dnf -y remove lua-lmod
+dnf -y --nogpgcheck install lua-lmod '--repo=*lua*' --repo '*network-cluster*'
+
 # shellcheck disable=SC2086
 dnf install ${dnf_install_args} ruby-devel
 gem install json -v 2.7.6

--- a/utils/scripts/install-leap15.sh
+++ b/utils/scripts/install-leap15.sh
@@ -76,8 +76,9 @@ dnf --nodocs install ${dnf_install_args} \
     yasm
 
 # Make sure we have lua-lmod > 8.7.34
-dnf -y remove lua-lmod
-dnf -y --nogpgcheck install lua-lmod '--repo=*lua*' --repo '*network-cluster*'
+dnf remove lua-lmod
+dnf --nodocs --nogpgcheck install ${dnf_install_args} \
+    lua-lmod --repo='*-oss*' --repo '*lua*' --repo '*network-cluster*'
 
 # shellcheck disable=SC2086
 dnf install ${dnf_install_args} ruby-devel


### PR DESCRIPTION
Use the opensuse-leap-15.6-x86_64.cfg mock config to build DAOS RPMs.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test: true
Skip-func-test-leap15: false
Skip-func-test-el8: true

Requires:

- [ ] https://github.com/daos-stack/pipeline-lib/pull/460

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
