### PR TITLE
DAOS-17907 rebuild: fix obj_inflight_io_check for delay rebuild

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -555,11 +555,16 @@ int ds_pool_svc_lookup_leader(uuid_t uuid, struct ds_pool_svc **ds_svcp, struct 
 void ds_pool_svc_put_leader(struct ds_pool_svc *ds_svc);
 
 static inline bool
-ds_pool_rebuild_enabled(struct ds_pool *pool)
+is_pool_rebuild_allowed(struct ds_pool *pool, bool check_delayed_rebuild)
 {
+	uint64_t flags = DAOS_SELF_HEAL_AUTO_REBUILD;
+
+	if (check_delayed_rebuild)
+		flags |= DAOS_SELF_HEAL_DELAY_REBUILD;
+
 	if (pool->sp_disable_rebuild)
 		return false;
-	if (!(pool->sp_self_heal & (DAOS_SELF_HEAL_AUTO_REBUILD | DAOS_SELF_HEAL_DELAY_REBUILD)))
+	if (!(pool->sp_self_heal & flags))
 		return false;
 
 	return true;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2418,8 +2418,9 @@ obj_inflight_io_check(struct ds_cont_child *child, uint32_t opc,
 	 * which otherwise might be written duplicately, which might cause
 	 * the failure in VOS.
 	 */
-	if ((flags & ORF_REBUILDING_IO) && (ds_pool_rebuild_enabled(child->sc_pool->spc_pool) &&
-					    child->sc_pool->spc_rebuild_fence == 0)) {
+	if ((flags & ORF_REBUILDING_IO) &&
+	    (is_pool_rebuild_allowed(child->sc_pool->spc_pool, false) &&
+	     child->sc_pool->spc_rebuild_fence == 0)) {
 		D_ERROR("rebuilding "DF_UUID" retry.\n", DP_UUID(child->sc_pool->spc_uuid));
 		return -DER_UPDATE_AGAIN;
 	}

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7494,7 +7494,7 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 	}
 	d_freeenv_str(&env);
 
-	if (!ds_pool_rebuild_enabled(svc->ps_pool)) {
+	if (!is_pool_rebuild_allowed(svc->ps_pool, true)) {
 		D_DEBUG(DB_MD, DF_UUID ": self healing is disabled\n",
 			DP_UUID(svc->ps_pool->sp_uuid));
 		D_GOTO(out, rc);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -2489,9 +2489,8 @@ ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop)
 	D_ASSERT(entry != NULL);
 	if (entry->dpe_val & (DAOS_SELF_HEAL_AUTO_REBUILD | DAOS_SELF_HEAL_DELAY_REBUILD) &&
 	    !pool->sp_disable_rebuild) {
-		rc = regenerate_task_of_type(pool, PO_COMP_ST_DOWN,
-					     pool->sp_self_heal & DAOS_SELF_HEAL_DELAY_REBUILD ? -1
-											       : 0);
+		rc = regenerate_task_of_type(
+		    pool, PO_COMP_ST_DOWN, entry->dpe_val & DAOS_SELF_HEAL_DELAY_REBUILD ? -1 : 0);
 		if (rc != 0)
 			return rc;
 


### PR DESCRIPTION
cd7c53ded intrdocued a regression where obj_inflight_io_check() would incorrectly return EAGAIN for delayed rebuild cases.

Also unify to use @dpe_val in ds_rebuild_regenerate_task(), leftover from the review process of commit cd7c53ded.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
