### PR TITLE
DAOS-17950 test: Fix dfuse/daos_build.py test

### DIFF
--- a/src/tests/ftest/dfuse/daos_build.yaml
+++ b/src/tests/ftest/dfuse/daos_build.yaml
@@ -16,7 +16,6 @@ server_config:
       targets: 4
       nr_xs_helpers: 0
       storage: auto
-  system_ram_reserved: 3
 
 pool:
   size: 20G


### PR DESCRIPTION
Remove the system_ram_reserved entry from the dfuse/daos_build.py test yaml.

Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
