### PR TITLE
DAOS-17979 object: fixes for EC object consistency verification

### DIFF
--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -485,7 +485,7 @@ ec_verify_parity_data(struct ioreq *req, char *dkey, char *akey,
 	recx.rx_nr = size;
 	recx.rx_idx = offset;
 	if (degraded)
-		daos_fail_loc_set(DAOS_OBJ_FORCE_DEGRADE | DAOS_FAIL_ONCE);
+		daos_fail_loc_set(DAOS_OBJ_FORCE_DEGRADE | DAOS_FAIL_ALWAYS);
 
 	lookup_recxs(dkey, akey, 1, th, &recx, 1, data, size, req);
 	assert_memory_equal(data, verify_data, size);

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -33,7 +33,7 @@ rebuild_ec_internal(void **state, daos_oclass_id_t oclass, int kill_data_nr,
 	d_rank_t		extra_kill_ranks[4] = { -1 };
 	int			rc;
 
-	if (oclass == OC_EC_2P1G1 && !test_runable(arg, 4))
+	if (oclass == OC_EC_2P1GX && !test_runable(arg, 4))
 		return;
 	if (oclass == OC_EC_4P2G1 && !test_runable(arg, 8))
 		return;
@@ -70,7 +70,7 @@ rebuild_ec_internal(void **state, daos_oclass_id_t oclass, int kill_data_nr,
 	/*
 	 * let's kill extra data node to verify parity is correct.
 	 */
-	if (oclass == OC_EC_2P1G1) {
+	if (oclass == OC_EC_2P1GX) {
 		get_killing_rank_by_oid(arg, oid, 1, 0, extra_kill_ranks, NULL);
 		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[0], 1, true);
 	} else { /* oclass OC_EC_4P2G1 */
@@ -78,7 +78,7 @@ rebuild_ec_internal(void **state, daos_oclass_id_t oclass, int kill_data_nr,
 		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[0], 2, true);
 	}
 
-	if (oclass == OC_EC_2P1G1)
+	if (oclass == OC_EC_2P1GX)
 		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 1, true);
 	else /* oclass OC_EC_4P2G1 */
 		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 2, true);
@@ -317,7 +317,7 @@ static void
 rebuild_partial_fail_data(void **state)
 {
 	print_message("BEGIN %s\n", __FUNCTION__);
-	rebuild_ec_internal(state, OC_EC_2P1G1, 1, 0, PARTIAL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 1, 0, PARTIAL_UPDATE);
 	print_message("END %s\n", __FUNCTION__);
 }
 
@@ -325,49 +325,49 @@ static void
 rebuild_partial_fail_parity(void **state)
 {
 	print_message("BEGIN %s\n", __FUNCTION__);
-	rebuild_ec_internal(state, OC_EC_2P1G1, 0, 1, PARTIAL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 0, 1, PARTIAL_UPDATE);
 }
 
 static void
 rebuild_full_fail_data(void **state)
 {
 	print_message("BEGIN %s\n", __FUNCTION__);
-	rebuild_ec_internal(state, OC_EC_2P1G1, 1, 0, FULL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 1, 0, FULL_UPDATE);
 }
 
 static void
 rebuild_full_fail_parity(void **state)
 {
 	print_message("BEGIN %s\n", __FUNCTION__);
-	rebuild_ec_internal(state, OC_EC_2P1G1, 0, 1, FULL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 0, 1, FULL_UPDATE);
 }
 
 static void
 rebuild_full_partial_fail_data(void **state)
 {
 	print_message("BEGIN %s\n", __FUNCTION__);
-	rebuild_ec_internal(state, OC_EC_2P1G1, 1, 0, FULL_PARTIAL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 1, 0, FULL_PARTIAL_UPDATE);
 }
 
 static void
 rebuild_full_partial_fail_parity(void **state)
 {
 	print_message("BEGIN %s\n", __FUNCTION__);
-	rebuild_ec_internal(state, OC_EC_2P1G1, 0, 1, FULL_PARTIAL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 0, 1, FULL_PARTIAL_UPDATE);
 }
 
 static void
 rebuild_partial_full_fail_data(void **state)
 {
 	print_message("BEGIN %s\n", __FUNCTION__);
-	rebuild_ec_internal(state, OC_EC_2P1G1, 1, 0, PARTIAL_FULL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 1, 0, PARTIAL_FULL_UPDATE);
 }
 
 static void
 rebuild_partial_full_fail_parity(void **state)
 {
 	print_message("BEGIN %s\n", __FUNCTION__);
-	rebuild_ec_internal(state, OC_EC_2P1G1, 0, 1, PARTIAL_FULL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 0, 1, PARTIAL_FULL_UPDATE);
 }
 
 static void


### PR DESCRIPTION
Mainly include the following:

1. The old implementation sets dc_obj_verify_args::current_shard as the shard in the first EC redundancy group. It causes that we always verify the first EC redundancy group without others. That is wrong. We need to combine it with the group index.

2. Set DIOF_TO_SPEC_SHARD flag for dc_obj_fetch task to read data from the specified data shard. Otherwise, the expected reading data from data shard maybe automatically converted as degraded fetch from parity shard.

3. Replace DAOS_OBJ_FORCE_DEGRADE fail_loc as OBJ fetch API flag DIOF_FOR_FORCE_DEGRADE for EC verification logic. Then if the degraded fetch RPC is retried for some reason, the retry task will also be degraded fetch. That will avoid self-comparing.

4. Cleanup d_sg_list_t::sg_nr_out parameter for OBJ fetch task in object consistency verification logic.

5. For rebuild related test cases, if need to verify parity shard, then set fail_loc as DAOS_OBJ_FORCE_DEGRADE | DAOS_FAIL_ALWAYS, That will handle RPC retry cases properly.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
