### PR TITLE
DAOS-17888 test: ftest config_generate_run.py fail on creating daos_server log file

### DIFF
--- a/src/tests/ftest/control/config_generate_run.py
+++ b/src/tests/ftest/control/config_generate_run.py
@@ -40,7 +40,6 @@ class ConfigGenerateRun(TestWithServers):
         :avocado: tags=control,dmg_config_generate
         :avocado: tags=ConfigGenerateRun,test_config_generate_run
         """
-        self.log_step(f"self.test_env.log_dir =  {self.test_env.log_dir}")
         num_engines = self.params.get("num_engines", "/run/config_generate_params/*/")
         scm_only = self.params.get("scm_only", "/run/config_generate_params/*/")
         net_class = self.params.get("net_class", "/run/config_generate_params/*/")
@@ -75,8 +74,6 @@ class ConfigGenerateRun(TestWithServers):
         for engine in engines:
             engine["log_file"] = os.path.join(
                 self.test_env.log_dir, os.path.basename(engine["log_file"]))
-
-        self.log.debug("Modified log_file in generated config %s", engines)
 
         # Stop and restart daos_server. self.start_server_managers() has the
         # server start-up check built into it, so if there's something wrong,


### PR DESCRIPTION
Updating the default log file location for test.

Skip-unit-tests: true
Quick-Functional: true
Test-tag: test_config_generate_run

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
