### PR TITLE
DAOS-17879 control: ftest config_generate_run.py fail on creating daos_server log file

### DIFF
--- a/src/tests/ftest/control/config_generate_run.py
+++ b/src/tests/ftest/control/config_generate_run.py
@@ -31,6 +31,7 @@ class ConfigGenerateRun(TestWithServers):
         6. Restart daos_server.
 
         See yaml for the test cases.
+        This is dummy message... SAMIR
 
         Note: When running locally, use 50 sec timeout in DaosServerCommand.__init__()
 


### PR DESCRIPTION
Skip-unit-tests: true
Quick-Functional: true
Test-tag: test_config_generate_run

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
