### PR TITLE
DAOS-17772 rebuild: refine sc_ec_agg_eph_boundary related processing

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1823,109 +1823,126 @@ ds_cont_tgt_refresh_agg_eph(uuid_t pool_uuid, uuid_t cont_uuid,
 	return rc;
 }
 
-#define EC_AGG_EPH_INTV	 (10ULL * 1000)	/* seconds interval to check*/
+static void
+cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
+{
+	d_rank_list_t       fail_ranks = {0};
+	struct cont_ec_agg *ec_agg;
+	struct cont_ec_agg *tmp;
+	daos_epoch_t        cur_eph, new_eph;
+	daos_epoch_t        min_eph;
+	d_rank_t            rank;
+	int                 i;
+	int                 rc;
+
+	rc = map_ranks_init(pool->sp_map, PO_COMP_ST_DOWNOUT | PO_COMP_ST_DOWN, &fail_ranks);
+	if (rc) {
+		D_ERROR(DF_UUID ": ranks init failed: %d\n", DP_UUID(pool->sp_uuid), rc);
+		return;
+	}
+
+	d_list_for_each_entry_safe(ec_agg, tmp, &svc->cs_ec_agg_list, ea_list) {
+		if (ec_agg->ea_deleted) {
+			d_list_del(&ec_agg->ea_list);
+			D_FREE(ec_agg->ea_server_ephs);
+			D_FREE(ec_agg);
+			continue;
+		}
+
+		min_eph = DAOS_EPOCH_MAX;
+		for (i = 0; i < ec_agg->ea_servers_num; i++) {
+			rank = ec_agg->ea_server_ephs[i].rank;
+
+			if (d_rank_in_rank_list(&fail_ranks, rank)) {
+				D_DEBUG(DB_MD, DF_CONT " skip %u\n",
+					DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid), rank);
+				continue;
+			}
+
+			if (ec_agg->ea_server_ephs[i].eph < min_eph)
+				min_eph = ec_agg->ea_server_ephs[i].eph;
+		}
+
+		if (min_eph == ec_agg->ea_current_eph)
+			continue;
+
+		/**
+		 * NB: during extending or reintegration, the new
+		 * server might cause the minimum epoch is less than
+		 * ea_current_eph.
+		 */
+		D_DEBUG(DB_MD, DF_CONT " minimum " DF_U64 " current " DF_X64 "\n",
+			DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid), min_eph,
+			ec_agg->ea_current_eph);
+
+		cur_eph = d_hlc2sec(ec_agg->ea_current_eph);
+		new_eph = d_hlc2sec(min_eph);
+		if (cur_eph && new_eph > cur_eph && (new_eph - cur_eph) >= 600)
+			D_WARN(DF_CONT ": Sluggish EC boundary reporting. "
+				       "cur:" DF_U64 " new:" DF_U64 " gap:" DF_U64 "\n",
+			       DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid), cur_eph, new_eph,
+			       new_eph - cur_eph);
+
+		rc = cont_iv_ec_agg_eph_refresh(pool->sp_iv_ns, ec_agg->ea_cont_uuid, min_eph);
+		if (rc) {
+			DL_CDEBUG(rc == -DER_NONEXIST, DLOG_INFO, DLOG_ERR, rc,
+				  DF_CONT ": refresh failed",
+				  DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid));
+
+			/* If there are network error or pool map inconsistency,
+			 * let's skip the following eph sync, which will fail
+			 * anyway.
+			 */
+			if (daos_crt_network_error(rc) || rc == -DER_GRPVER) {
+				D_INFO(DF_UUID ": skip refresh due to: " DF_RC "\n",
+				       DP_UUID(svc->cs_pool_uuid), DP_RC(rc));
+				break;
+			}
+
+			continue;
+		}
+		ec_agg->ea_current_eph = min_eph;
+	}
+
+	map_ranks_fini(&fail_ranks);
+}
+
+int
+ds_cont_svc_refresh_agg_eph(uuid_t pool_uuid)
+{
+	struct cont_svc *svc;
+	int              rc;
+
+	rc = cont_svc_lookup_leader(pool_uuid, 0 /* id */, &svc, NULL /* hint */);
+	if (rc != 0)
+		return rc;
+
+	cont_agg_eph_sync(svc->cs_pool, svc);
+
+	cont_svc_put_leader(svc);
+	return 0;
+}
+
+#define EC_AGG_EPH_INTV (10ULL * 1000) /* seconds interval to check*/
 static void
 cont_agg_eph_leader_ult(void *arg)
 {
-	struct cont_svc		*svc = arg;
-	struct ds_pool		*pool = svc->cs_pool;
-	struct cont_ec_agg	*ec_agg;
-	struct cont_ec_agg	*tmp;
-	uint64_t		cur_eph, new_eph;
-	int			rc = 0;
+	struct cont_svc    *svc  = arg;
+	struct ds_pool     *pool = svc->cs_pool;
+	struct cont_ec_agg *ec_agg;
+	struct cont_ec_agg *tmp;
+	int                 rc = 0;
 
 	if (svc->cs_ec_leader_ephs_req == NULL)
 		goto out;
 
 	while (!dss_ult_exiting(svc->cs_ec_leader_ephs_req)) {
-		d_rank_list_t		fail_ranks = { 0 };
-
 		if (pool->sp_rebuilding) {
-			D_DEBUG(DB_MD, DF_UUID "skip during rebuilding.\n",
-				DP_UUID(pool->sp_uuid));
+			D_DEBUG(DB_MD, DF_UUID "skip during rebuilding.\n", DP_UUID(pool->sp_uuid));
 			goto yield;
 		}
 
-		rc = map_ranks_init(pool->sp_map, PO_COMP_ST_DOWNOUT | PO_COMP_ST_DOWN,
-				    &fail_ranks);
-		if (rc) {
-			D_ERROR(DF_UUID": ranks init failed: %d\n",
-				DP_UUID(pool->sp_uuid), rc);
-			goto yield;
-		}
-
-		d_list_for_each_entry_safe(ec_agg, tmp, &svc->cs_ec_agg_list, ea_list) {
-			daos_epoch_t min_eph = DAOS_EPOCH_MAX;
-			int	     i;
-
-			if (ec_agg->ea_deleted) {
-				d_list_del(&ec_agg->ea_list);
-				D_FREE(ec_agg->ea_server_ephs);
-				D_FREE(ec_agg);
-				continue;
-			}
-
-			for (i = 0; i < ec_agg->ea_servers_num; i++) {
-				d_rank_t rank = ec_agg->ea_server_ephs[i].rank;
-
-				if (d_rank_in_rank_list(&fail_ranks, rank)) {
-					D_DEBUG(DB_MD, DF_CONT" skip %u\n",
-						DP_CONT(svc->cs_pool_uuid,
-							ec_agg->ea_cont_uuid),
-						rank);
-					continue;
-				}
-
-				if (ec_agg->ea_server_ephs[i].eph < min_eph)
-					min_eph = ec_agg->ea_server_ephs[i].eph;
-			}
-
-			if (min_eph == ec_agg->ea_current_eph)
-				continue;
-
-			/**
-			 * NB: during extending or reintegration, the new
-			 * server might cause the minimum epoch is less than
-			 * ea_current_eph.
-			 */
-			D_DEBUG(DB_MD, DF_CONT" minimum "DF_U64" current "DF_X64"\n",
-				DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid),
-				min_eph, ec_agg->ea_current_eph);
-
-			cur_eph = d_hlc2sec(ec_agg->ea_current_eph);
-			new_eph = d_hlc2sec(min_eph);
-			if (cur_eph && new_eph > cur_eph && (new_eph - cur_eph) >= 600)
-				D_WARN(DF_CONT": Sluggish EC boundary reporting. "
-				       "cur:"DF_U64" new:"DF_U64" gap:"DF_U64"\n",
-				       DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid),
-				       cur_eph, new_eph, new_eph - cur_eph);
-
-			rc = cont_iv_ec_agg_eph_refresh(pool->sp_iv_ns,
-							ec_agg->ea_cont_uuid,
-							min_eph);
-			if (rc) {
-				DL_CDEBUG(rc == -DER_NONEXIST, DLOG_INFO, DLOG_ERR, rc,
-					  DF_CONT ": refresh failed",
-					  DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid));
-
-				/* If there are network error or pool map inconsistency,
-				 * let's skip the following eph sync, which will fail
-				 * anyway.
-				 */
-				if (daos_crt_network_error(rc) || rc == -DER_GRPVER) {
-					D_INFO(DF_UUID": skip refresh due to: "DF_RC"\n",
-					       DP_UUID(svc->cs_pool_uuid), DP_RC(rc));
-					break;
-				}
-
-				continue;
-			}
-			ec_agg->ea_current_eph = min_eph;
-			if (pool->sp_rebuilding)
-				break;
-		}
-
-		map_ranks_fini(&fail_ranks);
+		cont_agg_eph_sync(pool, svc);
 
 		if (dss_ult_exiting(svc->cs_ec_leader_ephs_req))
 			break;

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -36,6 +36,8 @@ void ds_cont_svc_step_down(struct cont_svc *svc);
 int
     ds_cont_svc_set_prop(uuid_t pool_uuid, const char *cont_id, d_rank_list_t *ranks,
 			 daos_prop_t *prop);
