### PR TITLE
DAOS-17845 container: keep CONT_TGT_SNAPSHOT_NOTIFY RPC errno

### DIFF
--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -220,9 +220,8 @@ snap_oit_create(struct rdb_tx *tx, struct cont *cont, uuid_t coh_uuid,
 	out = crt_reply_get(rpc);
 	rc = out->tso_rc;
 	if (rc != 0) {
-		D_ERROR(DF_CONT": snapshot notify failed on %d targets\n",
-			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), rc);
-		rc = -DER_IO;
+		D_ERROR(DF_CONT " snapshot notify failed: " DF_RC "\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
 		goto out_rpc;
 	}
 	*epoch = in->tsi_epoch;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -2233,7 +2233,8 @@ ds_cont_tgt_snapshot_notify_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 
 	out_source = crt_reply_get(source);
 	out_result = crt_reply_get(result);
-	out_result->tso_rc += out_source->tso_rc;
+	if (out_result->tso_rc >= 0 && out_source->tso_rc < 0)
+		out_result->tso_rc = out_source->tso_rc;
 	return 0;
 }
 


### PR DESCRIPTION
Return CONT_TGT_SNAPSHOT_NOTIFY RPC errno to the snap_oit_create() sponsor instead of converting it as -DER_IO. Then related client side logic can know what the failure is.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
