### PR TITLE
DAOS-17895 control: Fix TestPoolCommands failures

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -676,14 +676,23 @@ type PoolGetPropReq struct {
 
 // PoolGetProp sends a pool get-prop request to the pool service leader.
 func PoolGetProp(ctx context.Context, rpcClient UnaryInvoker, req *PoolGetPropReq) ([]*daos.PoolProperty, error) {
-	// Get all by default.
 	if len(req.Properties) == 0 {
+		// Get all by default.
 		allProps := daos.PoolProperties()
 		req.Properties = make([]*daos.PoolProperty, 0, len(allProps))
 		for _, key := range allProps.Keys() {
 			hdlr := allProps[key]
 			req.Properties = append(req.Properties, hdlr.GetProperty(key))
 		}
+	} else {
+		for _, prop := range req.Properties {
+			if prop == nil {
+				return nil, errors.New("nil property")
+			}
+		}
+		slices.SortFunc(req.Properties, func(a, b *daos.PoolProperty) int {
+			return strings.Compare(a.Name, b.Name)
+		})
 	}
 
 	pbReq := &mgmtpb.PoolGetPropReq{
@@ -723,9 +732,7 @@ func PoolGetProp(ctx context.Context, rpcClient UnaryInvoker, req *PoolGetPropRe
 		pbMap[prop.GetNumber()] = prop
 	}
 
-	slices.SortFunc(req.Properties, func(a, b *daos.PoolProperty) int {
-		return strings.Compare(a.Name, b.Name)
-	})
+	// We've already sorted req.Properties above.
 	resp := make([]*daos.PoolProperty, 0, len(req.Properties))
 	for _, prop := range req.Properties {
 		pbProp, found := pbMap[prop.Number]


### PR DESCRIPTION
TestPoolCommands/Get_pool_properties still fails from time to time with my previous PR #16711. It turns out that I overlooked the hint right at the beginning of the diff,

    === RUN   TestPoolCommands/Get_pool_properties
        command_test.go:291: unexpected function calls (-want, +got):
              strings.Join({
              	`*control.PoolGetPropReq-{"Sys":"","HostList":null,"ID":"031bcaf8`,
                                     ^^^

which clearly indicates that the problem is with the request, rather than the response. Hence, this patch revises the approach to sort both the properties in the request and the command output.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
