### PR TITLE
DAOS-17802 pool: Check RF for dc_pool_exclude

### DIFF
--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -1473,9 +1473,10 @@ Administrator can set the default pool redundancy factor by environment variable
 "DAOS_POOL_RF" in the server yaml file. If SWIM detects and reports an engine is
 dead and the number of failed fault domain exceeds or is going to exceed the pool
 redundancy factor, it will not change pool map immediately. Instead, it will give
-critical log message:
+log messages:
 ```
-intolerable unavailability: engine rank x
+log_unavailable_targets() 76fc8a41: unavailable ranks/targets:
+log_unavailable_targets() 76fc8a41:  rank 1
 ```
 To recover, see [Servers or engines become unavailable](troubleshooting.md#engines-become-unavailable).
 

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1768,8 +1768,7 @@ dc_pool_update_internal(tse_task_t *task, daos_pool_update_t *args, int opc)
 		list.pta_addrs[i].pta_target = args->tgts->tl_tgts[i];
 	}
 
-	pool_tgt_update_in_set_data(rpc, list.pta_addrs, (size_t)list.pta_number,
-				    POOL_TGT_UPDATE_SKIP_RF_CHECK);
+	pool_tgt_update_in_set_data(rpc, list.pta_addrs, (size_t)list.pta_number, 0 /* flags */);
 
 	crt_req_addref(rpc);
 


### PR DESCRIPTION
The dc_pool_exclude code path, used by NVMe fault handling, skips the RF check, potentially raising safety concerns. This patch drops flag POOL_TGT_UPDATE_SKIP_RF_CHECK in that code path, so that the RF check will apply.

The error messages logged when the RF check fails focus on ranks. To make them slightly more accurate, this patch updates the wording, and offers the list of DOWN targets when corresponding ranks are UPIN, in the draft pool map built by this POOL_EXCLUDE request. But we are unable to log the list of _all_ unavailable ranks/targets at the moment; the administrator needs to use `dmg pool query` and `dmg storage query list-devices`.

Since NVMe fault handling retries dc_pool_exclude upon -DER_RF, this patch tunes down the engine stdout/stderr output caused by those errors.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
