### PR TITLE
DAOS-17948 object: fix bugs for sgl duplicate logic

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4908,29 +4908,23 @@ obj_dup_sgls_free(struct obj_auxi_args *obj_auxi)
 			uint32_t     dup_sg_idx   = 0;
 			uint32_t     dup_buf_size = 0;
 			uint32_t     dup_data_len = 0;
-			uint32_t     sg_nr_out    = 0;
 			char        *dup_buf;
 
 			if (!ctx->alloc_bitmaps || !ctx->alloc_bitmaps[i])
 				continue;
 
 			D_ASSERT(ctx->merged_bitmaps[i] != NULL);
-			for (j = 0; j < sg_orig->sg_nr && dup_sg_idx < sg_dup->sg_nr_out;) {
+			for (j = 0; j < sg_orig->sg_nr && dup_sg_idx < sg_dup->sg_nr_out; j++) {
 				iov     = &sg_orig->sg_iovs[j];
 				iov_dup = &sg_dup->sg_iovs[dup_sg_idx];
 
-				if (skip_sgl_iov(false, iov)) {
-					j++;
-					sg_nr_out++;
+				if (skip_sgl_iov(false, iov))
 					continue;
-				}
 
 				/* Direct copy if entry wasn't modified */
 				if (!isset_range((uint8_t *)ctx->merged_bitmaps[i], j, j)) {
 					*iov = *iov_dup;
 					D_ASSERT(dup_data_len == 0);
-					j++;
-					sg_nr_out++;
 					dup_sg_idx++;
 					continue;
 				}
@@ -4949,14 +4943,12 @@ obj_dup_sgls_free(struct obj_auxi_args *obj_auxi)
 				dup_data_len -= iov->iov_len;
 				dup_buf += iov->iov_len;
 				dup_buf_size -= iov->iov_len;
-				sg_nr_out++;
-				j++;
 
 				/* When current duplicate buffer is exhausted, get next entry */
 				if (dup_data_len == 0)
 					dup_sg_idx++;
 			}
-			sg_orig->sg_nr_out = sg_nr_out;
+			sg_orig->sg_nr_out = j;
 		}
 	}
 

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4843,19 +4843,17 @@ obj_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args, bool updat
 			setbits64(ctx.alloc_bitmaps[i], sgl_idx, 1);
 
 			/* Copy data from original IOVs to merged buffer */
-			if (update) {
-				offset = 0;
-				for (k = merge_start; k < j; k++) {
-					uint64_t merge_len;
+			offset = 0;
+			for (k = merge_start; k < j; k++) {
+				uint64_t merge_len;
 
-					iov = &sg->sg_iovs[k];
-					if (skip_sgl_iov(update, iov))
-						continue;
-					D_ASSERT(offset < merged_buf_size);
-					merge_len = update ? iov->iov_len : iov->iov_buf_len;
-					memcpy(merged_buf + offset, iov->iov_buf, merge_len);
-					offset += merge_len;
-				}
+				iov = &sg->sg_iovs[k];
+				if (skip_sgl_iov(update, iov))
+					continue;
+				D_ASSERT(offset < merged_buf_size);
+				merge_len = update ? iov->iov_len : iov->iov_buf_len;
+				memcpy(merged_buf + offset, iov->iov_buf, merge_len);
+				offset += merge_len;
 			}
 
 			/* Create merged IOV entry */


### PR DESCRIPTION
 1. When IO retries occur, a use-after-free scenario may arise during
    scatter-gather list (sgl) merging. This happens because retried I/O's
    sgl references dup_sgls, which could be prematurely freed in obj_reasb_io_fini().

    To fix above issue, dup_sgls must not be freed during retry operations
    and should be called only once per I/O operation.

 2. If both short reads and duplicated SGLs occur, the iov_len of the original
 SGLs must be updated properly to ensure the correct number of read data bytes
 is returned.

3. A test case has been added to verify that short reads function as expected during SGL merging.
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
