### PR TITLE
DAOS-17325 object: use EC_xP3 for auto oclass selection

### DIFF
--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -812,9 +812,22 @@ dc_set_oclass(uint32_t rf, int domain_nr, int target_nr, enum daos_otype_t otype
 		}
 		break;
 	case DAOS_PROP_CO_REDUN_RF3:
-		/** EC not supported here */
-		*ord = OR_RP_4;
-		grp_size = 4;
+		if ((rdd == DAOS_OCH_RDD_EC || (rdd == 0 && daos_is_array_type(otype))) &&
+		    domain_nr >= 10) {
+			if (domain_nr >= 22) {
+				*ord     = OR_RS_16P3;
+				grp_size = 19;
+			} else if (domain_nr >= 14) {
+				*ord     = OR_RS_8P3;
+				grp_size = 11;
+			} else {
+				*ord     = OR_RS_4P3;
+				grp_size = 7;
+			}
+		} else {
+			*ord     = OR_RP_4;
+			grp_size = 4;
+		}
 		break;
 	case DAOS_PROP_CO_REDUN_RF4:
 		/** EC not supported here */


### PR DESCRIPTION
Since we support EC for RF3 now, we should utilize the object class in the auto selection for files / objects.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
