### PR TITLE
DAOS-12648 spdk: workaround for SPDK AMD iommu support

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -173,6 +173,10 @@ bio_spdk_env_init(void)
 		}
 	}
 
+	if (geteuid() != 0) {
+		opts.iova_mode = "va"; // workaround for spdk issue #2683 when running as non-root
+	}
+
 	/* Don't pass opt for reinitialization, otherwise it will fail */
 	rc = spdk_env_init(spdk_env_dpdk_external_init() ? &opts : NULL);
 	if (rc != 0) {

--- a/src/control/lib/spdk/src/nvme_control.c
+++ b/src/control/lib/spdk/src/nvme_control.c
@@ -509,6 +509,9 @@ daos_spdk_init(int mem_sz, char *env_ctx, size_t nr_pcil, char **pcil)
 		opts.num_pci_addr = nr_pcil;
 	}
 	opts.name = "daos_server_helper";
+	if (geteuid() != 0) {
+		opts.iova_mode = "va"; // workaround for spdk issue #2683 when running as non-root
+	}
 
 	rc = spdk_env_init(&opts);
 	if (rc < 0) {


### PR DESCRIPTION
In SPDK issue 2683, SPDK incorrectly determines that an AMD iommu does not support virtual addressing.  As a result, DAOS engines cannot run as non-root on an AMD server.  Change DAOS to specify iova_mode = "va" when calling spdk_env_init() when running as non-root.  This is a workaround until SPDK issue 2683 is fixed.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
