### PR TITLE
DAOS-17905 object: fixes excessive waiting time in system xstream dur…

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1920,9 +1920,7 @@ migrate_system_enter(struct migrate_pool_tls *tls, int tgt_idx, bool *yielded)
 		D_DEBUG(DB_REBUILD, "tgt%d:%u max %u\n",
 			tgt_idx, tgt_cnt, tls->mpt_inflight_max_ult / dss_tgt_nr);
 		*yielded = true;
-		ABT_mutex_lock(tls->mpt_inflight_mutex);
-		ABT_cond_wait(tls->mpt_inflight_cond, tls->mpt_inflight_mutex);
-		ABT_mutex_unlock(tls->mpt_inflight_mutex);
+		dss_sleep(1);
 		if (tls->mpt_fini)
 			D_GOTO(out, rc = -DER_SHUTDOWN);
 
@@ -1962,29 +1960,6 @@ out:
 }
 
 static void
-migrate_system_try_wakeup(struct migrate_pool_tls *tls)
-{
-	bool wakeup = false;
-	int i;
-
-	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
-	for (i = 0; i < dss_tgt_nr; i++) {
-		uint32_t total_cnt;
-
-		total_cnt = atomic_load(&tls->mpt_obj_ult_cnts[i]) +
-			    atomic_load(&tls->mpt_dkey_ult_cnts[i]);
-		if (tls->mpt_inflight_max_ult / dss_tgt_nr > total_cnt)
-			wakeup = true;
-	}
-
-	if (wakeup) {
-		ABT_mutex_lock(tls->mpt_inflight_mutex);
-		ABT_cond_broadcast(tls->mpt_inflight_cond);
-		ABT_mutex_unlock(tls->mpt_inflight_mutex);
-	}
-}
-
-static void
 migrate_system_exit(struct migrate_pool_tls *tls, unsigned int tgt_idx)
 {
 	/* NB: this will only be called during errr handling. In normal case
@@ -1992,7 +1967,6 @@ migrate_system_exit(struct migrate_pool_tls *tls, unsigned int tgt_idx)
 	 */
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 	atomic_fetch_sub(&tls->mpt_obj_ult_cnts[tgt_idx], 1);
-	migrate_system_try_wakeup(tls);
 }
 
 static void
@@ -3927,7 +3901,6 @@ ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, unsigned int generation,
 	if (dms != NULL)
 		*dms = arg.dms;
 
-	migrate_system_try_wakeup(tls);
 	D_DEBUG(DB_REBUILD, "pool "DF_UUID" ver %u migrating=%s,"
 		" obj_count="DF_U64", rec_count="DF_U64
 		" size="DF_U64" ult cnt %u status %d\n",

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1920,7 +1920,7 @@ migrate_system_enter(struct migrate_pool_tls *tls, int tgt_idx, bool *yielded)
 		D_DEBUG(DB_REBUILD, "tgt%d:%u max %u\n",
 			tgt_idx, tgt_cnt, tls->mpt_inflight_max_ult / dss_tgt_nr);
 		*yielded = true;
-		dss_sleep(1);
+		dss_sleep(0);
 		if (tls->mpt_fini)
 			D_GOTO(out, rc = -DER_SHUTDOWN);
 


### PR DESCRIPTION
…ing object ULT creation

During migration, the system xstream only wakes up in ds_migrate_query_status() (called by rebuild_tgt_status_check_ult()), where it sleeps for RBLD_CHECK_INTV (2 seconds). This caused the system xstream to remain blocked for 2-second intervals without performing any operations, severely degrading rebuild performance.

Benchmark results demonstrate the improvement:

Without patch: 99,780 objects processed in 120 seconds

With patch: 225,136 objects processed in 11 seconds

The patch achieves approximately 20x performance improvement

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
