### PR TITLE
DAOS-17853 ci: new warning in strict mode - DO NOT MERGE - TEST ONLY

### DIFF
--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -1570,6 +1570,7 @@ lock_pool_memory(struct vos_pool *pool)
 
 		if (rlim.rlim_cur != RLIM_INFINITY || rlim.rlim_max != RLIM_INFINITY) {
 			D_WARN("Infinite rlimit not detected, not locking VOS pool memory\n");
+			D_WARN("Dummy warning in strict mode\n");
 			lock_mem = LM_FLAG_DISABLED;
 			return;
 		}


### PR DESCRIPTION
Test if new warning in core DASO also triggers NLT issue.



Skip-build-el9-gcc: true
Skip-build-leap15-gcc: true
Skip-build-leap15-icc: true
Skip-build-ubuntu20-gcc: true

Skip-build-el9-rpm: true
Skip-build-leap15-rpm: true

Skip-unit-test-memcheck: true
Skip-unit-test: true

Skip-func-test-el8: true
Skip-fault-injection-test: true

Skip-func-hw-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
