### PR TITLE
DAOS-17926 test: workaround mux limitations

### DIFF
--- a/src/tests/ftest/control/config_generate_run.yaml
+++ b/src/tests/ftest/control/config_generate_run.yaml
@@ -12,9 +12,6 @@ server_config:
           class: ram
           scm_mount: /mnt/daos0
 # Force the use of certificates regardless of the launch.py --insecure setting.
-pool:
-  transport_config:
-    allow_insecure: False
 agent_config:
   transport_config:
     allow_insecure: False

--- a/src/tests/ftest/erasurecode/cell_size.py
+++ b/src/tests/ftest/erasurecode/cell_size.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -30,8 +31,21 @@ class EcodCellSize(IorTestBase):
         :avocado: tags=ec,ec_ior,ior
         :avocado: tags=EcodCellSize,ec_cell_size,test_ec_cell_size
         """
-        obj_class = self.params.get("dfs_oclass", '/run/ior/objectclass/*')
+        pool_cell_sizes = self.params.get("cell_sizes", '/run/pool/*')
+        dfs_oclass_list = self.params.get("dfs_oclass", '/run/ior/*')
+        transfersize_blocksize = self.params.get("transfersize_blocksize", '/run/ior/*')
 
-        for oclass in obj_class:
-            self.ior_cmd.dfs_oclass.update(oclass)
-            self.run_ior_with_pool()
+        for cell_size in pool_cell_sizes:
+            self.pool = self.get_pool(properties=f"ec_cell_sz:{cell_size}")
+            for dfs_oclass in dfs_oclass_list:
+                self.ior_cmd.dfs_oclass.update(dfs_oclass)
+                for transfer_size, block_size in transfersize_blocksize:
+                    self.ior_cmd.transfer_size.update(transfer_size)
+                    self.ior_cmd.block_size.update(block_size)
+                    self.log_step(
+                        f"Running IOR with cell size: {cell_size}, "
+                        f"object class: {dfs_oclass}, "
+                        f"transfer size: {transfer_size}, "
+                        f"block size: {block_size}")
+                    self.run_ior_with_pool()
+            self.pool.destroy()

--- a/src/tests/ftest/erasurecode/cell_size.yaml
+++ b/src/tests/ftest/erasurecode/cell_size.yaml
@@ -1,10 +1,7 @@
 hosts:
   test_servers: 5
   test_clients: 3
-timeout: 900
-setup:
-  start_agents_once: false
-  start_servers_once: false
+timeout: 1600
 server_config:
   name: daos_server
   engines_per_host: 2
@@ -27,18 +24,13 @@ server_config:
       storage: auto
 pool:
   size: 93%
-  cell_size: !mux
-    cell_size_4K:
-      properties: ec_cell_sz:4KiB
-    cell_size_64K:
-      properties: ec_cell_sz:64KiB
-    cell_size_128K:
-      properties: ec_cell_sz:128KiB
-    cell_size_1M:
-      properties: ec_cell_sz:1MiB
+  cell_sizes:
+    - 4KiB
+    - 64KiB
+    - 128KiB
+    - 1MiB
 container:
   type: POSIX
-  control_method: daos
 ior:
   api: "DFS"
   client_processes:
@@ -47,18 +39,13 @@ ior:
   iorflags:
     flags: "-w -W -r -R -G 1 -vv"
   test_file: /testFile
-  repetitions: 1
-  transfersize_blocksize: !mux
-    1M_128M:
-      transfer_size: 8k
-      block_size: 64M
-    2M_128M:
-      transfer_size: 1M
-      block_size: 128M
-  objectclass:
-    dfs_oclass:
-      - "EC_2P1GX"
-      - "EC_2P2GX"
-      - "EC_4P1GX"
-      - "EC_4P2GX"
-      - "EC_4P3GX"
+  transfersize_blocksize:
+    # [transfer size, block size]
+    - [8k, 64M]
+    - [1M, 128M]
+  dfs_oclass:
+    - "EC_2P1GX"
+    - "EC_2P2GX"
+    - "EC_4P1GX"
+    - "EC_4P2GX"
+    - "EC_4P3GX"

--- a/src/tests/ftest/erasurecode/cell_size_property.py
+++ b/src/tests/ftest/erasurecode/cell_size_property.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -50,43 +51,46 @@ class EcodCellSizeProperty(IorTestBase):
         :avocado: tags=ec,ec_ior,daos_cmd
         :avocado: tags=EcodCellSizeProperty,ec_cell_property,test_ec_pool_property
         """
