### PR TITLE
DAOS-17356 rebuild: interactive stop/start RPCs, ds_mgmt API

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -329,6 +329,11 @@ int dsc_pool_svc_query_target(uuid_t pool_uuid, d_rank_list_t *ps_ranks, uint64_
 int ds_pool_prop_fetch(struct ds_pool *pool, unsigned int bit,
 		       daos_prop_t **prop_out);
 int dsc_pool_svc_upgrade(uuid_t pool_uuid, d_rank_list_t *ranks, uint64_t deadline);
+int
+dsc_pool_svc_rebuild_stop(uuid_t pool_uuid, uint32_t force, d_rank_list_t *ps_ranks,
+			  uint64_t deadline);
+int
+     dsc_pool_svc_rebuild_start(uuid_t pool_uuid, d_rank_list_t *ps_ranks, uint64_t deadline);
 int ds_pool_failed_add(uuid_t uuid, int rc);
 void ds_pool_failed_remove(uuid_t uuid);
 int ds_pool_failed_lookup(uuid_t uuid);
@@ -407,7 +412,7 @@ void ds_pool_enable_exclude(void);
 int
 ds_pool_rebuild_start(uuid_t pool_uuid, struct rsvc_hint *hint);
 int
-	    ds_pool_rebuild_stop(uuid_t pool_uuid, struct rsvc_hint *hint);
+	    ds_pool_rebuild_stop(uuid_t pool_uuid, uint32_t force, struct rsvc_hint *hint);
 
 extern bool ec_agg_disabled;
 

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -97,7 +97,7 @@ void ds_rebuild_leader_stop_all(void);
 void ds_rebuild_abort(uuid_t pool_uuid, unsigned int version, uint32_t rebuild_gen,
 		      uint64_t term);
 int
-ds_rebuild_admin_stop(struct ds_pool *pool);
+ds_rebuild_admin_stop(struct ds_pool *pool, uint32_t force);
 int
 ds_rebuild_admin_start(struct ds_pool *pool);
 #endif

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -143,6 +143,10 @@ int ds_mgmt_check_query(int pool_nr, char **pools, chk_query_head_cb_t head_cb,
 			chk_query_pool_cb_t pool_cb, void *buf);
 int ds_mgmt_check_prop(chk_prop_cb_t prop_cb, void *buf);
 int ds_mgmt_check_act(uint64_t seq, uint32_t act, bool for_all);
+int
+ds_mgmt_pool_rebuild_stop(uuid_t pool_uuid, uint32_t force, d_rank_list_t *svc_ranks);
+int
+     ds_mgmt_pool_rebuild_start(uuid_t pool_uuid, d_rank_list_t *svc_ranks);
 bool ds_mgmt_check_enabled(void);
 
 /** srv_query.c */

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -636,6 +636,43 @@ out:
 }
 
 /**
+ * Calls into the pool svc to request stopping a rebuild.
+ *
+ * \param[in]		pool_uuid		UUID of the pool.
+ * \param[in]		force			boolean. force a rebuild in op:Fail_reclaim to stop.
+ * \param[in]		svc_ranks		Ranks of pool svc replicas.
+ *
+ * \return			0				Success
+ *					Negative value	Error
+ */
+int
+ds_mgmt_pool_rebuild_stop(uuid_t pool_uuid, uint32_t force, d_rank_list_t *svc_ranks)
+{
+	D_DEBUG(DB_MGMT, "Sending request to stop rebuild for pool " DF_UUID "\n",
+		DP_UUID(pool_uuid));
+
+	return dsc_pool_svc_rebuild_stop(pool_uuid, force, svc_ranks, mgmt_ps_call_deadline());
+}
+
+/**
+ * Calls into the pool svc to request start/resume rebuilding.
+ *
+ * \param[in]		pool_uuid		UUID of the pool.
+ * \param[in]		svc_ranks		Ranks of pool svc replicas.
+ *
+ * \return			0				Success
+ *					Negative value	Error
+ */
+int
+ds_mgmt_pool_rebuild_start(uuid_t pool_uuid, d_rank_list_t *svc_ranks)
+{
+	D_DEBUG(DB_MGMT, "Sending request to start/resume rebuilding for pool " DF_UUID "\n",
+		DP_UUID(pool_uuid));
+
+	return dsc_pool_svc_rebuild_start(pool_uuid, svc_ranks, mgmt_ps_call_deadline());
+}
+
+/**
  * Destroy the specified pool shard on the specified storage rank
  */
 int

