### PR TITLE
DAOS-17878 placement: Replace spinlock with atomic refcount in pl_map

### DIFF
--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -15,6 +16,8 @@
 #include <daos/common.h>
 #include <daos/pool_map.h>
 #include <daos/object.h>
+
+#include <gurt/atomic.h>
 
 /** default placement map when none are specified */
 #define DEFAULT_PL_TYPE PL_TYPE_JUMP_MAP
@@ -82,13 +85,11 @@ struct pl_map {
 	/** corresponding pool uuid */
 	uuid_t			 pl_uuid;
 	/** link chain on hash */
-	d_list_t		 pl_link;
-	/** protect refcount */
-	pthread_spinlock_t	 pl_lock;
+	d_list_t                 pl_link;
 	/** refcount */
-	int			 pl_ref;
+	ATOMIC uint32_t          pl_ref;
 	/** pool connections, protected by pl_rwlock */
-	int			 pl_connects;
+	int                      pl_connects;
 	/** type of placement map */
 	pl_map_type_t		 pl_type;
 	/** reference to pool map */


### PR DESCRIPTION
We could use atomic for ref counting to avoid spinlock, since on the server side, this spinlock could be shared between different threads and hurts performance.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
