### PR TITLE
DAOS-17899 object: force bind mode bulk transfer and disable HG pool

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -129,6 +129,11 @@ crt_hg_pool_enable(struct crt_hg_context *hg_ctx, int32_t max_num,
 	hg_return_t		 hg_ret = HG_SUCCESS;
 	int			 rc = 0;
 
+	{
+		D_INFO("Bypass HG pool for test purpose\n");
+		return 0;
+	}
+
 	if (hg_ctx == NULL || max_num <= 0 || prepost_num < 0 ||
 	    prepost_num > max_num) {
 		D_ERROR("Invalid parameter of crt_hg_pool_enable, hg_ctx %p, "

--- a/src/object/cli_mod.c
+++ b/src/object/cli_mod.c
@@ -209,6 +209,7 @@ dc_obj_init(void)
 	tx_verify_rdg = false;
 	d_getenv_bool("DAOS_TX_VERIFY_RDG", &tx_verify_rdg);
 	D_INFO("%s TX redundancy group verification\n", tx_verify_rdg ? "Enable" : "Disable");
+	D_INFO("Enable bind mode by force for bulk transfer\n");
 
 out_class:
 	if (rc)

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2049,8 +2049,9 @@ obj_bulk_prep(d_sg_list_t *sgls, unsigned int nr, bool bulk_bind,
 					     bulk_perm, &bulks[i]);
 			if (rc < 0)
 				D_GOTO(out, rc);
-			if (!bulk_bind)
+			if (bulk_perm != CRT_BULK_RO)
 				continue;
+
 			rc = crt_bulk_bind(bulks[i], daos_task2ctx(task));
 			if (rc != 0)
 				D_GOTO(out, rc);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1218,7 +1218,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		orw->orw_sgls.ca_arrays = NULL;
 		orw->orw_bulks.ca_count = nr;
 		orw->orw_bulks.ca_arrays = args->bulks;
-		if (fw_shard_tgts != NULL)
+		if (opc != DAOS_OBJ_RPC_FETCH)
 			orw->orw_flags |= ORF_BULK_BIND;
 	} else {
 		if ((args->reasb_req && args->reasb_req->orr_size_fetch) ||


### PR DESCRIPTION
To check whether still DRAM leak or not.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
