### PR TITLE
DAOS-17871 cart: Improve swim notification test

### DIFF
--- a/src/tests/ftest/cart/rpc/swim_notification.yaml
+++ b/src/tests/ftest/cart/rpc/swim_notification.yaml
@@ -4,7 +4,7 @@
 ENV:
   default:
     #!filter-only : /run/tests/proto_np
-    - D_LOG_MASK: "WARN"
+    - D_LOG_MASK: "INFO"
     - D_INTERFACE: "eth0"
     - CRT_TEST_CONT: "1"
     - test_servers_CRT_CTX_NUM: "16"
@@ -29,11 +29,11 @@ tests: !mux
     test_clients_env: ""
     test_clients_ppn: "1"
     test_clients_arg:
-      - "--name client_group --attach_to tg_srv_grp_swim_test --init_only --holdtime 20"
-      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 0,1 --verify_swim_status 'rank2=alive' --skip_shutdown --skip_check_in"
-      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 2   --shut_only --holdtime 30"
-      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 0,1 --verify_swim_status 'rank2=dead'  --skip_shutdown --skip_check_in"
-      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 0,1 --verify_swim_status 'rank1=alive' --skip_shutdown --skip_check_in"
-      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 0,1 --verify_swim_status 'rank0=alive' --skip_shutdown --skip_check_in"
-      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 0,1 --disable_swim --skip_shutdown --skip_check_in"
-      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 0,1 --shut_only"
+      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 0,1,2 --init_only --holdtime 30"
+      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 0,1 --verify_swim_status 'rank2=alive' --skip_shutdown --skip_check_in --skip_wait"
+      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 2   --shut_only --holdtime 30 --skip_wait"
+      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 0,1 --verify_swim_status 'rank2=dead'  --skip_shutdown --skip_check_in --skip_wait"
+      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 0,1 --verify_swim_status 'rank1=alive' --skip_shutdown --skip_check_in --skip_wait"
+      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 0,1 --verify_swim_status 'rank0=alive' --skip_shutdown --skip_check_in --skip_wait"
+      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 0,1 --disable_swim --skip_shutdown --skip_check_in --skip_wait"
+      - "--name client_group --attach_to tg_srv_grp_swim_test --rank 0,1 --shut_only --skip_wait"

--- a/src/tests/ftest/cart/test_group_np_cli.c
+++ b/src/tests/ftest/cart/test_group_np_cli.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -23,21 +24,20 @@
 static void
 send_rpc_swim_check(crt_endpoint_t server_ep, crt_rpc_t *rpc_req)
 {
-	struct test_swim_status_in	*rpc_req_input;
+	struct test_swim_status_in *input;
 
 	int rc = crt_req_create(test_g.t_crt_ctx[0], &server_ep,
 				TEST_OPC_SWIM_STATUS, &rpc_req);
 	D_ASSERTF(rc == 0 && rpc_req != NULL,
 		  "crt_req_create() failed. "
-		  "rc: %d, rpc_req: %p\n", rc, rpc_req);
+		  "rc: %d, rpc_req: %p\n",
+		  rc, rpc_req);
 
-	rpc_req_input = crt_req_get(rpc_req);
-	D_ASSERTF(rpc_req_input != NULL, "crt_req_get() failed."
-		  " rpc_req_input: %p\n", rpc_req_input);
+	input = crt_req_get(rpc_req);
 
 	/* Set rank and expected swim status based on CLI options */
-	rpc_req_input->rank = test_g.t_verify_swim_status.rank;
-	rpc_req_input->exp_status = test_g.t_verify_swim_status.swim_status;
+	input->rank       = test_g.t_verify_swim_status.rank;
+	input->exp_status = test_g.t_verify_swim_status.swim_status;
 
 	/* RPC is expected to finish in 10 seconds */
 	rc = crt_req_set_timeout(rpc_req, 10);
@@ -52,20 +52,19 @@ send_rpc_swim_check(crt_endpoint_t server_ep, crt_rpc_t *rpc_req)
 static void
 send_rpc_disable_swim(crt_endpoint_t server_ep, crt_rpc_t *rpc_req)
 {
-	struct test_disable_swim_in	*rpc_req_input;
+	struct test_disable_swim_in *input;
 
 	int rc = crt_req_create(test_g.t_crt_ctx[0], &server_ep,
 				TEST_OPC_DISABLE_SWIM, &rpc_req);
 	D_ASSERTF(rc == 0 && rpc_req != NULL,
 		  "crt_req_create() failed. "
-		  "rc: %d, rpc_req: %p\n", rc, rpc_req);
+		  "rc: %d, rpc_req: %p\n",
+		  rc, rpc_req);
 
-	rpc_req_input = crt_req_get(rpc_req);
-	D_ASSERTF(rpc_req_input != NULL, "crt_req_get() failed."
-		  " rpc_req_input: %p\n", rpc_req_input);
+	input = crt_req_get(rpc_req);
 
 	/* Set rank and expected swim status based on CLI options */
