### PR TITLE
DAOS-17897 common: Implement separate allocation classes for evictabl…

### DIFF
--- a/src/common/dav_v2/alloc_class.h
+++ b/src/common/dav_v2/alloc_class.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright 2016-2023, Intel Corporation */
+/* (C) Copyright 2025 Hewlett Packard Enterprise Development LP */
 
 /*
  * alloc_class.h -- internal definitions for allocation classes
@@ -41,7 +42,8 @@ struct alloc_class {
 	struct run_descriptor rdsc;
 };
 
-struct alloc_class_collection *alloc_class_collection_new(void);
+struct alloc_class_collection                     *
+alloc_class_collection_new(bool evictable_mb);
 void alloc_class_collection_delete(struct alloc_class_collection *ac);
 
 struct alloc_class *alloc_class_by_run(

--- a/src/common/dav_v2/dav_v2.h
+++ b/src/common/dav_v2/dav_v2.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright 2015-2024, Intel Corporation */
+/* (C) Copyright 2025 Hewlett Packard Enterprise Development LP */
 
 /*
  * dav_flags.h -- Interfaces exported by DAOS internal Allocator for VOS (DAV)
@@ -270,7 +271,7 @@ struct dav_alloc_class_desc;
  * Registers an allocation class handle with the DAV object.
  */
 int
-dav_class_register_v2(dav_obj_t *pop, struct dav_alloc_class_desc *p);
+dav_class_register_v2(dav_obj_t *pop, struct dav_alloc_class_desc *p, int is_evictable_mb);
 
 struct dav_heap_stats;
 /*

--- a/src/common/dav_v2/heap.h
+++ b/src/common/dav_v2/heap.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright 2015-2024, Intel Corporation */
+/* (C) Copyright 2025 Hewlett Packard Enterprise Development LP */
 
 /*
  * heap.h -- internal definitions for heap
@@ -74,6 +75,8 @@ heap_zinfo_init(struct palloc_heap *heap, bool is_create);
 
 struct alloc_class *
 heap_get_best_class(struct palloc_heap *heap, size_t size);
+struct alloc_class *
+mbrt_get_best_class(struct mbrt *mb, size_t size);
 struct bucket *
 mbrt_bucket_acquire(struct mbrt *mb, uint8_t class_id);
 void
@@ -102,7 +105,9 @@ heap_foreach_object(struct palloc_heap *heap, object_callback cb, void *arg,
 		    struct memory_block start);
 
 struct alloc_class_collection *
-heap_alloc_classes(struct palloc_heap *heap);
+heap_alloc_classes(struct palloc_heap *heap, bool evictable_mb);
+struct alloc_class_collection *
+mbrt_alloc_classes(struct mbrt *mb);
 
 void
 heap_vg_open(struct palloc_heap *heap, object_callback cb, void *arg, int objects);

--- a/src/common/dav_v2/memblock.c
+++ b/src/common/dav_v2/memblock.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright 2016-2024, Intel Corporation */
+/* (C) Copyright 2025 Hewlett Packard Enterprise Development LP */
 
 /*
  * memblock.c -- implementation of memory block
@@ -1571,7 +1572,8 @@ memblock_from_offset_opt(struct palloc_heap *heap, uint64_t off, int size)
 		off -= m.block_off * unit_size;
 	}
 
-	struct alloc_class_collection *acc = heap_alloc_classes(heap);
+	struct mbrt                   *mb  = heap_mbrt_get_mb(heap, m.zone_id);
+	struct alloc_class_collection *acc = mbrt_alloc_classes(mb);
 
 	if (acc != NULL) {
 		struct alloc_class *ac = alloc_class_by_run(acc,

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -186,9 +186,19 @@ set_slab_desc(struct umem_pool *ph_p, struct umem_slab_desc *slab)
 		davslab.units_per_block = 1000;
 		davslab.header_type = DAV_HEADER_NONE;
 		davslab.class_id = slab->class_id;
-		rc = dav_class_register_v2((dav_obj_t *)ph_p->up_priv, &davslab);
+		rc = dav_class_register_v2((dav_obj_t *)ph_p->up_priv, &davslab, 0);
+		if (rc)
+			break;
 		/* update with the new slab id */
 		slab->class_id = davslab.class_id;
+
+		davslab.units_per_block = 1;
+		davslab.class_id        = slab->class_id;
+		rc = dav_class_register_v2((dav_obj_t *)ph_p->up_priv, &davslab, 1);
+		if (rc)
+			D_ERROR(
+			    "Reregistering slab of unit size %ld with class_id %d for emb failed",
+			    slab->unit_size, slab->class_id);
 		break;
 	case DAOS_MD_ADMEM:
 		/* NOOP for ADMEM now */

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -178,7 +178,7 @@ struct umem_store {
 
 struct umem_slab_desc {
 	size_t		unit_size;
-	unsigned	class_id;
+	unsigned        class_id;
 };
 
 struct umem_pool {


### PR DESCRIPTION
…e memory buckets

Implement separate allocation class collections for evictable memory buckets with optimized smaller allocation slabs (1 chunk) to reduce memory waste and improve fragmentation handling.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
