### PR TITLE
DAOS-17878 placement: Replace spinlock with atomic refcount in pl_map

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -14,6 +14,8 @@
 #include <daos/pool_map.h>
 #include "fault_domain.h"
 
+#include <gurt/atomic.h>
+
 /** counters for component (sub)tree */
 struct pool_comp_cntr {
 	/** # of domains in the top level */
@@ -56,12 +58,10 @@ struct pool_comp_sorter {
 
 /** In memory data structure for pool map */
 struct pool_map {
-	/** protect the refcount */
-	pthread_mutex_t		 po_lock;
 	/** Current version of pool map */
 	uint32_t		 po_version;
 	/** refcount on the pool map */
-	int			 po_ref;
+	ATOMIC uint32_t          po_ref;
 	/** # domain layers */
 	unsigned int		 po_domain_layers;
 	/**
@@ -943,8 +943,6 @@ pool_map_finalise(struct pool_map *map)
 		pool_tree_free(map->po_tree);
 		map->po_tree = NULL;
 	}
-
-	D_MUTEX_DESTROY(&map->po_lock);
 }
 
 void
@@ -993,10 +991,6 @@ pool_map_initialise(struct pool_map *map, struct pool_domain *tree)
 		goto out_tree;
 	}
 
-	rc = D_MUTEX_INIT(&map->po_lock, NULL);
-	if (rc != 0)
-		goto out_tree;
-
 	pool_tree_count(tree, &cntr);
 
 	/* po_map_print(map); */
@@ -1009,7 +1003,7 @@ pool_map_initialise(struct pool_map *map, struct pool_domain *tree)
 	D_ALLOC_ARRAY(map->po_comp_fail_cnts, map->po_domain_layers);
 	if (map->po_comp_fail_cnts == NULL) {
 		rc = -DER_NOMEM;
-		goto out_mutex;
+		goto out_domain_layers;
 	}
 
 	D_ALLOC_ARRAY(map->po_domain_sorters, map->po_domain_layers);
@@ -1072,9 +1066,8 @@ out_domain_sorters:
 	D_FREE(map->po_domain_sorters);
 out_comp_fail_cnts:
 	D_FREE(map->po_comp_fail_cnts);
-out_mutex:
+out_domain_layers:
 	map->po_domain_layers = 0;
-	D_MUTEX_DESTROY(&map->po_lock);
 out_tree:
 	pool_tree_free(map->po_tree);
 	map->po_tree = NULL;
@@ -1839,7 +1832,7 @@ pool_map_create(struct pool_buf *buf, uint32_t version, struct pool_map **mapp)
 	}
 
 	map->po_version = version;
-	map->po_ref = 1; /* 1 for caller */
+	atomic_store_relaxed(&map->po_ref, 1); /* for caller */
 out:
 	if (rc != 0)
 		D_FREE(map);
@@ -2000,9 +1993,7 @@ pool_map_destroy(struct pool_map *map)
 void
 pool_map_addref(struct pool_map *map)
 {
-	D_MUTEX_LOCK(&map->po_lock);
-	map->po_ref++;
-	D_MUTEX_UNLOCK(&map->po_lock);
+	atomic_fetch_add_relaxed(&map->po_ref, 1);
 }
 
 /**
@@ -2012,15 +2003,11 @@ pool_map_addref(struct pool_map *map)
 void
 pool_map_decref(struct pool_map *map)
 {
-	bool free;
+	uint32_t oldref;
 
-	D_MUTEX_LOCK(&map->po_lock);
-	D_ASSERT(map->po_ref > 0);
-	map->po_ref--;
-	free = (map->po_ref == 0);
-	D_MUTEX_UNLOCK(&map->po_lock);
-
-	if (free)
+	oldref = atomic_fetch_sub_relaxed(&map->po_ref, 1);
+	D_ASSERT(oldref > 0);
+	if (oldref == 1)
 		pool_map_destroy(map);
 }
 

--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -15,6 +16,8 @@
 #include <daos/common.h>
 #include <daos/pool_map.h>
 #include <daos/object.h>
+
+#include <gurt/atomic.h>
 
 /** default placement map when none are specified */
 #define DEFAULT_PL_TYPE PL_TYPE_JUMP_MAP
@@ -82,13 +85,11 @@ struct pl_map {
 	/** corresponding pool uuid */
 	uuid_t			 pl_uuid;
 	/** link chain on hash */
-	d_list_t		 pl_link;
-	/** protect refcount */
-	pthread_spinlock_t	 pl_lock;
+	d_list_t                 pl_link;
 	/** refcount */
-	int			 pl_ref;
+	ATOMIC uint32_t          pl_ref;
 	/** pool connections, protected by pl_rwlock */
-	int			 pl_connects;
+	int                      pl_connects;
 	/** type of placement map */
 	pl_map_type_t		 pl_type;
 	/** reference to pool map */


### PR DESCRIPTION
We could use atomic for ref counting to avoid spinlock, since 
on the server side, this spinlock could be shared between different threads and hurts performance.
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
