### PR TITLE
DAOS-17935 control: Remove spdk lockfiles before scan or format (DON"T LAND)

### DIFF
--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -733,8 +733,25 @@ func (cs *ControlService) adjustScmSize(resp *ctlpb.ScanScmResp) {
 	}
 }
 
+func (cs *ControlService) cleanSpdkResources() error {
+	bdevCfgs := cs.srvCfg.GetBdevConfigs()
+	pciAddrs := bdevCfgs.NVMeBdevs().Devices()
+
+	// For the moment assume that both lockfile and hugepage cleanup should be skipped if
+	// hugepages have been disabled in the server config.
+	if !cs.srvCfg.DisableHugepages {
+		err := cleanSpdkResources(cs.log, cs.NvmePrepare, pciAddrs)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // StorageScan discovers non-volatile storage hardware on node.
 func (cs *ControlService) StorageScan(ctx context.Context, req *ctlpb.StorageScanReq) (*ctlpb.StorageScanResp, error) {
+
 	if req == nil {
 		return nil, errNilReq
 	}
@@ -755,6 +772,10 @@ func (cs *ControlService) StorageScan(ctx context.Context, req *ctlpb.StorageSca
 			State: new(ctlpb.ResponseState),
 		}
 	} else {
+		if err := cs.cleanSpdkResources(); err != nil {
+			return nil, errors.Wrap(err, "clean spdk resources")
+		}
+
 		respNvme, err := scanBdevs(ctx, cs, req.Nvme, respScm.Namespaces)
 		if err != nil {
 			return nil, err
@@ -1055,6 +1076,10 @@ func (cs *ControlService) StorageFormat(ctx context.Context, req *ctlpb.StorageF
 		cs.log.Debug("skipping bdev format as use of hugepages disabled in config")
 		hugepagesDisabled = true
 	} else {
+		if err := cs.cleanSpdkResources(); err != nil {
+			return nil, errors.Wrap(err, "clean spdk resources")
+		}
+
 		fnr := formatNvmeReq{
 			log:         cs.log,
 			instances:   instances,

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -385,9 +385,14 @@ func prepBdevStorage(srv *server, iommuEnabled bool, smi *common.SysMemInfo) err
 	}
 
 	// Clean leftover SPDK hugepages and lockfiles for configured NVMe SSDs before prepare.
+	// For the moment assume that both lockfile and hugepage cleanup should be skipped if
+	// hugepages have been disabled in the server config.
 	pciAddrs := bdevCfgs.NVMeBdevs().Devices()
-	if err := cleanSpdkResources(srv, pciAddrs); err != nil {
-		srv.log.Error(errors.Wrap(err, "prepBdevStorage").Error())
+	if !srv.cfg.DisableHugepages {
+		err := cleanSpdkResources(srv.log, srv.ctlSvc.NvmePrepare, pciAddrs)
+		if err != nil {
+			srv.log.Error(errors.Wrap(err, "prepBdevStorage").Error())
+		}
 	}
 
 	// When requesting to prepare NVMe drives during service start-up, use all addresses
@@ -497,15 +502,11 @@ func setEngineMemSize(srv *server, ei *EngineInstance, smi *common.SysMemInfo) {
 	ei.setHugepageSz(pageSizeMiB)
 }
 
+type nvmePrepFnSig func(storage.BdevPrepareRequest) (*storage.BdevPrepareResponse, error)
+
 // Clean SPDK resources, both lockfiles and orphaned hugepages. Orphaned hugepages will be cleaned
 // whether or not device PCI addresses are supplied.
-func cleanSpdkResources(srv *server, pciAddrs []string) error {
-	// For the moment assume that both lockfile and hugepage cleanup should be skipped if
-	// hugepages have been disabled in the server config.
-	if srv.cfg.DisableHugepages {
-		return nil
-	}
-
+func cleanSpdkResources(log logging.Logger, prepFn nvmePrepFnSig, pciAddrs []string) error {
 	req := storage.BdevPrepareRequest{
 		CleanSpdkHugepages: true,
 		CleanSpdkLockfiles: true,
@@ -514,13 +515,13 @@ func cleanSpdkResources(srv *server, pciAddrs []string) error {
 
 	msg := "cleanup spdk resources"
 
-	resp, err := srv.ctlSvc.NvmePrepare(req)
+	resp, err := prepFn(req)
 	if err != nil {
 		return errors.Wrap(err, msg)
 	}
 
-	srv.log.Debugf("%s: %d hugepages and lockfiles %v removed", msg,
-		resp.NrHugepagesRemoved, resp.LockfilesRemoved)
+	log.Debugf("%s: %d hugepages and lockfiles %v removed", msg, resp.NrHugepagesRemoved,
+		resp.LockfilesRemoved)
 
 	return nil
 }
@@ -615,9 +616,14 @@ func registerEngineEventCallbacks(srv *server, engine *EngineInstance, allStarte
 		storageCfg := engine.runner.GetConfig().Storage
 		pciAddrs := storageCfg.Tiers.NVMeBdevs().Devices()
 
-		if err := cleanSpdkResources(srv, pciAddrs); err != nil {
-			srv.log.Error(
-				errors.Wrapf(err, "engine instance %d", engine.Index()).Error())
+		// For the moment assume that both lockfile and hugepage cleanup should be skipped if
+		// hugepages have been disabled in the server config.
+		if !srv.cfg.DisableHugepages {
+			err := cleanSpdkResources(srv.log, srv.ctlSvc.NvmePrepare, pciAddrs)
+			if err != nil {
+				srv.log.Error(errors.Wrapf(err, "engine instance %d",
+					engine.Index()).Error())
+			}
 		}
 
 		return nil
@@ -643,9 +649,12 @@ func registerEngineEventCallbacks(srv *server, engine *EngineInstance, allStarte
 		storageCfg := engine.runner.GetConfig().Storage
 		pciAddrs := storageCfg.Tiers.NVMeBdevs().Devices()
 
-		if err := cleanSpdkResources(srv, pciAddrs); err != nil {
-			srv.log.Error(
-				errors.Wrapf(err, "engine instance %d", engine.Index()).Error())
+		if !srv.cfg.DisableHugepages {
+			err := cleanSpdkResources(srv.log, srv.ctlSvc.NvmePrepare, pciAddrs)
+			if err != nil {
+				srv.log.Error(errors.Wrapf(err, "engine instance %d",
+					engine.Index()).Error())
+			}
 		}
 
 		// Retrieve up-to-date meminfo to check resource availability.

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -1205,13 +1205,6 @@ func TestServer_cleanEngineSpdkResources(t *testing.T) {
 		expErr      error
 		expPrepCall *storage.BdevPrepareRequest
 	}{
-		"bdevs configured; hugepages disabled": {
-			srvCfgExtra: func(sc *config.Server) *config.Server {
-				return sc.WithDisableHugepages(true).
-					WithEngines(pmemEngine(1))
-			},
-			// Returns early so no prep call.
-		},
 		"no bdevs configured": {
 			srvCfgExtra: func(sc *config.Server) *config.Server {
 				return sc.WithEngines(pmemOnlyEngine(1))
@@ -1302,7 +1295,8 @@ func TestServer_cleanEngineSpdkResources(t *testing.T) {
 			storageCfg := ei.runner.GetConfig().Storage
 			pciAddrs := storageCfg.Tiers.NVMeBdevs().Devices()
 
-			test.CmpErr(t, tc.expErr, cleanSpdkResources(srv, pciAddrs))
+			test.CmpErr(t, tc.expErr, cleanSpdkResources(srv.log, srv.ctlSvc.NvmePrepare,
+				pciAddrs))
 
 			mbb.RLock()
 			if tc.expPrepCall != nil {


### PR DESCRIPTION
Creating to run PR #16769 on HDR-205. 

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
