### PR TITLE
DAOS-17534 dtx: not add cont to batched commit list if being stopped

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -38,7 +38,7 @@ struct dtx_batched_pool_args {
 };
 
 struct dtx_batched_cont_args {
-	/* Link to dss_module_info::dmi_dtx_batched_cont_{open,close}_list. */
+	/* Link to dss_module_info::dmi_dtx_batched_cont_open_list when opened. */
 	d_list_t			 dbca_sys_link;
 	/* Link to dtx_batched_pool_args::dbpa_cont_list. */
 	d_list_t			 dbca_pool_link;
@@ -623,9 +623,8 @@ dtx_batched_commit_one(void *arg)
 				D_ASSERT(!dtx_cont_opened(cont));
 
 				dbca->dbca_flush_pending = 0;
-				d_list_del(&dbca->dbca_sys_link);
-				d_list_add_tail(&dbca->dbca_sys_link,
-						&dmi->dmi_dtx_batched_cont_close_list);
+				if (likely(dbca->dbca_deregister == 0))
+					d_list_del_init(&dbca->dbca_sys_link);
 			}
 			break;
 		}
@@ -1653,13 +1652,10 @@ dtx_flush_on_close(struct dss_module_info *dmi, struct dtx_batched_cont_args *db
 
 out:
 	if (rc < 0) {
-		D_ERROR(DF_UUID": Fail to flush CoS cache: rc = %d\n",
-			DP_UUID(cont->sc_uuid), rc);
-		if (likely(!dtx_cont_opened(cont))) {
-			d_list_del(&dbca->dbca_sys_link);
-			/* Give it to the batched commit for further handling asynchronously. */
+		D_ERROR(DF_UUID ": Fail to flush CoS cache: rc = %d\n", DP_UUID(cont->sc_uuid), rc);
+		if (likely(!dtx_cont_opened(cont) && dbca->dbca_deregister == 0))
+			/* Add it to the batched commit for further handling asynchronously. */
 			d_list_add_tail(&dbca->dbca_sys_link, &dmi->dmi_dtx_batched_cont_open_list);
-		}
 	} else {
 		dbca->dbca_flush_pending = 0;
 	}
@@ -1831,7 +1827,7 @@ dtx_cont_register(struct ds_cont_child *cont)
 	dbca->dbca_cont = cont;
 	dbca->dbca_pool = dbpa;
 	dbca->dbca_agg_gen = tls->dt_agg_gen;
-	d_list_add_tail(&dbca->dbca_sys_link, &dmi->dmi_dtx_batched_cont_close_list);
+	D_INIT_LIST_HEAD(&dbca->dbca_sys_link);
 	d_list_add_tail(&dbca->dbca_pool_link, &dbpa->dbpa_cont_list);
 	if (new_pool)
 		d_list_add_tail(&dbpa->dbpa_sys_link, &dmi->dmi_dtx_batched_pool_list);
@@ -1896,7 +1892,9 @@ dtx_cont_open(struct ds_cont_child *cont)
 					return rc;
 
 				dbca->dbca_flush_pending = 0;
-				d_list_del(&dbca->dbca_sys_link);
+				if (unlikely(dbca->dbca_deregister == 1))
+					return -DER_SHUTDOWN;
+
 				d_list_add_tail(&dbca->dbca_sys_link,
 						&dmi->dmi_dtx_batched_cont_open_list);
 				return 0;
@@ -1935,9 +1933,10 @@ dtx_cont_close(struct ds_cont_child *cont, bool force)
 					return;
 				}
 
-				d_list_del(&dbca->dbca_sys_link);
-				d_list_add_tail(&dbca->dbca_sys_link,
-						&dmi->dmi_dtx_batched_cont_close_list);
+				if (unlikely(dbca->dbca_deregister == 1))
+					goto put;
+
+				d_list_del_init(&dbca->dbca_sys_link);
 
 				dtx_flush_on_close(dmi, dbca);
 
@@ -1951,6 +1950,7 @@ dtx_cont_close(struct ds_cont_child *cont, bool force)
 				if (likely(!dtx_cont_opened(cont) && cont->sc_dtx_delay_reset == 0))
 					vos_dtx_cache_reset(cont->sc_hdl, false);
 
+put:
 				dtx_put_dbca(dbca);
 				return;
 			}

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -417,7 +417,6 @@ dss_srv_handler(void *arg)
 	dmi->dmi_tgt_id	= dx->dx_tgt_id;
 	dmi->dmi_ctx_id	= -1;
 	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_cont_open_list);
-	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_cont_close_list);
 	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_pool_list);
 
 	(void)pthread_setname_np(pthread_self(), dx->dx_name);

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -77,24 +77,22 @@ void dss_set_start_epoch(void);
 bool dss_has_enough_helper(void);
 
 struct dss_module_info {
-	crt_context_t		dmi_ctx;
-	struct bio_xs_context  *dmi_nvme_ctxt;
-	struct dss_xstream     *dmi_xstream;
+	crt_context_t          dmi_ctx;
+	struct bio_xs_context *dmi_nvme_ctxt;
+	struct dss_xstream    *dmi_xstream;
 	/* the xstream id */
-	int			dmi_xs_id;
+	int                    dmi_xs_id;
 	/* the VOS target id */
-	int			dmi_tgt_id;
+	int                    dmi_tgt_id;
 	/* the cart context id */
-	int			dmi_ctx_id;
-	uint32_t		dmi_dtx_batched_started:1,
-				dmi_srv_shutting_down:1;
-	d_list_t		dmi_dtx_batched_cont_open_list;
-	d_list_t		dmi_dtx_batched_cont_close_list;
-	d_list_t		dmi_dtx_batched_pool_list;
+	int                    dmi_ctx_id;
+	uint32_t               dmi_dtx_batched_started : 1, dmi_srv_shutting_down : 1;
+	d_list_t               dmi_dtx_batched_cont_open_list;
+	d_list_t               dmi_dtx_batched_pool_list;
 	/* the profile information */
-	struct daos_profile	*dmi_dp;
-	struct sched_request	*dmi_dtx_cmt_req;
-	struct sched_request	*dmi_dtx_agg_req;
+	struct daos_profile   *dmi_dp;
+	struct sched_request  *dmi_dtx_cmt_req;
+	struct sched_request  *dmi_dtx_agg_req;
 };
 
 extern struct dss_module_key	daos_srv_modkey;


### PR DESCRIPTION
When close the container, dtx_flush_on_close logic will try to commit pending committable DTX entries. If such flush failed for some reason, then it will ask async-batched-commit logic to do that sometime later. But if the container is in stopping, then do not re-add the container back to the async-batched-commit list; otherwise the stop logic maybe blocked for long time (or for ever).

Similar cases for when open/close the container.

Some code cleanup for DTX logic.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
