### PR TITLE
DAOS-17876 control: Expect lowercase hostname in unit test (#16710)

### DIFF
--- a/src/control/server/faultdomain_test.go
+++ b/src/control/server/faultdomain_test.go
@@ -1,5 +1,6 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -10,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -142,7 +144,7 @@ func TestServer_getFaultDomain(t *testing.T) {
 		},
 		"default gets hostname": {
 			cfg:       &config.Server{},
-			expResult: system.FaultDomainSeparator + realHostname,
+			expResult: system.FaultDomainSeparator + strings.ToLower(realHostname),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
If the host where the test was run had a capital letter in the name, this test failed. Fault domain code normalizes names to lowercase.

Skip-func-test: true

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
