### PR TITLE
DAOS-17508 vos: allow DAOS_INTENT_CHECK for EV iterators (#16737)

### DIFF
--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -644,19 +644,19 @@ int evt_debug(daos_handle_t toh, int debug_level);
 
 enum {
 	/** Return extents visible in the search rectangle */
-	EVT_ITER_VISIBLE	= (1 << 0),
+	EVT_ITER_VISIBLE = (1 << 0),
 	/** Add fully or partially covered extents to EVT_ITER_VISIBLE */
-	EVT_ITER_COVERED	= (1 << 1) | EVT_ITER_VISIBLE,
+	EVT_ITER_COVERED = (1 << 1) | EVT_ITER_VISIBLE,
 	/** Skip visible holes (Only valid with EVT_ITER_VISIBLE) */
-	EVT_ITER_SKIP_HOLES	= (1 << 2),
+	EVT_ITER_SKIP_HOLES = (1 << 2),
 	/**
 	 * Use the embedded iterator of the open handle.
 	 * It can reduce memory consumption, but state of iterator can be
 	 * overwritten by other tree operation.
 	 */
-	EVT_ITER_EMBEDDED	= (1 << 3),
+	EVT_ITER_EMBEDDED = (1 << 3),
 	/** Reverse iterator (ordered iterator only) */
-	EVT_ITER_REVERSE	= (1 << 4),
+	EVT_ITER_REVERSE = (1 << 4),
 	/* If EVT_ITER_VISIBLE is set, evt_iter_probe will calculate and cache
 	 * visible extents and iterate through the cached extents.   Each
 	 * rectangle will be marked as visible or covered.  The partial bit will
@@ -668,15 +668,18 @@ enum {
 	 * search rectangle, including punched extents, are returned.
 	 */
 	/** The iterator is for purge operation */
-	EVT_ITER_FOR_PURGE	= (1 << 5),
+	EVT_ITER_FOR_PURGE = (1 << 5),
 	/** The iterator is for data migration scan */
-	EVT_ITER_FOR_MIGRATION	= (1 << 6),
+	EVT_ITER_FOR_MIGRATION = (1 << 6),
 	/** The iterator is for data discard */
-	EVT_ITER_FOR_DISCARD	= (1 << 7),
+	EVT_ITER_FOR_DISCARD = (1 << 7),
 	/** Skip visible data (Only valid with EVT_ITER_VISIBLE) */
-	EVT_ITER_SKIP_DATA	= (1 << 8),
+	EVT_ITER_SKIP_DATA = (1 << 8),
 	/** Only process removals */
-	EVT_ITER_REMOVALS	= (1 << 9),
+	EVT_ITER_REMOVALS = (1 << 9),
+	/** Checking whether the target is aborted or not. */
+	EVT_ITER_FOR_CHECK = (1 << 10),
+
 };
 
 D_CASSERT((int)EVT_VISIBLE == (int)EVT_ITER_VISIBLE);

--- a/src/vos/evt_iter.c
+++ b/src/vos/evt_iter.c
@@ -214,6 +214,8 @@ evt_iter_intent(struct evt_iterator *iter)
 		return DAOS_INTENT_DISCARD;
 	if (iter->it_options & EVT_ITER_FOR_MIGRATION)
 		return DAOS_INTENT_MIGRATION;
+	if (iter->it_options & EVT_ITER_FOR_CHECK)
+		return DAOS_INTENT_CHECK;
 	return DAOS_INTENT_DEFAULT;
 }
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1526,6 +1526,8 @@ recx_get_flags(struct vos_obj_iter *oiter, bool embed)
 		options |= EVT_ITER_FOR_DISCARD;
 	if (oiter->it_flags & VOS_IT_FOR_MIGRATION)
 		options |= EVT_ITER_FOR_MIGRATION;
+	if (oiter->it_flags & VOS_IT_FOR_CHECK)
+		options |= EVT_ITER_FOR_CHECK;
 	return options;
 }
 


### PR DESCRIPTION
DAOS_INTENT_CHECK is intended for offline utilities like DDB and DLCK to inspect the contents of the pool while it is idle. EV iterators must support it as well.

**Clean cherry-pick of #16737**

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
