### PR TITLE
DAOS-17659 control: Enable setting property value with multiple strin…

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -799,7 +799,7 @@ type poolSetPropCmd struct {
 	poolCmd
 
 	Args struct {
-		Props PoolSetPropsFlag `positional-arg-name:"<key:val[,key:val...]>" required:"1"`
+		Props PoolSetPropsFlag `positional-arg-name:"<key:val[,key:val1[;val2...]...]>" required:"1"`
 	} `positional-args:"yes"`
 }
 

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -734,6 +734,20 @@ func TestPoolCommands(t *testing.T) {
 			nil,
 		},
 		{
+			"Set pool properties with semi-colon separated self_heal value",
+			`pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb self_heal:exclude;rebuild,space_rb:42`,
+			strings.Join([]string{
+				printRequest(t, &control.PoolSetPropReq{
+					ID: "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
+					Properties: []*daos.PoolProperty{
+						propWithVal("self_heal", "exclude;rebuild"),
+						propWithVal("space_rb", "42"),
+					},
+				}),
+			}, " "),
+			nil,
+		},
+		{
 			"Set pool properties with pool flag",
 			"pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb label:foo,space_rb:42",
 			strings.Join([]string{
@@ -804,6 +818,20 @@ func TestPoolCommands(t *testing.T) {
 					ID: "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
 					Properties: []*daos.PoolProperty{
 						propWithVal("label", ""),
+					},
+				}),
+			}, " "),
+			nil,
+		},
+		{
+			"Get pool properties",
+			"pool get-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb label,self_heal",
+			strings.Join([]string{
+				printRequest(t, &control.PoolGetPropReq{
+					ID: "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
+					Properties: []*daos.PoolProperty{
+						propWithVal("label", ""),
+						propWithVal("self_heal", ""),
 					},
 				}),
 			}, " "),

--- a/src/control/lib/daos/pool_property.go
+++ b/src/control/lib/daos/pool_property.go
@@ -59,9 +59,9 @@ func PoolProperties() PoolPropertyMap {
 					case PoolSelfHealingDelayRebuild:
 						return "delay_rebuild"
 					case PoolSelfHealingAutoExclude | PoolSelfHealingAutoRebuild:
-						return "exclude,rebuild"
+						return "exclude;rebuild"
 					case PoolSelfHealingAutoExclude | PoolSelfHealingDelayRebuild:
-						return "exclude,delay_rebuild"
+						return "exclude;delay_rebuild"
 					default:
 						return "unknown"
 					}
@@ -71,10 +71,10 @@ func PoolProperties() PoolPropertyMap {
 				"exclude":               PoolSelfHealingAutoExclude,
 				"rebuild":               PoolSelfHealingAutoRebuild,
 				"delay_rebuild":         PoolSelfHealingDelayRebuild,
-				"exclude,rebuild":       PoolSelfHealingAutoExclude | PoolSelfHealingAutoRebuild,
-				"rebuild,exclude":       PoolSelfHealingAutoExclude | PoolSelfHealingAutoRebuild,
-				"delay_rebuild,exclude": PoolSelfHealingAutoExclude | PoolSelfHealingDelayRebuild,
-				"exclude,delay_rebuild": PoolSelfHealingAutoExclude | PoolSelfHealingDelayRebuild,
+				"exclude;rebuild":       PoolSelfHealingAutoExclude | PoolSelfHealingAutoRebuild,
+				"rebuild;exclude":       PoolSelfHealingAutoExclude | PoolSelfHealingAutoRebuild,
+				"delay_rebuild;exclude": PoolSelfHealingAutoExclude | PoolSelfHealingDelayRebuild,
+				"exclude;delay_rebuild": PoolSelfHealingAutoExclude | PoolSelfHealingDelayRebuild,
 			},
 		},
 		"space_rb": {

--- a/src/control/lib/daos/pool_property_test.go
+++ b/src/control/lib/daos/pool_property_test.go
@@ -174,23 +174,23 @@ func TestControl_PoolProperties(t *testing.T) {
 			expStr:  "self_heal:delay_rebuild",
 			expJson: []byte(`{"name":"self_heal","description":"Self-healing policy","value":"delay_rebuild"}`),
 		},
-		"self_heal-exclude,rebuild": {
+		"self_heal-exclude;rebuild": {
 			name:    "self_heal",
-			value:   "exclude,rebuild",
-			expStr:  "self_heal:exclude,rebuild",
-			expJson: []byte(`{"name":"self_heal","description":"Self-healing policy","value":"exclude,rebuild"}`),
+			value:   "exclude;rebuild",
+			expStr:  "self_heal:exclude;rebuild",
+			expJson: []byte(`{"name":"self_heal","description":"Self-healing policy","value":"exclude;rebuild"}`),
 		},
-		"self_heal-rebuild,exclude": {
+		"self_heal-rebuild;exclude": {
 			name:    "self_heal",
-			value:   "rebuild,exclude",
-			expStr:  "self_heal:exclude,rebuild",
-			expJson: []byte(`{"name":"self_heal","description":"Self-healing policy","value":"exclude,rebuild"}`),
+			value:   "rebuild;exclude",
+			expStr:  "self_heal:exclude;rebuild",
+			expJson: []byte(`{"name":"self_heal","description":"Self-healing policy","value":"exclude;rebuild"}`),
 		},
-		"self_heal-exclude,delay_rebuild": {
+		"self_heal-exclude;delay_rebuild": {
 			name:    "self_heal",
-			value:   "exclude,delay_rebuild",
-			expStr:  "self_heal:exclude,delay_rebuild",
-			expJson: []byte(`{"name":"self_heal","description":"Self-healing policy","value":"exclude,delay_rebuild"}`),
+			value:   "exclude;delay_rebuild",
+			expStr:  "self_heal:exclude;delay_rebuild",
+			expJson: []byte(`{"name":"self_heal","description":"Self-healing policy","value":"exclude;delay_rebuild"}`),
 		},
 		"self_heal-invalid": {
 			name:   "self_heal",

--- a/src/control/lib/ui/prop_flags_test.go
+++ b/src/control/lib/ui/prop_flags_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2023 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -105,7 +106,6 @@ func TestUI_SetPropertiesFlag_UnmarshalFlag(t *testing.T) {
 
 }
 
-/* NB: Doesn't work with go < 1.18
 func FuzzUI_SetPropertiesFlag_UnmarshalFlag(f *testing.F) {
 	f.Fuzz(func(t *testing.T, fv string) {
 		f := ui.SetPropertiesFlag{}
@@ -118,7 +118,6 @@ func FuzzUI_SetPropertiesFlag_UnmarshalFlag(f *testing.F) {
 		}
 	})
 }
-*/
 
 func TestUI_SetPropertiesFlag_Complete(t *testing.T) {
 	comps := ui.CompletionMap{


### PR DESCRIPTION
…gs (#16503)

Fix issue where a property value containing multiple comma-separated strings cannot be set e.g. self_heal:exclude,rebuild.

New syntax for key-value positional argument:
key:val[,key:val1[;val2...]...]
e.g. dmg pool set-prop bob self_heal:"exclude;rebuild"

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
