### PR TITLE
DAOS-17878 gurt: reduce lock contention

### DIFF
--- a/src/gurt/hash.c
+++ b/src/gurt/hash.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1283,7 +1284,7 @@ d_hhash_link_lookup(struct d_hhash *hhash, uint64_t key)
 			return NULL;
 		}
 
-		d_hash_rec_addref(&hhash->ch_htable, &hlink->hl_link.rl_link);
+		ch_rec_addref(&hhash->ch_htable, &hlink->hl_link.rl_link);
 		return hlink;
 	} else {
 		return d_hlink_find(&hhash->ch_htable, (void *)&key,


### PR DESCRIPTION
On the server side, dc_{pool/cont}2hdl() is frequently called. In d_hhash_link_lookup(), d_hash_rec_addref() is called for pointer keys. This unnecessarily invokes a mutex lock for handle hash since atomic reference counting is used. Additionally, the @dp_map_lock around pool_map_get_version() in obj_dkey2grpidx() has been removed.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