--- a/src/pool/rpc.c
+++ b/src/pool/rpc.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -198,6 +199,8 @@ CRT_RPC_DEFINE(pool_query_info_v6, DAOS_ISEQ_POOL_QUERY_INFO, DAOS_OSEQ_POOL_QUE
 CRT_RPC_DEFINE(pool_query_info, DAOS_ISEQ_POOL_QUERY_INFO, DAOS_OSEQ_POOL_QUERY_INFO)
 CRT_RPC_DEFINE(pool_tgt_query_map, DAOS_ISEQ_POOL_TGT_QUERY_MAP, DAOS_OSEQ_POOL_TGT_QUERY_MAP)
 CRT_RPC_DEFINE(pool_tgt_discard, DAOS_ISEQ_POOL_TGT_DISCARD, DAOS_OSEQ_POOL_TGT_DISCARD)
+CRT_RPC_DEFINE(pool_rebuild_stop, DAOS_ISEQ_POOL_REBUILD_STOP, DAOS_OSEQ_POOL_REBUILD_STOP)
+CRT_RPC_DEFINE(pool_rebuild_start, DAOS_ISEQ_POOL_REBUILD_START, DAOS_OSEQ_POOL_REBUILD_START)
 CRT_RPC_DEFINE(pool_tgt_warmup, DAOS_ISEQ_POOL_TGT_WARMUP, DAOS_OSEQ_POOL_TGT_WARMUP)
 
 /* Define for cont_rpcs[] array population below.

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -77,7 +77,9 @@
 	X(POOL_ACL_DELETE, 0, &CQF_pool_acl_delete, ds_pool_acl_delete_handler, NULL)              \
 	X(POOL_RANKS_GET, 0, &CQF_pool_ranks_get, ds_pool_ranks_get_handler, NULL)                 \
 	X(POOL_UPGRADE, 0, &CQF_pool_upgrade, ds_pool_upgrade_handler, NULL)                       \
-	X(POOL_TGT_DISCARD, 0, &CQF_pool_tgt_discard, ds_pool_tgt_discard_handler, NULL)
+	X(POOL_TGT_DISCARD, 0, &CQF_pool_tgt_discard, ds_pool_tgt_discard_handler, NULL)           \
+	X(POOL_REBUILD_STOP, 0, &CQF_pool_rebuild_stop, ds_pool_rebuild_stop_handler, NULL)        \
+	X(POOL_REBUILD_START, 0, &CQF_pool_rebuild_start, ds_pool_rebuild_start_handler, NULL)
 
 #define POOL_PROTO_RPC_LIST                                                                        \
 	POOL_PROTO_CLI_RPC_LIST(DAOS_POOL_VERSION)                                                 \
@@ -901,6 +903,23 @@ CRT_RPC_DECLARE(pool_tgt_query_map, DAOS_ISEQ_POOL_TGT_QUERY_MAP, DAOS_OSEQ_POOL
 	((int32_t)			(ptdo_rc)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_tgt_discard, DAOS_ISEQ_POOL_TGT_DISCARD, DAOS_OSEQ_POOL_TGT_DISCARD)
+
+#define DAOS_ISEQ_POOL_REBUILD_STOP	/* input fields */       \
+	((struct pool_op_in)	(rstpi_op)		CRT_VAR)     \
+	((uint32_t)				(rstpi_force)	CRT_VAR)
+
+#define DAOS_OSEQ_POOL_REBUILD_STOP	/* output fields */      \
+	((struct pool_op_out)		(rstpo_op)		CRT_VAR)
+
+CRT_RPC_DECLARE(pool_rebuild_stop, DAOS_ISEQ_POOL_REBUILD_STOP, DAOS_OSEQ_POOL_REBUILD_STOP)
+
+#define DAOS_ISEQ_POOL_REBUILD_START	/* input fields */   \
+	((struct pool_op_in)		(rstai_op)		CRT_VAR)
+
+#define DAOS_OSEQ_POOL_REBUILD_START	/* output fields */  \
+	((struct pool_op_out)		(rstao_op)		CRT_VAR)
+
+CRT_RPC_DECLARE(pool_rebuild_start, DAOS_ISEQ_POOL_REBUILD_START, DAOS_OSEQ_POOL_REBUILD_START)
 
 /* clang-format on */
 

--- a/src/pool/srv_cli.c
+++ b/src/pool/srv_cli.c
@@ -1224,3 +1224,90 @@ dsc_pool_svc_upgrade(uuid_t pool_uuid, d_rank_list_t *ranks, uint64_t deadline)
 	D_DEBUG(DB_MGMT, DF_UUID ": Upgrading pool prop\n", DP_UUID(pool_uuid));
 	return dsc_pool_svc_call(pool_uuid, ranks, &pool_upgrade_cbs, NULL /* arg */, deadline);
 }
