### PR TITLE
DAOS-17868 common: Reclaim empty slabs under memory pressure to impro…

### DIFF
--- a/src/common/dav_v2/heap.c
+++ b/src/common/dav_v2/heap.c
@@ -797,6 +797,42 @@ heap_mbrt_mb_reclaim_garbage(struct palloc_heap *heap, uint32_t zid)
 	return 0;
 }
 
+static int
+heap_detach_and_try_discard_run(struct palloc_heap *heap, struct bucket *b);
+
+static int
+heap_mbrt_recycle_runs(struct palloc_heap *heap, struct mbrt *mb, int exclude_cid)
+{
+	int                           i;
+	int                           cnt = 0;
+	struct bucket                *b;
+	struct recycler_element       e;
+	struct run_bitmap             bmap;
+	struct memory_block          *m;
+	struct memory_block_reserved *msrv;
+
+	if (mb->mb_id == 0)
+		return 0;
+
+	for (i = 0; i < MAX_ALLOCATION_CLASSES; i++) {
+		if ((mb->buckets[i] == NULL) || (i == exclude_cid))
+			continue;
+		b = bucket_acquire(mb->buckets[i]);
+		if ((msrv = bucket_active_block(b)) == NULL)
+			goto next;
+		m = &msrv->m;
+		if (m == NULL)
+			goto next;
+		e = recycler_element_new(heap, m);
+		m->m_ops->get_bitmap(m, &bmap);
+		if (e.free_space == bmap.nbits)
+			cnt += !heap_detach_and_try_discard_run(heap, b);
+next:
+		mbrt_bucket_release(b);
+	}
+	return cnt;
+}
+
 void
 heap_soemb_active_iter_init(struct palloc_heap *heap)
 {
@@ -1670,6 +1706,7 @@ heap_ensure_run_bucket_filled(struct palloc_heap *heap, struct bucket *b,
 	struct mbrt        *mb     = bucket_get_mbrt(b);
 	struct memory_block m;
 	struct bucket      *defb;
+	int                 count = mb->mb_id ? 0 : 1;
 
 	D_ASSERT(mb != NULL);
 	ASSERTeq(aclass->type, CLASS_RUN);
@@ -1683,6 +1720,7 @@ heap_ensure_run_bucket_filled(struct palloc_heap *heap, struct bucket *b,
 	if (heap_reuse_from_recycler(heap, b, units, 0) == 0)
 		goto out;
 
+retry:
 	m = MEMORY_BLOCK_NONE;
 
 	m.size_idx = aclass->rdsc.size_idx;
@@ -1703,6 +1741,9 @@ heap_ensure_run_bucket_filled(struct palloc_heap *heap, struct bucket *b,
 
 	if (heap_reuse_from_recycler(heap, b, units, 1) == 0)
 		goto out;
+
+	if (!count++ && heap_mbrt_recycle_runs(heap, mb, aclass->id))
+		goto retry;
 
 	mbrt_set_laf(mb, aclass->id);
 	ret = ENOMEM;

--- a/src/vos/tests/vts_wal.c
+++ b/src/vos/tests/vts_wal.c
@@ -651,6 +651,20 @@ setup_mb_io(void **state)
 	return rc;
 }
 
+#define MDTEST_VOS_SIZE_V2       (1ul * 1024 * 1024 * 1024)
+#define MDTEST_META_BLOB_SIZE_V2 (2ul * 1024 * 1024 * 1024)
+static int
+setup_mb_io_v2(void **state)
+{
+	int rc;
+
+	d_setenv("DAOS_NEMB_EMPTY_RECYCLE_THRESHOLD", "1", true);
+	memset(&test_args, 0, sizeof(test_args));
+	rc     = vts_ctx_init_ex(&test_args.ctx, MDTEST_VOS_SIZE_V2, MDTEST_META_BLOB_SIZE_V2);
+	*state = (void *)&test_args;
+	return rc;
+}
+
 static int
 teardown_mb_io(void **state)
 {
@@ -2930,6 +2944,126 @@ p2_fill_test(void **state)
 	D_FREE(buf);
 }
 
+/* Fill single evictable bucket with single array object */
+static void
+p2_fill_single(void **state)
+{
+	struct io_test_args  *arg  = *state;
+	struct vos_container *cont = vos_hdl2cont(arg->ctx.tc_co_hdl);
+	struct umem_pool     *umm_pool;
+	struct vos_object    *obj;
+	daos_unit_oid_t       oid;
+	daos_epoch_t          epoch = 1;
+	uint64_t              dkey  = 0;
+	daos_key_t            dkey_iov;
+	daos_iod_t            iod  = {0};
+	daos_recx_t           recx = {0};
+	d_sg_list_t           sgl  = {0};
+	char                 *buf;
+	uint32_t              bkt_id = UMEM_DEFAULT_MBKT_ID;
+	uint32_t written = 0, total_written = 0, io_size = (4 << 10), chunk_size = (1 << 17);
+	uint64_t ne_used = 0, ne_init = 0, ne_total = 0;
+	uint64_t used = 0, total = 0, prev_used = 0;
+	int      rc;
+
+	D_ALLOC(buf, io_size);
+	assert_non_null(buf);
+	dts_buf_render(buf, io_size);
+
+	rc = d_sgl_init(&sgl, 1);
+	assert_rc_equal(rc, 0);
+
+	sgl.sg_iovs[0].iov_buf     = buf;
+	sgl.sg_iovs[0].iov_buf_len = io_size;
+	sgl.sg_iovs[0].iov_len     = io_size;
+
+	/* Get initial NE space usage */
+	rc = umempobj_get_mbusage(vos_cont2umm(cont)->umm_pool, UMEM_DEFAULT_MBKT_ID, &ne_init,
+				  &ne_total);
+	assert_int_equal(rc, 0);
+
+	oid      = dts_unit_oid_gen(DAOS_OT_ARRAY, 0);
+	arg->oid = oid;
+
+	/* Fill one evictable bucket with single array object */
+	while (1) {
+		if ((written * io_size) >= chunk_size) {
+			dkey++;
+			written = 0;
+		}
+
+		d_iov_set(&dkey_iov, &dkey, sizeof(dkey));
+
+		iod.iod_name  = dkey_iov;
+		iod.iod_nr    = 1;
+		iod.iod_type  = DAOS_IOD_ARRAY;
+		iod.iod_size  = 1;
+		recx.rx_idx   = (written * io_size);
+		recx.rx_nr    = io_size;
+		iod.iod_recxs = &recx;
+
+		rc = io_test_obj_update(arg, epoch++, 0, &dkey_iov, &iod, &sgl, NULL, true);
+		if (rc != 0)
+			break;
+
+		if (bkt_id == UMEM_DEFAULT_MBKT_ID) {
+			rc = vos_obj_acquire(cont, oid, false, &obj);
+			assert_rc_equal(rc, 0);
+
+			bkt_id = obj->obj_bkt_ids[0];
+			vos_obj_release(obj, 0, false);
+			assert_true(bkt_id != UMEM_DEFAULT_MBKT_ID);
+		}
+
+		rc = umempobj_get_mbusage(vos_cont2umm(cont)->umm_pool, bkt_id, &used, &total);
+		assert_int_equal(rc, 0);
+		assert_int_equal(total, MDTEST_MB_SIZE);
+
+		/* This evictable bucket is filled up */
+		if (used == prev_used)
+			break;
+
+		prev_used = used;
+		written += 1;
+		total_written += 1;
+	}
+
+	d_sgl_fini(&sgl, false);
+	D_FREE(buf);
+
+	/* Get NE usage */
+	rc = umempobj_get_mbusage(vos_cont2umm(cont)->umm_pool, UMEM_DEFAULT_MBKT_ID, &ne_used,
+				  &ne_total);
+	assert_int_equal(rc, 0);
+	assert_true(ne_used > ne_init);
+
+	print_message("Bucket is filled. bkt_id:%u, io_size:%u, chunk_size:%u, written:%u, "
+		      "used:" DF_U64 "/" DF_U64 ", NE_used:" DF_U64 "/" DF_U64 "\n",
+		      bkt_id, io_size, chunk_size, total_written, used, total, ne_used - ne_init,
+		      ne_total);
+
+	assert_in_range(used * 100 / total, 97, 100);
+	checkpoint_fn(&arg->ctx.tc_po_hdl);
+	umm_pool = vos_cont2umm(cont)->umm_pool;
+	/* Close container */
+	rc = vos_cont_close(arg->ctx.tc_co_hdl);
+	assert_rc_equal(rc, 0);
+	arg->ctx.tc_step = TCX_CO_CREATE;
+
+	/* Destroy container */
+	rc = vos_cont_destroy(arg->ctx.tc_po_hdl, arg->ctx.tc_co_uuid);
+	assert_rc_equal(rc, 0);
+	arg->ctx.tc_step = TCX_PO_CREATE_OPEN;
+
+	gc_wait();
+
+	rc = umempobj_get_mbusage(umm_pool, bkt_id, &used, &total);
+	assert_int_equal(rc, 0);
+	assert_int_equal(total, MDTEST_MB_SIZE);
+	print_message("Bucket %u usage after cont destroy. " DF_U64 "/" DF_U64 "\n", bkt_id, used,
+		      total);
+}
+
 static const struct CMUnitTest wal_tests[] = {
     {"WAL01: Basic pool/cont create/destroy test", wal_tst_pool_cont, NULL, NULL},
     {"WAL02: Basic pool/cont create/destroy test with checkpointing", wal_tst_pool_cont,
@@ -2975,6 +3109,7 @@ static const struct CMUnitTest wal_MB_tests[] = {
     {"WAL40: nemb pct test", wal_mb_nemb_pct, setup_mb_io_nembpct, teardown_mb_io_nembpct},
     {"WAL41: nemb unused test", nemb_unused, setup_mb_io, teardown_mb_io},
     {"WAL42: soemb test", soemb_test, setup_mb_io, teardown_mb_io},
+    {"WAL43: P2 fill single", p2_fill_single, setup_mb_io_v2, teardown_mb_io},
 };
 
 int


### PR DESCRIPTION
…ve evictable bucket utilization

Fixes an issue with phase-2 allocator where allocation slabs with zero allocated blocks were not being reclaimed under memory pressure. This led to underutilization of evictable buckets.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
