### PR TITLE
DAOS-623 cq: no copyright check for documentation

### DIFF
--- a/utils/cq/check_update_copyright.sh
+++ b/utils/cq/check_update_copyright.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 #  Copyright 2024 Intel Corporation.
-#  Copyright 2025 Hewlett Packard Enterprise Development LP
+#  Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 #  Copyright 2025 Google LLC
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -55,8 +55,6 @@ targets=(
     '*README*'
     '*LICENSE*'
     '*NOTICE*'
-    '*.txt'
-    '*.md'
     # Entries without a wildcard
     'Makefile'
     'Jenkinsfile'


### PR DESCRIPTION
Expecting that documentation (*.md, *.txt) contains copyright header leads to false positives in GHA copyright check on GitHub.

There is no file (*.md, *.txt) except licenses texts and third parts' README that contain a Copyright header.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