+
+struct pool_rebuild_stop_arg {
+	uint32_t rstpa_force;
+};
+
+static int
+pool_rebuild_stop_init(uuid_t pool_uuid, crt_rpc_t *rpc, void *varg)
+{
+	struct pool_rebuild_stop_arg *arg = varg;
+	struct pool_rebuild_stop_in  *in;
+
+	in              = crt_req_get(rpc);
+	in->rstpi_force = arg->rstpa_force;
+	return 0;
+}
+
+static int
+pool_rebuild_stop_consume(uuid_t pool_uuid, crt_rpc_t *rpc, void *varg)
+{
+	struct pool_rebuild_stop_out *out = crt_reply_get(rpc);
+	int                           rc  = out->rstpo_op.po_rc;
+
+	if (rc != 0)
+		DL_ERROR(rc, DF_UUID ": failed to stop rebuild", DP_UUID(pool_uuid));
+	return rc;
+}
+
+static struct dsc_pool_svc_call_cbs pool_rebuild_stop_cbs = {.pscc_op   = POOL_REBUILD_STOP,
+							     .pscc_init = pool_rebuild_stop_init,
+							     .pscc_consume =
+								 pool_rebuild_stop_consume,
+							     .pscc_fini = NULL};
+
+/**
+ * Request pool stop a running rebuild.
+ *
+ * \param[in]		pool_uuid		UUID of the pool.
+ * \param[in]		force			boolean. force a rebuild in op:Fail_reclaim to stop.
+ * \param[in]		ps_ranks		Ranks of pool svc replicas.
+ * \param[in]		deadline		Unix time deadline in milliseconds
+ *
+ * \return	0		Success
+ *		Negative value	Error
+ */
+
+int
+dsc_pool_svc_rebuild_stop(uuid_t pool_uuid, uint32_t force, d_rank_list_t *ps_ranks,
+			  uint64_t deadline)
+{
+	struct pool_rebuild_stop_arg arg = {.rstpa_force = force};
+
+	return dsc_pool_svc_call(pool_uuid, ps_ranks, &pool_rebuild_stop_cbs, &arg, deadline);
+}
+
+static int
+pool_rebuild_start_consume(uuid_t pool_uuid, crt_rpc_t *rpc, void *varg)
+{
+	struct pool_rebuild_start_out *out = crt_reply_get(rpc);
+	int                            rc  = out->rstao_op.po_rc;
+
+	if (rc != 0)
+		DL_ERROR(rc, DF_UUID ": failed to start/resume rebuild", DP_UUID(pool_uuid));
+	return rc;
+}
+
+static struct dsc_pool_svc_call_cbs pool_rebuild_start_cbs = {.pscc_op   = POOL_REBUILD_START,
+							      .pscc_init = NULL,
+							      .pscc_consume =
+								  pool_rebuild_start_consume,
+							      .pscc_fini = NULL};
+
+/**
+ * Request pool start/resume rebuilding.
+ *
+ * \param[in]		pool_uuid		UUID of the pool.
+ * \param[in]		ps_ranks		Ranks of pool svc replicas.
+ * \param[in]		deadline		Unix time deadline in milliseconds
+ *
+ * \return	0		Success
+ *		Negative value	Error
+ */
+int
+dsc_pool_svc_rebuild_start(uuid_t pool_uuid, d_rank_list_t *ps_ranks, uint64_t deadline)
+{
+	return dsc_pool_svc_call(pool_uuid, ps_ranks, &pool_rebuild_start_cbs, NULL /* varg */,
+				 deadline);
+}

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -225,6 +225,10 @@ int ds_pool_tgt_connect(struct ds_pool *pool, struct pool_iv_conn *pic);
 void ds_pool_tgt_query_map_handler(crt_rpc_t *rpc);
 void ds_pool_tgt_discard_handler(crt_rpc_t *rpc);
 void
