### PR TITLE
DAOS-17844 cart: Add barrier to some cart tests

### DIFF
--- a/src/tests/ftest/cart/SConscript
+++ b/src/tests/ftest/cart/SConscript
@@ -37,7 +37,7 @@ def scons():
     ##############################
     tenv = env.Clone()
 
-    tenv.AppendUnique(LIBS=['cart', 'gurt', 'pthread', 'm'])
+    tenv.AppendUnique(LIBS=['cart', 'gurt', 'pthread', 'm', 'dpar'])
     tenv.AppendUnique(LIBS=['daos', 'daos_common'])
     tenv.AppendUnique(CPPPATH=[Dir('../../../cart/utils').srcnode()])
     tenv.require('crypto', 'mercury', 'protobufc')

--- a/src/tests/ftest/cart/test_ep_cred_server.c
+++ b/src/tests/ftest/cart/test_ep_cred_server.c
@@ -6,6 +6,7 @@
  */
 #include <semaphore.h>
 
+#include <daos/dpar.h>
 #include "crt_utils.h"
 #include "test_ep_cred_common.h"
 
@@ -33,6 +34,9 @@ test_run(d_rank_t my_rank)
 
 	rc = crt_proto_register(&my_proto_fmt_0);
 	D_ASSERT(rc == 0);
+
+	if (grp_size > 1)
+		par_barrier(PAR_COMM_WORLD);
 
 	if (my_rank == 0) {
 		rc = crt_group_config_save(NULL, true);

--- a/src/tests/ftest/cart/test_group_np_srv.c
+++ b/src/tests/ftest/cart/test_group_np_srv.c
@@ -15,6 +15,7 @@
 #include <getopt.h>
 #include <semaphore.h>
 
+#include <daos/dpar.h>
 #include "crt_utils.h"
 #include "test_group_rpc.h"
 #include "test_group_np_common.h"
@@ -99,13 +100,15 @@ test_run(d_rank_t my_rank)
 	}
 	DBG_PRINT("Contexts created %d\n", test_g.t_srv_ctx_num);
 
+	if (grp_size > 1)
+		par_barrier(PAR_COMM_WORLD);
+
 	if (my_rank == 0) {
 		rc = crt_group_config_save(NULL, true);
 		D_ASSERTF(rc == 0,
 			  "crt_group_config_save() failed. rc: %d\n", rc);
 		DBG_PRINT("Group config file saved\n");
 	}
-
 
 	if (test_g.t_hold)
 		sleep(test_g.t_hold_time);

--- a/src/tests/ftest/cart/test_proto_server.c
+++ b/src/tests/ftest/cart/test_proto_server.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
 #include <semaphore.h>
+#include <daos/dpar.h>
 
 #include "crt_utils.h"
 #include "test_proto_common.h"
@@ -26,14 +27,6 @@ test_run(d_rank_t my_rank)
 	rc = sem_init(&test.tg_token_to_proceed, 0, 0);
 	D_ASSERTF(rc == 0, "sem_init() failed.\n");
 
-	/* START: FIXME: always save */
-	if (my_rank == 0) {
-		rc = crt_group_config_save(NULL, true);
-		D_ASSERTF(rc == 0,
-			  "crt_group_config_save() failed. rc: %d\n", rc);
-	}
-	/* END: FIXME: always save */
-
 	switch (test.tg_num_proto) {
 	case 4:
 		rc = crt_proto_register(&my_proto_fmt_3);
@@ -49,6 +42,14 @@ test_run(d_rank_t my_rank)
 		D_ASSERT(rc == 0);
 	default:
 		break;
+	}
+
+	if (grp_size > 1)
+		par_barrier(PAR_COMM_WORLD);
+
+	if (my_rank == 0) {
+		rc = crt_group_config_save(NULL, true);
+		D_ASSERTF(rc == 0, "crt_group_config_save() failed. rc: %d\n", rc);
 	}
 
 	rc = pthread_join(test.tg_tid, NULL);


### PR DESCRIPTION
- add par_barrier() to some cart test serers to avoid race conditions at test startup.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
