### PR TITLE
DAOS-17861 cart: avoid sending RPC reply repeatedly

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -933,7 +934,6 @@ forward_done:
 
 		D_SPIN_LOCK(&rpc_priv->crp_lock);
 		co_info->co_local_done = 1;
-		rpc_priv->crp_reply_pending = 0;
 		D_SPIN_UNLOCK(&rpc_priv->crp_lock);
 
 		/* Handle ref count difference between call on root vs

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1597,6 +1597,9 @@ crt_hg_reply_send(struct crt_rpc_priv *rpc_priv)
 
 	D_ASSERT(rpc_priv != NULL);
 
+	if (rpc_priv->crp_reply_sent != 0)
+		goto out;
+
 	RPC_ADDREF(rpc_priv);
 	hg_ret = HG_Respond(rpc_priv->crp_hg_hdl, crt_hg_reply_send_cb,
 			    rpc_priv, &rpc_priv->crp_pub.cr_output);
@@ -1607,6 +1610,9 @@ crt_hg_reply_send(struct crt_rpc_priv *rpc_priv)
 		RPC_DECREF(rpc_priv);
 		D_GOTO(out, rc = crt_hgret_2_der(hg_ret));
 	}
+
+	rpc_priv->crp_reply_pending = 0;
+	rpc_priv->crp_reply_sent    = 1;
 
 	/* Release input buffer */
 	if (rpc_priv->crp_release_input_early && !rpc_priv->crp_forward) {
@@ -1631,6 +1637,9 @@ crt_hg_reply_error_send(struct crt_rpc_priv *rpc_priv, int error_code)
 	D_ASSERT(rpc_priv != NULL);
 	D_ASSERT(error_code != 0);
 
+	if (rpc_priv->crp_reply_sent != 0)
+		return;
+
 	hg_out_struct = &rpc_priv->crp_pub.cr_output;
 	rpc_priv->crp_reply_hdr.cch_rc = error_code;
 	hg_ret = HG_Respond(rpc_priv->crp_hg_hdl, NULL, NULL, hg_out_struct);
@@ -1639,11 +1648,12 @@ crt_hg_reply_error_send(struct crt_rpc_priv *rpc_priv, int error_code)
 			  "HG_Respond failed, hg_ret: " DF_HG_RC "\n",
 			  DP_HG_RC(hg_ret));
 	} else {
+		rpc_priv->crp_reply_pending = 0;
+		rpc_priv->crp_reply_sent    = 1;
 		RPC_TRACE(DB_NET, rpc_priv,
 			  "Sent CART level error message back to client. error_code: %d\n",
 			  error_code);
 	}
-	rpc_priv->crp_reply_pending = 0;
 }
 
 int

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1545,7 +1545,6 @@ crt_reply_send(crt_rpc_t *req)
 				rc, rpc_priv->crp_pub.cr_opc);
 	}
 
-	rpc_priv->crp_reply_pending = 0;
 out:
 	return rc;
 }
@@ -1791,9 +1790,8 @@ crt_rpc_common_hdlr(struct crt_rpc_priv *rpc_priv)
 		D_GOTO(out, rc = -DER_BAD_TARGET);
 	}
 skip_check:
-
 	/* Set the reply pending bit unless this is a one-way OPCODE */
-	if (!rpc_priv->crp_opc_info->coi_no_reply)
+	if (!rpc_priv->crp_opc_info->coi_no_reply && !rpc_priv->crp_reply_sent)
 		rpc_priv->crp_reply_pending = 1;
 
 	if (crt_rpc_cb_customized(crt_ctx, &rpc_priv->crp_pub) &&

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -168,6 +168,7 @@ struct crt_rpc_priv {
 	 * match with crp_req_hdr.cch_flags.
 	 */
 	uint32_t		crp_flags;
+	/* clang-format off */
 	uint32_t                 crp_srv : 1, /* flag of server received request */
 	    crp_output_got : 1, crp_input_got : 1,
 	    /* flag of collective RPC request */
@@ -180,6 +181,8 @@ struct crt_rpc_priv {
 	    crp_in_binheap          : 1,
 	    /* set if a call to crt_req_reply pending */
 	    crp_reply_pending       : 1,
+	    /* set RPC reply is sent. */
+	    crp_reply_sent          : 1,
 	    /* set to 1 if target ep is set */
 	    crp_have_ep             : 1,
 	    /* RPC is tracked by the context */
@@ -192,6 +195,7 @@ struct crt_rpc_priv {
 	    crp_src_is_primary      : 1,
 	    /* release input buffer early */
 	    crp_release_input_early : 1;
+	/* clang-format on */
 
 	struct crt_opc_info	*crp_opc_info;
 	/* corpc info, only valid when (crp_coll == 1) */

--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -571,6 +571,7 @@ out:
 		 * Let's trigger it explicitly to release related buffer.
 		 */
 		chk_start_post_reply(req, NULL);
+		crt_req_decref(req);
 
 		if (rc < 0) {
 			rc1 = chk_stop_remote(rank_list, gen, pool_nr, pools, NULL, NULL);
@@ -578,8 +579,6 @@ out:
 				D_ERROR("Failed to cleanup DAOS check with gen "DF_X64": "DF_RC"\n",
 					gen, DP_RC(rc1));
 		}
-
-		crt_req_decref(req);
 	}
 
 	D_CDEBUG(rc < 0, DLOG_ERR, DLOG_INFO,


### PR DESCRIPTION
When handle collective RPC, some failure may happen before invoking RPC handler for local node process. Then crt_hg_reply_send() may be triggered. And then in subsequent process, crt_rpc_handler_common() will call crt_hg_reply_error_send() to reply the RPC repeatedly. It is observed that the latter one maybe failed with NA_BUSY and cause the callback for former reply to be blocked or lost. Then reference on the RPC cannot be released. Such RPC leaking may cause assertion in UCX environment when destroy related CaRT context.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