+ds_pool_rebuild_stop_handler(crt_rpc_t *rpc);
+void
+ds_pool_rebuild_start_handler(crt_rpc_t *rpc);
+void
 ds_pool_tgt_warmup_handler(crt_rpc_t *rpc);
 int
 ds_pool_lookup_map_bc(struct ds_pool *pool, crt_context_t ctx, struct ds_pool_map_bc **map_bc_out,

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -878,7 +878,7 @@ static uuid_t test_stop_start_puuid;
 
 /* administrator (via dmg command) asks to stop the currently-running rebuild for pool */
 int
-ds_rebuild_admin_stop(struct ds_pool *pool)
+ds_rebuild_admin_stop(struct ds_pool *pool, uint32_t force)
 {
 	struct rebuild_global_pool_tracker *rgt;
 
@@ -891,12 +891,14 @@ ds_rebuild_admin_stop(struct ds_pool *pool)
 		return 0;
 	}
 
-	/* admin stop command does not terminate reclaim/fail_reclaim jobs */
-	if ((rgt->rgt_opc == RB_OP_REBUILD) || (rgt->rgt_opc == RB_OP_UPGRADE)) {
-		D_INFO(DF_RB ": stopping rebuild opc %u(%s)\n", DP_RB_RGT(rgt), rgt->rgt_opc,
-		       RB_OP_STR(rgt->rgt_opc));
-		rgt->rgt_abort      = 1;
-		rgt->rgt_stop_admin = 1;
+	/* admin stop command does not terminate reclaim/fail_reclaim jobs (unless forced) */
+	if (((rgt->rgt_opc == RB_OP_REBUILD) || (rgt->rgt_opc == RB_OP_UPGRADE)) ||
+	    ((rgt->rgt_opc == RB_OP_FAIL_RECLAIM) && force)) {
+		D_INFO(DF_RB ": stopping rebuild force=%u opc %u(%s)\n", DP_RB_RGT(rgt), force,
+		       rgt->rgt_opc, RB_OP_STR(rgt->rgt_opc));
+		rgt->rgt_abort           = 1;
+		rgt->rgt_stop_admin      = 1;
+		rgt->rgt_status.rs_errno = -DER_OP_CANCELED;
 	} else {
 		D_INFO(DF_RB ": NOT stopping rebuild during opc %u(%s)\n", DP_RB_RGT(rgt),
 		       rgt->rgt_opc, RB_OP_STR(rgt->rgt_opc));
@@ -954,7 +956,7 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 
 			/* What the real RPC handler will call. We will exit below due to rgt_abort
 			 */
-			ds_pool_rebuild_stop(test_stop_start_puuid, NULL /* hint */);
+			ds_pool_rebuild_stop(test_stop_start_puuid, 0 /* force */, NULL /* hint */);
 		}
 
 		ABT_rwlock_rdlock(pool->sp_lock);
@@ -1829,12 +1831,6 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 complete:
 	/* Update the rebuild complete status for pool query */
 	if (task->dst_rebuild_op != RB_OP_FAIL_RECLAIM) {
-		/* During and after an admin stop, pool query should show an indication.
-		 * Query rs_state from original Rebuild = IN_PROGRESS until Fail_reclaim finishes
-		 * later.
-		 */
-		if (rgt->rgt_stop_admin && rgt->rgt_abort)
-			rgt->rgt_status.rs_errno = -DER_OP_CANCELED;
 		rc1 = rebuild_status_completed_update(task->dst_pool_uuid, &rgt->rgt_status);
 		DL_CDEBUG(rc1, DLOG_ERR, DLOG_INFO, rc1, DF_RB ": updated, state %d errno " DF_RC,
 			  DP_RB_RGT(rgt), rgt->rgt_status.rs_state,
@@ -1974,14 +1970,10 @@ done:
 			DP_RC(rgt->rgt_status.rs_errno));
 
 		if (rgt->rgt_abort && rgt->rgt_stop_admin) {
-			/* Administrator asked to stop rebuild (more than a leader abort - stop on
-			 * all engines). Notify all engines to stop with
+			/* Administrator asked to stop rebuild. Notify engines with
 			 * rebuild_leader_status_notify().
 			 */
-			D_INFO(DF_RB ": stop rebuild due to admin command, change rc %d -> " DF_RC
-				     "\n",
-			       DP_RB_RGT(rgt), rgt->rgt_status.rs_errno, DP_RC(-DER_OP_CANCELED));
-			rgt->rgt_status.rs_errno = -DER_OP_CANCELED;
+			D_INFO(DF_RB ": stop rebuild due to admin command\n", DP_RB_RGT(rgt));
 		} else if (rgt->rgt_abort && rgt->rgt_status.rs_errno == 0) {
 			/* If the leader rebuild is aborted due to a leader change, then do not
 			 * abort the real rebuild(scan/pull ults), because the new leader will


### PR DESCRIPTION
This patch establishes a framework for integration with the control plane dmg commands and MS engine dRPC handlers to be implemented soon for this feature. The new code in this patch is not yet exercised. Specifically, the following are added:
- Pool service (PS) CaRT RPC definitions and handler implementations for POOL_REBUILD_STOP/START. The handlers call the previously-implemented interactive rebuild stop/start behavior.
- For DAOS-17357 a ds_mgmt_pool_rebuild_stop()/start() API functions to interface with the PS leader as POOL_REBIULD_STOP/START clients. The new functions use dsc_pool_svc_call() internally like other ds_mgmt_ functions.

Also, the existing interactive rebuild stop/start logic is updated with these cleanups/enhancements:
- upon stop, at time of handling, immediately change the rebuild state to reflect errno -DER_OP_CANCELED (rather than wait for subsequent functions in the calling sequence to assign it).
- add a boolean force argument to the stop functions and RPC definitions to allow an administrator to forcibly terminate a rebuild that is in the Fail_reclaim phase. This is intended to support unusual situations in which a rebuild is constantly looping op:Fail_reclaim and encountering errors in each attempt.

Features: rebuild
Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