-        ior_transfer_size = self.params.get("ior_transfer_size",
-                                            '/run/ior/iorflags/*')
-        cont_cell_size = self.params.get("cont_cell_size",
-                                         '/run/container/*')
-        # Create the pool
-        self.add_pool()
+        pool_cell_sizes = self.params.get("cell_sizes", "/run/pool/*")
+        cont_cell_sizes = self.params.get("cell_sizes", "/run/cont/*")
+        ior_transfer_sizes = self.params.get("transfer_sizes", "/run/ior/*")
 
-        # Verify pool EC cell size
-        pool_prop_expected = int(self.pool.properties.value.split(":")[1])
-        self.assertEqual(pool_prop_expected,
-                         self.pool.get_property("ec_cell_sz"))
+        for pool_cell_size in pool_cell_sizes:
+            # Create the pool
+            self.pool = self.get_pool(properties=f"ec_cell_sz:{pool_cell_size}")
 
-        # Run IOR for different Transfer size and container cell size.
-        for tx_size, cont_cell in product(ior_transfer_size,
-                                          cont_cell_size):
-            # Initial container
-            self.add_container(self.pool, create=False)
+            # Verify pool EC cell size
+            pool_prop_expected = int(self.pool.properties.value.split(":")[1])
+            self.assertEqual(
+                pool_prop_expected, self.pool.get_property("ec_cell_sz"),
+                "pool get-prop ec_cell_sz does not match set property")
 
-            # Use the default pool property for container and do not update
-            if cont_cell != pool_prop_expected:
-                self.container.properties.update("ec_cell_sz:{}"
-                                                 .format(cont_cell))
+            # Run IOR for different Transfer size and container cell size.
+            for tx_size, cont_cell in product(ior_transfer_sizes, cont_cell_sizes):
+                # Initial container
+                self.add_container(self.pool, create=False)
 
-            # Create the container and open handle
-            self.container.create()
-            self.container.open()
+                # Use the default pool property for container and do not update
+                if cont_cell != pool_prop_expected:
+                    self.container.properties.update(f"ec_cell_sz:{cont_cell}")
 
-            # Verify container EC cell size property
-            self.verify_cont_ec_cell_size(cont_cell)
+                # Create the container and open handle
+                self.container.create()
+                self.container.open()
 
-            # Update IOR Command and Run
-            self.update_ior_cmd_with_pool(create_cont=False)
-            self.ior_cmd.transfer_size.update(tx_size)
-            self.run_ior_with_pool(create_pool=False, create_cont=False)
+                # Verify container EC cell size property
+                self.verify_cont_ec_cell_size(cont_cell)
 
-            # Verify container EC cell size property after IOR
-            self.verify_cont_ec_cell_size(cont_cell)
+                # Update IOR Command and Run
+                self.update_ior_cmd_with_pool(create_cont=False)
+                self.ior_cmd.transfer_size.update(tx_size)
+                self.run_ior_with_pool(create_pool=False, create_cont=False)
 
-            # Destroy the container.
-            self.container.destroy()
+                # Verify container EC cell size property after IOR
+                self.verify_cont_ec_cell_size(cont_cell)
+
+                # Destroy the container.
+                self.container.destroy()
+
+            # Destroy the pool
+            self.pool.destroy()

--- a/src/tests/ftest/erasurecode/cell_size_property.yaml
+++ b/src/tests/ftest/erasurecode/cell_size_property.yaml
@@ -25,17 +25,13 @@ server_config:
       storage: auto
 pool:
   size: 93%
-  cell_size: !mux
-    cell_size_4K:
-      properties: ec_cell_sz:4096
-    cell_size_64K:
-      properties: ec_cell_sz:65536
-    cell_size_111K:
-      properties: ec_cell_sz:131072
+  cell_sizes:
+    - 4096
+    - 65536
+    - 131072
 container:
   type: POSIX
-  control_method: daos
-  cont_cell_size:
+  cell_sizes:
     - 4096
     - 65536
     - 131072
@@ -44,12 +40,10 @@ ior:
   api: "DFS"
   client_processes:
     np: 48
-  dfs_destroy: False
   iorflags:
     flags: "-w -W -r -R -G 1 -vv"
   test_file: /testFile
-  repetitions: 1
-  ior_transfer_size:
+  transfer_sizes:
     - 8M
     - 4K
   block_size: 64M