-	rpc_req_input->rank = server_ep.ep_rank;
+	input->rank = server_ep.ep_rank;
 
 	/* RPC is expected to finish in 10 seconds */
 	rc = crt_req_set_timeout(rpc_req, 10);
@@ -94,43 +93,43 @@ test_run(void)
 
 	if (test_g.t_skip_init) {
 		DBG_PRINT("Skipping init stage.\n");
+		goto skip_init;
+	}
 
-	} else {
-		if (test_g.t_save_cfg) {
-			rc = crt_group_config_path_set(test_g.t_cfg_path);
-			D_ASSERTF(rc == 0,
-				  "crt_group_config_path_set failed %d\n", rc);
+	if (test_g.t_save_cfg) {
+		DBG_PRINT("Setting group config path: %p\n", test_g.t_cfg_path);
+		rc = crt_group_config_path_set(test_g.t_cfg_path);
+		D_ASSERTF(rc == 0, "crt_group_config_path_set failed %d\n", rc);
+	}
+
+	rc = crtu_cli_start_basic(test_g.t_local_group_name, test_g.t_remote_group_name, &grp,
+				  &rank_list, &test_g.t_crt_ctx[0], &test_g.t_tid[0],
+				  test_g.t_srv_ctx_num, test_g.t_use_cfg, NULL,
+				  test_g.t_use_daos_agent_env);
+	D_ASSERTF(rc == 0, "crtu_cli_start_basic() failed\n");
+
+	rc = sem_init(&test_g.t_token_to_proceed, 0, 0);
+	D_ASSERTF(rc == 0, "sem_init() failed.\n");
+
+	/* register RPCs */
+	rc = crt_proto_register(&my_proto_fmt_test_group1);
+	D_ASSERTF(rc == 0, "crt_proto_register() failed. rc: %d\n", rc);
+
+	/* Process the --rank option, e.g., --rank 1,2-4 */
+	if (test_g.cg_num_ranks > 0) {
+		_cg_ranks     = (uint32_t *)test_g.cg_ranks;
+		_cg_num_ranks = test_g.cg_num_ranks;
+
+		/* free up rank list from crtu_cli_start_basic */
+		if (rank_list != NULL) {
+			/* avoid checkpatch warning */
+			d_rank_list_free(rank_list);
 		}
+		rank_list = uint32_array_to_rank_list(_cg_ranks, _cg_num_ranks);
+		D_ASSERTF(rank_list != NULL, "failed to convert array to rank list\n");
+	}
 
-		rc = crtu_cli_start_basic(test_g.t_local_group_name,
-					  test_g.t_remote_group_name,
-					  &grp, &rank_list, &test_g.t_crt_ctx[0],
-					  &test_g.t_tid[0], test_g.t_srv_ctx_num,
-					  test_g.t_use_cfg, NULL, test_g.t_use_daos_agent_env);
-		D_ASSERTF(rc == 0, "crtu_cli_start_basic() failed\n");
-
-		rc = sem_init(&test_g.t_token_to_proceed, 0, 0);
-		D_ASSERTF(rc == 0, "sem_init() failed.\n");
-
-		/* register RPCs */
-		rc = crt_proto_register(&my_proto_fmt_test_group1);
-		D_ASSERTF(rc == 0, "crt_proto_register() failed. rc: %d\n",
-			  rc);
-
-		/* Process the --rank option, e.g., --rank 1,2-4 */
-		if (test_g.cg_num_ranks > 0) {
-			_cg_ranks = (uint32_t *)test_g.cg_ranks;
-			_cg_num_ranks = test_g.cg_num_ranks;
-
-			/* free up rank list from crtu_cli_start_basic */
-			if (rank_list != NULL) {
-				/* avoid checkpatch warning */
-				d_rank_list_free(rank_list);
-			}
-			rank_list = uint32_array_to_rank_list(_cg_ranks, _cg_num_ranks);
-			D_ASSERTF(rank_list != NULL, "failed to convert array to rank list\n");
-		}
-
+	if (!test_g.t_skip_wait) {
 		rc = crtu_wait_for_ranks(test_g.t_crt_ctx[0],
 					 grp,
 					 rank_list,
@@ -140,6 +139,8 @@ test_run(void)
 					 test_g.t_wait_ranks_time);
 		D_ASSERTF(rc == 0, "wait_for_ranks() failed; rc=%d\n", rc);
 	}
+
+skip_init:
 
 	if (test_g.t_init_only) {
 		DBG_PRINT("Init only. Returning now.\n");


### PR DESCRIPTION
Change how the test behaves. At start it will now wait for all 3 ranks to be present and waits 30 seconds after that before rank=2 is shut down.

30 seconds is left to allow for swim notification status to be propagated across all 3 servers in this group.

Added --skip_wait option to clients to skip crtu_wait_for_ranks() call as only first client invocation needs to ensure all 3 servers are up.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
