### PR TITLE
Modify DAOS agent to enable generic authentication

### DIFF
--- a/src/control/cmd/daos_agent/infocache_test.go
+++ b/src/control/cmd/daos_agent/infocache_test.go
@@ -102,7 +102,7 @@ func TestAgent_newCachedAttachInfo(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer test.ShowBufferOnFailure(t, buf)
 
-	expSys := "my_system"
+	expSys := "GetAttachInfo-daos_server"
 	expRefreshInterval := time.Second
 	expClient := control.NewMockInvoker(log, &control.MockInvokerConfig{})
 

--- a/src/control/cmd/daos_agent/security_rpc.go
+++ b/src/control/cmd/daos_agent/security_rpc.go
@@ -10,11 +10,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"net"
-	"os/user"
+	"slices"
 	"time"
 
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/cache"
@@ -26,7 +26,7 @@ import (
 
 type (
 	// credSignerFn defines the function signature for signing credentials.
-	credSignerFn func(context.Context, *auth.CredentialRequest) (*auth.Credential, error)
+	credSignerFn func(context.Context, logging.Logger, auth.CredentialRequest) (*auth.Credential, error)
 
 	// credentialCache implements a cache for signed credentials.
 	credentialCache struct {
@@ -48,6 +48,8 @@ type (
 	securityConfig struct {
 		credentials *security.CredentialConfig
 		transport   *security.TransportConfig
+		infoCache   *InfoCache
+		sys         string
 	}
 
 	// SecurityModule is the security drpc module struct
@@ -55,23 +57,43 @@ type (
 		log            logging.Logger
 		signCredential credSignerFn
 		credCache      *credentialCache
-
-		config *securityConfig
+		config         *securityConfig
+		infoCache      *InfoCache
 	}
 )
 
 var _ cache.ExpirableItem = (*cachedCredential)(nil)
 
+func getCredReq(reqb []byte) (*auth.GetCredReq, error) {
+	credReq := new(auth.GetCredReq)
+
+	reqbSize := len(reqb)
+	if reqbSize == 0 {
+		credReq.Flavor = auth.AuthSysCredentialFactory{}.GetAuthFlavor()
+	} else {
+		if err := proto.Unmarshal(reqb, credReq); err != nil {
+			return nil, drpc.UnmarshalingPayloadFailure()
+		}
+	}
+
+	return credReq, nil
+}
+
+// Wrapper function, helps with fulfilling cache interface.
+func credentialRequestGetSigned(ctx context.Context, log logging.Logger, req auth.CredentialRequest) (*auth.Credential, error) {
+	return req.GetSignedCredential(log, ctx)
+}
+
 // NewSecurityModule creates a new module with the given initialized TransportConfig.
 func NewSecurityModule(log logging.Logger, cfg *securityConfig) *SecurityModule {
 	var credCache *credentialCache
-	credSigner := auth.GetSignedCredential
+	credSigner := credentialRequestGetSigned
 	if cfg.credentials.CacheExpiration > 0 {
 		credCache = &credentialCache{
 			log:          log,
 			cache:        cache.NewItemCache(log),
 			credLifetime: cfg.credentials.CacheExpiration,
-			cacheMissFn:  auth.GetSignedCredential,
+			cacheMissFn:  credentialRequestGetSigned,
 		}
 		credSigner = credCache.getSignedCredential
 		log.Noticef("credential cache enabled (entry lifetime: %s)", cfg.credentials.CacheExpiration)
@@ -82,11 +104,8 @@ func NewSecurityModule(log logging.Logger, cfg *securityConfig) *SecurityModule 
 		signCredential: credSigner,
 		credCache:      credCache,
 		config:         cfg,
+		infoCache:      cfg.infoCache,
 	}
-}
-
-func credReqKey(req *auth.CredentialRequest) string {
-	return fmt.Sprintf("%d:%d:%s", req.DomainInfo.Uid(), req.DomainInfo.Gid(), req.DomainInfo.Ctx())
 }
 
 // Key returns the key for the cached credential.
@@ -107,12 +126,12 @@ func (cred *cachedCredential) IsExpired() bool {
 	return time.Now().After(cred.expiredAt)
 }
 
-func (cc *credentialCache) getSignedCredential(ctx context.Context, req *auth.CredentialRequest) (*auth.Credential, error) {
-	key := credReqKey(req)
+func (cc *credentialCache) getSignedCredential(ctx context.Context, log logging.Logger, req auth.CredentialRequest) (*auth.Credential, error) {
+	key := req.GetKey()
 
 	createItem := func() (cache.Item, error) {
 		cc.log.Tracef("cache miss for %s", key)
-		cred, err := cc.cacheMissFn(ctx, req)
+		cred, err := cc.cacheMissFn(ctx, log, req)
 		if err != nil {
 			return nil, err
 		}
@@ -146,77 +165,71 @@ func newCachedCredential(key string, cred *auth.Credential, lifetime time.Durati
 	}, nil
 }
 
-// GetMethod gets the corresponding Method for a method ID.
-func (m *SecurityModule) GetMethod(id int32) (drpc.Method, error) {
-	if id == daos.MethodRequestCredentials.ID() {
-		return daos.MethodRequestCredentials, nil
-	}
-
-	return nil, fmt.Errorf("invalid method ID %d for module %s", id, m.String())
-}
-
-func (m *SecurityModule) String() string {
-	return "agent_security"
-}
-
 // HandleCall is the handler for calls to the SecurityModule
-func (m *SecurityModule) HandleCall(ctx context.Context, session *drpc.Session, method drpc.Method, body []byte) ([]byte, error) {
-	if method != daos.MethodRequestCredentials {
-		return nil, drpc.UnknownMethodFailure()
+func (m *SecurityModule) HandleCall(ctx context.Context, session *drpc.Session, method drpc.Method, reqb []byte) ([]byte, error) {
+	credReq, err := getCredReq(reqb)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse request body")
 	}
 
-	return m.getCredential(ctx, session)
+	switch method {
+	case daos.MethodRequestCredentials:
+		validAuthFlavors, err := m.retrieveAuthFromServer(ctx)
+		if err != nil || len(validAuthFlavors) == 0 {
+			return nil, errors.Wrap(err, "error in retrieving auth flavors from server")
+		}
+
+		if !slices.Contains(validAuthFlavors, credReq.Flavor) {
+			return nil, errors.Errorf("invalid authentication method: the method requested is not allowed by the server configuration.")
+		}
+		return m.getCredential(ctx, session, credReq)
+	case daos.MethodRequestValidFlavors:
+		return m.getValidAuthFlavors(ctx)
+	}
+
+	return nil, drpc.UnknownMethodFailure()
 }
 
-// getCredentials generates a signed user credential based on the data attached to
-// the Unix Domain Socket.
-func (m *SecurityModule) getCredential(ctx context.Context, session *drpc.Session) ([]byte, error) {
-	if session == nil {
-		return nil, drpc.NewFailureWithMessage("session is nil")
-	}
-
-	uConn, ok := session.Conn.(*net.UnixConn)
-	if !ok {
-		return nil, drpc.NewFailureWithMessage("connection is not a unix socket")
-	}
-
-	info, err := security.DomainInfoFromUnixConn(m.log, uConn)
+func (m *SecurityModule) retrieveAuthFromServer(ctx context.Context) ([]auth.Flavor, error) {
+	resp, err := m.infoCache.GetAttachInfo(ctx, m.config.sys)
 	if err != nil {
-		m.log.Errorf("Unable to get credentials for client socket: %s", err)
-		return m.credRespWithStatus(daos.MiscError)
+		return nil, errors.Wrap(err, "failed to get attach info")
 	}
 
+	validAuthFlavors := make([]auth.Flavor, len(resp.ValidAuthFlavors))
+	for i := 0; i < len(resp.ValidAuthFlavors); i++ {
+		validAuthFlavors[i] = auth.Flavor(resp.ValidAuthFlavors[i])
+	}
+
+	if len(validAuthFlavors) == 0 {
+		return nil, errors.Errorf("failed to receive valid authentication flavors from server.")
+	}
+
+	return validAuthFlavors, nil
+}
+
+// getCredentials generates a signed user credential based on the authentication method requested.
+func (m *SecurityModule) getCredential(ctx context.Context, session *drpc.Session, credReq *auth.GetCredReq) ([]byte, error) {
 	signingKey, err := m.config.transport.PrivateKey()
 	if err != nil {
-		m.log.Errorf("%s: failed to get signing key: %s", info, err)
+		m.log.Errorf("failed to get signing key: %s", err)
 		// something is wrong with the cert config
 		return m.credRespWithStatus(daos.BadCert)
 	}
 
-	req := auth.NewCredentialRequest(info, signingKey)
-	cred, err := m.signCredential(ctx, req)
+	req, err := auth.FlavorToFactory[credReq.Flavor].Init(m.log, m.config.credentials, session, credReq.Data, signingKey)
 	if err != nil {
-		if err := func() error {
-			if !errors.Is(err, user.UnknownUserIdError(info.Uid())) {
-				return err
-			}
-
-			mu := m.config.credentials.ClientUserMap.Lookup(info.Uid())
-			if mu == nil {
-				return user.UnknownUserIdError(info.Uid())
-			}
-
-			req.WithUserAndGroup(mu.User, mu.Group, mu.Groups...)
-			cred, err = m.signCredential(ctx, req)
-			if err != nil {
-				return err
-			}
-
-			return nil
-		}(); err != nil {
-			m.log.Errorf("%s: failed to get user credential: %s", info, err)
-			return m.credRespWithStatus(daos.MiscError)
+		if errors.Is(err, daos.MiscError) {
+			return m.credRespWithStatus(err.(daos.Status))
 		}
+		m.log.Errorf("Unable to get credentials for client socket: %s", err)
+		return nil, err
+	}
+
+	cred, err := m.signCredential(ctx, m.log, req)
+	if err != nil {
+		m.log.Errorf("failed to get user credential: %s", err)
+		return m.credRespWithStatus(daos.FailedSign)
 	}
 
 	resp := &auth.GetCredResp{Cred: cred}
@@ -226,6 +239,31 @@ func (m *SecurityModule) getCredential(ctx context.Context, session *drpc.Sessio
 func (m *SecurityModule) credRespWithStatus(status daos.Status) ([]byte, error) {
 	resp := &auth.GetCredResp{Status: int32(status)}
 	return drpc.Marshal(resp)
+}
+
+func (m *SecurityModule) getValidAuthFlavors(ctx context.Context) ([]byte, error) {
+	validAuthFlavors, err := m.retrieveAuthFromServer(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "error in retrieving auth flavors from server")
+	}
+
+	resp := &auth.GetValidFlavorsResp{ValidAuthFlavors: validAuthFlavors}
+	return drpc.Marshal(resp)
+}
+
+// GetMethod gets the corresponding Method for a method ID.
+func (m *SecurityModule) GetMethod(id int32) (drpc.Method, error) {
+	if id == daos.MethodRequestCredentials.ID() {
+		return daos.MethodRequestCredentials, nil
+	} else if id == daos.MethodRequestValidFlavors.ID() {
+		return daos.MethodRequestValidFlavors, nil
+	}
+
+	return nil, fmt.Errorf("invalid method ID %d for module %s", id, m.String())
+}
+
+func (m *SecurityModule) String() string {
+	return "agent_security"
 }
 
 // ID will return Security module ID

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -110,8 +110,12 @@ func (cmd *startCmd) Execute(_ []string) error {
 	secCfg := &securityConfig{
 		transport:   cmd.cfg.TransportConfig,
 		credentials: cmd.cfg.CredentialConfig,
+		infoCache:   cache,
+		sys:         cmd.cfg.SystemName,
 	}
-	drpcServer.RegisterRPCModule(NewSecurityModule(cmd.Logger, secCfg))
+	module := NewSecurityModule(cmd.Logger, secCfg)
+
+	drpcServer.RegisterRPCModule(module)
 	mgmtMod := &mgmtModule{
 		log:           cmd.Logger,
 		sys:           cmd.cfg.SystemName,

--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -598,6 +598,9 @@ allow_numa_imbalance: false
 control_log_mask: INFO
 control_log_file: /var/log/daos/daos_server.log
 core_dump_filter: 19
+auth_config:
+  valid_auth:
+  - AUTH_SYS
 name: daos_server
 socket_dir: /var/run/daos_server
 provider: ofi+verbs

--- a/src/control/lib/control/network.go
+++ b/src/control/lib/control/network.go
@@ -22,6 +22,7 @@ import (
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/security/auth"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
@@ -241,6 +242,7 @@ type (
 		ClientNetHint           ClientNetworkHint     `json:"client_net_hint"`
 		AlternateClientNetHints []ClientNetworkHint   `json:"secondary_client_net_hints"`
 		BuildInfo               BuildInfo             `json:"build_info"`
+		ValidAuthFlavors        []auth.Flavor         `json:"valid_auth_flavors"`
 	}
 )
 

--- a/src/control/lib/daos/drpc.go
+++ b/src/control/lib/daos/drpc.go
@@ -55,7 +55,8 @@ func (m securityAgentMethod) ID() int32 {
 
 func (m securityAgentMethod) String() string {
 	if s, ok := map[securityAgentMethod]string{
-		MethodRequestCredentials: "request agent credentials",
+		MethodRequestCredentials:  "request agent credentials",
+		MethodRequestValidFlavors: "request valid authentication flavors",
 	}[m]; ok {
 		return s
 	}
@@ -66,6 +67,8 @@ func (m securityAgentMethod) String() string {
 const (
 	// MethodRequestCredentials is a ModuleSecurityAgent method
 	MethodRequestCredentials securityAgentMethod = C.DRPC_METHOD_SEC_AGENT_REQUEST_CREDS
+	// MethodRequestCredentials is a ModuleSecurityAgent method
+	MethodRequestValidFlavors securityAgentMethod = C.DRPC_METHOD_SEC_AGENT_REQUEST_AUTH_FLAVORS
 )
 
 type MgmtMethod int32

--- a/src/control/lib/daos/status.go
+++ b/src/control/lib/daos/status.go
@@ -120,6 +120,8 @@ const (
 	MercuryFatalError Status = -C.DER_HG_FATAL
 	// NoService indicates the pool service is not up and didn't process the pool request
 	NoService Status = -C.DER_NO_SERVICE
+	// FailedSign indicates the DAOS agent was not able to return a signed credential
+	FailedSign Status = -C.DER_FAILED_SIGN
 )
 
 const (

--- a/src/control/security/auth/auth.go
+++ b/src/control/security/auth/auth.go
@@ -1,0 +1,143 @@
+//
+// (C) Copyright 2018-2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package auth
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"strings"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/security"
+)
+
+// VerifierFromToken will return a SHA512 hash of the token data. If a signing key
+// is passed in it will additionally sign the hash of the token.
+func VerifierFromToken(key crypto.PublicKey, token *Token) ([]byte, error) {
+	var sig []byte
+	tokenBytes, err := proto.Marshal(token)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to marshal Token")
+	}
+
+	signer := security.DefaultTokenSigner()
+
+	if key == nil {
+		return signer.Hash(tokenBytes)
+	}
+	sig, err = signer.Sign(key, tokenBytes)
+	return sig, errors.Wrap(err, "signing verifier failed")
+}
+
+// VerifyToken takes the auth token and the signature bytes in the verifier and
+// verifies it against the public key provided for the agent who claims to have
+// provided the token. It also confirms that the token is from an authentication
+// source supported by the server.
+func VerifyToken(key crypto.PublicKey, token *Token, sig []byte) error {
+	tokenBytes, err := proto.Marshal(token)
+	if err != nil {
+		return errors.Wrap(err, "unable to marshal Token")
+	}
+
+	signer := security.DefaultTokenSigner()
+
+	if key == nil {
+		digest, err := signer.Hash(tokenBytes)
+		if err != nil {
+			return err
+		}
+		if bytes.Equal(digest, sig) {
+			return nil
+		}
+		return errors.Errorf("unsigned hash failed to verify.")
+	}
+
+	err = signer.Verify(key, tokenBytes, sig)
+	return errors.Wrap(err, "token verification Failed")
+}
+
+// AuthSysFromAuthToken takes an opaque AuthToken and turns it into a
+// concrete AuthSys data structure.
+func AuthSysFromAuthToken(authToken *Token) (*Sys, error) {
+	if authToken.GetFlavor() != Flavor_AUTH_SYS {
+		return nil, errors.New("Attempting to convert an invalid AuthSys Token")
+	}
+
+	sysToken := &Sys{}
+	err := proto.Unmarshal(authToken.GetData(), sysToken)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unmarshaling %s", authToken.GetFlavor())
+	}
+	return sysToken, nil
+}
+
+// ParseValidAuthFlavors takes in case-insensitive strings representing
+// authentication methods the server will allow and returns a list
+// of authentication flavors, as defined in the auth protobuf.
+func ParseValidAuthFlavors(authStrings []string) ([]Flavor, error) {
+	validAuthFlavors := make([]Flavor, len(authStrings))
+	for i := 0; i < len(authStrings); i++ {
+		// Uppercase avoids case sensitivity, we trim the AUTH_ prefix to enable raw authentication names.
+		authString := strings.TrimPrefix(strings.ToUpper(authStrings[i]), "AUTH_")
+		flavor, ok := Flavor_value["AUTH_"+authString]
+		if !ok {
+			return nil, errors.Errorf("auth string %s is not recognized", authStrings[i])
+		}
+		validAuthFlavors[i] = Flavor(flavor)
+	}
+
+	return validAuthFlavors, nil
+}
+
+type (
+	AuthMap map[Flavor]CredentialRequestFactory
+
+	// CredentialRequestIdentity interface {
+	// 	// Returns the auth flavor that refers to the CredentialRequest implementation.
+	// 	GetAuthFlavor() Flavor
+	// }
+
+	CredentialRequestFactory interface {
+		// Using information stored in the agent's security config, the session/socket, request body, and the agent's signing key,
+		// initalize the state of the Credential Request so that it can sign a credential in the future. Return an error if
+		// a problem occurs during initializiation.
+		Init(log logging.Logger, secCfg *security.CredentialConfig, session *drpc.Session, reqBody []byte, key crypto.PrivateKey) (CredentialRequest, error)
+		// Returns the auth flavor that refers to the CredentialRequest implementation.
+		GetAuthFlavor() Flavor
+	}
+
+	CredentialRequest interface {
+		// Contact a source of authenticity (e.g. domain socket, access manager) using the initalized state of the CredentialRequest
+		// to construct a Credential object.
+		GetSignedCredential(log logging.Logger, ctx context.Context) (*Credential, error)
+		// Returns a key, as a string, representing a unique identifer specific to the request. This key is used by the cache
+		// to remember credentials. It is vital for security that this identifer cannot be forged or easily guessed by the client -
+		// otherwise cached credentials can be "stolen".
+		GetKey() string
+		// Returns the auth flavor that refers to the CredentialRequest implementation.
+		GetAuthFlavor() Flavor
+	}
+)
+
+// CredentialRequests is a list of authentication methods the agent can use.
+// To implement a new type of authentication: satisfy the CredentialRequest and
+// CredentialRequestFactory interfaces, add a new flavor in auth.proto, ensure
+// that your `GetAuthFlavor` method returns this new unique flavor and add your
+// interface to the `CredentialRequests` list below.
+// The server must be configured to allow an authentication method when it is initalized.
+// By default, only Unix authentication is enabled.
+
+// var CredentialRequests = []CredentialRequestFactory{&AuthSysCredentialFactory{}, &AuthAccManCredentialFactory{}}
+var FlavorToFactory = map[Flavor]CredentialRequestFactory{
+	AuthSysCredentialFactory{}.GetAuthFlavor():    &AuthSysCredentialFactory{},
+	AuthAccManCredentialFactory{}.GetAuthFlavor(): &AuthAccManCredentialFactory{},
+}

--- a/src/control/security/auth/auth_accman.go
+++ b/src/control/security/auth/auth_accman.go
@@ -1,0 +1,227 @@
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package auth
+
+import (
+	"context"
+	"crypto"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/security"
+)
+
+type (
+	// AuthAccManCredentialFactory is a factory interface for AuthAccManCredentialRequests.
+	AuthAccManCredentialFactory struct {
+	}
+
+	// AuthAccManCredentialRequest defines the request parameters for GetSignedCredential for the AUTH_ACCMAN flavor.
+	AuthAccManCredentialRequest struct {
+		delegationCredential string
+		signingKey           crypto.PrivateKey
+		callerID             string
+		baseURL              string
+	}
+
+	accManInfo struct {
+		Identity string   `json:"id"`
+		Roles    []string `json:"roles"`
+	}
+
+	amErr struct {
+		ResponseCode int    `json:"error"`
+		Message      string `json:"message"`
+	}
+
+	amResp struct {
+		Error amErr  `json:"error"`
+		Info  string `json:"info"`
+	}
+)
+
+func (r *AuthAccManCredentialRequest) request_am(ctx context.Context, apiPath string, method string, kv ...string) ([]byte, error) {
+	u, err := url.ParseRequestURI(r.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("check agent config to ensure AM url is correct (can't happen: %w)", err)
+	}
+	u.Path = apiPath
+	params := url.Values{}
+	if len(kv)%2 != 0 {
+		return nil, fmt.Errorf("must have an even number of key/value pairs")
+	}
+	for i := 0; i < len(kv); i += 2 {
+		params.Set(kv[i], kv[i+1])
+	}
+
+	params.Set("caller_id", r.callerID)
+	u.RawQuery = params.Encode()
+
+	request, err := http.NewRequestWithContext(
+		ctx,
+		method,
+		u.String(),
+		http.NoBody,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(`cannot create request for "%s": %w`, u.String(), err)
+	}
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf(`cannot access "%s": %w`, u.String(), err)
+	}
+
+	//goland:noinspection GoUnhandledErrorResult
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(`unexpected status code "%d"`, response.StatusCode)
+	}
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf(`error reading response from %s: %w`, u.String(), err)
+	}
+	return responseBody, err
+}
+
+func (r *AuthAccManCredentialRequest) validateAndParseDelegationCredential() (*accManInfo, error) {
+	var amResp amResp
+	var authInfo accManInfo
+
+	resp, err := r.request_am(context.Background(), "/validate", http.MethodGet, "credential", r.delegationCredential)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to validate the provided credential - check AM server and agent configuration")
+	}
+
+	err = json.Unmarshal(resp, &amResp)
+	if err != nil {
+		return nil, err
+	}
+
+	if amResp.Error.ResponseCode != 0 {
+		return nil, errors.New(amResp.Error.Message)
+	}
+
+	err = json.Unmarshal([]byte(amResp.Info), &authInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return &authInfo, nil
+}
+
+// func (req *AuthAccManCredentialRequest) AllocCredentialRequest() CredentialRequest {
+// 	return &AuthAccManCredentialRequest{}
+// }
+
+func (fac *AuthAccManCredentialFactory) Init(log logging.Logger, secCfg *security.CredentialConfig, session *drpc.Session, reqBody []byte, key crypto.PrivateKey) (CredentialRequest, error) {
+	req := &AuthAccManCredentialRequest{}
+	req.delegationCredential = string(reqBody)
+	req.signingKey = key
+	req.callerID = secCfg.AMConfig.CallerID
+	req.baseURL = secCfg.AMConfig.BaseURL
+
+	return req, nil
+}
+
+func GetAccManFlavor() Flavor {
+	return Flavor_AUTH_ACCMAN
+}
+
+func (fac AuthAccManCredentialFactory) GetAuthFlavor() Flavor {
+	return GetAccManFlavor()
+}
+
+func (req *AuthAccManCredentialRequest) GetAuthFlavor() Flavor {
+	return GetAccManFlavor()
+}
+
+// GetSignedCredential returns a credential based on the provided domain info and
+// signing key.
+func (req *AuthAccManCredentialRequest) GetSignedCredential(log logging.Logger, ctx context.Context) (*Credential, error) {
+	// DAOS is built with UNIX groups in mind. We cannot use the AM-style URLS as they contain colons, and do not end with an '@'.
+	// This function helps parse out the path.
+	seperate := func(url string) (string, string, error) {
+		var split_url = strings.Split(url, "://")
+		if len(split_url) != 2 {
+			return "", "", errors.New("Access manager url does not follow expected format 'foo://bar/...'")
+		}
+		split_url[0] += "://"
+		split_url[1] += "@am"
+		return split_url[0], split_url[1], nil
+	}
+
+	authInfo, err := req.validateAndParseDelegationCredential()
+	if err != nil {
+		return nil, err
+	}
+
+	machineName, identity, err := seperate(authInfo.Identity)
+
+	if err != nil {
+		return nil, err
+	}
+
+	groups := make([]string, len(authInfo.Roles))
+	for i := range groups {
+		var _, role, err = seperate(authInfo.Roles[i])
+		if err != nil {
+			return nil, err
+		}
+		groups[i] = role
+	}
+
+	// Craft AuthToken
+	sys := Sys{
+		Stamp:       0,
+		Machinename: machineName,
+		User:        identity,
+		Group:       "",
+		Groups:      groups,
+		Secctx:      ""}
+
+	// Marshal our AuthSys token into a byte array
+	tokenBytes, err := proto.Marshal(&sys)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to marshal AuthSys token")
+	}
+
+	token := Token{
+		Flavor: req.GetAuthFlavor(),
+		Data:   tokenBytes}
+
+	verifier, err := VerifierFromToken(req.signingKey, &token)
+	if err != nil {
+		return nil, errors.WithMessage(err, "Unable to generate verifier")
+	}
+
+	verifierToken := Token{
+		Flavor: req.GetAuthFlavor(),
+		Data:   verifier}
+
+	credential := Credential{
+		Token:    &token,
+		Verifier: &verifierToken,
+		Origin:   "agent"}
+
+	logging.FromContext(ctx).Tracef("%s: successfully signed credential", authInfo)
+
+	return &credential, nil
+}
+
+func (req *AuthAccManCredentialRequest) GetKey() string {
+	return req.delegationCredential
+}

--- a/src/control/security/auth/auth_sys.go
+++ b/src/control/security/auth/auth_sys.go
@@ -7,64 +7,24 @@
 package auth
 
 import (
-	"bytes"
 	"context"
 	"crypto"
+	"fmt"
+	"net"
 	"os"
 	"os/user"
+	"reflect"
 	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 )
-
-// VerifierFromToken will return a SHA512 hash of the token data. If a signing key
-// is passed in it will additionally sign the hash of the token.
-func VerifierFromToken(key crypto.PublicKey, token *Token) ([]byte, error) {
-	var sig []byte
-	tokenBytes, err := proto.Marshal(token)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to marshal Token")
-	}
-
-	signer := security.DefaultTokenSigner()
-
-	if key == nil {
-		return signer.Hash(tokenBytes)
-	}
-	sig, err = signer.Sign(key, tokenBytes)
-	return sig, errors.Wrap(err, "signing verifier failed")
-}
-
-// VerifyToken takes the auth token and the signature bytes in the verifier and
-// verifies it against the public key provided for the agent who claims to have
-// provided the token.
-func VerifyToken(key crypto.PublicKey, token *Token, sig []byte) error {
-	tokenBytes, err := proto.Marshal(token)
-	if err != nil {
-		return errors.Wrap(err, "unable to marshal Token")
-	}
-
-	signer := security.DefaultTokenSigner()
-
-	if key == nil {
-		digest, err := signer.Hash(tokenBytes)
-		if err != nil {
-			return err
-		}
-		if bytes.Equal(digest, sig) {
-			return nil
-		}
-		return errors.Errorf("unsigned hash failed to verify.")
-	}
-
-	err = signer.Verify(key, tokenBytes, sig)
-	return errors.Wrap(err, "token verification Failed")
-}
 
 func sysNameToPrincipalName(name string) string {
 	return name + "@"
@@ -85,25 +45,47 @@ func GetMachineName() (string, error) {
 }
 
 type (
+	GetSignedCredentialInternalFn func(ctx context.Context, req *AuthSysCredentialRequest) (*Credential, error)
+
 	getHostnameFn   func() (string, error)
 	getUserFn       func(string) (*user.User, error)
 	getGroupFn      func(string) (*user.Group, error)
-	getGroupIdsFn   func(*CredentialRequest) ([]string, error)
-	getGroupNamesFn func(*CredentialRequest) ([]string, error)
+	getGroupIdsFn   func(*AuthSysCredentialRequest) ([]string, error)
+	getGroupNamesFn func(*AuthSysCredentialRequest) ([]string, error)
 
-	// CredentialRequest defines the request parameters for GetSignedCredential.
-	CredentialRequest struct {
-		DomainInfo    *security.DomainInfo
-		SigningKey    crypto.PrivateKey
-		getHostname   getHostnameFn
-		getUser       getUserFn
-		getGroup      getGroupFn
-		getGroupIds   getGroupIdsFn
-		getGroupNames getGroupNamesFn
+	// AuthSysCredentialFactory is a factory interface for AuthSysCredentialRequests.
+	AuthSysCredentialFactory struct {
+	}
+
+	// AuthSysCredentialRequest defines the request parameters for GetSignedCredential for the AUTH_SYS flavor.
+	AuthSysCredentialRequest struct {
+		DomainInfo                  *security.DomainInfo
+		signingKey                  crypto.PrivateKey
+		getHostname                 getHostnameFn
+		getUser                     getUserFn
+		getGroup                    getGroupFn
+		getGroupIds                 getGroupIdsFn
+		getGroupNames               getGroupNamesFn
+		clientMap                   *security.ClientUserMap
+		GetSignedCredentialInternal GetSignedCredentialInternalFn
 	}
 )
 
-func getGroupIds(req *CredentialRequest) ([]string, error) {
+// NewCredentialRequest returns default instantiation of CredentialRequest.
+func NewCredentialRequest(info *security.DomainInfo, key crypto.PrivateKey) *AuthSysCredentialRequest {
+	return &AuthSysCredentialRequest{
+		DomainInfo:                  info,
+		signingKey:                  key,
+		getHostname:                 GetMachineName,
+		getUser:                     user.LookupId,
+		getGroup:                    user.LookupGroupId,
+		getGroupIds:                 getGroupIds,
+		getGroupNames:               getGroupNames,
+		GetSignedCredentialInternal: GetSignedCredentialInternalImpl,
+	}
+}
+
+func getGroupIds(req *AuthSysCredentialRequest) ([]string, error) {
 	u, err := req.user()
 	if err != nil {
 		return nil, err
@@ -111,7 +93,7 @@ func getGroupIds(req *CredentialRequest) ([]string, error) {
 	return u.GroupIds()
 }
 
-func getGroupNames(req *CredentialRequest) ([]string, error) {
+func getGroupNames(req *AuthSysCredentialRequest) ([]string, error) {
 	groupIds, err := req.getGroupIds(req)
 	if err != nil {
 		return nil, err
@@ -129,20 +111,7 @@ func getGroupNames(req *CredentialRequest) ([]string, error) {
 	return groupNames, nil
 }
 
-// NewCredentialRequest returns a properly initialized CredentialRequest.
-func NewCredentialRequest(info *security.DomainInfo, key crypto.PrivateKey) *CredentialRequest {
-	return &CredentialRequest{
-		DomainInfo:    info,
-		SigningKey:    key,
-		getHostname:   GetMachineName,
-		getUser:       user.LookupId,
-		getGroup:      user.LookupGroupId,
-		getGroupIds:   getGroupIds,
-		getGroupNames: getGroupNames,
-	}
-}
-
-func (r *CredentialRequest) hostname() (string, error) {
+func (r *AuthSysCredentialRequest) hostname() (string, error) {
 	if r.getHostname == nil {
 		return "", errors.New("hostname lookup function not set")
 	}
@@ -154,14 +123,14 @@ func (r *CredentialRequest) hostname() (string, error) {
 	return stripHostName(hostname), nil
 }
 
-func (r *CredentialRequest) user() (*user.User, error) {
+func (r *AuthSysCredentialRequest) user() (*user.User, error) {
 	if r.getUser == nil {
 		return nil, errors.New("user lookup function not set")
 	}
 	return r.getUser(strconv.Itoa(int(r.DomainInfo.Uid())))
 }
 
-func (r *CredentialRequest) userPrincipal() (string, error) {
+func (r *AuthSysCredentialRequest) userPrincipal() (string, error) {
 	u, err := r.user()
 	if err != nil {
 		return "", err
@@ -169,14 +138,14 @@ func (r *CredentialRequest) userPrincipal() (string, error) {
 	return sysNameToPrincipalName(u.Username), nil
 }
 
-func (r *CredentialRequest) group() (*user.Group, error) {
+func (r *AuthSysCredentialRequest) group() (*user.Group, error) {
 	if r.getGroup == nil {
 		return nil, errors.New("group lookup function not set")
 	}
 	return r.getGroup(strconv.Itoa(int(r.DomainInfo.Gid())))
 }
 
-func (r *CredentialRequest) groupPrincipal() (string, error) {
+func (r *AuthSysCredentialRequest) groupPrincipal() (string, error) {
 	g, err := r.group()
 	if err != nil {
 		return "", err
@@ -184,7 +153,7 @@ func (r *CredentialRequest) groupPrincipal() (string, error) {
 	return sysNameToPrincipalName(g.Name), nil
 }
 
-func (r *CredentialRequest) groupPrincipals() ([]string, error) {
+func (r *AuthSysCredentialRequest) groupPrincipals() ([]string, error) {
 	if r.getGroupNames == nil {
 		return nil, errors.New("groupNames function not set")
 	}
@@ -202,7 +171,7 @@ func (r *CredentialRequest) groupPrincipals() ([]string, error) {
 
 // WithUserAndGroup provides an override to set the user, group, and optional list
 // of group names to be used for the request.
-func (r *CredentialRequest) WithUserAndGroup(userStr, groupStr string, groupStrs ...string) {
+func (r *AuthSysCredentialRequest) WithUserAndGroup(userStr, groupStr string, groupStrs ...string) {
 	r.getUser = func(id string) (*user.User, error) {
 		return &user.User{
 			Uid:      id,
@@ -216,14 +185,49 @@ func (r *CredentialRequest) WithUserAndGroup(userStr, groupStr string, groupStrs
 			Name: groupStr,
 		}, nil
 	}
-	r.getGroupNames = func(*CredentialRequest) ([]string, error) {
+	r.getGroupNames = func(*AuthSysCredentialRequest) ([]string, error) {
 		return groupStrs, nil
 	}
 }
 
+// func (req *AuthSysCredentialRequest) AllocCredentialRequest() CredentialRequest {
+// 	return &AuthSysCredentialRequest{}
+// }
+
+func (fact *AuthSysCredentialFactory) Init(log logging.Logger, secCfg *security.CredentialConfig, session *drpc.Session, reqBody []byte, key crypto.PrivateKey) (CredentialRequest, error) {
+	req := &AuthSysCredentialRequest{}
+
+	if session == nil {
+		return req, drpc.NewFailureWithMessage("session is nil")
+	}
+
+	uConn, ok := session.Conn.(*net.UnixConn)
+	if !ok {
+		return req, drpc.NewFailureWithMessage("connection is not a unix socket")
+	}
+
+	info, err := security.DomainInfoFromUnixConn(log, uConn)
+	if err != nil {
+		log.Errorf("Unable to get credentials for client socket: %s", err)
+		return req, daos.MiscError
+	}
+
+	req.DomainInfo = info
+	req.signingKey = key
+	req.getHostname = GetMachineName
+	req.getUser = user.LookupId
+	req.getGroup = user.LookupGroupId
+	req.getGroupIds = getGroupIds
+	req.getGroupNames = getGroupNames
+	req.clientMap = &secCfg.ClientUserMap
+	req.GetSignedCredentialInternal = GetSignedCredentialInternalImpl
+
+	return req, nil
+}
+
 // GetSignedCredential returns a credential based on the provided domain info and
 // signing key.
-func GetSignedCredential(ctx context.Context, req *CredentialRequest) (*Credential, error) {
+func GetSignedCredentialInternalImpl(ctx context.Context, req *AuthSysCredentialRequest) (*Credential, error) {
 	if req == nil {
 		return nil, errors.Errorf("%T is nil", req)
 	}
@@ -267,16 +271,16 @@ func GetSignedCredential(ctx context.Context, req *CredentialRequest) (*Credenti
 		return nil, errors.Wrap(err, "Unable to marshal AuthSys token")
 	}
 	token := Token{
-		Flavor: Flavor_AUTH_SYS,
+		Flavor: req.GetAuthFlavor(),
 		Data:   tokenBytes}
 
-	verifier, err := VerifierFromToken(req.SigningKey, &token)
+	verifier, err := VerifierFromToken(req.signingKey, &token)
 	if err != nil {
 		return nil, errors.WithMessage(err, "Unable to generate verifier")
 	}
 
 	verifierToken := Token{
-		Flavor: Flavor_AUTH_SYS,
+		Flavor: req.GetAuthFlavor(),
 		Data:   verifier}
 
 	credential := Credential{
@@ -288,17 +292,73 @@ func GetSignedCredential(ctx context.Context, req *CredentialRequest) (*Credenti
 	return &credential, nil
 }
 
-// AuthSysFromAuthToken takes an opaque AuthToken and turns it into a
-// concrete AuthSys data structure.
-func AuthSysFromAuthToken(authToken *Token) (*Sys, error) {
-	if authToken.GetFlavor() != Flavor_AUTH_SYS {
-		return nil, errors.New("Attempting to convert an invalid AuthSys Token")
+// To satisfy the unit tests, https://stackoverflow.com/a/76595928
+func IsNilish(val any) bool {
+	if val == nil {
+		return true
 	}
 
-	sysToken := &Sys{}
-	err := proto.Unmarshal(authToken.GetData(), sysToken)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unmarshaling %s", authToken.GetFlavor())
+	v := reflect.ValueOf(val)
+	k := v.Kind()
+	switch k {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer,
+		reflect.UnsafePointer, reflect.Interface, reflect.Slice:
+		return v.IsNil()
 	}
-	return sysToken, nil
+
+	return false
+}
+
+// Unix auth has custom error handling logic for UnknownUserIDError. To solve this we
+// use a helper function - getSignedCredentialInternal - and hide
+func (req *AuthSysCredentialRequest) GetSignedCredential(log logging.Logger, ctx context.Context) (*Credential, error) {
+	print(req)
+	if IsNilish(req) {
+		return nil, errors.New("is nil")
+	}
+
+	cred, err := req.GetSignedCredentialInternal(ctx, req)
+	if err != nil {
+		if req.DomainInfo == nil {
+			return nil, err
+		}
+		if err := func() error {
+			if !errors.Is(err, user.UnknownUserIdError(req.DomainInfo.Uid())) {
+				return err
+			}
+
+			mu := req.clientMap.Lookup(req.DomainInfo.Uid())
+			if mu == nil {
+				return user.UnknownUserIdError(req.DomainInfo.Uid())
+			}
+
+			req.WithUserAndGroup(mu.User, mu.Group, mu.Groups...)
+			cred, err = req.GetSignedCredentialInternal(ctx, req)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}(); err != nil {
+			log.Errorf("%s: failed to get user credential: %s", req.DomainInfo, err)
+			return nil, err
+		}
+	}
+	return cred, nil
+}
+
+func (req *AuthSysCredentialRequest) GetKey() string {
+	return fmt.Sprintf("%d:%d:%s", req.DomainInfo.Uid(), req.DomainInfo.Gid(), req.DomainInfo.Ctx())
+}
+
+func GetSysFlavor() Flavor {
+	return Flavor_AUTH_SYS
+}
+
+func (fac AuthSysCredentialFactory) GetAuthFlavor() Flavor {
+	return GetSysFlavor()
+}
+
+func (req AuthSysCredentialRequest) GetAuthFlavor() Flavor {
+	return GetSysFlavor()
 }

--- a/src/control/security/auth/auth_test.go
+++ b/src/control/security/auth/auth_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 )
 
@@ -130,7 +131,7 @@ func testGroupFn(expErr error, groupName string) getGroupFn {
 }
 
 func testGroupIdsFn(expErr error, groupNames ...string) getGroupIdsFn {
-	return func(*CredentialRequest) ([]string, error) {
+	return func(*AuthSysCredentialRequest) ([]string, error) {
 		if expErr != nil {
 			return nil, expErr
 		}
@@ -139,7 +140,7 @@ func testGroupIdsFn(expErr error, groupNames ...string) getGroupIdsFn {
 }
 
 func testGroupNamesFn(expErr error, groupNames ...string) getGroupNamesFn {
-	return func(*CredentialRequest) ([]string, error) {
+	return func(*AuthSysCredentialRequest) ([]string, error) {
 		if expErr != nil {
 			return nil, expErr
 		}
@@ -207,7 +208,7 @@ func TestAuth_GetSignedCred(t *testing.T) {
 	}
 
 	for name, tc := range map[string]struct {
-		req    *CredentialRequest
+		req    *AuthSysCredentialRequest
 		expErr error
 	}{
 		"nil request": {
@@ -215,11 +216,11 @@ func TestAuth_GetSignedCred(t *testing.T) {
 			expErr: errors.New("is nil"),
 		},
 		"nil DomainInfo": {
-			req:    &CredentialRequest{},
+			req:    &AuthSysCredentialRequest{GetSignedCredentialInternal: GetSignedCredentialInternalImpl},
 			expErr: errors.New("No domain info supplied"),
 		},
 		"bad hostname": {
-			req: func() *CredentialRequest {
+			req: func() *AuthSysCredentialRequest {
 				req := NewCredentialRequest(getTestCreds(1, 2), nil)
 				req.getHostname = testHostnameFn(errors.New("bad hostname"), "")
 				return req
@@ -227,7 +228,7 @@ func TestAuth_GetSignedCred(t *testing.T) {
 			expErr: errors.New("bad hostname"),
 		},
 		"bad uid": {
-			req: func() *CredentialRequest {
+			req: func() *AuthSysCredentialRequest {
 				req := NewCredentialRequest(getTestCreds(1, 2), nil)
 				req.getUser = testUserFn(errors.New("bad uid"), "")
 				return req
@@ -235,7 +236,7 @@ func TestAuth_GetSignedCred(t *testing.T) {
 			expErr: errors.New("bad uid"),
 		},
 		"bad gid": {
-			req: func() *CredentialRequest {
+			req: func() *AuthSysCredentialRequest {
 				req := NewCredentialRequest(getTestCreds(1, 2), nil)
 				req.getGroup = testGroupFn(errors.New("bad gid"), "")
 				return req
@@ -243,7 +244,7 @@ func TestAuth_GetSignedCred(t *testing.T) {
 			expErr: errors.New("bad gid"),
 		},
 		"bad group IDs": {
-			req: func() *CredentialRequest {
+			req: func() *AuthSysCredentialRequest {
 				req := NewCredentialRequest(getTestCreds(1, 2), nil)
 				req.getGroupIds = testGroupIdsFn(errors.New("bad group IDs"))
 				return req
@@ -251,7 +252,7 @@ func TestAuth_GetSignedCred(t *testing.T) {
 			expErr: errors.New("bad group IDs"),
 		},
 		"bad group names": {
-			req: func() *CredentialRequest {
+			req: func() *AuthSysCredentialRequest {
 				req := NewCredentialRequest(getTestCreds(1, 2), nil)
 				req.getGroupNames = testGroupNamesFn(errors.New("bad group names"))
 				return req
@@ -259,7 +260,7 @@ func TestAuth_GetSignedCred(t *testing.T) {
 			expErr: errors.New("bad group names"),
 		},
 		"valid": {
-			req: func() *CredentialRequest {
+			req: func() *AuthSysCredentialRequest {
 				req := NewCredentialRequest(getTestCreds(1, 2), nil)
 				req.getHostname = testHostnameFn(nil, testHostname)
 				req.getUser = testUserFn(nil, testUsername)
@@ -270,7 +271,7 @@ func TestAuth_GetSignedCred(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			cred, gotErr := GetSignedCredential(test.Context(t), tc.req)
+			cred, gotErr := tc.req.GetSignedCredential(logging.FromContext(test.Context(t)), test.Context(t))
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return
@@ -286,7 +287,7 @@ func TestAuth_CredentialRequestOverrides(t *testing.T) {
 	req.getHostname = testHostnameFn(nil, "test-host")
 	req.WithUserAndGroup("test-user", "test-group", "test-secondary")
 
-	cred, err := GetSignedCredential(test.Context(t), req)
+	cred, err := req.GetSignedCredential(logging.FromContext(test.Context(t)), test.Context(t))
 	if err != nil {
 		t.Fatalf("Failed to get credential: %s", err)
 	}

--- a/src/control/security/config.go
+++ b/src/control/security/config.go
@@ -94,8 +94,16 @@ func (cm ClientUserMap) Lookup(uid uint32) *MappedClientUser {
 // CredentialConfig contains configuration details for managing user
 // credentials.
 type CredentialConfig struct {
-	CacheExpiration time.Duration `yaml:"cache_expiration,omitempty"`
-	ClientUserMap   ClientUserMap `yaml:"client_user_map,omitempty"`
+	CacheExpiration  time.Duration       `yaml:"cache_expiration,omitempty"`
+	ClientUserMap    ClientUserMap       `yaml:"client_user_map,omitempty"`
+	ValidAuthMethods []string            `yaml:"valid_auth_methods,omitempty"`
+	AMConfig         AccessManagerConfig `yaml:"access_manager_config,omitempty"`
+}
+
+// AccessManagerConfig contains configuration details for managing access manager
+type AccessManagerConfig struct {
+	CallerID string `yaml:"caller_id,omitempty"`
+	BaseURL  string `yaml:"base_url,omitempty"`
 }
 
 // TransportConfig contains all the information on whether or not to use

--- a/src/control/server/drpc.go
+++ b/src/control/server/drpc.go
@@ -19,6 +19,7 @@ import (
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
+	"github.com/daos-stack/daos/src/control/security/auth"
 	"github.com/daos-stack/daos/src/control/system/raft"
 )
 
@@ -70,6 +71,7 @@ type drpcServerSetupReq struct {
 	sockDir string
 	engines []Engine
 	tc      *security.TransportConfig
+	vaf     []auth.Flavor
 	sysdb   *raft.Database
 	events  *events.PubSub
 }
@@ -90,8 +92,10 @@ func drpcServerSetup(ctx context.Context, req *drpcServerSetupReq) error {
 		return errors.Wrap(err, "unable to create socket server")
 	}
 
+	securityModule := NewSecurityModule(req.log, req.tc, req.vaf)
+
 	// Create and add our modules
-	drpcServer.RegisterRPCModule(NewSecurityModule(req.log, req.tc))
+	drpcServer.RegisterRPCModule(securityModule)
 	drpcServer.RegisterRPCModule(newMgmtModule())
 	drpcServer.RegisterRPCModule(newSrvModule(req.log, req.sysdb, req.sysdb, req.engines, req.events))
 

--- a/src/control/server/mgmt_cont_test.go
+++ b/src/control/server/mgmt_cont_test.go
@@ -85,7 +85,7 @@ func TestMgmt_ListContainers(t *testing.T) {
 				db := raft.MockDatabase(t, log)
 				ms := system.MockMembership(t, log, db, mockTCPResolver)
 				return newMgmtSvc(NewEngineHarness(log), ms, db, nil,
-					events.NewPubSub(test.Context(t), log))
+					events.NewPubSub(test.Context(t), log), nil)
 			},
 			req:    validListContReq(),
 			expErr: FaultHarnessNotStarted,
@@ -185,7 +185,7 @@ func TestMgmt_ContSetOwner(t *testing.T) {
 				db := raft.MockDatabase(t, log)
 				ms := system.MockMembership(t, log, db, mockTCPResolver)
 				return newMgmtSvc(NewEngineHarness(log), ms, db, nil,
-					events.NewPubSub(test.Context(t), log))
+					events.NewPubSub(test.Context(t), log), nil)
 			},
 			req:    validContSetOwnerReq(),
 			expErr: FaultHarnessNotStarted,

--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -24,6 +24,7 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/security/auth"
 	"github.com/daos-stack/daos/src/control/system"
 	"github.com/daos-stack/daos/src/control/system/raft"
 )
@@ -83,9 +84,10 @@ type mgmtSvc struct {
 	serialReqs        batchReqChan
 	groupUpdateReqs   chan bool
 	lastMapVer        uint32
+	validAuthFlavors  []auth.Flavor
 }
 
-func newMgmtSvc(h *EngineHarness, m *system.Membership, s *raft.Database, c control.UnaryInvoker, p *events.PubSub) *mgmtSvc {
+func newMgmtSvc(h *EngineHarness, m *system.Membership, s *raft.Database, c control.UnaryInvoker, p *events.PubSub, a []auth.Flavor) *mgmtSvc {
 	return &mgmtSvc{
 		log:               h.log,
 		harness:           h,
@@ -99,6 +101,7 @@ func newMgmtSvc(h *EngineHarness, m *system.Membership, s *raft.Database, c cont
 		batchReqs:         make(batchReqChan),
 		serialReqs:        make(batchReqChan),
 		groupUpdateReqs:   make(chan bool),
+		validAuthFlavors:  a,
 	}
 }
 

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -129,6 +129,14 @@ func (svc *mgmtSvc) GetAttachInfo(ctx context.Context, req *mgmtpb.GetAttachInfo
 		}
 	}
 
+	vaf := make([]uint32, len(svc.validAuthFlavors))
+
+	for index, value := range svc.validAuthFlavors {
+		vaf[index] = uint32(value)
+	}
+
+	resp.ValidAuthFlavors = vaf
+
 	return resp, nil
 }
 

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -222,7 +222,7 @@ func TestServer_MgmtSvc_GetAttachInfo(t *testing.T) {
 
 			db := raft.MockDatabaseWithAddr(t, log, msReplica.Addr)
 			m := system.NewMembership(log, db)
-			tc.svc = newMgmtSvc(harness, m, db, nil, nil)
+			tc.svc = newMgmtSvc(harness, m, db, nil, nil, nil)
 			if _, err := tc.svc.membership.Add(msReplica); err != nil {
 				t.Fatal(err)
 			}

--- a/src/control/server/util_test.go
+++ b/src/control/server/util_test.go
@@ -245,7 +245,7 @@ func newTestMgmtSvcWithProvider(t *testing.T, log logging.Logger, provider *stor
 	db := raft.MockDatabase(t, log)
 	ms := system.MockMembership(t, log, db, mockTCPResolver)
 	ctx := test.Context(t)
-	svc := newMgmtSvc(harness, ms, db, nil, events.NewPubSub(ctx, log))
+	svc := newMgmtSvc(harness, ms, db, nil, events.NewPubSub(ctx, log), nil)
 	svc.batchInterval = 100 * time.Microsecond // Speed up tests
 	svc.startAsyncLoops(ctx)
 	svc.startLeaderLoops(ctx)

--- a/src/include/daos/drpc_modules.h
+++ b/src/include/daos/drpc_modules.h
@@ -29,7 +29,7 @@ enum drpc_module {
 
 enum drpc_sec_agent_method {
 	DRPC_METHOD_SEC_AGENT_REQUEST_CREDS	= 101,
-
+	DRPC_METHOD_SEC_AGENT_REQUEST_AUTH_FLAVORS	= 102,
 	NUM_DRPC_SEC_AGENT_METHODS		/* Must be last */
 };
 

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -201,6 +201,8 @@ extern "C" {
 	ACTION(DER_CONTROL_INCOMPAT, One or more control plane components are incompatible)        \
 	/** No service available */                                                                \
 	ACTION(DER_NO_SERVICE, No service available)                                               \
+	/** Faild to sign credential */                                                            \
+	ACTION(DER_FAILED_SIGN, Faild to sign credential)                                          \
 	/** The TX ID may be reused. */                                                            \
 	ACTION(DER_TX_ID_REUSED, TX ID may be reused)                                              \
 	/** Re-update again */                                                                     \

--- a/src/proto/mgmt/svc.proto
+++ b/src/proto/mgmt/svc.proto
@@ -8,102 +8,111 @@
 syntax = "proto3";
 package mgmt;
 
-option go_package = "github.com/daos-stack/daos/src/control/common/proto/mgmt";
+option  go_package = "github.com/daos-stack/daos/src/control/common/proto/mgmt";
 
 // Management Service Protobuf Definitions related to interactions between
 // DAOS control server and DAOS IO Engines.
 
 // Generic response just containing DER from I/O Engine.
-message DaosResp {
-	int32 status = 1;	// DAOS error code.
+message DaosResp
+{
+	int32 status = 1; // DAOS error code.
 }
 
-message GroupUpdateReq {
-	message Engine {
+message GroupUpdateReq
+{
+	message Engine
+	{
 		uint32 rank = 1;
-		string uri = 2; // primary URI is the only one group update is concerned with
+		string uri  = 2; // primary URI is the only one group update is concerned with
 		uint64 incarnation = 3;
 	}
-	uint32 map_version = 1;
-	repeated Engine engines = 2;
+	uint32          map_version = 1;
+	repeated Engine engines     = 2;
 }
 
-message GroupUpdateResp {
-	int32 status = 1;
-}
+message GroupUpdateResp { int32 status = 1; }
 
-message JoinReq {
-	string sys = 1;			// DAOS system name.
-	string          uuid  = 2;                 // Engine UUID.
-	uint32          rank  = 3;                 // Engine rank desired, if not MAX_UINT32.
+message JoinReq
+{
+	string          sys   = 1; // DAOS system name.
+	string          uuid  = 2; // Engine UUID.
+	uint32          rank  = 3; // Engine rank desired, if not MAX_UINT32.
 	string          uri   = 4; // Engine CaRT primary provider URI (i.e., for context 0).
 	uint32          nctxs = 5; // Engine CaRT context count.
-	string addr = 6;		// Server management address.
-	string srvFaultDomain = 7; 	// Fault domain for this instance's server
-	uint32 idx = 8;			// Instance index on server node.
-	uint64 incarnation = 9; 	// rank incarnation
-	repeated string secondary_uris = 10; // URIs for any secondary providers
+	string          addr  = 6; // Server management address.
+	string          srvFaultDomain  = 7;  // Fault domain for this instance's server
+	uint32          idx             = 8;  // Instance index on server node.
+	uint64          incarnation     = 9;  // rank incarnation
+	repeated string secondary_uris  = 10; // URIs for any secondary providers
 	repeated uint32 secondary_nctxs = 11; // CaRT context count for each secondary provider
-	bool check_mode = 12; 		// rank started in check mode
+	bool            check_mode      = 12; // rank started in check mode
 	bool            replace         = 13; // Rank's engine instance metadata to be replaced
 }
 
-message JoinResp {
-	int32 status = 1;	// DAOS error code
-	uint32 rank = 2;	// Server rank assigned.
+message JoinResp
+{
+	int32  status = 1; // DAOS error code
+	uint32 rank   = 2; // Server rank assigned.
 	enum State {
-		IN = 0;		// Server in the system.
-		OUT = 1;	// Server excluded from the system.
-		CHECK = 2;	// Server should start in checker mode.
+		IN    = 0; // Server in the system.
+		OUT   = 1; // Server excluded from the system.
+		CHECK = 2; // Server should start in checker mode.
 	}
-	State state = 3;	// Server state in the system map.
-	string faultDomain = 4; // Fault domain for the instance
-	bool localJoin = 5;	// Join processed locally.
-	uint32 map_version = 6; // Join processed in this version of the system map.
+	State  state        = 3; // Server state in the system map.
+	string faultDomain  = 4; // Fault domain for the instance
+	bool   localJoin    = 5; // Join processed locally.
+	uint32 map_version  = 6; // Join processed in this version of the system map.
 	uint32 daos_version = 7; // DAOS version that system supported.
 }
 
-message LeaderQueryReq {
-	string sys = 1;		// System name.
-	string hosts = 2;	// hostset to query
+message LeaderQueryReq
+{
+	string sys   = 1; // System name.
+	string hosts = 2; // hostset to query
 }
 
-message LeaderQueryResp {
-	string current_leader = 1;
-	repeated string replicas = 2;
-	repeated string DownReplicas = 3;
+message LeaderQueryResp
+{
+	string          current_leader = 1;
+	repeated string replicas       = 2;
+	repeated string DownReplicas   = 3;
 }
 
-message GetAttachInfoReq {
-	string sys = 1;		// System name. For daos_agent only.
-	bool all_ranks = 2;	// Return Rank URIs for all ranks.
-	string interface = 3;	// Preferred fabric interface.
-	string domain = 4;	// Preferred fabric domain.
+message GetAttachInfoReq
+{
+	string sys       = 1; // System name. For daos_agent only.
+	bool   all_ranks = 2; // Return Rank URIs for all ranks.
+	string interface = 3; // Preferred fabric interface.
+	string domain    = 4; // Preferred fabric domain.
 }
 
-message ClientNetHint {
+message ClientNetHint
+{
 	reserved 4;
-	string provider = 1;		// CaRT provider
-	string interface = 2;		// CaRT D_INTERFACE
-	string domain = 3;		// CaRT D_DOMAIN for given D_INTERFACE
-	uint32 crt_timeout = 5;		// CaRT CRT_TIMEOUT
-	uint32 net_dev_class = 6;	// ARP protocol hardware identifier of the
-					// I/O Engine network interface
-	int32 srv_srx_set = 7;		// Server SRX setting (-1, 0, 1; -1 == unset)
-	repeated string env_vars = 8;	// Client-side environment variables to set
-	uint32 provider_idx = 9;	// Provider index - anything > 0 is a secondary provider
+	string          provider      = 1; // CaRT provider
+	string          interface     = 2; // CaRT D_INTERFACE
+	string          domain        = 3; // CaRT D_DOMAIN for given D_INTERFACE
+	uint32          crt_timeout   = 5; // CaRT CRT_TIMEOUT
+	uint32          net_dev_class = 6; // ARP protocol hardware identifier of the
+					   // I/O Engine network interface
+	int32           srv_srx_set  = 7;  // Server SRX setting (-1, 0, 1; -1 == unset)
+	repeated string env_vars     = 8;  // Client-side environment variables to set
+	uint32          provider_idx = 9;  // Provider index - anything > 0 is a secondary provider
 }
 
-message FabricInterface {
+message FabricInterface
+{
 	uint32 numa_node = 1;
 	string interface = 2;
-	string domain = 3;
-	string provider = 4;
+	string domain    = 3;
+	string provider  = 4;
 }
 
-message FabricInterfaces {
-	uint32 numa_node = 1;
-	repeated FabricInterface ifaces = 2;
+message FabricInterfaces
+{
+	uint32                   numa_node = 1;
+	repeated FabricInterface ifaces    = 2;
 }
 
 message BuildInfo
@@ -114,52 +123,60 @@ message BuildInfo
 	string tag   = 4;
 }
 
-message GetAttachInfoResp {
-	int32 status = 1;		// DAOS error code
-	message RankUri {
-		uint32 rank = 1;
-		string uri = 2;
+message GetAttachInfoResp
+{
+	int32 status = 1; // DAOS error code
+	message RankUri
+	{
+		uint32 rank         = 1;
+		string uri          = 2;
 		uint32 provider_idx = 3;
-		uint32 num_ctxs = 4;
+		uint32 num_ctxs     = 4;
 	}
-	repeated RankUri rank_uris = 2;	// Rank URIs for the primary provider
-					// These CaRT settings are shared with the
-					// libdaos client to aid in CaRT initialization.
-	repeated uint32 ms_ranks = 3;	// Ranks local to MS replicas
-	ClientNetHint client_net_hint = 4; // Primary provider hint
-	uint64 data_version = 5; // Version of the system database.
-	string sys = 6;			// Name of the DAOS system
-	repeated RankUri secondary_rank_uris = 7; // Rank URIs for additional providers
-	repeated ClientNetHint secondary_client_net_hints = 8; // Hints for additional providers
-	BuildInfo              build_info = 9; // Structured server build information
-	repeated FabricInterfaces numa_fabric_interfaces = 10; // Usable fabric interfaces by NUMA node (populated by agent)
+	repeated RankUri          rank_uris = 2; // Rank URIs for the primary provider
+						 // These CaRT settings are shared with the
+						 // libdaos client to aid in CaRT initialization.
+	repeated uint32           ms_ranks            = 3; // Ranks local to MS replicas
+	ClientNetHint             client_net_hint     = 4; // Primary provider hint
+	uint64                    data_version        = 5; // Version of the system database.
+	string                    sys                 = 6; // Name of the DAOS system
+	repeated RankUri          secondary_rank_uris = 7; // Rank URIs for additional providers
+	repeated ClientNetHint    secondary_client_net_hints = 8; // Hints for additional providers
+	BuildInfo                 build_info = 9; // Structured server build information
+	repeated FabricInterfaces numa_fabric_interfaces =
+	    10; // Usable fabric interfaces by NUMA node (populated by agent)
+	repeated uint32 valid_auth_flavors = 11; // Authentication flavors allowed by the server
 }
 
-message PrepShutdownReq {
-	uint32 rank = 1;	// DAOS I/O Engine unique identifier.
+message PrepShutdownReq
+{
+	uint32 rank = 1; // DAOS I/O Engine unique identifier.
 }
 
 // PrepShutdownResp is identical to DaosResp.
 
-message PingRankReq {
-	uint32 rank = 1;	// DAOS I/O Engine unique identifier.
+message PingRankReq
+{
+	uint32 rank = 1; // DAOS I/O Engine unique identifier.
 }
 
 // PingRankResp is identical to DaosResp.
 
-message SetRankReq {
-	uint32 rank = 1;	// DAOS I/O Engine unique identifier.
-	uint32 map_version = 2;	// System map version in which the rank joined the system.
+message SetRankReq
+{
+	uint32 rank         = 1; // DAOS I/O Engine unique identifier.
+	uint32 map_version  = 2; // System map version in which the rank joined the system.
 	uint32 daos_version = 3; // DAOS version that system supported.
 }
 
 // SetRankResp is identical to DaosResp.
 
-message PoolMonitorReq {
-	string sys = 1; // DAOS system identifier
-	string poolUUID = 2;	// Pool UUID associated with the Pool Handle
+message PoolMonitorReq
+{
+	string sys            = 1; // DAOS system identifier
+	string poolUUID       = 2; // Pool UUID associated with the Pool Handle
 	string poolHandleUUID = 3; // Pool Handle UUID for the connection
-	string jobid = 4;	// Job ID to associate instance with.
+	string jobid          = 4; // Job ID to associate instance with.
 }
 
 message ClientTelemetryReq

--- a/src/proto/security/auth.proto
+++ b/src/proto/security/auth.proto
@@ -7,52 +7,73 @@
 syntax = "proto3";
 package auth;
 
-option go_package = "github.com/daos-stack/daos/src/control/security/auth;auth";
+option  go_package = "github.com/daos-stack/daos/src/control/security/auth;auth";
 
 // Types of authentication token
 enum Flavor {
-	AUTH_NONE = 0;
-	AUTH_SYS = 1;
+	AUTH_NONE = 0; // No authentication.
+	AUTH_SYS  = 1; // Traditional Unix identity based authentication.
+	AUTH_ACCMAN   = 2; // Authentication provided by the Access Manager.
 }
 
-message Token {
+message Token
+{
 	Flavor flavor = 1; // flavor of this authentication token
-	bytes data = 2; // packed structure of the specified flavor
+	bytes  data   = 2; // packed structure of the specified flavor
 }
 
 // Token structure for AUTH_SYS flavor cred
-message Sys {
-	uint64 stamp = 1; // timestamp
-	string machinename = 2; // machine name
-	string user = 3; // user name
-	string group = 4; // primary group name
-	repeated string groups = 5; // secondary group names
-	string secctx = 6; // Additional field for MAC label
+message Sys
+{
+	uint64          stamp       = 1; // timestamp
+	string          machinename = 2; // machine name
+	string          user        = 3; // user name
+	string          group       = 4; // primary group name
+	repeated string groups      = 5; // secondary group names
+	string          secctx      = 6; // Additional field for MAC label
 }
 
 // Token and verifier are expected to have the same flavor type.
-message Credential {
-	Token token = 1; // authentication token
-	Token verifier = 2; // to verify integrity of the token
-	string origin = 3; // the agent that created this credential
+message Credential
+{
+	Token  token    = 1; // authentication token
+	Token  verifier = 2; // to verify integrity of the token
+	string origin   = 3; // the agent that created this credential
+}
+
+message GetCredReq
+{
+	Flavor flavor = 1; // flavor of this request
+	bytes  data   = 2; // data for authentication
 }
 
 // GetCredResp represents the result of a request to fetch authentication
 // credentials.
-message GetCredResp {
-	int32 status = 1; // Status of the request
-	Credential cred = 2; // Caller's authentication credential
+message GetCredResp
+{
+	int32      status = 1; // Status of the request
+	Credential cred   = 2; // Caller's authentication credential
+}
+
+// GetCredResp represents the result of a request to fetch authentication
+// credentials.
+message GetValidFlavorsResp
+{
+	int32           status           = 1; // Status of the request
+	repeated Flavor validAuthFlavors = 2; // Auth flavors accepted by agent/server
 }
 
 // ValidateCredReq represents a request to verify a set of authentication
 // credentials.
-message ValidateCredReq {
+message ValidateCredReq
+{
 	Credential cred = 1; // Credential to be validated
 }
 
 // ValidateCredResp represents the result of a request to validate
 // authentication credentials.
-message ValidateCredResp {
+message ValidateCredResp
+{
 	int32 status = 1; // Status of the request
-	Token token = 2; // Validated authentication token from the credential
+	Token token  = 2; // Validated authentication token from the credential
 }


### PR DESCRIPTION
The DAOS agent currently authenticates users using Unix Domain Sockets (UDS). While this works for many users, there is a growing demand for alternative authentication methods. This pull request reworks the DAOS agent code to make it simple to implement new sources of authentication for use in addition to/besides UDS. We also added a new example alternative authentication method in use at our company (part of a project soon to be open-sourced), and are happy to leave it in the codebase as an example.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
