### PR TITLE
DAOS-17949 build: Add -Wno-stringop-truncation to ASan builds

### DIFF
--- a/site_scons/site_tools/compiler_setup.py
+++ b/site_scons/site_tools/compiler_setup.py
@@ -73,7 +73,8 @@ def _base_setup(env):
                 env["CCFLAGS"].remove(flag)
         cc_flags = [f"-Wframe-larger-than={ASAN_FRAME_SIZE_MAX[cc]}",
                     '-fno-omit-frame-pointer',
-                    '-fno-common']
+                    '-fno-common',
+                    '-Wno-stringop-truncation']
 
         asan_flags = []
         for sanitizer in env['SANITIZERS'].split(','):


### PR DESCRIPTION
See the Jira ticket for the (long) background.

Skip-unit-tests: true
Skip-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
