### PR TITLE
DAOS-17444 rebuild: increase inline buffer size

### DIFF
--- a/src/object/srv_enum.c
+++ b/src/object/srv_enum.c
@@ -608,6 +608,7 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct ds_obj_enum_arg *ar
 				data_size = iod_size;
 		} else {
 			iod_size = key_ent->ie_rsize;
+			data_size = iod_size * key_ent->ie_recx.rx_nr;
 		}
 	}
 
@@ -680,12 +681,13 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct ds_obj_enum_arg *ar
 		 * may be invisible to current enumeration. Then it
 		 * may be located on SCM or NVMe.
 		 */
-		D_ASSERT(type != OBJ_ITER_RECX);
-		D_ASSERTF(key_ent->ie_biov.bi_addr.ba_type ==
-			  DAOS_MEDIA_SCM, "Invalid storage media type %d, ba_off "
-			  DF_X64", thres %ld, data_size %ld, type %d, iod_size %ld\n",
-			  key_ent->ie_biov.bi_addr.ba_type, key_ent->ie_biov.bi_addr.ba_off,
-			  arg->inline_thres, data_size, type, iod_size);
+		if (type != OBJ_ITER_RECX) {
+			D_ASSERTF(key_ent->ie_biov.bi_addr.ba_type ==
+				DAOS_MEDIA_SCM, "Invalid storage media type %d, ba_off "
+				DF_X64", thres %ld, data_size %ld, type %d, iod_size %ld\n",
+				key_ent->ie_biov.bi_addr.ba_type, key_ent->ie_biov.bi_addr.ba_off,
+				arg->inline_thres, data_size, type, iod_size);
+		}
 
 		d_iov_set(&iov_out, iovs[arg->sgl_idx].iov_buf +
 				       iovs[arg->sgl_idx].iov_len, data_size);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -3428,7 +3428,7 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 	anchors->ia_ev = oei->oei_anchor;
 
 	/* TODO: Transfer the inline_thres from enumerate RPC */
-	enum_arg.inline_thres = 32;
+	enum_arg.inline_thres = 128;
 
 	if (opc == DAOS_OBJ_RECX_RPC_ENUMERATE) {
 		oeo->oeo_eprs.ca_count = 0;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2859,7 +2859,7 @@ put:
 }
 
 #define KDS_NUM		96
-#define ITER_BUF_SIZE	2048
+#define ITER_BUF_SIZE   4096
 
 /**
  * Iterate akeys/dkeys of the object


### PR DESCRIPTION
Increase inline buffer size so rebuild enumeration can return inode without extra fetch

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
