### PR TITLE
DAOS-16563 client: mark pool/cont handle as g2l after fork (#15125)

### DIFF
--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -366,3 +366,32 @@ unlock:
 	D_MUTEX_UNLOCK(&module_lock);
 	return rc;
 }
+
+/**
+ * Re-initialize the DAOS library in the child process after fork.
+ */
+int
+daos_reinit(void)
+{
+	int rc;
+
+	rc = daos_eq_lib_reset_after_fork();
+	if (rc)
+		return rc;
+
+	daos_dti_reset();
+
+	/**
+	 * Mark all pool and container handles owned by the parent process as if they were created
+	 * in the child processes with g2l to avoid confusing the DAOS engines.
+	 */
+	rc = dc_pool_mark_all_slave();
+	if (rc)
+		return rc;
+
+	rc = dc_cont_mark_all_slave();
+	if (rc)
+		return rc;
+
+	return 0;
+}

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -631,6 +631,12 @@ daos_hhash_link_delete(struct d_hlink *hlink)
 	return d_hhash_link_delete(daos_ht.dht_hhash, hlink);
 }
 
+int
+daos_hhash_traverse(int type, daos_hhash_traverse_cb_t cb, void *arg)
+{
+	return d_hhash_traverse(daos_ht.dht_hhash, type, cb, arg);
+}
+
 /**
  * a helper to get the needed crt_init_opt.
  *

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -3524,3 +3524,20 @@ dc_cont_hdl2props(daos_handle_t coh)
 
 	return result;
 }
+
+static int
+cont_mark_slave(struct d_hlink *link, void *arg)
+{
+	struct dc_cont *cont;
+
+	cont           = container_of(link, struct dc_cont, dc_hlink);
+	cont->dc_slave = 1;
+
+	return 0;
+}
+
+int
+dc_cont_mark_all_slave(void)
+{
+	return daos_hhash_traverse(DAOS_HTYPE_CO, cont_mark_slave, NULL);
+}

--- a/src/include/daos.h
+++ b/src/include/daos.h
@@ -46,6 +46,17 @@ daos_init(void);
 int
 daos_fini(void);
 
+/**
+ * Reinitialize DAOS library after a fork call.
+ * For applications that initialize DAOS and then call fork without exec, some
+ * internal data structures must be reinitialized in the child process.
+ * It is recommended to call this function from a fork handler registered via
+ * pthread_atfork(). If any event queues were created prior to the fork call,
+ * those must be re-created in the child process.
+ */
+int
+daos_reinit(void);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -964,6 +964,10 @@ bool daos_hhash_link_delete(struct d_hlink *hlink);
 #define daos_hhash_link_empty(hlink)		d_hhash_link_empty(hlink)
 #define daos_hhash_link_key(hlink, key)		d_hhash_link_key(hlink, key)
 
+typedef int (*daos_hhash_traverse_cb_t)(struct d_hlink *link, void *arg);
+int
+daos_hhash_traverse(int type, daos_hhash_traverse_cb_t cb, void *arg);
+
 /* daos_recx_t overlap detector */
 #define DAOS_RECX_OVERLAP(recx_1, recx_2)				\
 	(((recx_1).rx_idx < (recx_2).rx_idx + (recx_2).rx_nr) &&	\

--- a/src/include/daos/container.h
+++ b/src/include/daos/container.h
@@ -149,4 +149,6 @@ dc_cont_open_flags_valid(uint64_t flags)
 	return true;
 }
 
+int
+dc_cont_mark_all_slave(void);
 #endif /* __DD_CONT_H__ */

--- a/src/include/daos/pool.h
+++ b/src/include/daos/pool.h
@@ -198,4 +198,7 @@ int dc_pool_create_map_refresh_task(daos_handle_t pool_hdl, uint32_t map_version
 				    tse_sched_t *sched, tse_task_t **task);
 void dc_pool_abandon_map_refresh_task(tse_task_t *task);
 
+int
+dc_pool_mark_all_slave(void);
+
 #endif /* __DD_POOL_H__ */

--- a/src/include/gurt/hash.h
+++ b/src/include/gurt/hash.h
@@ -580,6 +580,9 @@ int  d_hhash_key_type(uint64_t key);
 bool d_hhash_key_isptr(uint64_t key);
 int  d_hhash_set_ptrtype(struct d_hhash *hhash);
 bool d_hhash_is_ptrtype(struct d_hhash *hhash);
+typedef int (*d_hhash_traverse_cb_t)(struct d_hlink *link, void *arg);
+int
+d_hhash_traverse(struct d_hhash *hhash, int type, d_hhash_traverse_cb_t cb, void *arg);
 
 /******************************************************************************
  * UUID Hash Table Wrapper

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -3665,3 +3665,20 @@ dc_pool_tgt_idx2ptr(struct dc_pool *pool, uint32_t tgt_idx,
 	}
 	return 0;
 }
+
+static int
+pool_mark_slave(struct d_hlink *link, void *arg)
+{
+	struct dc_pool *pool;
+
+	pool           = container_of(link, struct dc_pool, dp_hlink);
+	pool->dp_slave = 1;
+
+	return 0;
+}
+
+int
+dc_pool_mark_all_slave(void)
+{
+	return daos_hhash_traverse(DAOS_HTYPE_POOL, pool_mark_slave, NULL);
+}


### PR DESCRIPTION
This patch marks all pool and container handles as if they were created with g2l in the child processes after fork. It prevents misinteractions if one of the child processes closes the handle.
The marking is done by iterating through all the pool and container handles which was not supported by the hhash code.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
