### PR TITLE
DAOS-17828 vos: fix a pointer misuse

### DIFF
--- a/src/vos/evt_iter.c
+++ b/src/vos/evt_iter.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -407,7 +408,6 @@ int
 evt_iter_probe(daos_handle_t ih, enum evt_iter_opc opc,
 	       const struct evt_rect *rect, const daos_anchor_t *anchor)
 {
-	struct vos_iterator	*oiter = vos_hdl2iter(ih);
 	struct evt_iterator	*iter;
 	struct evt_context	*tcx;
 	struct evt_entry_array	*enta;
@@ -457,8 +457,7 @@ evt_iter_probe(daos_handle_t ih, enum evt_iter_opc opc,
 		rtmp = *rect;
 	}
 
-	rc = evt_ent_array_fill(tcx, fopc, vos_iter_intent(oiter),
-				&iter->it_filter, &rtmp, enta);
+	rc = evt_ent_array_fill(tcx, fopc, evt_iter_intent(iter), &iter->it_filter, &rtmp, enta);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -473,7 +472,7 @@ evt_iter_probe(daos_handle_t ih, enum evt_iter_opc opc,
 		iter->it_state = EVT_ITER_READY;
 		iter->it_skip_move = 0;
 	}
- out:
+out:
 	return rc;
 }
 


### PR DESCRIPTION
A handle passed to evt_iter_probe() is an EVT context not a VOS iterator.

**Note**: It is a clean cherry-pick: #16635

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
