### PR TITLE
DAOS-17910 doc: maximum number of targets per SSD

### DIFF
--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -304,6 +304,12 @@
 #  #
 #  # The server should have sufficiently many physical cores to support the
 #  # number of targets, plus the additional service threads.
+#  #
+#  # Besides the number of CPU cores, this target number is limited by the number of
+#  # SSDs listed in the bdev_list as well. One NVMe SSD in the bdev_list can be assigned
+#  # to at most 64 targets in pmem mode, or 21 targets in md-on-ssd mode (when the SSD
+#  # has three roles), so the maximum target number will be 'number_of_SSD * 64' in
+#  # pmem mode or 'number_of_SSD * 21' in md-on-ssd mode.
 #
 #  targets: 16
 #


### PR DESCRIPTION
Target number is limited by number of SSDs, specify this limitation in daos_server.yml

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
