### PR TITLE
DAOS-17659 control: Sort dmg pool get-prop output

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"math"
 	"os/user"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -722,6 +723,9 @@ func PoolGetProp(ctx context.Context, rpcClient UnaryInvoker, req *PoolGetPropRe
 		pbMap[prop.GetNumber()] = prop
 	}
 
+	slices.SortFunc(req.Properties, func(a, b *daos.PoolProperty) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 	resp := make([]*daos.PoolProperty, 0, len(req.Properties))
 	for _, prop := range req.Properties {
 		pbProp, found := pbMap[prop.Number]


### PR DESCRIPTION
When specific properties are requested, dmg pool get-prop outputs the properties in (Go map) random order, leading to unit test failures. (It is also a good idea to offer stable UI output.) This patch sorts the list of properties in the output.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
