### PR TITLE
DAOS-17607 sched: sched monitor (#16798)

### DIFF
--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -883,7 +883,7 @@ server_init(int argc, char *argv[])
 	if (rc)
 		D_GOTO(exit_init_state, rc);
 
-	dss_xstreams_open_barrier();
+	dss_xstreams_open_barrier(false);
 	D_INFO("Service fully up\n");
 
 	/** Report timestamp when engine was open for business */

--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -179,6 +179,8 @@ unsigned int	sched_relax_intvl = SCHED_RELAX_INTVL_DEFAULT;
 unsigned int	sched_relax_mode;
 unsigned int	sched_unit_runtime_max = 32; /* ms */
 bool		sched_watchdog_all;
+unsigned int    sched_inactive_max = 40000; /* ms */
+bool            sched_monitor_kill = true;
 
 enum {
 	/* All requests for various pools are processed in FIFO */
@@ -464,6 +466,9 @@ sched_info_fini(struct dss_xstream *dx)
 		d_list_del_init(&req->sr_link);
 		D_FREE(req);
 	}
+
+	if (info->si_hist_seqs != NULL)
+		D_FREE(info->si_hist_seqs);
 }
 
 static int
@@ -581,6 +586,12 @@ static struct d_binheap_ops rpc_heap_ops = {
 	.hop_compare	= rpc_heap_node_cmp,
 };
 
+static inline bool
+is_monitor_xs(struct dss_xstream *dx)
+{
+	return dx->dx_xs_id == 1; /* SWIM xstream */
+}
+
 static int
 sched_info_init(struct dss_xstream *dx)
 {
@@ -599,6 +610,7 @@ sched_info_init(struct dss_xstream *dx)
 	info->si_sleep_cnt = 0;
 	info->si_wait_cnt = 0;
 	info->si_stop = 0;
+	info->si_hist_seqs     = NULL;
 	sched_metrics_init(dx);
 
 	rc = d_hash_table_create(D_HASH_FT_NOLOCK, 4,
@@ -619,7 +631,19 @@ sched_info_init(struct dss_xstream *dx)
 	}
 
 	rc = prealloc_requests(info, count);
+	if (rc != 0) {
+		D_ERROR("Failed to preallocate sched requests.\n");
+		goto out;
+	}
 
+	if (is_monitor_xs(dx)) {
+		D_ALLOC_ARRAY(info->si_hist_seqs, dss_xstream_cnt());
+		if (info->si_hist_seqs == NULL) {
+			rc = -DER_NOMEM;
+			D_ERROR("Failed to allocate hist seq array.\n");
+			goto out;
+		}
+	}
 out:
 	if (rc)
 		sched_info_fini(dx);
@@ -2063,6 +2087,71 @@ sched_try_relax(struct dss_xstream *dx, ABT_pool *pools, uint32_t running)
 	d_tm_inc_counter(info->si_stats.ss_relax_time, sleep_time);
 }
 
