### PR TITLE
DAOS-17973 control: Allow empty values in property syntax

### DIFF
--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -180,12 +180,15 @@ func TestPoolCommands(t *testing.T) {
 	propWithVal := func(key, val string) *daos.PoolProperty {
 		hdlr := daos.PoolProperties()[key]
 		prop := hdlr.GetProperty(key)
-		if val != "" {
-			if err := prop.SetValue(val); err != nil {
-				panic(err)
-			}
+		if err := prop.SetValue(val); err != nil {
+			panic(err)
 		}
 		return prop
+	}
+
+	propWithNoVal := func(key string) *daos.PoolProperty {
+		hdlr := daos.PoolProperties()[key]
+		return hdlr.GetProperty(key)
 	}
 
 	setQueryMask := func(xfrm func(qm *daos.PoolQueryMask)) daos.PoolQueryMask {
@@ -834,6 +837,20 @@ func TestPoolCommands(t *testing.T) {
 			nil,
 		},
 		{
+			"Set pool properties with empty self_heal value",
+			`pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb self_heal:,space_rb:42`,
+			strings.Join([]string{
+				printRequest(t, &control.PoolSetPropReq{
+					ID: "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
+					Properties: []*daos.PoolProperty{
+						propWithVal("self_heal", ""),
+						propWithVal("space_rb", "42"),
+					},
+				}),
+			}, " "),
+			nil,
+		},
+		{
 			"Set pool properties with pool flag",
 			"pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb label:foo,space_rb:42",
 			strings.Join([]string{
@@ -870,7 +887,7 @@ func TestPoolCommands(t *testing.T) {
 			"Set pool property missing value",
 			"pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb label:",
 			"",
-			errors.New("invalid property"),
+			errors.New("invalid label"),
 		},
 		{
 			"Set pool property bad value",
@@ -903,7 +920,7 @@ func TestPoolCommands(t *testing.T) {
 				printRequest(t, &control.PoolGetPropReq{
 					ID: "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
 					Properties: []*daos.PoolProperty{
-						propWithVal("label", ""),
+						propWithNoVal("label"),
 					},
 				}),
 			}, " "),
@@ -916,8 +933,8 @@ func TestPoolCommands(t *testing.T) {
 				printRequest(t, &control.PoolGetPropReq{
 					ID: "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
 					Properties: []*daos.PoolProperty{
-						propWithVal("label", ""),
-						propWithVal("self_heal", ""),
+						propWithNoVal("label"),
+						propWithNoVal("self_heal"),
 					},
 				}),
 			}, " "),

--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -549,7 +549,7 @@ func (f *systemSetPropsFlag) UnmarshalFlag(fv string) error {
 	for k, v := range f.SetPropertiesFlag.ParsedProps {
 		if prop, ok := f.SystemProps.Get(k); ok {
 			if err := prop.Value.Handler(v); err != nil {
-				return errors.Wrapf(err, "invalid system property value for %s", k)
+				return errors.Wrapf(err, "invalid system property value for %s: %s", k, v)
 			}
 			f.ParsedProps[prop.Key] = prop.Value
 		} else {

--- a/src/control/lib/daos/pool_property.go
+++ b/src/control/lib/daos/pool_property.go
@@ -265,6 +265,8 @@ func PoolProperties() PoolPropertyMap {
 						return "not set"
 					}
 					switch n {
+					case 0:
+						return ""
 					case PoolSelfHealingAutoExclude:
 						return "exclude"
 					case PoolSelfHealingAutoRebuild:
@@ -281,6 +283,7 @@ func PoolProperties() PoolPropertyMap {
 				},
 			},
 			values: map[string]uint64{
+				"":                      0,
 				"exclude":               PoolSelfHealingAutoExclude,
 				"rebuild":               PoolSelfHealingAutoRebuild,
 				"delay_rebuild":         PoolSelfHealingDelayRebuild,

--- a/src/control/lib/ui/prop_flags_test.go
+++ b/src/control/lib/ui/prop_flags_test.go
@@ -40,8 +40,8 @@ func TestUI_SetPropertiesFlag_UnmarshalFlag(t *testing.T) {
 			expErr: errors.New("must not be empty"),
 		},
 		"empty value": {
-			fv:     "key: ",
-			expErr: errors.New("must not be empty"),
+			fv:       "key: ",
+			expProps: map[string]string{"key": ""},
 		},
 		"key too long": {
 			fv:     strings.Repeat("x", ui.MaxPropKeyLen+1) + ":value",

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -735,7 +736,7 @@ pool_op_retry(void **state)
 	/* pool set prop success committed, "lost" reply - duplicate RPC retry */
 	test_set_engine_fail_loc(arg, leader_rank, DAOS_MD_OP_PASS_NOREPLY | DAOS_FAIL_ONCE);
 	print_message("set pool prop (retry / dup rpc detection)... ");
-	rc = daos_pool_set_prop(arg->pool.pool_uuid, "self_heal", "rebuild");
+	rc = daos_pool_set_prop(arg->pool.pool_uuid, "self_heal", "");
 	assert_rc_equal(rc, 0);
 	print_message("success\n");
 


### PR DESCRIPTION
It is impossible to turn off all flags of pool property `self_heal`, because `dmg pool set-prop` disallows empty value syntax. This patch changes SetPropertiesFlag.UnmarshalFlag to allow an empty value, leaving its validity to the property type handler.

Features: control

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
