### PR TITLE
DAOS-17492 control: Ensure updated members can become voters (#16392)

### DIFF
--- a/src/control/system/raft/database.go
+++ b/src/control/system/raft/database.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -816,6 +817,10 @@ func (db *Database) UpdateMember(m *system.Member) error {
 
 	_, err := db.FindMemberByUUID(m.UUID)
 	if err != nil {
+		return err
+	}
+
+	if err := db.manageVoter(m, raftOpUpdateMember); err != nil {
 		return err
 	}
 

--- a/src/control/system/raft/database_test.go
+++ b/src/control/system/raft/database_test.go
@@ -437,10 +437,9 @@ func checkMemberDB(t *testing.T, mdb *MemberDatabase, expMember *Member, opts ..
 
 	cmpOpts := []cmp.Option{
 		cmp.AllowUnexported(Member{}),
+		cmpopts.IgnoreFields(Member{}, "LastUpdate"),
 	}
-	for _, o := range opts {
-		cmpOpts = append(cmpOpts, o)
-	}
+	cmpOpts = append(cmpOpts, opts...)
 
 	uuidM, ok := mdb.Uuids[expMember.UUID]
 	if !ok {
@@ -477,12 +476,11 @@ func checkMemberDB(t *testing.T, mdb *MemberDatabase, expMember *Member, opts ..
 	}
 }
 
-func TestSystem_Database_memberRaftOps(t *testing.T) {
+func genTestMembers(t *testing.T, num int) []*Member {
 	ctx := test.Context(t)
-
-	testMembers := make([]*Member, 0)
-	nextAddr := ctrlAddrGen(ctx, net.IPv4(127, 0, 0, 1), 4)
-	for i := 0; i < 3; i++ {
+	nextAddr := ctrlAddrGen(ctx, net.IPv4(127, 0, 0, 1), 1)
+	testMembers := make([]*Member, 0, num)
+	for i := 0; i < num; i++ {
 		testMembers = append(testMembers, &Member{
 			Rank:        Rank(i),
 			UUID:        uuid.New(),
@@ -491,6 +489,29 @@ func TestSystem_Database_memberRaftOps(t *testing.T) {
 			FaultDomain: MustCreateFaultDomainFromString("/rack0"),
 		})
 	}
+	return testMembers
+}
+
+func expectMembersInDB(t *testing.T, db *Database, expMembers []*Member) {
+	for _, expMember := range expMembers {
+		checkMemberDB(t, db.data.Members, expMember)
+	}
+
+	if len(db.data.Members.Uuids) != len(expMembers) {
+		t.Fatalf("expected %d members, got %d", len(expMembers), len(db.data.Members.Uuids))
+	}
+
+	totalMemberAddrs := 0
+	for _, members := range db.data.Members.Addrs {
+		totalMemberAddrs += len(members)
+	}
+	if totalMemberAddrs != len(expMembers) {
+		t.Fatalf("expected %d members in address table, got %d: %+v", len(expMembers), totalMemberAddrs, db.data.Members.Addrs)
+	}
+}
+
+func TestSystem_Database_memberRaftOps(t *testing.T) {
+	testMembers := genTestMembers(t, 3)
 
 	changedFaultDomainMember := &Member{
 		Rank:        testMembers[1].Rank,
@@ -505,6 +526,7 @@ func TestSystem_Database_memberRaftOps(t *testing.T) {
 		op              raftOp
 		updateMember    *Member
 		expMembers      []*Member
+		expVotersAdded  []string
 		expFDTree       *FaultDomainTree
 	}{
 		"add success": {
@@ -586,27 +608,125 @@ func TestSystem_Database_memberRaftOps(t *testing.T) {
 			raftUpdateTestMember(t, db, tc.op, tc.updateMember)
 
 			// Check member DB was updated
-			for _, expMember := range tc.expMembers {
-				checkMemberDB(t, db.data.Members, expMember)
-			}
-			if len(db.data.Members.Uuids) != len(tc.expMembers) {
-				t.Fatalf("expected %d member UUIDs, got %d: %+v", len(tc.expMembers), len(db.data.Members.Uuids), db.data.Members.Uuids)
-			}
-			if len(db.data.Members.Ranks) != len(tc.expMembers) {
-				t.Fatalf("expected %d member ranks, got %d: %+v", len(tc.expMembers), len(db.data.Members.Ranks), db.data.Members.Ranks)
-			}
-
-			totalMemberAddrs := 0
-			for _, members := range db.data.Members.Addrs {
-				totalMemberAddrs += len(members)
-			}
-			if totalMemberAddrs != len(tc.expMembers) {
-				t.Fatalf("expected %d members in address table, got %d: %+v", len(tc.expMembers), totalMemberAddrs, db.data.Members.Addrs)
-			}
+			expectMembersInDB(t, db, tc.expMembers)
 
 			if diff := cmp.Diff(tc.expFDTree, db.data.Members.FaultDomains, ignoreFaultDomainIDOption()); diff != "" {
 				t.Fatalf("wrong FaultDomainTree in DB (-want, +got):\n%s\n", diff)
 			}
+		})
+	}
+}
+
+func TestSystem_Database_UpdateMember(t *testing.T) {
+	const numReplicas = 3
+	testMembers := genTestMembers(t, 5)
+	fakeUUID := uuid.MustParse("ffffffff-ffff-ffff-ffff-ffffffffffff")
+
+	for name, tc := range map[string]struct {
+		startingMembers []*Member
+		notLeader       bool
+		updateMember    *Member
+		expMembers      []*Member
+		expErr          error
+		expVotersAdded  []string
+	}{
+		"not leader": {
+			startingMembers: testMembers,
+			updateMember:    testMembers[1],
+			notLeader:       true,
+			expMembers:      testMembers,
+			expErr:          errors.New("Management Service leader"),
+		},
+		"member not found": {
+			startingMembers: testMembers,
+			updateMember: &Member{
+				Rank: 123,
+				UUID: fakeUUID,
+			},
+			expMembers: testMembers,
+			expErr:     ErrMemberUUIDNotFound(fakeUUID),
+		},
+		"update replica": {
+			startingMembers: testMembers,
+			updateMember: &Member{
+				Rank:        testMembers[1].Rank,
+				UUID:        testMembers[1].UUID,
+				Addr:        testMembers[1].Addr,
+				State:       MemberStateReady,
+				FaultDomain: testMembers[1].FaultDomain,
+			},
+			expMembers: []*Member{
+				testMembers[0],
+				{
+					Rank:        testMembers[1].Rank,
+					UUID:        testMembers[1].UUID,
+					Addr:        testMembers[1].Addr,
+					State:       MemberStateReady,
+					FaultDomain: testMembers[1].FaultDomain,
+				},
+				testMembers[2],
+				testMembers[3],
+				testMembers[4],
+			},
+			expVotersAdded: []string{testMembers[1].Addr.String()},
+		},
+		"update non-replica": {
+			startingMembers: testMembers,
+			updateMember: &Member{
+				Rank:        testMembers[4].Rank,
+				UUID:        testMembers[4].UUID,
+				Addr:        testMembers[4].Addr,
+				State:       MemberStateReady,
+				FaultDomain: testMembers[4].FaultDomain,
+			},
+			expMembers: []*Member{
+				testMembers[0],
+				testMembers[1],
+				testMembers[2],
+				testMembers[3],
+				{
+					Rank:        testMembers[4].Rank,
+					UUID:        testMembers[4].UUID,
+					Addr:        testMembers[4].Addr,
+					State:       MemberStateReady,
+					FaultDomain: testMembers[4].FaultDomain,
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := test.MustLogContext(t)
+
+			replicaAddrs := make([]*net.TCPAddr, 0, numReplicas)
+			for i := 0; i < numReplicas; i++ {
+				replicaAddrs = append(replicaAddrs, tc.startingMembers[i].Addr)
+			}
+			t.Logf("%+v", replicaAddrs)
+
+			db := MockDatabaseWithCfg(t, logging.FromContext(ctx), &DatabaseConfig{
+				Replicas: replicaAddrs,
+			})
+			db.replicaAddr = replicaAddrs[0]
+
+			// setup initial member DB
+			for _, initMember := range tc.startingMembers {
+				raftUpdateTestMember(t, db, raftOpAddMember, initMember)
+			}
+
+			mockRaftSvc, ok := db.raft.svc.(*mockRaftService)
+			if !ok {
+				t.Fatal("raft service used wasn't a mockRaftService!")
+			}
+			if tc.notLeader {
+				mockRaftSvc.cfg.State = raft.Follower
+			}
+
+			err := db.UpdateMember(tc.updateMember)
+
+			test.CmpErr(t, tc.expErr, err)
+			expectMembersInDB(t, db, tc.expMembers)
+
+			test.CmpAny(t, "AddVoter calls", tc.expVotersAdded, mockRaftSvc.addVoterCalledForAddrs)
 		})
 	}
 }

--- a/src/control/system/raft/database_test.go
+++ b/src/control/system/raft/database_test.go
@@ -695,7 +695,8 @@ func TestSystem_Database_UpdateMember(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			ctx := test.MustLogContext(t)
+			log, _ := logging.NewTestLogger(t.Name())
+			ctx := test.MustLogContext(t, log)
 
 			replicaAddrs := make([]*net.TCPAddr, 0, numReplicas)
 			for i := 0; i < numReplicas; i++ {
@@ -726,7 +727,9 @@ func TestSystem_Database_UpdateMember(t *testing.T) {
 			test.CmpErr(t, tc.expErr, err)
 			expectMembersInDB(t, db, tc.expMembers)
 
-			test.CmpAny(t, "AddVoter calls", tc.expVotersAdded, mockRaftSvc.addVoterCalledForAddrs)
+			if diff := cmp.Diff(tc.expVotersAdded, mockRaftSvc.addVoterCalledForAddrs); diff != "" {
+				t.Fatalf("wrong raft voters added (-want, +got):\n%s\n", diff)
+			}
 		})
 	}
 }

--- a/src/control/system/raft/raft.go
+++ b/src/control/system/raft/raft.go
@@ -297,11 +297,49 @@ func (db *Database) ConfigureTransport(srv *grpc.Server, dialOpts ...grpc.DialOp
 	return nil
 }
 
+type getCfgFn func(logging.Logger, *DatabaseConfig) (raft.Configuration, error)
+type recoverFn func(logging.Logger, *DatabaseConfig) error
+
+// replicasRemoved checks whether replicas have been removed from the system configuration since the
+// last time the raft service ran. Raft persists the list in its configuration.
+func (db *Database) replicasRemoved(getCfg getCfgFn) (bool, error) {
+	raftCfg, err := getCfg(db.log, db.cfg)
+	if err != nil {
+		return false, errors.Wrap(err, "getting raft config")
+	}
+
+	current := common.NewStringSet(db.cfg.stringReplicas()...)
+	for _, raftSrv := range raftCfg.Servers {
+		if !current.Has(string(raftSrv.Address)) {
+			db.log.Debugf("detected removed MS replica: %s", raftSrv.Address)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// recoverIfReplicasRemoved detects whether nodes have been removed from the last known MS replica
+// list. If so, it may not be possible to hold an election with the voter list in the raft config.
+// We must recover the DB with a fresh raft configuration to allow an election to be held.
+func (db *Database) recoverIfReplicasRemoved(getCfg getCfgFn, recover recoverFn) error {
+	if removed, err := db.replicasRemoved(getCfg); err != nil {
+		return errors.Wrap(err, "checking for removed replicas")
+	} else if removed {
+		db.log.Infof("detected at least one MS replica removed, attempting to recover raft DB")
+		return recover(db.log, db.cfg)
+	}
+	return nil
+}
+
 // initRaft sets up the backing raft service for use. If the service has
 // already been bootstrapped, then it will start immediately. Otherwise,
 // it will need to be bootstrapped before it can be used.
 func (db *Database) initRaft() error {
 	if err := createRaftDir(db.cfg.RaftDir); err != nil {
+		return err
+	}
+
+	if err := db.recoverIfReplicasRemoved(GetRaftConfiguration, RecoverLocalReplica); err != nil {
 		return err
 	}
 

--- a/src/control/system/raft/raft_test.go
+++ b/src/control/system/raft/raft_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -7,6 +8,7 @@
 package raft
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -96,6 +98,99 @@ func TestRaft_Database_WaitForLeaderStepUp(t *testing.T) {
 
 			// Wiggle room for the total duration: 10ms for loop interval + a little more for potentially slow machines
 			test.AssertTrue(t, duration <= tc.stepUpDelay+50*time.Millisecond, "")
+		})
+	}
+}
+
+func TestRaft_recoverIfReplicasRemoved(t *testing.T) {
+	testReplicaAddrs := func(n int) []*net.TCPAddr {
+		addrs := make([]*net.TCPAddr, 0, n)
+		for i := 0; i < n; i++ {
+			addrs = append(addrs, system.MockControlAddr(t, uint32(i)))
+		}
+		return addrs
+	}
+
+	testRaftServers := func(addrs ...*net.TCPAddr) []raft.Server {
+		srvs := make([]raft.Server, 0, len(addrs))
+		for _, a := range addrs {
+			srvs = append(srvs, raft.Server{
+				ID:      raft.ServerID(a.String()),
+				Address: raft.ServerAddress(a.String()),
+			})
+		}
+		return srvs
+	}
+
+	for name, tc := range map[string]struct {
+		replicaAddrs     []*net.TCPAddr
+		getCfgResult     raft.Configuration
+		getCfgErr        error
+		recoverErr       error
+		expRecoverCalled bool
+		expErr           error
+	}{
+		"get config fails": {
+			replicaAddrs: testReplicaAddrs(1),
+			getCfgErr:    errors.New("mock getCfg"),
+			expErr:       errors.New("mock getCfg"),
+		},
+		"single server, no change": {
+			replicaAddrs: testReplicaAddrs(1),
+			getCfgResult: raft.Configuration{
+				Servers: testRaftServers(testReplicaAddrs(1)...),
+			},
+		},
+		"multi server, no change": {
+			replicaAddrs: testReplicaAddrs(5),
+			getCfgResult: raft.Configuration{
+				Servers: testRaftServers(testReplicaAddrs(5)...),
+			},
+		},
+		"server added": {
+			replicaAddrs: testReplicaAddrs(6),
+			getCfgResult: raft.Configuration{
+				Servers: testRaftServers(testReplicaAddrs(5)...),
+			},
+		},
+		"server removed": {
+			replicaAddrs: testReplicaAddrs(3),
+			getCfgResult: raft.Configuration{
+				Servers: testRaftServers(testReplicaAddrs(4)...),
+			},
+			expRecoverCalled: true,
+		},
+		"recover error": {
+			replicaAddrs: testReplicaAddrs(3),
+			getCfgResult: raft.Configuration{
+				Servers: testRaftServers(testReplicaAddrs(4)...),
+			},
+			recoverErr:       errors.New("mock recover"),
+			expErr:           errors.New("mock recover"),
+			expRecoverCalled: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := test.MustLogContext(t)
+
+			mockGetCfg := func(_ logging.Logger, _ *DatabaseConfig) (raft.Configuration, error) {
+				return tc.getCfgResult, tc.getCfgErr
+			}
+
+			recoverCalled := false
+			mockRecover := func(_ logging.Logger, _ *DatabaseConfig) error {
+				recoverCalled = true
+				return tc.recoverErr
+			}
+
+			db := MockDatabaseWithCfg(t, logging.FromContext(ctx), &DatabaseConfig{
+				Replicas: tc.replicaAddrs,
+			})
+
+			err := db.recoverIfReplicasRemoved(mockGetCfg, mockRecover)
+
+			test.CmpErr(t, tc.expErr, err)
+			test.AssertEqual(t, tc.expRecoverCalled, recoverCalled, "")
 		})
 	}
 }

--- a/src/control/system/raft/raft_test.go
+++ b/src/control/system/raft/raft_test.go
@@ -171,7 +171,8 @@ func TestRaft_recoverIfReplicasRemoved(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			ctx := test.MustLogContext(t)
+			log, _ := logging.NewTestLogger(t.Name())
+			ctx := test.MustLogContext(t, log)
 
 			mockGetCfg := func(_ logging.Logger, _ *DatabaseConfig) (raft.Configuration, error) {
 				return tc.getCfgResult, tc.getCfgErr


### PR DESCRIPTION
When adding a new access point to config and restarting, the member is updated, not added, so it was not being considered a voter in the MS leader election.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
