### PR TITLE
DAOS-17341 control: Remove spdk lockfiles on engine exit (#16181)

### DIFF
--- a/src/control/cmd/daos_server/storage_nvme_test.go
+++ b/src/control/cmd/daos_server/storage_nvme_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2022-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -30,6 +31,13 @@ var (
 	defaultSingleAddrList = test.MockPCIAddr(1)
 	spaceSepMultiAddrList = fmt.Sprintf("%s%s%s", test.MockPCIAddr(1), storage.BdevPciAddrSep, test.MockPCIAddr(2))
 	currentUsername       string
+
+	defPrepCmpOpt = cmp.Comparer(func(x, y *storage.BdevDeviceList) bool {
+		if x == nil && y == nil {
+			return true
+		}
+		return x.Equals(y)
+	})
 )
 
 func getCurrentUsername(t *testing.T) string {
@@ -90,31 +98,58 @@ func TestDaosServer_prepareNVMe(t *testing.T) {
 		bmbc          bdev.MockBackendConfig
 		iommuDisabled bool
 		expErr        error
-		expPrepCall   *storage.BdevPrepareRequest
+		expPrepCalls  []storage.BdevPrepareRequest
 	}{
+		"hugepages disabled in config": {
+			cfg:    new(config.Server).WithDisableHugepages(true),
+			expErr: storage.FaultHugepagesDisabled,
+		},
 		"no devices; success": {
-			expPrepCall: &storage.BdevPrepareRequest{
-				// always set in local storage prepare to allow automatic detection
-				EnableVMD: true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				{
+					CleanSpdkHugepages:    true,
+					CleanSpdkLockfiles:    true,
+					CleanSpdkLockfilesAny: true,
+				},
+				{
+					// always set in local storage prepare to allow automatic detection
+					EnableVMD: true,
+				},
 			},
 		},
 		"succeeds; user params": {
 			prepCmd: newPrepCmd(),
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: testNrHugepages,
-				PCIAllowList:  defaultSingleAddrList,
-				PCIBlockList:  spaceSepMultiAddrList,
-				EnableVMD:     true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				{
+					CleanSpdkHugepages: true,
+					CleanSpdkLockfiles: true,
+					PCIAllowList:       defaultSingleAddrList,
+					PCIBlockList:       spaceSepMultiAddrList,
+				},
+				{
+					HugepageCount: testNrHugepages,
+					PCIAllowList:  defaultSingleAddrList,
+					PCIBlockList:  spaceSepMultiAddrList,
+					EnableVMD:     true,
+				},
 			},
 		},
 		"succeeds; different target user; multi allow list": {
 			prepCmd: newPrepCmd().WithTargetUser("bob").WithPCIAllowList(defaultMultiAddrList),
-			expPrepCall: &storage.BdevPrepareRequest{
-				TargetUser:    "bob",
-				HugepageCount: testNrHugepages,
-				PCIAllowList:  spaceSepMultiAddrList,
-				PCIBlockList:  spaceSepMultiAddrList,
-				EnableVMD:     true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				{
+					CleanSpdkHugepages: true,
+					CleanSpdkLockfiles: true,
+					PCIAllowList:       spaceSepMultiAddrList,
+					PCIBlockList:       spaceSepMultiAddrList,
+				},
+				{
+					TargetUser:    "bob",
+					HugepageCount: testNrHugepages,
+					PCIAllowList:  spaceSepMultiAddrList,
+					PCIBlockList:  spaceSepMultiAddrList,
+					EnableVMD:     true,
+				},
 			},
 		},
 		"fails; user params": {
@@ -122,11 +157,20 @@ func TestDaosServer_prepareNVMe(t *testing.T) {
 			bmbc: bdev.MockBackendConfig{
 				PrepareErr: errors.New("backend prep setup failed"),
 			},
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: testNrHugepages,
-				PCIAllowList:  defaultSingleAddrList,
-				PCIBlockList:  spaceSepMultiAddrList,
-				EnableVMD:     true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				{
+					CleanSpdkHugepages: true,
+					CleanSpdkLockfiles: true,
+					PCIAllowList:       defaultSingleAddrList,
+					PCIBlockList:       spaceSepMultiAddrList,
+				},
+				{
+					TargetUser:    "bob",
+					HugepageCount: testNrHugepages,
+					PCIAllowList:  defaultSingleAddrList,
+					PCIBlockList:  spaceSepMultiAddrList,
+					EnableVMD:     true,
+				},
 			},
 			expErr: errors.New("backend prep setup failed"),
 		},
@@ -141,12 +185,20 @@ func TestDaosServer_prepareNVMe(t *testing.T) {
 		"root; vfio disabled; iommu not detected": {
 			prepCmd:       newPrepCmd().WithTargetUser("root").WithDisableVFIO(true),
 			iommuDisabled: true,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: testNrHugepages,
-				TargetUser:    "root",
-				PCIAllowList:  defaultSingleAddrList,
-				PCIBlockList:  spaceSepMultiAddrList,
-				DisableVFIO:   true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				{
+					CleanSpdkHugepages: true,
+					CleanSpdkLockfiles: true,
+					PCIAllowList:       defaultSingleAddrList,
+					PCIBlockList:       spaceSepMultiAddrList,
+				},
+				{
+					HugepageCount: testNrHugepages,
+					TargetUser:    "root",
+					PCIAllowList:  defaultSingleAddrList,
+					PCIBlockList:  spaceSepMultiAddrList,
+					DisableVFIO:   true,
+				},
 			},
 		},
 		"config parameters ignored as cmd settings already exist": {
@@ -158,11 +210,19 @@ func TestDaosServer_prepareNVMe(t *testing.T) {
 						WithBdevDeviceList(test.MockPCIAddr(8)))).
 				WithBdevExclude(test.MockPCIAddr(9)).
 				WithNrHugepages(1024),
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: testNrHugepages,
-				PCIAllowList:  defaultSingleAddrList,
-				PCIBlockList:  spaceSepMultiAddrList,
-				EnableVMD:     true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				{
+					CleanSpdkHugepages: true,
+					CleanSpdkLockfiles: true,
+					PCIAllowList:       defaultSingleAddrList,
+					PCIBlockList:       spaceSepMultiAddrList,
+				},
+				{
+					HugepageCount: testNrHugepages,
+					PCIAllowList:  defaultSingleAddrList,
+					PCIBlockList:  spaceSepMultiAddrList,
+					EnableVMD:     true,
+				},
 			},
 		},
 		"config parameters applied; disable vmd": {
@@ -180,11 +240,20 @@ func TestDaosServer_prepareNVMe(t *testing.T) {
 				WithBdevExclude(test.MockPCIAddr(9)).
 				WithNrHugepages(1024).
 				WithDisableVMD(true),
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 1024,
-				PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(7), storage.BdevPciAddrSep,
-					test.MockPCIAddr(8)),
-				PCIBlockList: test.MockPCIAddr(9),
+			expPrepCalls: []storage.BdevPrepareRequest{
+				{
+					CleanSpdkHugepages: true,
+					CleanSpdkLockfiles: true,
+					PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(7),
+						storage.BdevPciAddrSep, test.MockPCIAddr(8)),
+					PCIBlockList: test.MockPCIAddr(9),
+				},
+				{
+					HugepageCount: 1024,
+					PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(7),
+						storage.BdevPciAddrSep, test.MockPCIAddr(8)),
+					PCIBlockList: test.MockPCIAddr(9),
+				},
 			},
 		},
 		"config parameters applied; disable vfio": {
@@ -194,8 +263,15 @@ func TestDaosServer_prepareNVMe(t *testing.T) {
 		},
 		"nil config; parameters not applied (simulates effect of --ignore-config)": {
 			prepCmd: &prepareNVMeCmd{},
-			expPrepCall: &storage.BdevPrepareRequest{
-				EnableVMD: true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				{
+					CleanSpdkHugepages:    true,
+					CleanSpdkLockfiles:    true,
+					CleanSpdkLockfilesAny: true,
+				},
+				{
+					EnableVMD: true,
+				},
 			},
 		},
 	} {
@@ -230,24 +306,19 @@ func TestDaosServer_prepareNVMe(t *testing.T) {
 			gotErr := prepareNVMe(req, &tc.prepCmd.nvmeCmd)
 			test.CmpErr(t, tc.expErr, gotErr)
 
+			// If empty TargetUser in cmd, expect current user in call.
+			if tc.prepCmd.TargetUser == "" {
+				for i := range tc.expPrepCalls {
+					if tc.expPrepCalls[i].CleanSpdkHugepages {
+						continue
+					}
+					tc.expPrepCalls[i].TargetUser = getCurrentUsername(t)
+				}
+			}
+
 			mbb.RLock()
-			if tc.expPrepCall == nil {
-				if len(mbb.PrepareCalls) != 0 {
-					t.Fatalf("unexpected number of prepare calls, want 0 got %d",
-						len(mbb.PrepareCalls))
-				}
-			} else {
-				if len(mbb.PrepareCalls) != 1 {
-					t.Fatalf("unexpected number of prepare calls, want 1 got %d",
-						len(mbb.PrepareCalls))
-				}
-				// If empty TargetUser in cmd, expect current user in call.
-				if tc.prepCmd.TargetUser == "" {
-					tc.expPrepCall.TargetUser = getCurrentUsername(t)
-				}
-				if diff := cmp.Diff(*tc.expPrepCall, mbb.PrepareCalls[0]); diff != "" {
-					t.Fatalf("unexpected prepare calls (-want, +got):\n%s\n", diff)
-				}
+			if diff := cmp.Diff(tc.expPrepCalls, mbb.PrepareCalls, defPrepCmpOpt); diff != "" {
+				t.Fatalf("unexpected prepare calls (-want, +got):\n%s\n", diff)
 			}
 			if len(mbb.ResetCalls) != 0 {
 				t.Fatalf("unexpected number of reset calls, want 0 got %d",
@@ -268,15 +339,32 @@ func TestDaosServer_resetNVMe(t *testing.T) {
 		return rdc
 	}
 
+	defCleanCall := storage.BdevPrepareRequest{
+		CleanSpdkHugepages: true,
+		CleanSpdkLockfiles: true,
+		PCIAllowList:       defaultSingleAddrList,
+		PCIBlockList:       spaceSepMultiAddrList,
+	}
+
 	for name, tc := range map[string]struct {
 		resetCmd      *resetNVMeCmd
 		cfg           *config.Server
 		bmbc          bdev.MockBackendConfig
 		iommuDisabled bool
 		expErr        error
+		expCleanCall  *storage.BdevPrepareRequest
 		expResetCalls []storage.BdevPrepareRequest
 	}{
+		"hugepages disabled in config": {
+			cfg:    new(config.Server).WithDisableHugepages(true),
+			expErr: storage.FaultHugepagesDisabled,
+		},
 		"no devices; success": {
+			expCleanCall: &storage.BdevPrepareRequest{
+				CleanSpdkHugepages:    true,
+				CleanSpdkLockfiles:    true,
+				CleanSpdkLockfilesAny: true,
+			},
 			expResetCalls: []storage.BdevPrepareRequest{
 				{
 					EnableVMD: true,
@@ -295,6 +383,7 @@ func TestDaosServer_resetNVMe(t *testing.T) {
 					VMDPrepared: true,
 				},
 			},
+			expCleanCall: &defCleanCall,
 			expResetCalls: []storage.BdevPrepareRequest{
 				{
 					PCIAllowList: defaultSingleAddrList,
@@ -316,6 +405,12 @@ func TestDaosServer_resetNVMe(t *testing.T) {
 			resetCmd: newResetCmd().
 				WithTargetUser("bob").
 				WithPCIAllowList(defaultMultiAddrList),
+			expCleanCall: &storage.BdevPrepareRequest{
+				CleanSpdkHugepages: true,
+				CleanSpdkLockfiles: true,
+				PCIAllowList:       spaceSepMultiAddrList,
+				PCIBlockList:       spaceSepMultiAddrList,
+			},
 			expResetCalls: []storage.BdevPrepareRequest{
 				{
 					EnableVMD:    true,
@@ -334,6 +429,7 @@ func TestDaosServer_resetNVMe(t *testing.T) {
 				},
 				ResetErr: errors.New("backend prep reset failed"),
 			},
+			expCleanCall: &defCleanCall,
 			expResetCalls: []storage.BdevPrepareRequest{
 				{
 					EnableVMD:    true,
@@ -356,6 +452,7 @@ func TestDaosServer_resetNVMe(t *testing.T) {
 		"root; vfio disabled; iommu not detected": {
 			resetCmd:      newResetCmd().WithTargetUser("root").WithDisableVFIO(true),
 			iommuDisabled: true,
+			expCleanCall:  &defCleanCall,
 			expResetCalls: []storage.BdevPrepareRequest{
 				{
 					TargetUser:   "root",
@@ -375,6 +472,7 @@ func TestDaosServer_resetNVMe(t *testing.T) {
 						WithBdevDeviceList(test.MockPCIAddr(8)))).
 				WithBdevExclude(test.MockPCIAddr(9)).
 				WithNrHugepages(1024),
+			expCleanCall: &defCleanCall,
 			expResetCalls: []storage.BdevPrepareRequest{
 				{
 					EnableVMD:    true,
@@ -400,6 +498,13 @@ func TestDaosServer_resetNVMe(t *testing.T) {
 				WithBdevExclude(test.MockPCIAddr(9)).
 				WithNrHugepages(1024).
 				WithDisableVMD(true),
+			expCleanCall: &storage.BdevPrepareRequest{
+				CleanSpdkHugepages: true,
+				CleanSpdkLockfiles: true,
+				PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(7),
+					storage.BdevPciAddrSep, test.MockPCIAddr(8)),
+				PCIBlockList: test.MockPCIAddr(9),
+			},
 			expResetCalls: []storage.BdevPrepareRequest{
 				{
 					PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(7),
@@ -417,6 +522,11 @@ func TestDaosServer_resetNVMe(t *testing.T) {
 		},
 		"nil config; parameters not applied (simulates effect of --ignore-config)": {
 			resetCmd: &resetNVMeCmd{},
+			expCleanCall: &storage.BdevPrepareRequest{
+				CleanSpdkHugepages:    true,
+				CleanSpdkLockfiles:    true,
+				CleanSpdkLockfilesAny: true,
+			},
 			expResetCalls: []storage.BdevPrepareRequest{
 				{
 					TargetUser: getCurrentUsername(t),
@@ -458,14 +568,24 @@ func TestDaosServer_resetNVMe(t *testing.T) {
 			test.CmpErr(t, tc.expErr, gotErr)
 
 			mbb.RLock()
+			log.Tracef("mock bdev backend prepare calls: %+v", mbb.PrepareCalls)
+			log.Tracef("mock bdev backend reset calls: %+v", mbb.ResetCalls)
+
 			// Call to clean hugepages should always be expected first.
-			if len(mbb.PrepareCalls) != 1 {
-				t.Fatalf("unexpected number of prepare calls, want 1w got %d",
-					len(mbb.PrepareCalls))
-			}
-			if diff := cmp.Diff(storage.BdevPrepareRequest{CleanHugepagesOnly: true},
-				mbb.PrepareCalls[0]); diff != "" {
-				t.Fatalf("unexpected clean hugepage calls (-want, +got):\n%s\n", diff)
+			switch len(mbb.PrepareCalls) {
+			case 0:
+				if tc.expCleanCall != nil {
+					t.Fatalf("unexpected number of prepare calls, want 1 got 0")
+				}
+			case 1:
+				if diff := cmp.Diff(tc.expCleanCall, &mbb.PrepareCalls[0]); diff != "" {
+					t.Fatalf("unexpected clean hugepage calls (-want, +got):\n%s\n", diff)
+				}
+			default:
+				if tc.expCleanCall != nil {
+					t.Fatalf("unexpected number of prepare calls, want 1 got %d",
+						len(mbb.PrepareCalls))
+				}
 			}
 
 			if diff := cmp.Diff(tc.expResetCalls, mbb.ResetCalls); diff != "" {
@@ -525,13 +645,6 @@ func TestDaosServer_getVMDState(t *testing.T) {
 }
 
 func TestDaosServer_scanNVMe(t *testing.T) {
-	cmpopt := cmp.Comparer(func(x, y *storage.BdevDeviceList) bool {
-		if x == nil && y == nil {
-			return true
-		}
-		return x.Equals(y)
-	})
-
 	for name, tc := range map[string]struct {
 		scanCmd       *scanNVMeCmd
 		cfg           *config.Server
@@ -544,6 +657,10 @@ func TestDaosServer_scanNVMe(t *testing.T) {
 		expScanCall   *storage.BdevScanRequest
 		expScanResp   *storage.BdevScanResponse
 	}{
+		"hugepages disabled in config": {
+			cfg:    new(config.Server).WithDisableHugepages(true),
+			expErr: storage.FaultHugepagesDisabled,
+		},
 		"normal scan": {
 			bmbc: bdev.MockBackendConfig{
 				ScanRes: &storage.BdevScanResponse{
@@ -553,11 +670,27 @@ func TestDaosServer_scanNVMe(t *testing.T) {
 				},
 			},
 			expPrepCalls: []storage.BdevPrepareRequest{
-				{TargetUser: getCurrentUsername(t), EnableVMD: true},
-				{CleanHugepagesOnly: true},
+				{
+					CleanSpdkHugepages:    true,
+					CleanSpdkLockfiles:    true,
+					CleanSpdkLockfilesAny: true,
+				},
+				{
+					TargetUser: getCurrentUsername(t),
+					EnableVMD:  true,
+				},
+				{
+					CleanSpdkHugepages:    true,
+					CleanSpdkLockfiles:    true,
+					CleanSpdkLockfilesAny: true,
+				},
 			},
 			expResetCalls: []storage.BdevPrepareRequest{
-				{TargetUser: getCurrentUsername(t), EnableVMD: true, Reset_: true},
+				{
+					TargetUser: getCurrentUsername(t),
+					EnableVMD:  true,
+					Reset_:     true,
+				},
 			},
 			expScanCall: &storage.BdevScanRequest{},
 		},
@@ -587,11 +720,20 @@ func TestDaosServer_scanNVMe(t *testing.T) {
 			),
 			expPrepCalls: []storage.BdevPrepareRequest{
 				{
+					CleanSpdkHugepages: true,
+					CleanSpdkLockfiles: true,
+					PCIAllowList:       spaceSepMultiAddrList,
+				},
+				{
 					TargetUser:   getCurrentUsername(t),
 					EnableVMD:    true,
 					PCIAllowList: spaceSepMultiAddrList,
 				},
-				{CleanHugepagesOnly: true},
+				{
+					CleanSpdkHugepages: true,
+					CleanSpdkLockfiles: true,
+					PCIAllowList:       spaceSepMultiAddrList,
+				},
 			},
 			expResetCalls: []storage.BdevPrepareRequest{
 				{
@@ -620,11 +762,25 @@ func TestDaosServer_scanNVMe(t *testing.T) {
 				(&engine.Config{}).WithStorage(),
 			).WithDisableVMD(true),
 			expPrepCalls: []storage.BdevPrepareRequest{
-				{TargetUser: getCurrentUsername(t)},
-				{CleanHugepagesOnly: true},
+				{
+					CleanSpdkHugepages:    true,
+					CleanSpdkLockfiles:    true,
+					CleanSpdkLockfilesAny: true,
+				},
+				{
+					TargetUser: getCurrentUsername(t),
+				},
+				{
+					CleanSpdkHugepages:    true,
+					CleanSpdkLockfiles:    true,
+					CleanSpdkLockfilesAny: true,
+				},
 			},
 			expResetCalls: []storage.BdevPrepareRequest{
-				{TargetUser: getCurrentUsername(t), Reset_: true},
+				{
+					TargetUser: getCurrentUsername(t),
+					Reset_:     true,
+				},
 			},
 			expScanCall: &storage.BdevScanRequest{},
 		},
@@ -639,8 +795,20 @@ func TestDaosServer_scanNVMe(t *testing.T) {
 				},
 			},
 			expPrepCalls: []storage.BdevPrepareRequest{
-				{TargetUser: getCurrentUsername(t), EnableVMD: true},
-				{CleanHugepagesOnly: true},
+				{
+					CleanSpdkHugepages:    true,
+					CleanSpdkLockfiles:    true,
+					CleanSpdkLockfilesAny: true,
+				},
+				{
+					TargetUser: getCurrentUsername(t),
+					EnableVMD:  true,
+				},
+				{
+					CleanSpdkHugepages:    true,
+					CleanSpdkLockfiles:    true,
+					CleanSpdkLockfilesAny: true,
+				},
 			},
 			expResetCalls: []storage.BdevPrepareRequest{
 				{TargetUser: getCurrentUsername(t), EnableVMD: true, Reset_: true},
@@ -678,7 +846,7 @@ func TestDaosServer_scanNVMe(t *testing.T) {
 				return
 			}
 
-			if diff := cmp.Diff(tc.expScanResp, gotResp, cmpopt); diff != "" {
+			if diff := cmp.Diff(tc.expScanResp, gotResp, defPrepCmpOpt); diff != "" {
 				t.Fatalf("unexpected scan resp (-want, +got):\n%s\n", diff)
 			}
 
@@ -686,13 +854,13 @@ func TestDaosServer_scanNVMe(t *testing.T) {
 			if len(mbb.ScanCalls) != 1 {
 				t.Fatalf("unexpected number of scan calls, want 1 got %d", len(mbb.ScanCalls))
 			}
-			if diff := cmp.Diff(tc.expScanCall, &mbb.ScanCalls[0], cmpopt); diff != "" {
+			if diff := cmp.Diff(tc.expScanCall, &mbb.ScanCalls[0], defPrepCmpOpt); diff != "" {
 				t.Fatalf("unexpected scan calls (-want, +got):\n%s\n", diff)
 			}
-			if diff := cmp.Diff(tc.expPrepCalls, mbb.PrepareCalls, cmpopt); diff != "" {
+			if diff := cmp.Diff(tc.expPrepCalls, mbb.PrepareCalls, defPrepCmpOpt); diff != "" {
 				t.Fatalf("unexpected prepare calls (-want, +got):\n%s\n", diff)
 			}
-			if diff := cmp.Diff(tc.expResetCalls, mbb.ResetCalls, cmpopt); diff != "" {
+			if diff := cmp.Diff(tc.expResetCalls, mbb.ResetCalls, defPrepCmpOpt); diff != "" {
 				t.Fatalf("unexpected reset calls (-want, +got):\n%s\n", diff)
 			}
 			mbb.RUnlock()

--- a/src/control/common/file_utils.go
+++ b/src/control/common/file_utils.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -9,7 +10,6 @@ package common
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -24,27 +24,22 @@ import (
 // log message context refers to caller not callee.
 const UtilLogDepth = 4
 
-// GetFilePaths return full file paths in given directory with
-// matching file extensions
-func GetFilePaths(dir string, ext string) ([]string, error) {
-	files, err := ioutil.ReadDir(dir)
+// GetFilenames returns names of files in a directory.
+func GetFilenames(dir string) ([]string, error) {
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
-	extension := ext
-	// if extension has been provided without '.' prefix, add one
-	if filepath.Ext(ext) == "" {
-		extension = fmt.Sprintf(".%s", ext)
-	}
-	var matchingFiles []string
+
+	names := []string{}
 	for _, file := range files {
-		if filepath.Ext(file.Name()) == extension {
-			matchingFiles = append(
-				matchingFiles,
-				fmt.Sprintf("%s/%s", dir, file.Name()))
+		if file.IsDir() {
+			continue
 		}
+		names = append(names, file.Name())
 	}
-	return matchingFiles, nil
+
+	return names, nil
 }
 
 // TruncFile overrides existing or creates new file with default options

--- a/src/control/common/test/utils.go
+++ b/src/control/common/test/utils.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2018-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -252,6 +253,21 @@ func CreateTestDir(t *testing.T) (string, func()) {
 			t.Fatalf("Couldn't remove tmp dir: %v", err)
 		}
 	}
+}
+
+// RemoveContents removes contents of a directory.
+func RemoveContents(t *testing.T, dir string) error {
+	files, err := filepath.Glob(filepath.Join(dir, "*"))
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		err = os.RemoveAll(file)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // CreateTestFile creates a file in the given directory with a random name, and

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -63,6 +63,7 @@ const (
 	StorageTargetAlreadyMounted
 	StoragePathAccessDenied
 	StorageDeviceWithFsNoMountpoint
+	StorageHugepagesDisabled
 )
 
 // SCM fault codes
@@ -155,7 +156,6 @@ const (
 	ServerIncompatibleComponents
 	ServerNoCompatibilityInsecure
 	ServerPoolHasContainers
-	ServerHugepagesDisabled
 	ServerJoinReplaceEnabledPoolRank
 	ServerRankAdminExcluded
 )
@@ -197,6 +197,7 @@ const (
 	ServerConfigScmDiffClass
 	ServerConfigEngineBdevRolesMismatch
 	ServerConfigSysRsvdZero
+	ServerConfigBdevExcludeClash
 )
 
 // SPDK library bindings codes

--- a/src/control/lib/spdk/nvme_default.go
+++ b/src/control/lib/spdk/nvme_default.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2022-2023 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -43,6 +44,15 @@ func realRemove(name string) error {
 	return os.Remove(name)
 }
 
+// Clean implements the method of the same name for the Nvme interface on the NvmeImpl struct.
+func (n *NvmeImpl) Clean(log logging.Logger, pciAddrChecker LockfileAddrCheckFn) ([]string, error) {
+	if n == nil {
+		return nil, errors.New("nil NvmeImpl")
+	}
+
+	return cleanLockfiles(log, n.LocksDir, pciAddrChecker, realRemove)
+}
+
 // Discover NVMe devices, including NVMe devices behind VMDs if enabled,
 // accessible by SPDK on a given host.
 //
@@ -55,7 +65,7 @@ func (n *NvmeImpl) Discover(log logging.Logger) (storage.NvmeControllers, error)
 		return nil, errors.New("nil NvmeImpl")
 	}
 
-	ctrlrs, err := collectCtrlrs(C.nvme_discover(), "NVMe Discover(): C.nvme_discover")
+	ctrlrs, errCollect := collectCtrlrs(C.nvme_discover(), "NVMe Discover(): C.nvme_discover")
 
 	pciAddrs := make([]string, 0, len(ctrlrs))
 	for _, c := range ctrlrs {
@@ -63,7 +73,9 @@ func (n *NvmeImpl) Discover(log logging.Logger) (storage.NvmeControllers, error)
 		pciAddrs = append(pciAddrs, c.PciAddr)
 	}
 
-	return ctrlrs, wrapCleanError(err, cleanLockfiles(log, realRemove, pciAddrs...))
+	errRemLocks := cleanKnownLockfiles(log, n, pciAddrs...)
+
+	return ctrlrs, wrapCleanError(errCollect, errRemLocks)
 }
 
 // Format devices available through SPDK, destructive operation!
@@ -75,13 +87,15 @@ func (n *NvmeImpl) Format(log logging.Logger) ([]*FormatResult, error) {
 		return nil, errors.New("nil NvmeImpl")
 	}
 
-	results, err := collectFormatResults(C.nvme_wipe_namespaces(),
+	results, errCollect := collectFormatResults(C.nvme_wipe_namespaces(),
 		"NVMe Format(): C.nvme_wipe_namespaces()")
 
 	pciAddrs := resultPCIAddresses(results)
 	log.Debugf("formatted nvme ssds: %v", pciAddrs)
 
-	return results, wrapCleanError(err, cleanLockfiles(log, realRemove, pciAddrs...))
+	errRemLocks := cleanKnownLockfiles(log, n, pciAddrs...)
+
+	return results, wrapCleanError(errCollect, errRemLocks)
 }
 
 // Update updates the firmware image via SPDK in a given slot on the device.
@@ -98,10 +112,12 @@ func (n *NvmeImpl) Update(log logging.Logger, ctrlrPciAddr string, path string, 
 	csPci := C.CString(ctrlrPciAddr)
 	defer C.free(unsafe.Pointer(csPci))
 
-	_, err := collectCtrlrs(C.nvme_fwupdate(csPci, csPath, C.uint(slot)),
+	_, errCollect := collectCtrlrs(C.nvme_fwupdate(csPci, csPath, C.uint(slot)),
 		"NVMe Update(): C.nvme_fwupdate")
 
-	return wrapCleanError(err, cleanLockfiles(log, realRemove, ctrlrPciAddr))
+	errRemLocks := cleanKnownLockfiles(log, n, ctrlrPciAddr)
+
+	return wrapCleanError(errCollect, errRemLocks)
 }
 
 // c2GoController is a private translation function.

--- a/src/control/lib/spdk/nvme_stubs.go
+++ b/src/control/lib/spdk/nvme_stubs.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2022 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -26,4 +27,9 @@ func (n *NvmeImpl) Format(log logging.Logger) ([]*FormatResult, error) {
 // Update updates the firmware image via SPDK in a given slot on the device.
 func (n *NvmeImpl) Update(log logging.Logger, ctrlrPciAddr string, path string, slot int32) error {
 	return nil
+}
+
+// Clean removes SPDK lockfiles.
+func (n *NvmeImpl) Clean(log logging.Logger, pciAddrChecker LockfileAddrCheckFn) ([]string, error) {
+	return []string{}, nil
 }

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2018-2022 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -22,6 +23,11 @@ type Env interface {
 
 // EnvImpl is a an implementation of the Env interface.
 type EnvImpl struct{}
+
+// NewEnvImpl is a constructor for the EnvImpl implementation of the Env interface.
+func NewEnvImpl() *EnvImpl {
+	return &EnvImpl{}
+}
 
 // EnvOptions describe parameters to be used when initializing a processes
 // SPDK environment.

--- a/src/control/run_go_tests.sh
+++ b/src/control/run_go_tests.sh
@@ -167,7 +167,7 @@ $output
 
 function get_test_runner()
 {
-	test_args="-mod vendor -race -cover -v ./... -tags firmware,fault_injection"
+	test_args="-mod vendor -race -cover -v ./... -tags firmware,fault_injection,spdk"
 	test_runner="go test"
 
 	if which gotestsum >/dev/null; then

--- a/src/control/server/config/faults.go
+++ b/src/control/server/config/faults.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -110,6 +111,11 @@ var (
 		code.ServerConfigSysRsvdZero,
 		"`system_ram_reserved` is set to zero in server config",
 		"set `system_ram_reserved` to a positive integer value in config",
+	)
+	FaultConfigBdevExcludeClash = serverConfigFault(
+		code.ServerConfigBdevExcludeClash,
+		"'bdev_exclude' list includes address used in engine config bdev_list",
+		"make sure addresses excluded are not included in engine storage configs then restart daos_server",
 	)
 )
 

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -945,6 +946,13 @@ func TestServerConfig_Validation(t *testing.T) {
 					)
 			},
 			expErr: storage.FaultBdevConfigRolesNoControlMetadata,
+		},
+		"bdev_exclude addresses clash with bdev_list": {
+			extraConfig: func(c *Server) *Server {
+				c.BdevExclude = c.Engines[0].Storage.GetBdevs().Strings()
+				return c
+			},
+			expErr: FaultConfigBdevExcludeClash,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -242,8 +242,11 @@ func bdevScan(ctx context.Context, cs *ControlService, req *ctlpb.ScanNvmeReq, n
 	if req == nil {
 		return nil, errNilReq
 	}
-	if cs.srvCfg != nil && cs.srvCfg.DisableHugepages {
-		return nil, errors.New("cannot scan bdevs if hugepages have been disabled")
+	if cs.srvCfg == nil {
+		return nil, errNoSrvCfg
+	}
+	if cs.srvCfg.DisableHugepages {
+		return nil, storage.FaultHugepagesDisabled
 	}
 
 	defer func() {
@@ -252,7 +255,7 @@ func bdevScan(ctx context.Context, cs *ControlService, req *ctlpb.ScanNvmeReq, n
 		}
 	}()
 
-	bdevCfgs := getBdevCfgsFromSrvCfg(cs.srvCfg)
+	bdevCfgs := cs.srvCfg.GetBdevConfigs()
 	nrCfgBdevs := bdevCfgs.Bdevs().Len()
 
 	if nrCfgBdevs == 0 {
@@ -1057,7 +1060,7 @@ func (cs *ControlService) StorageNvmeRebind(ctx context.Context, req *ctlpb.Nvme
 		return nil, errNoSrvCfg
 	}
 	if cs.srvCfg.DisableHugepages {
-		return nil, FaultHugepagesDisabled
+		return nil, storage.FaultHugepagesDisabled
 	}
 
 	cu, err := user.Current()
@@ -1100,7 +1103,7 @@ func (cs *ControlService) StorageNvmeAddDevice(ctx context.Context, req *ctlpb.N
 		return nil, errNoSrvCfg
 	}
 	if cs.srvCfg.DisableHugepages {
-		return nil, FaultHugepagesDisabled
+		return nil, storage.FaultHugepagesDisabled
 	}
 
 	engines := cs.harness.Instances()

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -78,7 +78,7 @@ func TestServer_bdevScan(t *testing.T) {
 		"hugepages disabled": {
 			req:        &ctlpb.ScanNvmeReq{},
 			disableHPs: true,
-			expErr:     errors.New("hugepages have been disabled"),
+			expErr:     storage.FaultHugepagesDisabled,
 		},
 		"scan local; no bdevs in config; scan fails": {
 			req:         &ctlpb.ScanNvmeReq{Health: true},
@@ -1942,7 +1942,7 @@ func TestServer_CtlSvc_StorageNvmeRebind(t *testing.T) {
 			bmbc: &bdev.MockBackendConfig{
 				PrepareErr: errors.New("failure"),
 			},
-			expErr: FaultHugepagesDisabled,
+			expErr: storage.FaultHugepagesDisabled,
 		},
 		"success": {
 			req: &ctlpb.NvmeRebindReq{
@@ -2068,7 +2068,7 @@ func TestServer_CtlSvc_StorageNvmeAddDevice(t *testing.T) {
 						WithStorageClass(storage.ClassDcpm.String()),
 				},
 			},
-			expErr: FaultHugepagesDisabled,
+			expErr: storage.FaultHugepagesDisabled,
 		},
 		"missing bdev config index 0": {
 			req: &ctlpb.NvmeAddDeviceReq{

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -58,11 +58,6 @@ var (
 		"cannot destroy a pool with existing containers",
 		"retry the operation with the recursive flag set to remove containers along with the pool",
 	)
-	FaultHugepagesDisabled = serverFault(
-		code.ServerHugepagesDisabled,
-		"the use of hugepages has been disabled in the server config",
-		"set false (or remove) disable_hugepages parameter in config and reformat storage, then retry the operation",
-	)
 )
 
 func FaultPoolInvalidServiceReps(maxSvcReps uint32) *fault.Fault {

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -572,16 +572,16 @@ func registerEngineEventCallbacks(srv *server, engine *EngineInstance, allStarte
 	engine.OnInstanceExit(createPublishInstanceExitFunc(srv.pubSub.Publish, srv.hostname))
 
 	engine.OnInstanceExit(func(_ context.Context, _ uint32, _ ranklist.Rank, _ error, _ int) error {
-		if engine.storage.BdevRoleMetaConfigured() {
-			return engine.storage.UnmountTmpfs()
-		}
-
 		storageCfg := engine.runner.GetConfig().Storage
 		pciAddrs := storageCfg.Tiers.NVMeBdevs().Devices()
 
 		if err := cleanSpdkResources(srv, pciAddrs); err != nil {
 			srv.log.Error(
 				errors.Wrapf(err, "engine instance %d", engine.Index()).Error())
+		}
+
+		if engine.storage.BdevRoleMetaConfigured() {
+			return engine.storage.UnmountTmpfs()
 		}
 
 		return nil

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -99,15 +100,6 @@ func resolveFirstAddr(addr string, lookup ipLookupFn) (*net.TCPAddr, error) {
 	})
 
 	return &net.TCPAddr{IP: addrs[0], Port: iPort}, nil
-}
-
-func getBdevCfgsFromSrvCfg(cfg *config.Server) storage.TierConfigs {
-	var bdevCfgs storage.TierConfigs
-	for _, engineCfg := range cfg.Engines {
-		bdevCfgs = append(bdevCfgs, engineCfg.Storage.Tiers.BdevConfigs()...)
-	}
-
-	return bdevCfgs
 }
 
 func cfgGetReplicas(cfg *config.Server, lookup ipLookupFn) ([]*net.TCPAddr, error) {
@@ -304,7 +296,7 @@ func getEngineNUMANodes(log logging.Logger, engineCfgs []*engine.Config) ([]stri
 
 // Prepare bdev storage. Assumes validation has already been performed on server config. Hugepages
 // are required for both emulated (AIO devices) and real NVMe bdevs. VFIO and IOMMU are not
-// required for emulated NVMe.
+// mandatory requirements for emulated NVMe.
 func prepBdevStorage(srv *server, iommuEnabled bool) error {
 	defer srv.logDuration(track("time to prepare bdev storage"))
 
@@ -313,7 +305,7 @@ func prepBdevStorage(srv *server, iommuEnabled bool) error {
 		return nil
 	}
 
-	bdevCfgs := getBdevCfgsFromSrvCfg(srv.cfg)
+	bdevCfgs := srv.cfg.GetBdevConfigs()
 
 	// Perform these checks only if non-emulated NVMe is used and user is unprivileged.
 	if bdevCfgs.HaveRealNVMe() && srv.runningUser.Username != "root" {
@@ -325,13 +317,19 @@ func prepBdevStorage(srv *server, iommuEnabled bool) error {
 		}
 	}
 
+	// Clean leftover SPDK hugepages and lockfiles for configured NVMe SSDs before prepare.
+	pciAddrs := bdevCfgs.NVMeBdevs().Devices()
+	if err := cleanSpdkResources(srv, pciAddrs); err != nil {
+		srv.log.Error(errors.Wrap(err, "prepBdevStorage").Error())
+	}
+
 	// When requesting to prepare NVMe drives during service start-up, use all addresses
 	// specified in engine config BdevList parameters as the PCIAllowList and the server
 	// config BdevExclude parameter as the PCIBlockList.
 
 	prepReq := storage.BdevPrepareRequest{
 		TargetUser:   srv.runningUser.Username,
-		PCIAllowList: strings.Join(bdevCfgs.NVMeBdevs().Devices(), storage.BdevPciAddrSep),
+		PCIAllowList: strings.Join(pciAddrs, storage.BdevPciAddrSep),
 		PCIBlockList: strings.Join(srv.cfg.BdevExclude, storage.BdevPciAddrSep),
 		DisableVFIO:  srv.cfg.DisableVFIO,
 	}
@@ -463,19 +461,30 @@ func updateHugeMemValues(srv *server, ei *EngineInstance, mi *common.MemInfo) er
 	return nil
 }
 
-func cleanEngineHugepages(srv *server) error {
-	req := storage.BdevPrepareRequest{
-		CleanHugepagesOnly: true,
+// Clean SPDK resources, both lockfiles and orphaned hugepages. Orphaned hugepages will be cleaned
+// whether or not device PCI addresses are supplied.
+func cleanSpdkResources(srv *server, pciAddrs []string) error {
+	// For the moment assume that both lockfile and hugepage cleanup should be skipped if
+	// hugepages have been disabled in the server config.
+	if srv.cfg.DisableHugepages {
+		return nil
 	}
 
-	msg := "cleanup hugepages via bdev backend"
+	req := storage.BdevPrepareRequest{
+		CleanSpdkHugepages: true,
+		CleanSpdkLockfiles: true,
+		PCIAllowList:       strings.Join(pciAddrs, storage.BdevPciAddrSep),
+	}
+
+	msg := "cleanup spdk resources"
 
 	resp, err := srv.ctlSvc.NvmePrepare(req)
 	if err != nil {
 		return errors.Wrap(err, msg)
 	}
 
-	srv.log.Debugf("%s: %d removed", msg, resp.NrHugepagesRemoved)
+	srv.log.Debugf("%s: %d hugepages and lockfiles %v removed", msg,
+		resp.NrHugepagesRemoved, resp.LockfilesRemoved)
 
 	return nil
 }
@@ -566,6 +575,15 @@ func registerEngineEventCallbacks(srv *server, engine *EngineInstance, allStarte
 		if engine.storage.BdevRoleMetaConfigured() {
 			return engine.storage.UnmountTmpfs()
 		}
+
+		storageCfg := engine.runner.GetConfig().Storage
+		pciAddrs := storageCfg.Tiers.NVMeBdevs().Devices()
+
+		if err := cleanSpdkResources(srv, pciAddrs); err != nil {
+			srv.log.Error(
+				errors.Wrapf(err, "engine instance %d", engine.Index()).Error())
+		}
+
 		return nil
 	})
 
@@ -586,11 +604,12 @@ func registerEngineEventCallbacks(srv *server, engine *EngineInstance, allStarte
 	engine.OnStorageReady(func(_ context.Context) error {
 		srv.log.Debugf("engine %d: storage ready", engine.Index())
 
-		if !srv.cfg.DisableHugepages {
-			// Attempt to remove unused hugepages, log error only.
-			if err := cleanEngineHugepages(srv); err != nil {
-				srv.log.Errorf(err.Error())
-			}
+		storageCfg := engine.runner.GetConfig().Storage
+		pciAddrs := storageCfg.Tiers.NVMeBdevs().Devices()
+
+		if err := cleanSpdkResources(srv, pciAddrs); err != nil {
+			srv.log.Error(
+				errors.Wrapf(err, "engine instance %d", engine.Index()).Error())
 		}
 
 		// Retrieve up-to-date meminfo to check resource availability.

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -295,6 +296,28 @@ func TestServer_prepBdevStorage(t *testing.T) {
 	if username == "root" {
 		t.Fatal("prepBdevStorage tests cannot be run as root user")
 	}
+	prepCmpOpt := cmp.Comparer(func(x, y *storage.BdevDeviceList) bool {
+		if x == nil && y == nil {
+			return true
+		}
+		return x.Equals(y)
+	})
+	defClean := storage.BdevPrepareRequest{
+		CleanSpdkHugepages: true,
+		CleanSpdkLockfiles: true,
+	}
+	defCleanSingleEngine := storage.BdevPrepareRequest{
+		CleanSpdkHugepages: true,
+		CleanSpdkLockfiles: true,
+		PCIAllowList:       test.MockPCIAddr(0),
+	}
+	defCleanDualEngine := storage.BdevPrepareRequest{
+		CleanSpdkHugepages: true,
+		CleanSpdkLockfiles: true,
+		PCIAllowList: strings.Join([]string{
+			test.MockPCIAddr(0), test.MockPCIAddr(1),
+		}, storage.BdevPciAddrSep),
+	}
 
 	for name, tc := range map[string]struct {
 		iommuDisabled   bool
@@ -303,7 +326,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 		bmbc            *bdev.MockBackendConfig
 		overrideUser    string
 		expPrepErr      error
-		expPrepCall     *storage.BdevPrepareRequest
+		expPrepCalls    []storage.BdevPrepareRequest
 		expMemChkErr    error
 		expMemSize      int
 		expHugepageSize int
@@ -323,12 +346,15 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			},
 			overrideUser:  "root",
 			hugepagesFree: 8192,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 8194,
-				HugeNodes:     "0",
-				TargetUser:    "root",
-				DisableVFIO:   true,
-				PCIAllowList:  test.MockPCIAddr(0),
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defCleanSingleEngine,
+				{
+					HugepageCount: 8194,
+					HugeNodes:     "0",
+					TargetUser:    "root",
+					DisableVFIO:   true,
+					PCIAllowList:  test.MockPCIAddr(0),
+				},
 			},
 			expMemSize:      16384,
 			expHugepageSize: 2,
@@ -339,11 +365,14 @@ func TestServer_prepBdevStorage(t *testing.T) {
 					WithEngines(pmemFakeNvmeEngine(0))
 			},
 			hugepagesFree: 8192,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 8194,
-				HugeNodes:     "0",
-				TargetUser:    username,
-				DisableVFIO:   true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defClean,
+				{
+					HugepageCount: 8194,
+					HugeNodes:     "0",
+					TargetUser:    username,
+					DisableVFIO:   true,
+				},
 			},
 			expMemSize:      16384,
 			expHugepageSize: 2,
@@ -362,11 +391,14 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			},
 			overrideUser:  "root",
 			hugepagesFree: 8192,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 8194,
-				HugeNodes:     "0",
-				TargetUser:    "root",
-				PCIAllowList:  test.MockPCIAddr(0),
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defCleanSingleEngine,
+				{
+					HugepageCount: 8194,
+					HugeNodes:     "0",
+					TargetUser:    "root",
+					PCIAllowList:  test.MockPCIAddr(0),
+				},
 			},
 			expMemSize:      16384,
 			expHugepageSize: 2,
@@ -377,10 +409,13 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				return sc.WithEngines(pmemFakeNvmeEngine(0))
 			},
 			hugepagesFree: 8192,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 8194,
-				HugeNodes:     "0",
-				TargetUser:    username,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defClean,
+				{
+					HugepageCount: 8194,
+					HugeNodes:     "0",
+					TargetUser:    username,
+				},
 			},
 			expMemSize:      16384,
 			expHugepageSize: 2,
@@ -396,10 +431,13 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				return sc.WithNrHugepages(0).
 					WithEngines(pmemOnlyEngine(0), pmemOnlyEngine(1))
 			},
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: scanMinHugepageCount,
-				TargetUser:    username,
-				EnableVMD:     true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defClean,
+				{
+					HugepageCount: scanMinHugepageCount,
+					TargetUser:    username,
+					EnableVMD:     true,
+				},
 			},
 		},
 		"no bdevs configured; nr_hugepages set": {
@@ -407,27 +445,33 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				return sc.WithNrHugepages(1024).
 					WithEngines(pmemOnlyEngine(0), pmemOnlyEngine(1))
 			},
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 1024,
-				TargetUser:    username,
-				EnableVMD:     true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defClean,
+				{
+					HugepageCount: 1024,
+					TargetUser:    username,
+					EnableVMD:     true,
+				},
 			},
 		},
 		"2 engines both numa 0; hugepage alloc only on numa 0": {
 			srvCfgExtra: func(sc *config.Server) *config.Server {
 				return sc.WithNrHugepages(16384).
 					WithEngines(pmemEngine(0), pmemEngine(1).WithPinnedNumaNode(0)).
-					WithBdevExclude(test.MockPCIAddr(1))
+					WithBdevExclude(test.MockPCIAddr(3))
 			},
 			hugepagesFree: 16384,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 16388, // 2 extra huge pages requested per engine
-				HugeNodes:     "0",
-				TargetUser:    username,
-				PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(0),
-					storage.BdevPciAddrSep, test.MockPCIAddr(1)),
-				PCIBlockList: test.MockPCIAddr(1),
-				EnableVMD:    true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defCleanDualEngine,
+				{
+					HugepageCount: 16388, // 2 extra huge pages requested per engine
+					HugeNodes:     "0",
+					TargetUser:    username,
+					PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(0),
+						storage.BdevPciAddrSep, test.MockPCIAddr(1)),
+					PCIBlockList: test.MockPCIAddr(3),
+					EnableVMD:    true,
+				},
 			},
 			expMemSize:      16384, // (16384 hugepages / 2 engines) * 2mib size
 			expHugepageSize: 2,
@@ -440,13 +484,16 @@ func TestServer_prepBdevStorage(t *testing.T) {
 					WithEngines(pmemEngine(0).WithPinnedNumaNode(1), pmemEngine(1))
 			},
 			hugepagesFree: 16384,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 16388, // 2 extra huge pages requested per engine
-				HugeNodes:     "1",
-				TargetUser:    username,
-				PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(0),
-					storage.BdevPciAddrSep, test.MockPCIAddr(1)),
-				EnableVMD: true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defCleanDualEngine,
+				{
+					HugepageCount: 16388, // 2 extra huge pages requested per engine
+					HugeNodes:     "1",
+					TargetUser:    username,
+					PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(0),
+						storage.BdevPciAddrSep, test.MockPCIAddr(1)),
+					EnableVMD: true,
+				},
 			},
 			expMemSize:      16384, // (16384 hugepages / 2 engines) * 2mib size
 			expHugepageSize: 2,
@@ -459,13 +506,16 @@ func TestServer_prepBdevStorage(t *testing.T) {
 					WithEngines(pmemEngine(0), pmemEngine(1))
 			},
 			hugepagesFree: 16384,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 8194, // 2 extra huge pages requested per engine
-				HugeNodes:     "0,1",
-				TargetUser:    username,
-				PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(0),
-					storage.BdevPciAddrSep, test.MockPCIAddr(1)),
-				EnableVMD: true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defCleanDualEngine,
+				{
+					HugepageCount: 8194, // 2 extra huge pages requested per engine
+					HugeNodes:     "0,1",
+					TargetUser:    username,
+					PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(0),
+						storage.BdevPciAddrSep, test.MockPCIAddr(1)),
+					EnableVMD: true,
+				},
 			},
 			expMemSize:      16384, // (16384 hugepages / 2 engines) * 2mib size
 			expHugepageSize: 2,
@@ -476,13 +526,16 @@ func TestServer_prepBdevStorage(t *testing.T) {
 					WithEngines(pmemEngine(0), pmemEngine(1))
 			},
 			hugepagesFree: 8191,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 8194, // 2 extra huge pages requested per engine
-				HugeNodes:     "0,1",
-				TargetUser:    username,
-				PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(0),
-					storage.BdevPciAddrSep, test.MockPCIAddr(1)),
-				EnableVMD: true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defCleanDualEngine,
+				{
+					HugepageCount: 8194, // 2 extra huge pages requested per engine
+					HugeNodes:     "0,1",
+					TargetUser:    username,
+					PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(0),
+						storage.BdevPciAddrSep, test.MockPCIAddr(1)),
+					EnableVMD: true,
+				},
 			},
 			// mem_size engine parameter reflects lower "free" value
 			expMemSize:      16382, // (16382 hugepages free / 2 engines) * 2mib size
@@ -493,35 +546,47 @@ func TestServer_prepBdevStorage(t *testing.T) {
 		},
 		"2 engines; scm only; nr_hugepages unset": {
 			hugepagesFree: 128,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 128,
-				TargetUser:    username,
-				EnableVMD:     true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defClean,
+				{
+					HugepageCount: 128,
+					TargetUser:    username,
+					EnableVMD:     true,
+				},
 			},
 		},
 		"2 engines; scm only; nr_hugepages unset; insufficient free": {
 			hugepagesFree: 0,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 128,
-				TargetUser:    username,
-				EnableVMD:     true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defClean,
+				{
+					HugepageCount: 128,
+					TargetUser:    username,
+					EnableVMD:     true,
+				},
 			},
 			expMemChkErr: errors.New("requested 128 hugepages; got 0"),
 		},
 		"0 engines; nr_hugepages unset": {
 			hugepagesFree: 128,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 128,
-				TargetUser:    username,
-				EnableVMD:     true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defClean,
+				{
+					HugepageCount: 128,
+					TargetUser:    username,
+					EnableVMD:     true,
+				},
 			},
 		},
 		"0 engines; nr_hugepages unset; insufficient free": {
 			hugepagesFree: 0,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 128,
-				TargetUser:    username,
-				EnableVMD:     true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defClean,
+				{
+					HugepageCount: 128,
+					TargetUser:    username,
+					EnableVMD:     true,
+				},
 			},
 			expMemChkErr: errors.New("requested 128 hugepages; got 0"),
 		},
@@ -530,20 +595,23 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			srvCfgExtra: func(sc *config.Server) *config.Server {
 				return sc.WithNrHugepages(16384).
 					WithEngines(pmemEngine(0), pmemEngine(1)).
-					WithBdevExclude(test.MockPCIAddr(1))
+					WithBdevExclude(test.MockPCIAddr(3))
 			},
 			hugepagesFree: 16384,
 			bmbc: &bdev.MockBackendConfig{
 				ResetErr: errors.New("backed prep reset failed"),
 			},
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 8194, // hugepages per engine plus 2 extra
-				HugeNodes:     "0,1",
-				TargetUser:    username,
-				PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(0),
-					storage.BdevPciAddrSep, test.MockPCIAddr(1)),
-				PCIBlockList: test.MockPCIAddr(1),
-				EnableVMD:    true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defCleanDualEngine,
+				{
+					HugepageCount: 8194, // hugepages per engine plus 2 extra
+					HugeNodes:     "0,1",
+					TargetUser:    username,
+					PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(0),
+						storage.BdevPciAddrSep, test.MockPCIAddr(1)),
+					PCIBlockList: test.MockPCIAddr(3),
+					EnableVMD:    true,
+				},
 			},
 			expMemSize:      16384, // (16384 hugepages / 2 engines) * 2mib size
 			expHugepageSize: 2,
@@ -556,12 +624,15 @@ func TestServer_prepBdevStorage(t *testing.T) {
 					WithDisableVMD(true)
 			},
 			hugepagesFree: 16384,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 8194, // hugepages per engine plus 2 extra
-				HugeNodes:     "0,1",
-				TargetUser:    username,
-				PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(0),
-					storage.BdevPciAddrSep, test.MockPCIAddr(1)),
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defCleanDualEngine,
+				{
+					HugepageCount: 8194, // hugepages per engine plus 2 extra
+					HugeNodes:     "0,1",
+					TargetUser:    username,
+					PCIAllowList: fmt.Sprintf("%s%s%s", test.MockPCIAddr(0),
+						storage.BdevPciAddrSep, test.MockPCIAddr(1)),
+				},
 			},
 			expMemSize:      16384, // (16384 hugepages / 2 engines) * 2mib size
 			expHugepageSize: 2,
@@ -573,10 +644,13 @@ func TestServer_prepBdevStorage(t *testing.T) {
 					WithEngines(pmemFakeNvmeEngine(0))
 			},
 			hugepagesFree: 8194,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 8194, // hugepages per engine plus 2 extra
-				HugeNodes:     "0",
-				TargetUser:    username,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				defClean,
+				{
+					HugepageCount: 8194, // hugepages per engine plus 2 extra
+					HugeNodes:     "0",
+					TargetUser:    username,
+				},
 			},
 			expMemSize:      16384, // 8192 hugepages * 2mib size
 			expHugepageSize: 2,
@@ -599,13 +673,23 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				)
 			},
 			hugepagesFree: 16384,
-			expPrepCall: &storage.BdevPrepareRequest{
-				HugepageCount: 8196, // hugepages plus 2 extra per engine
-				HugeNodes:     "0,1",
-				TargetUser:    username,
-				PCIAllowList: strings.Join(test.MockPCIAddrs(0, 1, 2, 3),
-					storage.BdevPciAddrSep),
-				EnableVMD: true,
+			expPrepCalls: []storage.BdevPrepareRequest{
+				{
+					CleanSpdkHugepages: true,
+					CleanSpdkLockfiles: true,
+					PCIAllowList: strings.Join([]string{
+						test.MockPCIAddr(0), test.MockPCIAddr(1), test.MockPCIAddr(2),
+						test.MockPCIAddr(3),
+					}, storage.BdevPciAddrSep),
+				},
+				{
+					HugepageCount: 8196, // hugepages plus 2 extra per engine
+					HugeNodes:     "0,1",
+					TargetUser:    username,
+					PCIAllowList: strings.Join(test.MockPCIAddrs(0, 1, 2, 3),
+						storage.BdevPciAddrSep),
+					EnableVMD: true,
+				},
 			},
 			expMemSize:      8192, // 16384 pages * 2mib divided by 4 engines
 			expHugepageSize: 2,
@@ -626,6 +710,16 @@ func TestServer_prepBdevStorage(t *testing.T) {
 						WithPinnedNumaNode(1).WithFabricInterface("ib1").
 						WithTargetCount(8).WithStorage(pmemTier(3), nvmeTier(3)),
 				)
+			},
+			expPrepCalls: []storage.BdevPrepareRequest{
+				{
+					CleanSpdkHugepages: true,
+					CleanSpdkLockfiles: true,
+					PCIAllowList: strings.Join([]string{
+						test.MockPCIAddr(0), test.MockPCIAddr(1), test.MockPCIAddr(2),
+						test.MockPCIAddr(3),
+					}, storage.BdevPciAddrSep),
+				},
 			},
 			expPrepErr: errors.New("uneven distribution"),
 		},
@@ -703,15 +797,12 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			gotPrepErr := prepBdevStorage(srv, !tc.iommuDisabled)
 
 			mbb.RLock()
-			if tc.expPrepCall != nil {
-				if len(mbb.PrepareCalls) != 1 {
-					t.Fatalf("expected prepare to be called once")
-				}
-				if diff := cmp.Diff(*tc.expPrepCall, mbb.PrepareCalls[0]); diff != "" {
-					t.Fatalf("unexpected prepare calls (-want, +got):\n%s\n", diff)
-				}
-			} else if len(mbb.PrepareCalls) != 0 {
-				t.Fatalf("expected prepare not to be called")
+			if diff := cmp.Diff(tc.expPrepCalls, mbb.PrepareCalls, prepCmpOpt); diff != "" {
+				t.Fatalf("unexpected prepare calls (-want, +got):\n%s\n", diff)
+			}
+			if len(mbb.ResetCalls) != 0 {
+				t.Fatalf("unexpected number of reset calls, want 0 got %d",
+					len(mbb.ResetCalls))
 			}
 			mbb.RUnlock()
 
@@ -747,6 +838,128 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				txtMod)
 			test.AssertEqual(t, tc.expNotice, strings.Contains(buf.String(), "NOTICE"),
 				msg)
+		})
+	}
+}
+
+func TestServer_cleanEngineSpdkResources(t *testing.T) {
+	for name, tc := range map[string]struct {
+		srvCfgExtra func(*config.Server) *config.Server
+		bmbc        *bdev.MockBackendConfig
+		expErr      error
+		expPrepCall *storage.BdevPrepareRequest
+	}{
+		"bdevs configured; hugepages disabled": {
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithDisableHugepages(true).
+					WithEngines(pmemEngine(1))
+			},
+			// Returns early so no prep call.
+		},
+		"no bdevs configured": {
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithEngines(pmemOnlyEngine(1))
+			},
+			bmbc: &bdev.MockBackendConfig{},
+			expPrepCall: &storage.BdevPrepareRequest{
+				CleanSpdkHugepages: true,
+				CleanSpdkLockfiles: true,
+			},
+		},
+		"bdev resources cleaned": {
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithEngines(pmemEngine(1))
+			},
+			bmbc: &bdev.MockBackendConfig{},
+			expPrepCall: &storage.BdevPrepareRequest{
+				CleanSpdkHugepages: true,
+				CleanSpdkLockfiles: true,
+				PCIAllowList:       test.MockPCIAddr(1),
+			},
+		},
+		"bdev resources cleaned; multiple ssds": {
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithEngines(
+					basicEngineCfg(1).WithTargetCount(16).
+						WithStorage(pmemTier(1),
+							storage.NewTierConfig().
+								WithStorageClass(storage.ClassNvme.String()).
+								WithBdevDeviceList(
+									test.MockPCIAddr(int32(1)),
+									test.MockPCIAddr(int32(2)))))
+			},
+			bmbc: &bdev.MockBackendConfig{},
+			expPrepCall: &storage.BdevPrepareRequest{
+				CleanSpdkHugepages: true,
+				CleanSpdkLockfiles: true,
+				PCIAllowList: strings.Join([]string{
+					test.MockPCIAddr(1), test.MockPCIAddr(2),
+				}, storage.BdevPciAddrSep),
+			},
+		},
+		"bdev resources clean fails": {
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithEngines(pmemEngine(1))
+			},
+			bmbc: &bdev.MockBackendConfig{
+				ResetErr: errors.New("backed prep reset failed"),
+			},
+			expPrepCall: &storage.BdevPrepareRequest{
+				CleanSpdkHugepages: true,
+				CleanSpdkLockfiles: true,
+				PCIAllowList:       test.MockPCIAddr(1),
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(name)
+			defer test.ShowBufferOnFailure(t, buf)
+
+			cfg := config.DefaultServer().
+				WithFabricProvider("ofi+verbs")
+			if tc.srvCfgExtra != nil {
+				cfg = tc.srvCfgExtra(cfg)
+			}
+
+			srv, err := newServer(log, cfg, &system.FaultDomain{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			mbb := bdev.NewMockBackend(tc.bmbc)
+			mbp := bdev.NewProvider(log, mbb)
+			sp := sysprov.NewMockSysProvider(log, nil)
+
+			srv.ctlSvc = &ControlService{
+				StorageControlService: *NewMockStorageControlService(log, nil,
+					sp, scm.NewProvider(log, scm.NewMockBackend(nil), sp, nil),
+					mbp, nil),
+				srvCfg: cfg,
+			}
+
+			if len(srv.cfg.Engines) == 0 {
+				t.Fatal("zero engines configured")
+			}
+
+			runner := engine.NewRunner(log, srv.cfg.Engines[0])
+			ei := NewEngineInstance(log, srv.ctlSvc.storage, nil, runner, nil)
+			storageCfg := ei.runner.GetConfig().Storage
+			pciAddrs := storageCfg.Tiers.NVMeBdevs().Devices()
+
+			test.CmpErr(t, tc.expErr, cleanSpdkResources(srv, pciAddrs))
+
+			mbb.RLock()
+			if tc.expPrepCall != nil {
+				if len(mbb.PrepareCalls) != 1 {
+					t.Fatalf("expected prepare to be called once")
+				}
+				if diff := cmp.Diff(*tc.expPrepCall, mbb.PrepareCalls[0]); diff != "" {
+					t.Fatalf("unexpected prepare calls (-want, +got):\n%s\n", diff)
+				}
+			} else if len(mbb.PrepareCalls) != 0 {
+				t.Fatalf("expected prepare not to be called")
+			}
+			mbb.RUnlock()
 		})
 	}
 }

--- a/src/control/server/storage/bdev.go
+++ b/src/control/server/storage/bdev.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -492,20 +493,23 @@ type (
 	// BdevPrepareRequest defines the parameters for a Prepare operation.
 	BdevPrepareRequest struct {
 		pbin.ForwardableRequest
-		HugepageCount      int
-		HugeNodes          string
-		CleanHugepagesOnly bool
-		PCIAllowList       string
-		PCIBlockList       string
-		TargetUser         string
-		Reset_             bool
-		DisableVFIO        bool
-		EnableVMD          bool
+		HugepageCount         int
+		HugeNodes             string
+		CleanSpdkHugepages    bool
+		CleanSpdkLockfiles    bool
+		CleanSpdkLockfilesAny bool
+		PCIAllowList          string
+		PCIBlockList          string
+		TargetUser            string
+		Reset_                bool
+		DisableVFIO           bool
+		EnableVMD             bool
 	}
 
 	// BdevPrepareResponse contains the results of a successful Prepare operation.
 	BdevPrepareResponse struct {
 		NrHugepagesRemoved uint
+		LockfilesRemoved   []string
 		VMDPrepared        bool
 	}
 

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -103,9 +104,12 @@ func (w *spdkWrapper) init(log logging.Logger, spdkOpts *spdk.EnvOptions) (resto
 
 func newBackend(log logging.Logger, sr *spdkSetupScript) *spdkBackend {
 	return &spdkBackend{
-		log:     log,
-		binding: &spdkWrapper{Env: &spdk.EnvImpl{}, Nvme: &spdk.NvmeImpl{}},
-		script:  sr,
+		log: log,
+		binding: &spdkWrapper{
+			Env:  spdk.NewEnvImpl(),
+			Nvme: spdk.NewNvmeImpl(),
+		},
+		script: sr,
 	}
 }
 
@@ -113,6 +117,8 @@ func defaultBackend(log logging.Logger) *spdkBackend {
 	return newBackend(log, defaultScriptRunner(log))
 }
 
+// Returns true if PID file matching input string is found in /proc/ directory indicating related
+// active process exists.
 func isPIDActive(pidStr string, stat statFn) (bool, error) {
 	filename := fmt.Sprintf("/proc/%s", pidStr)
 
@@ -153,8 +159,8 @@ func createHugepageWalkFunc(log logging.Logger, topDir string, stat statFn, remo
 		// PID string will be the first submatch at index 1 of the match results.
 
 		if isActive, err := isPIDActive(matches[1], stat); err != nil || isActive {
-			log.Debugf("walk func: active owner proc, skipping %s", path)
-			return err // skip files created by an existing process (isActive == true)
+			log.Tracef("spdk hugepage-clean walk: active owner proc, skipping %s", path)
+			return err
 		}
 
 		log.Debugf("walk func: removing %s", path)
@@ -190,29 +196,120 @@ func logNUMAStats(log logging.Logger) {
 	log.Debugf("run cmd numastat -m: %s", toLog)
 }
 
+// For nontrivial VMD case remove lockfiles with backing device addresses by parsing file names to
+// evaluate whether they refer to a given VMD address supplied in resultant allowed list. Do this by
+// creating an address check function which will verify if a given backing device PCI address matches
+// any VMD domain address contained in the input allowed list set. If nil allow list is supplied,
+// return true always.
+func createSpdkLockfileAddrCheckFunc(allowed *hardware.PCIAddressSet) spdk.LockfileAddrCheckFn {
+	if allowed == nil {
+		return nil
+	}
+
+	return func(pciAddr string) (bool, error) {
+		addrOrig, err := hardware.NewPCIAddress(pciAddr)
+		if err != nil {
+			return false, errors.Wrap(err, "controller pci address invalid")
+		}
+
+		addr, err := addrOrig.BackingToVMDAddress()
+		if err != nil {
+			if err != hardware.ErrNotVMDBackingAddress {
+				return false, err
+			}
+			addr = addrOrig
+		}
+
+		return allowed.Contains(addr), nil
+	}
+}
+
+func spdkLockfileAddrCheckAllowAll(_ string) (bool, error) {
+	return true, nil
+}
+
+// Skip addresses in block list if present then supply address check function that can detect VMD
+// backing device addresses during clean operation. If CleanSpdkLockfilesAny set, all lockfiles
+// should be removed.
+func (sb *spdkBackend) removeSpdkLockfiles(req storage.BdevPrepareRequest, resp *storage.BdevPrepareResponse) error {
+	var lfAddrCheckFn spdk.LockfileAddrCheckFn
+
+	if req.CleanSpdkLockfilesAny {
+		// Remove all lockfiles.
+		lfAddrCheckFn = spdkLockfileAddrCheckAllowAll
+	} else {
+		inAllowList, err := hardware.NewPCIAddressSetFromString(req.PCIAllowList)
+		if err != nil {
+			return err
+		}
+		inBlockList, err := hardware.NewPCIAddressSetFromString(req.PCIBlockList)
+		if err != nil {
+			return err
+		}
+
+		// Remove blocked VMD addresses from allow list.
+		allowedAddresses := inAllowList.Difference(inBlockList)
+
+		if allowedAddresses.IsEmpty() {
+			sb.log.Debug("clean spdk lockfiles skipped, zero devices selected")
+			return nil
+		}
+		sb.log.Debugf("clean spdk lockfiles for devices %v", allowedAddresses)
+
+		lfAddrCheckFn = createSpdkLockfileAddrCheckFunc(allowedAddresses)
+	}
+
+	locksRemoved, err := sb.binding.Clean(sb.log, lfAddrCheckFn)
+	if err != nil {
+		return err
+	}
+	resp.LockfilesRemoved = locksRemoved
+
+	return nil
+}
+
+// Remove hugepages that were created by a no-longer-active SPDK process. Note that when running
+// prepare, it's unlikely that any SPDK processes are active as this is performed prior to starting
+// engines.
+func (sb *spdkBackend) removeSpdkHugepages(req storage.BdevPrepareRequest, hpClean hpCleanFn, resp *storage.BdevPrepareResponse) error {
+	nrRemoved, err := hpClean(sb.log, hugepageDir)
+	if err != nil {
+		return err
+	}
+	resp.NrHugepagesRemoved = nrRemoved
+	logNUMAStats(sb.log)
+
+	return nil
+}
+
 // prepare receives function pointers for external interfaces.
 func (sb *spdkBackend) prepare(req storage.BdevPrepareRequest, vmdDetect vmdDetectFn, hpClean hpCleanFn) (*storage.BdevPrepareResponse, error) {
 	resp := &storage.BdevPrepareResponse{}
-
-	if req.CleanHugepagesOnly {
-		// Remove hugepages that were created by a no-longer-active SPDK process. Note that
-		// when running prepare, it's unlikely that any SPDK processes are active as this
-		// is performed prior to starting engines.
-		nrRemoved, err := hpClean(sb.log, hugepageDir)
-		if err != nil {
-			return resp, errors.Wrapf(err, "clean spdk hugepages")
-		}
-		resp.NrHugepagesRemoved = nrRemoved
-
-		logNUMAStats(sb.log)
-
-		return resp, nil
-	}
 
 	// Update request if VMD has been explicitly enabled and there are VMD endpoints configured.
 	if err := updatePrepareRequest(sb.log, &req, vmdDetect); err != nil {
 		return resp, errors.Wrapf(err, "update prepare request")
 	}
+
+	// Process a clean request, treated as exclusive and not compatible with backend prepare or
+	// reset.
+	if req.CleanSpdkHugepages || req.CleanSpdkLockfiles {
+		sb.log.Debugf("spdk backend: received a prepare-clean request: %+v", req)
+
+		if req.CleanSpdkHugepages {
+			if err := sb.removeSpdkHugepages(req, hpClean, resp); err != nil {
+				return resp, errors.Wrapf(err, "clean spdk hugepages")
+			}
+		}
+		if req.CleanSpdkLockfiles {
+			if err := sb.removeSpdkLockfiles(req, resp); err != nil {
+				return resp, errors.Wrapf(err, "clean spdk lockfiles")
+			}
+		}
+
+		return resp, nil
+	}
+
 	resp.VMDPrepared = req.EnableVMD
 
 	// Before preparing, reset device bindings.
@@ -250,8 +347,6 @@ func (sb *spdkBackend) reset(req storage.BdevPrepareRequest, vmdDetect vmdDetect
 // Reset will perform a lookup on the requested target user to validate existence
 // then reset non-VMD NVMe devices for use by the OS/kernel.
 // If EnableVmd is true in request then attempt to use VMD NVMe devices.
-// If DisableCleanHugepages is false in request then cleanup any leftover hugepages
-// owned by the target user.
 // Backend call executes the SPDK setup.sh script to rebind PCI devices as selected by
 // devs specified in bdev_list and bdev_exclude provided in the server config file.
 func (sb *spdkBackend) Reset(req storage.BdevPrepareRequest) (*storage.BdevPrepareResponse, error) {
@@ -262,8 +357,6 @@ func (sb *spdkBackend) Reset(req storage.BdevPrepareRequest) (*storage.BdevPrepa
 // Prepare will perform a lookup on the requested target user to validate existence
 // then prepare non-VMD NVMe devices for use with SPDK.
 // If EnableVmd is true in request then attempt to use VMD NVMe devices.
-// If DisableCleanHugepages is false in request then cleanup any leftover hugepages
-// owned by the target user.
 // Backend call executes the SPDK setup.sh script to rebind PCI devices as selected by
 // devs specified in bdev_list and bdev_exclude provided in the server config file.
 func (sb *spdkBackend) Prepare(req storage.BdevPrepareRequest) (*storage.BdevPrepareResponse, error) {

--- a/src/control/server/storage/faults.go
+++ b/src/control/server/storage/faults.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2022-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -194,6 +195,14 @@ var (
 		"'control_metadata.path' is required when MD-on-SSD roles are specified",
 		"set 'control_metadata.path' in the engine storage section of the server config file then "+
 			"restart daos_server")
+
+	// FaultHugepagesDisabled indicates a fault due to incompatibility between an operation and
+	// the use of hugepages having been disabled either in config file or via commandline option.
+	FaultHugepagesDisabled = storageFault(
+		code.StorageHugepagesDisabled,
+		"the use of hugepages has been disabled in the server config or via commandline option",
+		"set false (or remove) disable_hugepages parameter in config or remove the commandline option used to disable and retry the operation, a storage reformat might be necessary",
+	)
 )
 
 // FaultBdevConfigBadNrRoles creates a Fault when an unexpected number of roles have been assigned

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -402,7 +403,7 @@ func (p *Provider) FormatScm(force bool) error {
 }
 
 // GetBdevConfigs returns the Bdev tier configs.
-func (p *Provider) GetBdevConfigs() []*TierConfig {
+func (p *Provider) GetBdevConfigs() TierConfigs {
 	return p.engineStorage.Tiers.BdevConfigs()
 }
 
@@ -423,7 +424,8 @@ func (p *Provider) PrepareBdevs(req BdevPrepareRequest) (*BdevPrepareResponse, e
 	p.Lock()
 	defer p.Unlock()
 
-	if err == nil && resp != nil && !req.CleanHugepagesOnly {
+	// Perform sanity check on call details before enabling VMD on storage provider.
+	if err == nil && resp != nil && !(req.CleanSpdkHugepages || req.CleanSpdkLockfiles) {
 		p.vmdEnabled = resp.VMDPrepared
 		p.log.Debugf("setting vmd=%v on storage provider", p.vmdEnabled)
 	}

--- a/src/control/server/storage/scm.go
+++ b/src/control/server/storage/scm.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -614,9 +615,10 @@ func CalcRamdiskSize(log logging.Logger, memTotal, memHuge, memSys uint64, tgtCo
 	}
 
 	msgStats := fmt.Sprintf("mem stats: total %s (%d) - (hugepages %s + sys rsvd %s + "+
-		"(engine rsvd %s * nr engines %d). %d tgts-per-engine)", humanize.IBytes(memTotal),
-		memTotal, humanize.IBytes(memHuge), humanize.IBytes(memSys),
-		humanize.IBytes(memEng), engCount, tgtCount)
+		"(engine rsvd %s * nr engines %d), engine rsvd: max(%d tgts-per-engine * %s, %s)",
+		humanize.IBytes(memTotal), memTotal, humanize.IBytes(memHuge),
+		humanize.IBytes(memSys), humanize.IBytes(memEng), engCount, tgtCount,
+		humanize.IBytes(DefaultTgtMemRsvd), humanize.IBytes(DefaultEngineMemRsvd))
 
 	memRsvd := memHuge + memSys + (memEng * uint64(engCount))
 	if memTotal < memRsvd {

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1022,17 +1023,17 @@ Options:\n\
   --bypass_health_chk, -b\n\
       Boolean set to inhibit collection of NVME health data\n\
   --mem_size=mem_size, -r mem_size\n\
-      Allocates mem_size MB for SPDK when using primary process mode\n\
+      Allocates mem_size MiB for SPDK when using primary process mode\n\
   --hugepage_size=hugepage_size, -H hugepage_size\n\
-      Passes the configured hugepage size(2MB or 1GB)\n\
+      Passes the configured hugepage size(2MiB or 1GiB)\n\
   --storage_tiers=ntiers, -T ntiers\n\
       Number of storage tiers\n\
   --check, -C\n\
       Start engine with check mode, global consistency check\n\
   --help, -h\n\
       Print this description\n",
-		prog, prog, modules, daos_sysname, dss_storage_path,
-		dss_socket_dir, dss_nvme_conf, dss_instance_idx);
+		prog, prog, modules, daos_sysname, dss_storage_path, dss_socket_dir, dss_nvme_conf,
+		dss_instance_idx);
 }
 
 static int arg_strtoul(const char *str, unsigned int *value, const char *opt)


### PR DESCRIPTION
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
