### PR TITLE
DAOS-17472 build: Avoid undefined SL_SPDK_PREFIX

### DIFF
--- a/utils/setup_daos_server_helper.sh
+++ b/utils/setup_daos_server_helper.sh
@@ -63,20 +63,23 @@ fi
 chmod 4755 "$DA_DST"
 echo "Done."
 
-USR_SPDK=/usr/share/spdk
-USR_CTL=/usr/share/daos/control
-echo -n "Creating SPDK script links under $USR_SPDK ... "
-mkdir -p "$USR_SPDK/scripts" "$USR_CTL"
-if ! [ -e "$USR_SPDK/scripts/setup.sh" ]; then
-        ln -sf "$SL_SPDK_PREFIX/share/daos/spdk/scripts/setup.sh" "$USR_SPDK/scripts"
-fi
-if ! [ -e "$USR_SPDK/scripts/common.sh" ]; then
-        ln -sf "$SL_SPDK_PREFIX/share/daos/spdk/scripts/common.sh" "$USR_SPDK/scripts"
-fi
-if ! [ -e "$USR_SPDK/include" ]; then
-        ln -s "$SL_SPDK_PREFIX/include/daos_srv" "$USR_SPDK"/include
-fi
-if ! [ -e "$USR_CTL/setup_spdk.sh" ]; then
-	ln -s "$SL_PREFIX/share/daos/control/setup_spdk.sh" "$USR_CTL"
+# spdk may be installed already, so skip this if SL_PREFIX is defined
+if [ -n "${SL_SPDK_PREFIX:-}" ]; then
+  USR_SPDK=/usr/share/spdk
+  USR_CTL=/usr/share/daos/control
+  echo -n "Creating SPDK script links under $USR_SPDK ... "
+  mkdir -p "$USR_SPDK/scripts" "$USR_CTL"
+  if ! [ -e "$USR_SPDK/scripts/setup.sh" ]; then
+          ln -sf "$SL_SPDK_PREFIX/share/daos/spdk/scripts/setup.sh" "$USR_SPDK/scripts"
+  fi
+  if ! [ -e "$USR_SPDK/scripts/common.sh" ]; then
+          ln -sf "$SL_SPDK_PREFIX/share/daos/spdk/scripts/common.sh" "$USR_SPDK/scripts"
+  fi
+  if ! [ -e "$USR_SPDK/include" ]; then
+          ln -s "$SL_SPDK_PREFIX/include/daos_srv" "$USR_SPDK"/include
+  fi
+  if ! [ -e "$USR_CTL/setup_spdk.sh" ]; then
+          ln -s "$SL_PREFIX/share/daos/control/setup_spdk.sh" "$USR_CTL"
+  fi
 fi
 echo "Done."


### PR DESCRIPTION
The daos_server_helper script isn't really needed if spdk is installed already. Just assume that's the case if the variable is empty.

Change-Id: I64e6192958699af6b068bd859b9ac199aad55c2f

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