+int
+    ds_cont_svc_refresh_agg_eph(uuid_t pool_uuid);
 int ds_cont_list(uuid_t pool_uuid, struct daos_pool_cont_info **conts, uint64_t *ncont);
 int ds_cont_filter(uuid_t pool_uuid, daos_pool_cont_filter_t *filt,
 		   struct daos_pool_cont_info2 **conts, uint64_t *ncont);

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -71,7 +71,8 @@ int ds_rebuild_query(uuid_t pool_uuid,
 		     struct daos_rebuild_status *status);
 void ds_rebuild_running_query(uuid_t pool_uuid, uint32_t opc, uint32_t *rebuild_ver,
 			      daos_epoch_t *current_eph, uint32_t *rebuild_gen);
-int ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop);
+int
+     ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop, uint64_t delay_sec);
 void ds_rebuild_leader_stop_all(void);
 void ds_rebuild_abort(uuid_t pool_uuid, unsigned int version, uint32_t rebuild_gen,
 		      uint64_t term);

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -940,6 +940,7 @@ struct obj_io_context {
 	uint32_t		 ioc_opc;
 	uint64_t		 ioc_start_time;
 	uint64_t		 ioc_io_size;
+	uint64_t                 ioc_agg_hae;
 	uint32_t		 ioc_began:1,
 				 ioc_update_ec_ts:1,
 				 ioc_free_sgls:1,

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -764,7 +764,7 @@ mrone_obj_fetch_internal(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_
 retry:
 	rc = dsc_obj_fetch(oh, eph, &mrone->mo_dkey, iod_num, iods, sgls, NULL, flags, extra_arg,
 			   csum_iov_fetch);
-	if (rc == -DER_TIMEDOUT &&
+	if ((rc == -DER_TIMEDOUT || rc == -DER_FETCH_AGAIN) &&
 	    tls->mpt_version + 1 >= tls->mpt_pool->spc_map_version) {
 		if (tls->mpt_fini) {
 			DL_ERROR(rc, DF_RB ": dsc_obj_fetch " DF_UOID "failed when mpt_fini",

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2269,6 +2269,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	bool			cont_svc_up = false;
 	bool			events_initialized = false;
 	d_rank_t		rank = dss_self_rank();
+	uint64_t                age_sec, delay;
 	int			rc;
 
 	D_ASSERTF(svc->ps_error == 0, "ps_error: " DF_RC "\n", DP_RC(svc->ps_error));
@@ -2367,7 +2368,9 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	if (rc != 0)
 		goto out;
 
-	rc = ds_rebuild_regenerate_task(svc->ps_pool, prop);
+	age_sec = d_hlc_age2sec(dss_get_start_epoch());
+	delay   = age_sec < 600 ? (600 - age_sec) : 0;
+	rc      = ds_rebuild_regenerate_task(svc->ps_pool, prop, delay);
 	if (rc != 0)
 		goto out;
 

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -1652,7 +1652,8 @@ need_merge(daos_handle_t ih, uint16_t src_media, int lgc_cnt, daos_size_t seg_si
 	 * SCM records accumulated.
 	 */
 	if (tgt_media == DAOS_MEDIA_SCM)
-		return lgc_cnt >= VOS_EVT_ORDER;
+		//return lgc_cnt >= VOS_EVT_ORDER;
+		return lgc_cnt >= 2;
 
 	/*
 	 * Only trigger NVMe to NVMe data migration when:


### PR DESCRIPTION
1. synchronize the ec agg boundary before rebuild
2. for EC degraded fetch or data recovery, check ec agg boundary and a few other detailed refines.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
