### PR TITLE
DAOS-17772 rebuild: sync the ec agg boundary before rebuild

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -653,8 +653,18 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		} else if (entry->iv_class->iv_class_id ==
 						IV_CONT_AGG_EPOCH_BOUNDRY) {
 			rc = cont_iv_ent_agg_eph_refresh(entry, key, src);
-			if (rc)
+			if (rc) {
+				/* container non-exist possibly due to in reintegrate the container
+				 * discarded ahead. Ignore such err.
+				 */
+				if (rc == -DER_NONEXIST) {
+					DL_INFO(
+					    rc, DF_CONT " cont_iv_ent_agg_eph_refresh ignore",
+					    DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
+					rc = 0;
+				}
 				D_GOTO(out, rc);
+			}
 		}
 	}
 

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -2515,7 +2515,11 @@ ds_cont_tgt_ec_eph_query_ult(void *data)
 		if (pool->sp_map == NULL || pool->sp_stopping)
 			goto yield;
 
-		rc = ds_pool_get_failed_tgt_idx(pool->sp_uuid, &failed_tgts, &failed_tgts_nr);
+		/* on 2.6 branch no incremental reintegration, the UP status target will discard all
+		 * containers so it cannot report its EC aggregation boundary, so should skip
+		 * DOWN/DOWNOUT/UP ranks.
+		 */
+		rc = ds_pool_get_failedorup_tgt_idx(pool->sp_uuid, &failed_tgts, &failed_tgts_nr);
 		if (rc) {
 			D_DEBUG(DB_MD, DF_UUID "failed to get index : rc "DF_RC"\n",
 				DP_UUID(pool->sp_uuid), DP_RC(rc));

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -36,6 +36,8 @@ void ds_cont_svc_step_down(struct cont_svc *svc);
 int
     ds_cont_svc_set_prop(uuid_t pool_uuid, const char *cont_id, d_rank_list_t *ranks,
 			 daos_prop_t *prop);
+int
+    ds_cont_svc_refresh_agg_eph(uuid_t pool_uuid);
 int ds_cont_list(uuid_t pool_uuid, struct daos_pool_cont_info **conts, uint64_t *ncont);
 int ds_cont_filter(uuid_t pool_uuid, daos_pool_cont_filter_t *filt,
 		   struct daos_pool_cont_info2 **conts, uint64_t *ncont);

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -373,8 +373,9 @@ int ds_pool_get_ranks(const uuid_t pool_uuid, int status,
 		      d_rank_list_t *ranks);
 int ds_pool_get_tgt_idx_by_state(const uuid_t pool_uuid, unsigned int status, int **tgts,
 				 unsigned int *tgts_cnt);
-int ds_pool_get_failed_tgt_idx(const uuid_t pool_uuid, int **failed_tgts,
-			       unsigned int *failed_tgts_cnt);
+int
+		 ds_pool_get_failedorup_tgt_idx(const uuid_t pool_uuid, int **failed_tgts,
+						unsigned int *failed_tgts_cnt);
 int ds_pool_svc_list_cont(uuid_t uuid, d_rank_list_t *ranks,
 			  struct daos_pool_cont_info **containers,
 			  uint64_t *ncontainers);

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -71,7 +71,8 @@ int ds_rebuild_query(uuid_t pool_uuid,
 		     struct daos_rebuild_status *status);
 void ds_rebuild_running_query(uuid_t pool_uuid, uint32_t opc, uint32_t *rebuild_ver,
 			      daos_epoch_t *current_eph, uint32_t *rebuild_gen);
-int ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop);
+int
+     ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop, uint64_t delay_sec);
 void ds_rebuild_leader_stop_all(void);
 void ds_rebuild_abort(uuid_t pool_uuid, unsigned int version, uint32_t rebuild_gen,
 		      uint64_t term);

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -764,7 +764,7 @@ mrone_obj_fetch_internal(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_
 retry:
 	rc = dsc_obj_fetch(oh, eph, &mrone->mo_dkey, iod_num, iods, sgls, NULL, flags, extra_arg,
 			   csum_iov_fetch);
-	if (rc == -DER_TIMEDOUT &&
+	if ((rc == -DER_TIMEDOUT || rc == -DER_FETCH_AGAIN) &&
 	    tls->mpt_version + 1 >= tls->mpt_pool->spc_map_version) {
 		if (tls->mpt_fini) {
 			DL_ERROR(rc, DF_RB ": dsc_obj_fetch " DF_UOID "failed when mpt_fini",

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2269,6 +2269,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	bool			cont_svc_up = false;
 	bool			events_initialized = false;
 	d_rank_t		rank = dss_self_rank();
+	uint64_t                age_sec, delay;
 	int			rc;
 
 	D_ASSERTF(svc->ps_error == 0, "ps_error: " DF_RC "\n", DP_RC(svc->ps_error));
@@ -2367,7 +2368,9 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	if (rc != 0)
 		goto out;
 
-	rc = ds_rebuild_regenerate_task(svc->ps_pool, prop);
+	age_sec = d_hlc_age2sec(dss_get_start_epoch());
+	delay   = age_sec < 600 ? (600 - age_sec) : 0;
+	rc      = ds_rebuild_regenerate_task(svc->ps_pool, prop, delay);
 	if (rc != 0)
 		goto out;
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -2600,7 +2600,7 @@ ds_pool_task_collective(uuid_t pool_uuid, uint32_t ex_status, int (*coll_func)(v
 }
 
 /* Discard the objects by epoch in this pool */
-static void
+static int
 ds_pool_tgt_discard_ult(void *data)
 {
 	struct ds_pool		*pool;
@@ -2627,6 +2627,7 @@ ds_pool_tgt_discard_ult(void *data)
 	ds_pool_put(pool);
 free:
 	tgt_discard_arg_free(arg);
+	return rc;
 }
 
 void
@@ -2659,7 +2660,7 @@ ds_pool_tgt_discard_handler(crt_rpc_t *rpc)
 
 	pool->sp_need_discard = 1;
 	pool->sp_discard_status = 0;
-	rc = dss_ult_create(ds_pool_tgt_discard_ult, arg, DSS_XS_SYS, 0, 0, NULL);
+	rc = dss_ult_execute(ds_pool_tgt_discard_ult, arg, NULL, NULL, DSS_XS_SYS, 0, 0);
 
 	ds_pool_put(pool);
 out:

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1426,11 +1427,12 @@ output:
 }
 
 int
-ds_pool_get_failed_tgt_idx(const uuid_t pool_uuid, int **failed_tgts, unsigned int *failed_tgts_cnt)
+ds_pool_get_failedorup_tgt_idx(const uuid_t pool_uuid, int **failed_tgts,
+			       unsigned int *failed_tgts_cnt)
 {
 	unsigned int status;
 
-	status = PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT;
+	status = PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT | PO_COMP_ST_UP;
 	return ds_pool_get_tgt_idx_by_state(pool_uuid, status, failed_tgts, failed_tgts_cnt);
 }
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1601,8 +1601,7 @@ rebuild_task_ult(void *arg)
 	cur_ts = daos_gettime_coarse();
 	D_ASSERT(task->dst_schedule_time != (uint64_t)-1);
 	if (cur_ts < task->dst_schedule_time) {
-		D_DEBUG(DB_REBUILD, "rebuild task sleep "DF_U64" second\n",
-			task->dst_schedule_time - cur_ts);
+		D_INFO("rebuild task sleep " DF_U64 " second\n", task->dst_schedule_time - cur_ts);
 		dss_sleep((task->dst_schedule_time - cur_ts) * 1000);
 	}
 
@@ -1611,6 +1610,13 @@ rebuild_task_ult(void *arg)
 		D_ERROR(DF_UUID": failed to look up pool: %d\n",
 			DP_UUID(task->dst_pool_uuid), rc);
 		D_GOTO(out_task, rc = -DER_NONEXIST);
+	}
+
+	rc = ds_cont_svc_refresh_agg_eph(task->dst_pool_uuid);
+	if (rc) {
+		D_ERROR(DF_UUID ": ds_cont_svc_refresh_agg_eph failed, " DF_RC "\n",
+			DP_UUID(task->dst_pool_uuid), DP_RC(rc));
+		goto out_task;
 	}
 
 	while (1) {
@@ -2180,7 +2186,7 @@ regenerate_task_of_type(struct ds_pool *pool, pool_comp_state_t match_states, ui
 
 /* Regenerate the rebuild tasks when changing the leader. */
 int
-ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop)
+ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop, uint64_t delay_sec)
 {
 	struct daos_prop_entry *entry;
 	char                   *env;
@@ -2206,12 +2212,13 @@ ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop)
 	entry = daos_prop_entry_get(prop, DAOS_PROP_PO_SELF_HEAL);
 	D_ASSERT(entry != NULL);
 	if (entry->dpe_val & (DAOS_SELF_HEAL_AUTO_REBUILD | DAOS_SELF_HEAL_DELAY_REBUILD)) {
-		rc = regenerate_task_of_type(pool, PO_COMP_ST_DOWN,
-					    entry->dpe_val & DAOS_SELF_HEAL_DELAY_REBUILD ? -1 : 0);
+		rc = regenerate_task_of_type(
+		    pool, PO_COMP_ST_DOWN,
+		    entry->dpe_val & DAOS_SELF_HEAL_DELAY_REBUILD ? -1 : delay_sec);
 		if (rc != 0)
 			return rc;
 
-		rc = regenerate_task_of_type(pool, PO_COMP_ST_DRAIN, 0);
+		rc = regenerate_task_of_type(pool, PO_COMP_ST_DRAIN, delay_sec);
 		if (rc != 0)
 			return rc;
 	} else {
@@ -2229,7 +2236,7 @@ ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop)
 	 * discarding on an empty targets is harmless. So it is ok to use REINT to
 	 * do EXTEND here.
 	 */
-	rc = regenerate_task_of_type(pool, PO_COMP_ST_UP, 0);
+	rc = regenerate_task_of_type(pool, PO_COMP_ST_UP, delay_sec);
 	if (rc != 0)
 		return rc;
 


### PR DESCRIPTION
    1. synchronize the ec agg boundary before rebuild
    2. after system restart schedule the rebuild task for 10 minutes delay
    3. skip DOWN/DOWNOUT and UP tgt/rank for EC agg boundary sync

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
