### PR TITLE
SRE-3236 LUA-LMOD hack fix for Leap 15.6

### DIFF
--- a/ci/provisioning/post_provision_config_nodes_LEAP.sh
+++ b/ci/provisioning/post_provision_config_nodes_LEAP.sh
@@ -8,7 +8,7 @@
 bootstrap_dnf() {
     rm -rf "$REPOS_DIR"
     ln -s ../zypp/repos.d "$REPOS_DIR"
-    dnf -y remove lua-lmod
+    dnf -y remove lua54 lua-lmod
     dnf -y --nogpgcheck install lua-lmod '--repo=*lua*' --repo '*network-cluster*'
 }
 


### PR DESCRIPTION
ci/provisioning/post_provision_config_nodes_LEAP.sh:
  Something in Leap-15.6 added an additional dependency of the distro
  provided lua-lmod that is not removed when lua-lmod is removed and
  blocks the install of the newer lua-lmod.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
