### PR TITLE
DAOS-17534 dtx: not add cont to batched commit list if being stopped - b26

### DIFF
--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -417,7 +417,6 @@ dss_srv_handler(void *arg)
 	dmi->dmi_tgt_id	= dx->dx_tgt_id;
 	dmi->dmi_ctx_id	= -1;
 	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_cont_open_list);
-	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_cont_close_list);
 	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_pool_list);
 
 	(void)pthread_setname_np(pthread_self(), dx->dx_name);

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -74,24 +74,22 @@ void dss_set_start_epoch(void);
 bool dss_has_enough_helper(void);
 
 struct dss_module_info {
-	crt_context_t		dmi_ctx;
-	struct bio_xs_context  *dmi_nvme_ctxt;
-	struct dss_xstream     *dmi_xstream;
+	crt_context_t          dmi_ctx;
+	struct bio_xs_context *dmi_nvme_ctxt;
+	struct dss_xstream    *dmi_xstream;
 	/* the xstream id */
-	int			dmi_xs_id;
+	int                    dmi_xs_id;
 	/* the VOS target id */
-	int			dmi_tgt_id;
+	int                    dmi_tgt_id;
 	/* the cart context id */
-	int			dmi_ctx_id;
-	uint32_t		dmi_dtx_batched_started:1,
-				dmi_srv_shutting_down:1;
-	d_list_t		dmi_dtx_batched_cont_open_list;
-	d_list_t		dmi_dtx_batched_cont_close_list;
-	d_list_t		dmi_dtx_batched_pool_list;
+	int                    dmi_ctx_id;
+	uint32_t               dmi_dtx_batched_started : 1, dmi_srv_shutting_down : 1;
+	d_list_t               dmi_dtx_batched_cont_open_list;
+	d_list_t               dmi_dtx_batched_pool_list;
 	/* the profile information */
-	struct daos_profile	*dmi_dp;
-	struct sched_request	*dmi_dtx_cmt_req;
-	struct sched_request	*dmi_dtx_agg_req;
+	struct daos_profile   *dmi_dp;
+	struct sched_request  *dmi_dtx_cmt_req;
+	struct sched_request  *dmi_dtx_agg_req;
 };
 
 extern struct dss_module_key	daos_srv_modkey;


### PR DESCRIPTION
When close the container, dtx_flush_on_close logic will try to commit pending committable DTX entries. If such flush failed for some reason, then it will ask async-batched-commit logic to do that sometime later. But if the container is in stopping, then do not re-add the container back to the async-batched-commit list; otherwise the stop logic maybe blocked for long time (or for ever).

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
