### PR TITLE
DAOS-17579 chk: misc improvement for check leader and test - b26

### DIFF
--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -491,7 +492,10 @@ chk_pool_stop_one(struct chk_instance *ins, uuid_t uuid, uint32_t status, uint32
 			if (status == CHK__CHECK_POOL_STATUS__CPS_STOPPED)
 				ins->ci_pool_stopped = 1;
 			cbk->cb_time.ct_stop_time = time(NULL);
-			uuid_unparse_lower(uuid, uuid_str);
+			if (ins->ci_is_leader)
+				uuid_unparse_upper(uuid, uuid_str);
+			else
+				uuid_unparse_lower(uuid, uuid_str);
 			rc = chk_bk_update_pool(cbk, uuid_str);
 		}
 
@@ -583,7 +587,10 @@ chk_pool_start_one(struct chk_instance *ins, uuid_t uuid, uint64_t gen)
 	char			uuid_str[DAOS_UUID_STR_SIZE];
 	int			rc;
 
-	uuid_unparse_lower(uuid, uuid_str);
+	if (ins->ci_is_leader)
+		uuid_unparse_upper(uuid, uuid_str);
+	else
+		uuid_unparse_lower(uuid, uuid_str);
 	rc = chk_bk_fetch_pool(&cbk, uuid_str);
 	if (rc != 0 && rc != -DER_NONEXIST)
 		goto out;
@@ -623,7 +630,10 @@ chk_pools_load_list(struct chk_instance *ins, uint64_t gen, uint32_t flags,
 				break;
 		}
 
-		uuid_unparse_lower(pools[i], uuid_str);
+		if (ins->ci_is_leader)
+			uuid_unparse_upper(pools[i], uuid_str);
+		else
+			uuid_unparse_lower(pools[i], uuid_str);
 		rc = chk_bk_fetch_pool(&cbk, uuid_str);
 		if (rc != 0 && rc != -DER_NONEXIST)
 			break;
@@ -686,8 +696,13 @@ chk_pools_load_from_db(struct sys_db *db, char *table, d_iov_t *key, void *args)
 	struct chk_bookmark		 cbk;
 	int				 rc = 0;
 
-	if (!daos_is_valid_uuid_string(uuid_str))
-		D_GOTO(out, rc = 0);
+	if (ins->ci_is_leader) {
+		if (!daos_is_valid_uuid_upper_string(uuid_str))
+			D_GOTO(out, rc = 0);
+	} else {
+		if (!daos_is_valid_uuid_lower_string(uuid_str))
+			D_GOTO(out, rc = 0);
+	}
 
 	rc = chk_bk_fetch_pool(&cbk, uuid_str);
 	if (rc != 0)
@@ -753,7 +768,10 @@ chk_pools_update_bk(struct chk_instance *ins, uint32_t phase)
 		if (cbk->cb_phase < phase &&
 		    cbk->cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_CHECKING) {
 			cbk->cb_phase = phase;
-			uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
+			if (ins->ci_is_leader)
+				uuid_unparse_upper(cpr->cpr_uuid, uuid_str);
+			else
+				uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
 			rc1 = chk_bk_update_pool(cbk, uuid_str);
 			if (rc1 != 0)
 				rc = rc1;
@@ -808,7 +826,10 @@ chk_pool_handle_notify(struct chk_instance *ins, struct chk_iv *iv)
 	if (iv->ci_phase != cbk->cb_phase || iv->ci_pool_status != cbk->cb_pool_status) {
 		cbk->cb_phase = iv->ci_phase;
 		cbk->cb_pool_status = iv->ci_pool_status;
-		uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
+		if (ins->ci_is_leader)
+			uuid_unparse_upper(cpr->cpr_uuid, uuid_str);
+		else
+			uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
 		rc = chk_bk_update_pool(cbk, uuid_str);
 	}
 

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -297,7 +298,7 @@ chk_leader_post_repair(struct chk_instance *ins, struct chk_pool_rec *cpr,
 			cbk->cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_IMPLICATED;
 		}
 		cbk->cb_time.ct_stop_time = time(NULL);
-		uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
+		uuid_unparse_upper(cpr->cpr_uuid, uuid_str);
 		rc = chk_bk_update_pool(cbk, uuid_str);
 		if (rc != 0)
 			D_WARN("Failed to update pool (" DF_UUID ") bookmark after repair: %d\n",
@@ -356,9 +357,6 @@ chk_leader_cpr2ranklist(struct chk_pool_rec *cpr, bool svc)
 			ranks->rl_ranks[i++] = cps->cps_rank;
 		}
 
-		/* There is at least one valid rank. */
-		D_ASSERT(i > 0);
-
 		/* Reset the rl_nr according to the valid ranks. */
 		ranks->rl_nr = i;
 	}
