### PR TITLE
DAOS-17712 cart: race in test_multisend_server (#16599)

### DIFF
--- a/src/cart/utils/crt_utils.c
+++ b/src/cart/utils/crt_utils.c
@@ -596,9 +596,9 @@ out:
 }
 
 int
-crtu_srv_start_basic(char *srv_group_name, crt_context_t *crt_ctx,
-		     pthread_t *progress_thread, crt_group_t **grp,
-		     uint32_t *grp_size, crt_init_options_t *init_opt)
+crtu_srv_start_basic(char *srv_group_name, crt_context_t *crt_ctx, pthread_t *progress_thread,
+		     crt_group_t **grp, uint32_t *grp_size, crt_init_options_t *init_opt,
+		     struct crt_proto_format *p_fmt)
 {
 	char            *grp_cfg_file = NULL;
 	char            *my_uri       = NULL;
@@ -642,6 +642,12 @@ crtu_srv_start_basic(char *srv_group_name, crt_context_t *crt_ctx,
 	rc = crt_context_create(crt_ctx);
 	if (rc != 0)
 		D_GOTO(out, rc);
+
+	if (p_fmt != NULL) {
+		rc = crt_proto_register(p_fmt);
+		if (rc != 0)
+			D_GOTO(out, rc);
+	}
 
 	rc = pthread_create(progress_thread, NULL, crtu_progress_fn, crt_ctx);
 	if (rc != 0)

--- a/src/cart/utils/crt_utils.h
+++ b/src/cart/utils/crt_utils.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -84,9 +85,9 @@ crtu_cli_start_basic(char *local_group_name, char *srv_group_name,
 		     unsigned int total_srv_ctx, bool use_cfg,
 		     crt_init_options_t *init_opt, bool use_daos_agent_env);
 int
-crtu_srv_start_basic(char *srv_group_name, crt_context_t *crt_ctx,
-		     pthread_t *progress_thread, crt_group_t **grp,
-		     uint32_t *grp_size, crt_init_options_t *init_opt);
+crtu_srv_start_basic(char *srv_group_name, crt_context_t *crt_ctx, pthread_t *progress_thread,
+		     crt_group_t **grp, uint32_t *grp_size, crt_init_options_t *init_opt,
+		     struct crt_proto_format *p_fmt);
 int
 crtu_log_msg(crt_context_t ctx, crt_group_t *grp, d_rank_t rank, char *msg);
 

--- a/src/tests/ftest/cart/test_ep_cred_server.c
+++ b/src/tests/ftest/cart/test_ep_cred_server.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -22,8 +23,8 @@ test_run(d_rank_t my_rank)
 	opt.cio_use_credits = 1;
 	opt.cio_ep_credits = test.tg_credits;
 
-	rc = crtu_srv_start_basic(test.tg_local_group_name, &test.tg_crt_ctx,
-				  &test.tg_tid, &grp, &grp_size, &opt);
+	rc = crtu_srv_start_basic(test.tg_local_group_name, &test.tg_crt_ctx, &test.tg_tid, &grp,
+				  &grp_size, &opt, NULL);
 	D_ASSERT(rc == 0);
 
 	DBG_PRINT("Server started, grp_size = %d\n", grp_size);

--- a/src/tests/ftest/cart/test_group_np_srv.c
+++ b/src/tests/ftest/cart/test_group_np_srv.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -61,8 +62,8 @@ test_run(d_rank_t my_rank)
 	int			 i;
 	int			 rc = 0;
 
-	rc = crtu_srv_start_basic(test_g.t_local_group_name, &test_g.t_crt_ctx[0],
-				  &test_g.t_tid[0], &grp, &grp_size, NULL);
+	rc = crtu_srv_start_basic(test_g.t_local_group_name, &test_g.t_crt_ctx[0], &test_g.t_tid[0],
+				  &grp, &grp_size, NULL, NULL);
 	D_ASSERTF(rc == 0, "crtu_srv_start_basic() failed\n");
 
 	/* Register event callback after CaRT has initialized */

--- a/src/tests/ftest/cart/test_proto_server.c
+++ b/src/tests/ftest/cart/test_proto_server.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -18,8 +19,8 @@ test_run(d_rank_t my_rank)
 	fprintf(stderr, "local group: %s remote group: %s\n",
 		test.tg_local_group_name, test.tg_remote_group_name);
 
-	rc = crtu_srv_start_basic(test.tg_local_group_name, &test.tg_crt_ctx,
-				  &test.tg_tid, &grp, &grp_size, NULL);
+	rc = crtu_srv_start_basic(test.tg_local_group_name, &test.tg_crt_ctx, &test.tg_tid, &grp,
+				  &grp_size, NULL, NULL);
 	D_ASSERTF(rc == 0, "crtu_srv_start_basic() failed\n");
 
 	rc = sem_init(&test.tg_token_to_proceed, 0, 0);

--- a/src/tests/ftest/cart/test_rpc_to_ghost_rank.c
+++ b/src/tests/ftest/cart/test_rpc_to_ghost_rank.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -273,8 +274,8 @@ test_init(void)
 	D_ASSERTF(test_g.t_is_service == 1,
 		  "this should only run as server.\n");
 
-	rc = crtu_srv_start_basic(test_g.t_local_group_name, &test_g.t_crt_ctx[0],
-				  &test_g.t_tid[0], &grp, &grp_size, NULL);
+	rc = crtu_srv_start_basic(test_g.t_local_group_name, &test_g.t_crt_ctx[0], &test_g.t_tid[0],
+				  &grp, &grp_size, NULL, NULL);
 	D_ASSERTF(rc == 0, "crtu_srv_start_basic() failed\n");
 
 	/* Setup and add self rank, before calling rank/membership APIs. */


### PR DESCRIPTION
When multisend servers start, rank=0 saves group config file, which lets clients know they can start sending RPCs.

Since multisend test servers dont communicate with each other there is a small race where rank=0 might save group config file before all other test servers finished registering for RPCs.

Further, previously even rank=0 was saving group config file before it itself was ready to accept RPCs.

The workaround moves RPC registration before group_config_save and adds 5 second delay on rank=0 before group info is saved.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