+/* Use SWIM xstream to monitor scheduler activities of SYS & VOS xstreams */
+static void
+sched_xs_monitor(struct dss_xstream *cur_dx)
+{
+	struct dss_xstream    *dx;
+	struct sched_info     *info, *cur_info;
+	struct sched_hist_seq *hist;
+	unsigned int           gap;
+	int                    rc, i, inactive_tgt, inactive_id = -1;
+
+	D_ASSERT(is_monitor_xs(cur_dx));
+	/* Monitor isn't enabled */
+	if (sched_inactive_max == 0)
+		return;
+
+	cur_info = &cur_dx->dx_sched_info;
+	/* Check schedule activities every two seconds */
+	hist = &cur_info->si_hist_seqs[cur_dx->dx_xs_id];
+	if ((hist->sm_last_ts + 2000) > cur_info->si_cur_ts)
+		return;
+
+	hist->sm_last_ts = cur_info->si_cur_ts;
+	if (!dss_sched_monitor_enter())
+		return;
+
+	/* Accessing other xstream data without locking */
+	for (i = 0; i < dss_xstream_cnt(); i++) {
+		dx   = dss_get_xstream(i);
+		info = &dx->dx_sched_info;
+
+		/* Monitor SYS & VOS xstreams only */
+		if (dx->dx_xs_id != 0 && !dx->dx_main_xs)
+			continue;
+
+		D_ASSERT(!is_monitor_xs(dx));
+		hist = &cur_info->si_hist_seqs[i];
+		if (hist->sm_last_ts == 0 || hist->sm_last_seq != info->si_cur_seq) {
+			hist->sm_last_ts  = cur_info->si_cur_ts;
+			hist->sm_last_seq = info->si_cur_seq;
+			continue;
+		}
+
+		/* The schedule sequence isn't bumped for too long time */
+		if ((hist->sm_last_ts + sched_inactive_max) < cur_info->si_cur_ts) {
+			inactive_id  = dx->dx_xs_id;
+			inactive_tgt = dx->dx_tgt_id;
+			gap          = cur_info->si_cur_ts - hist->sm_last_ts;
+			break;
+		}
+	}
+
+	dss_sched_monitor_exit();
+
+	if (inactive_id >= 0) {
+		D_WARN("SCHED_MONITOR: xs %d (tgt:%d) is inactive for more than %u ms!\n",
+		       inactive_id, inactive_tgt, gap);
+		if (sched_monitor_kill) {
+			D_ERROR("SCHED_MONITOR: Killing engine...\n");
+			rc = kill(getpid(), SIGKILL);
+			if (rc != 0)
+				D_ERROR("Failed to raise SIGKILL: %d\n", errno);
+		}
+	}
+}
+
 static void
 sched_start_cycle(struct sched_data *data, ABT_pool *pools)
 {
@@ -2089,6 +2178,9 @@ sched_start_cycle(struct sched_data *data, ABT_pool *pools)
 	}
 	duration = cur_ts - info->si_cur_ts;
 	info->si_cur_ts = cur_ts;
+
+	if (is_monitor_xs(dx))
+		sched_xs_monitor(dx);
 
 	wakeup_all(dx);
 	process_all(dx);

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -40,6 +40,11 @@ struct sched_stats {
 	void			*ss_last_unit;		/* Last executed unit */
 };
 
+struct sched_hist_seq {
+	uint64_t sm_last_seq; /* Last sched sequence */
+	uint64_t sm_last_ts;  /* Timestamp of the last sched sequence */
+};
+
 struct sched_info {
 	uint64_t		 si_cur_ts;	/* Current timestamp (ms) */
 	uint64_t		 si_cur_seq;	/* Current schedule sequence */
@@ -53,6 +58,7 @@ struct sched_info {
 	d_list_t		 si_purge_list;	/* Stale sched_pool_info */
 	struct d_hash_table	*si_pool_hash;	/* All sched_pool_info */
 	struct d_binheap	 si_heap;	/* All retried RPC */
+	struct sched_hist_seq   *si_hist_seqs;  /* Historical sequence for SYS & VOS xstreams */
 	/* Total inuse request count */
 	uint32_t		 si_total_req_cnt;
 	/* Request count for each type of inuse request */
@@ -195,9 +201,14 @@ int dss_srv_init(void);
 int dss_srv_fini(bool force);
 void dss_srv_set_shutting_down(void);
 void dss_dump_ABT_state(FILE *fp);
-void dss_xstreams_open_barrier(void);
+void
+		    dss_xstreams_open_barrier(bool stopping);
 struct dss_xstream *dss_get_xstream(int stream_id);
 int dss_xstream_cnt(void);
+bool
+dss_sched_monitor_enter(void);
+void
+     dss_sched_monitor_exit(void);
 void dss_mem_total_alloc_track(void *arg, daos_size_t bytes);
 void dss_mem_total_free_track(void *arg, daos_size_t bytes);
 
@@ -250,6 +261,8 @@ extern unsigned int sched_relax_intvl;
 extern unsigned int sched_relax_mode;
 extern unsigned int sched_unit_runtime_max;
 extern bool sched_watchdog_all;
+extern unsigned int sched_inactive_max;
+extern bool         sched_monitor_kill;
 
 void dss_sched_fini(struct dss_xstream *dx);
 int dss_sched_init(struct dss_xstream *dx);


### PR DESCRIPTION
Introduce sched monitor, which uses SWIM xstream monitor the schedule activities of SYS and VOS xstreams, once any xstream is detected being inactive for an unexpected long time, warning message will be logged and the engine will be killed.

Set the env var DAOS_SCHED_INACTIVE_MAX (unit is ms) to tune the max inactive time (40000 ms by default), set it to zero will disable the monitor.

Set the env var DAOS_SCHED_MONITOR_KILL to 0 (the default value is 1) to disable engine killing (only warning message logged).

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