@@ -388,9 +386,12 @@ chk_leader_destroy_pool(struct chk_pool_rec *cpr, uint64_t seq, bool dereg)
 	if (ranks == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	rc = ds_mgmt_tgt_pool_destroy_ranks(cpr->cpr_uuid, ranks);
-	if (rc == -DER_NONEXIST)
-		rc = 0;
+	if (likely(ranks->rl_nr > 0)) {
+		rc = ds_mgmt_tgt_pool_destroy_ranks(cpr->cpr_uuid, ranks);
+		if (rc == -DER_NONEXIST)
+			rc = 0;
+	}
+
 	if (rc == 0)
 		cpr->cpr_destroyed = 1;
 	d_rank_list_free(ranks);
@@ -1381,6 +1382,12 @@ chk_leader_start_pool_svc(struct chk_pool_rec *cpr)
 		if (ranks == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 	} else {
+		/* Some engine(s) maybe dead during the checking, as to there is no valid engine for
+		 * the pool service.
+		 */
+		if (unlikely(ranks->rl_nr == 0))
+			D_GOTO(out, rc = -DER_EXCLUDED);
+
 		/*
 		 * We cannot start the pool service via regular quorum, but we can start it under
 		 * DS_RSVC_DICTATE mode.
@@ -1904,6 +1911,14 @@ chk_leader_pool_mbs_one(struct chk_pool_rec *cpr)
 	if (ps_ranks == NULL)
 		D_GOTO(out_post, rc = -DER_NOMEM);
 
+	/* Some engine(s) maybe dead during the checking, as to there is no valid engine for the
+	 * pool service.
+	 */
+	if (unlikely(ps_ranks->rl_nr == 0)) {
+		d_rank_list_free(ps_ranks);
+		D_GOTO(out_post, rc = -DER_EXCLUDED);
+	}
+
 	/*
 	 * The PS leader election needs some time, we do not need to retry chk_pool_mbs_remote()
 	 * too frequently. Here, for each PS leader candidate, we will try once per second. Then
@@ -1968,7 +1983,7 @@ chk_leader_pool_ult(void *arg)
 
 	D_INFO(DF_LEADER" pool ult enter for "DF_UUIDF"\n", DP_LEADER(ins), DP_UUID(cpr->cpr_uuid));
 
-	uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
+	uuid_unparse_upper(cpr->cpr_uuid, uuid_str);
 	if (chk_leader_pool_need_stop(cpr, &rc))
 		goto out;
 
@@ -2026,6 +2041,15 @@ start:
 		D_GOTO(out, rc = -DER_NOMEM);
 	}
 
+	/* Some engine(s) maybe dead during the checking, as to there is no valid engine for the
+	 * pool service.
+	 */
+	if (unlikely(ranks->rl_nr == 0)) {
+		cpr->cpr_skip = 1;
+		d_rank_list_free(ranks);
+		D_GOTO(out, rc = -DER_EXCLUDED);
+	}
+
 	if (cpr->cpr_for_orphan)
 		flags |= CPSF_FOR_ORPHAN;
 	if (cpr->cpr_not_export_ps)
@@ -2070,10 +2094,17 @@ start:
 out:
 	/* For stop case, the pool status will be updated via chk_pool_stop_one() by the sponsor. */
 	if ((rc < 0 || cpr->cpr_skip) && !cpr->cpr_notified_exit && !cpr->cpr_stop) {
+		if (rc < 0) {
+			cbk->cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_FAILED;
+			chk_bk_update_pool(cbk, uuid_str);
+			iv.ci_pool_status = CHK__CHECK_POOL_STATUS__CPS_FAILED;
+		} else {
+			iv.ci_pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKED;
+		}
+
 		iv.ci_gen = cbk->cb_gen;
 		uuid_copy(iv.ci_uuid, cpr->cpr_uuid);
 		iv.ci_phase = cbk->cb_phase;
-		iv.ci_pool_status = CHK__CHECK_POOL_STATUS__CPS_FAILED;
 
 		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
 				   CRT_IV_SYNC_EAGER, true);
@@ -2096,10 +2127,13 @@ exit:
 static void
 chk_leader_mark_rank_dead(struct chk_instance *ins, struct chk_dead_rank *cdr)
 {
-	struct chk_property	*prop = &ins->ci_prop;
-	struct chk_bookmark	*cbk = &ins->ci_bk;
-	uint32_t		 version = cbk->cb_gen - prop->cp_rank_nr - 1;
-	int			 rc = 0;
+	struct chk_pool_rec   *cpr;
+	struct chk_pool_shard *cps;
+	struct chk_pool_shard *tmp;
+	struct chk_property   *prop    = &ins->ci_prop;
+	struct chk_bookmark   *cbk     = &ins->ci_bk;
+	uint32_t               version = cbk->cb_gen - prop->cp_rank_nr - 1;
+	int                    rc      = 0;
 
 	if (!chk_remove_rank_from_list(ins->ci_ranks, cdr->cdr_rank))
 		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
@@ -2117,6 +2151,23 @@ chk_leader_mark_rank_dead(struct chk_instance *ins, struct chk_dead_rank *cdr)
 	rc = chk_rank_del(ins, cdr->cdr_rank);
 	if (rc != 0)
 		goto out;
+
+	/* Remove record for the dead rank from the check list. */
+	d_list_for_each_entry(cpr, &ins->ci_pool_list, cpr_link) {
+		d_list_for_each_entry_safe(cps, tmp, &cpr->cpr_shard_list, cps_link) {
+			if (cps->cps_rank == cdr->cdr_rank) {
+				d_list_del(&cps->cps_link);
+				if (cps->cps_data != NULL) {
+					if (cps->cps_free_cb != NULL)
+						cps->cps_free_cb(cps->cps_data);
+					else
+						D_FREE(cps->cps_data);
+				}
+				D_FREE(cps);
+				break;
+			}
+		}
+	}
 
 	/*
 	 * NOTE: Some thought about removing related shards from the ins->ci_pool_list,
@@ -2604,7 +2655,7 @@ chk_leader_start_post(struct chk_instance *ins)
 			cpr->cpr_done = 1;
 		}
 
-		uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
+		uuid_unparse_upper(cpr->cpr_uuid, uuid_str);
 		rc = chk_bk_update_pool(pool_cbk, uuid_str);
 		if (rc != 0)
 			break;
@@ -3238,22 +3289,23 @@ int
 chk_leader_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 		 chk_query_pool_cb_t pool_cb, void *buf)
 {
-	struct chk_instance		*ins = chk_leader;
-	struct chk_bookmark		*cbk = &ins->ci_bk;
-	struct chk_query_args		*cqa = NULL;
-	struct chk_pool_rec		*cpr;
-	struct chk_pool_rec		*tmp;
-	struct chk_pool_shard		*cps;
-	struct chk_query_pool_shard	*shard;
-	d_iov_t				 kiov;
-	d_iov_t				 riov;
-	uint64_t			 gen = cbk->cb_gen;
-	uint32_t			 status;
-	uint32_t			 phase;
-	uint32_t			 idx = 0;
-	int				 rc;
-	int				 i;
-	bool				 skip;
+	struct chk_instance         *ins = chk_leader;
+	struct chk_bookmark         *cbk = &ins->ci_bk;
+	struct chk_query_args       *cqa = NULL;
+	struct chk_pool_rec         *cpr;
+	struct chk_pool_shard       *cps;
+	struct chk_query_pool_shard *shard;
+	struct chk_bookmark          tmp;
+	d_iov_t                      kiov;
+	d_iov_t                      riov;
+	char                         uuid_str[DAOS_UUID_STR_SIZE];
+	uint64_t                     gen = cbk->cb_gen;
+	uint32_t                     idx = 0;
+	uint32_t                     status;
+	uint32_t                     phase;
+	int                          rc;
+	int                          i;
+	bool                         skip;
 
 	/*
 	 * NOTE: Similar as stop case, we need the ability to query check information from
@@ -3346,10 +3398,20 @@ again:
 		d_iov_set(&riov, NULL, 0);
 		d_iov_set(&kiov, cpr->cpr_uuid, sizeof(uuid_t));
 		rc = dbtree_lookup(ins->ci_pool_hdl, &kiov, &riov);
-		if (likely(rc == 0))
-			tmp = (struct chk_pool_rec *)riov.iov_buf;
-		else
-			tmp = NULL;
+		if (likely(rc == 0)) {
+			status = ((struct chk_pool_rec *)riov.iov_buf)->cpr_bk.cb_pool_status;
+			phase  = ((struct chk_pool_rec *)riov.iov_buf)->cpr_bk.cb_phase;
+		} else {
+			uuid_unparse_upper(cpr->cpr_uuid, uuid_str);
+			rc = chk_bk_fetch_pool(&tmp, uuid_str);
+			if (rc == 0) {
+				status = tmp.cb_pool_status;
+				phase  = tmp.cb_phase;
+			} else {
+				status = CHK__CHECK_POOL_STATUS__CPS_UNCHECKED;
+				phase  = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
+			}
+		}
 
 		d_list_for_each_entry(cps, &cpr->cpr_shard_list, cps_link) {
 			shard = cps->cps_data;
@@ -3361,11 +3423,11 @@ again:
 			 *	 result to avoid confusing. It is just temporary solution, and will
 			 *	 be moved to control plane in the future - DAOS-13989.
 			 */
-			if (cps->cps_rank != CHK_LEADER_RANK && tmp != NULL) {
-				shard->cqps_status = chk_pool_merge_status(shard->cqps_status,
-									tmp->cpr_bk.cb_pool_status);
-				if (shard->cqps_phase < tmp->cpr_bk.cb_phase)
-					shard->cqps_phase = tmp->cpr_bk.cb_phase;
+			if (cps->cps_rank != CHK_LEADER_RANK) {
+				shard->cqps_status =
+				    chk_pool_merge_status(shard->cqps_status, status);
+				if (shard->cqps_phase < phase)
+					shard->cqps_phase = phase;
 			}
 
 			rc = pool_cb(shard, idx++, buf);

--- a/src/chk/chk_vos.c
+++ b/src/chk/chk_vos.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -189,8 +190,8 @@ chk_bk_update_pool(struct chk_bookmark *cbk, char *uuid_str)
 
 	rc = chk_db_update(uuid_str, strlen(uuid_str), cbk, sizeof(*cbk));
 	DL_CDEBUG(rc == 0, DLOG_INFO, DLOG_ERR, rc,
-		  "Update pool %s bookmark on rank %u, status %u, phase %u",
-		  uuid_str, dss_self_rank(), cbk->cb_ins_status, cbk->cb_phase);
+		  "Update pool %s bookmark on rank %u, status %u, phase %u", uuid_str,
+		  dss_self_rank(), cbk->cb_pool_status, cbk->cb_phase);
 
 	return rc;
 }

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2015-2024 Intel Corporation.
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -257,6 +258,51 @@ daos_is_valid_uuid_string(const char *uuid)
 
 	return true;
 }
+
+static inline bool
+daos_is_valid_uuid_lower_string(const char *uuid)
+{
+	const char *p;
+	int         len = DAOS_UUID_STR_SIZE - 1; /* Not include the terminated '\0' */
+	int         i;
+
+	if (strnlen(uuid, len) != len)
+		return false;
+
+	for (i = 0, p = uuid; i < len; i++, p++) {
+		if (i == 8 || i == 13 || i == 18 || i == 23) {
+			if (*p != '-')
+				return false;
+		} else if (!isxdigit(*p) || isupper(*p)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static inline bool
+daos_is_valid_uuid_upper_string(const char *uuid)
+{
+	const char *p;
+	int         len = DAOS_UUID_STR_SIZE - 1; /* Not include the terminated '\0' */
+	int         i;
+
+	if (strnlen(uuid, len) != len)
+		return false;
+
+	for (i = 0, p = uuid; i < len; i++, p++) {
+		if (i == 8 || i == 13 || i == 18 || i == 23) {
+			if (*p != '-')
+				return false;
+		} else if (!isxdigit(*p) || islower(*p)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 /**
  * Corresponding rank and URI for a DAOS engine
  */


### PR DESCRIPTION
1. If some engine dead during check, then remove it from the ranks list for current check instance to avoid membership trouble in subsequent CHK RPC.

2. Use upper UUID string as per-pool based bookbmark name for the check leader to distinguish from check engine bookmarks.

3. Enhance CHK query logic to merge with check leader status and phase even if the check instance has already exited.

4. Fix CR test logic to verify the result properly. Some code cleanup.

Test-tag: cat_recov

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
