### PR TITLE
DAOS-17341 control: Fix remove locks on engine exit

### DIFF
--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -608,16 +608,16 @@ func registerEngineEventCallbacks(srv *server, engine *EngineInstance, allStarte
 	engine.OnInstanceExit(createPublishInstanceExitFunc(srv.pubSub.Publish, srv.hostname))
 
 	engine.OnInstanceExit(func(_ context.Context, _ uint32, _ ranklist.Rank, _ error, _ int) error {
-		if engine.storage.BdevRoleMetaConfigured() {
-			return engine.storage.UnmountTmpfs()
-		}
-
 		storageCfg := engine.runner.GetConfig().Storage
 		pciAddrs := storageCfg.Tiers.NVMeBdevs().Devices()
 
 		if err := cleanSpdkResources(srv, pciAddrs); err != nil {
 			srv.log.Error(
 				errors.Wrapf(err, "engine instance %d", engine.Index()).Error())
+		}
+
+		if engine.storage.BdevRoleMetaConfigured() {
+			return engine.storage.UnmountTmpfs()
 		}
 
 		return nil

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2020-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -440,7 +441,9 @@ kv_put(daos_handle_t oh, daos_size_t size)
 	char		*val;
 	daos_event_t	*evp;
 	int		rc, usage_ratio1, usage_ratio2;
-	int		eq_rc;
+	int              eq_rc;
+	int              num_events;
+	int              completions = 0;
 	clock_t		last_query = start, current;
 
 	deadline_count = 1;
@@ -485,12 +488,14 @@ kv_put(daos_handle_t oh, daos_size_t size)
 			 * Max request in flight reached, wait for one i/o to
 			 * complete to reuse the slot
 			 */
-			rc = daos_eq_poll(eq, 1, DAOS_EQ_WAIT, 1, &evp);
-			if (rc < 0)
-				break;
-			if (rc == 0) {
-				rc = -DER_IO;
-				break;
+			while (1) {
+				rc = daos_eq_poll(eq, 1, DAOS_EQ_NOWAIT, 1, &evp);
+				if (rc > 0)
+					break;
+				if (rc < 0) {
+					rc = -DER_IO;
+					break;
+				}
 			}
 
 			/** Check if completed operation failed */
@@ -540,19 +545,20 @@ kv_put(daos_handle_t oh, daos_size_t size)
 			break;
 
 		deadline_count++;
-
 	}
 
 	/** Wait for completion of all in-flight requests */
-	do {
-		eq_rc = daos_eq_poll(eq, 1, DAOS_EQ_WAIT, 1, &evp);
-		if (rc == 0 && eq_rc == 1) {
-			rc = evp->ev_error;
+	num_events = daos_eq_query(eq, DAOS_EQR_ALL, 0, NULL);
+	while (1) {
+		eq_rc = daos_eq_poll(eq, 1, DAOS_EQ_NOWAIT, 1, &evp);
+		if (eq_rc > 0)
+			completions += eq_rc;
+		if (eq_rc < 0) {
+			rc = eq_rc;
+			break;
 		}
-	} while (eq_rc == 1);
-
-	if (rc == 0 && eq_rc < 0) {
-		rc = eq_rc;
+		if (completions >= num_events)
+			break;
 	}
 
 	D_FREE(val);
@@ -581,6 +587,8 @@ kv_get(daos_handle_t oh, daos_size_t size)
 	uint64_t	res = 0;
 	int		rc;
 	int		eq_rc;
+	int              completions = 0;
+	int              num_events;
 
 	total_nr = deadline_count;
 	setup_progress();
@@ -620,12 +628,14 @@ kv_get(daos_handle_t oh, daos_size_t size)
 			 * Max request in flight reached, wait for one i/o to
 			 * complete to reuse the slot
 			 */
-			rc = daos_eq_poll(eq, 1, DAOS_EQ_WAIT, 1, &evp);
-			if (rc < 0)
-				break;
-			if (rc == 0) {
-				rc = -DER_IO;
-				break;
+			while (1) {
+				rc = daos_eq_poll(eq, 1, DAOS_EQ_NOWAIT, 1, &evp);
+				if (rc > 0)
+					break;
+				if (rc < 0) {
+					rc = -DER_IO;
+					break;
+				}
 			}
 
 			/** Check if completed operation failed */
@@ -665,11 +675,12 @@ kv_get(daos_handle_t oh, daos_size_t size)
 	}
 
 	/** Wait for completion of all in-flight requests */
-	do {
-		eq_rc = daos_eq_poll(eq, 1, DAOS_EQ_WAIT, 1, &evp);
-		if (rc == 0 && eq_rc == 1) {
-			rc = evp->ev_error;
-			if (rc == 0) {
+	num_events = daos_eq_query(eq, DAOS_EQR_ALL, 0, NULL);
+	while (1) {
+		eq_rc = daos_eq_poll(eq, 1, DAOS_EQ_NOWAIT, 1, &evp);
+		if (eq_rc > 0) {
+			completions += eq_rc;
+			if (!evp->ev_error) {
 				int slot = evp - ev_array;
 
 				if (val_sz[slot] != size) {
@@ -679,10 +690,12 @@ kv_get(daos_handle_t oh, daos_size_t size)
 				}
 			}
 		}
-	} while (eq_rc == 1);
-
-	if (rc == 0 && eq_rc < 0) {
-		rc = eq_rc;
+		if (eq_rc < 0) {
+			rc = eq_rc;
+			break;
+		}
+		if (completions >= num_events)
+			break;
 	}
 
 	D_FREE(val);


### PR DESCRIPTION
Lock removal on engine exit callback was being skipped in MD-on-SSD
mode. Fix by returning after lock cleanup.

Features: control

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