--- a/src/tests/ftest/erasurecode/rebuild_fio.py
+++ b/src/tests/ftest/erasurecode/rebuild_fio.py
@@ -25,7 +25,7 @@ class EcodFioRebuild(FioBase):
         Args:
             rebuild_mode (str): On-line or off-line rebuild mode
         """
-        aggregation_timeout = self.params.get("aggr_timeout", "/run/pool/aggregation/*")
+        aggregation_timeout = self.params.get("aggregation_timeout", "/run/pool/*")
         read_option = self.params.get("rw_read", "/run/fio/test/read_write/*")
 
         num_ranks = len(self.server_managers[0].ranks)

--- a/src/tests/ftest/erasurecode/rebuild_fio.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_fio.yaml
@@ -35,8 +35,7 @@ server_config:
       storage: auto
 pool:
   size: 60%
-  aggregation:
-    aggr_timeout: 180
+  aggregation_timeout: 180
   set_logmasks: False
 container:
   type: POSIX

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -85,7 +85,7 @@ class NvmeEnospace(ServerFillUp, TestWithTelemetry):
 
         for elt in self.media_names:
             self.pool_usage_min.append(float(
-                self.params.get(elt.casefold(), "/run/pool/usage_min/*", 0)))
+                self.params.get(f"usage_min_{elt.casefold()}", "/run/pool/*")))
 
         # initialize daos command
         self.daos_cmd = DaosCommand(self.bin)

--- a/src/tests/ftest/nvme/enospace.yaml
+++ b/src/tests/ftest/nvme/enospace.yaml
@@ -33,12 +33,11 @@ dmg:
 pool:
   scm_size: 5G
   nvme_size: 5G
-  usage_min:
-    # SCM usage will not be 100% because some space (<1%) is used for the system and data
-    # distribution is not fully uniform.
-    scm: 92
-    # NVMe will not be 100% because data distribution is not fully uniform.
-    nvme: 96
+  # SCM usage will not be 100% because some space (<1%) is used for the system and data
+  # distribution is not fully uniform.
+  usage_min_scm: 92
+  # NVMe will not be 100% because data distribution is not fully uniform.
+  usage_min_nvme: 96
 
 container:
   control_method: daos

--- a/src/tests/ftest/nvme/io_verification.py
+++ b/src/tests/ftest/nvme/io_verification.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -46,11 +47,11 @@ class NvmeIoVerification(IorTestBase):
         ior_processes = self.params.get("np", '/run/ior/*')
         ior_transfer_size = self.params.get("tsize", '/run/ior/transfersize/*/')
         ior_block_size = self.ior_cmd.block_size.value
-        ior_seq_pool_qty = self.params.get("ior_sequence_pool_qty", '/run/pool/*')
+        num_pools = self.params.get("num_pools", '/run/pool/*')
         job_manager = self.get_ior_job_manager_command()
 
         # Loop for every pool size
-        for index in range(ior_seq_pool_qty):
+        for index in range(num_pools):
             # Create and connect to a pool with namespace
             self.add_pool(namespace="/run/pool/pool_{}/*".format(index))
 
@@ -112,13 +113,13 @@ class NvmeIoVerification(IorTestBase):
         ior_processes = self.params.get("np", '/run/ior/*')
         ior_transfer_size = self.params.get("tsize", '/run/ior/transfersize/*/')
         ior_block_size = self.ior_cmd.block_size.value
-        ior_seq_pool_qty = self.params.get("ior_sequence_pool_qty", '/run/pool/*')
+        num_pools = self.params.get("num_pools", '/run/pool/*')
         ior_flag_write = self.params.get("write", '/run/ior/*/')
         ior_flag_read = self.params.get("read", '/run/ior/*/')
         job_manager = self.get_ior_job_manager_command()
 
         # Loop for every pool size
-        for index in range(ior_seq_pool_qty):
+        for index in range(num_pools):
             # Create and connect to a pool with namespace
             self.add_pool(namespace="/run/pool/pool_{}/*".format(index))
 

--- a/src/tests/ftest/nvme/io_verification.yaml
+++ b/src/tests/ftest/nvme/io_verification.yaml
@@ -21,15 +21,15 @@ server_config:
       log_file: daos_server1.log
       storage: auto
 pool:
-  ior_sequence_pool_qty: 4
-  pool_0:
-    size: 20%
-  pool_1:
-    size: 30%
-  pool_2:
-    size: 50%
-  pool_3:
-    size: 60%
+  num_pools: 4
+pool_0:
+  size: 20%
+pool_1:
+  size: 30%
+pool_2:
+  size: 50%
+pool_3:
+  size: 60%
 container:
   type: POSIX
   control_method: daos

--- a/src/tests/ftest/pool/rf.yaml
+++ b/src/tests/ftest/pool/rf.yaml
@@ -15,15 +15,11 @@ server_config:
           scm_mount: /mnt/daos0
 
 pool:
-  name: daos_server
   scm_size: 1G
-  rf: !mux
-    rf1:
-      properties: rd_fac:4
+  properties: rd_fac:4
 
 container:
   type: POSIX
-  control_method: daos
   cont_rf:
     - 0
     - 1


### PR DESCRIPTION
Since #16143, muxing is used in the pool config namespace to toggle md on ssd testing variants. But this means there cann't be nested keys in the pool namespace anymore, so workaround this by refactoring tests to use flat values.

Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
