### PR TITLE
DAOS-17979 object: fixes for EC object consistency verification - b26

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -653,6 +653,8 @@ enum daos_io_flags {
 	DIOF_RECX_REVERSE = 0x800,
 	/* Use for rebuild fetch epoch selection */
 	DIOF_FETCH_EPOCH_EC_AGG_BOUNDARY = 0x1000,
+	/* Do not degrade enumeration/fetch if data shard failed */
+	DIOF_EC_NO_DEGRADE = 0x2000,
 };
 
 /**

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5743,6 +5743,12 @@ obj_ec_fetch_shards_get(struct dc_object *obj, daos_obj_fetch_t *args, unsigned 
 		if (likely(ec_deg_tgt == tgt_idx))
 			continue;
 
+		if (args->extra_flags & DIOF_EC_NO_DEGRADE) {
+			D_WARN(DF_OID "have to degraded fetch for %u => %u, but sponsor forbid.\n",
+			       DP_OID(obj->cob_md.omd_id), tgt_idx, ec_deg_tgt);
+			D_GOTO(out, rc = -DER_IO);
+		}
+
 		if (obj_auxi->ec_in_recov) {
 			D_DEBUG(DB_IO, DF_OID " shard %d failed recovery.\n",
 				DP_OID(obj->cob_md.omd_id), grp_start + tgt_idx);

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -31,9 +32,9 @@ dc_obj_verify_list(struct dc_obj_verify_args *dova)
 	memset(dova->kds, 0, sizeof(daos_key_desc_t) * DOVA_NUM);
 	memset(dova->list_buf, 0, dova->list_buf_len);
 
-	dova->list_sgl.sg_nr = 1;
-	dova->list_sgl.sg_nr_out = 1;
-	dova->list_sgl.sg_iovs = &dova->list_iov;
+	dova->list_sgl.sg_nr     = 1;
+	dova->list_sgl.sg_nr_out = 0;
+	dova->list_sgl.sg_iovs   = &dova->list_iov;
 
 	dova->size = 0;
 	dova->num = DOVA_NUM;
@@ -113,9 +114,9 @@ dc_obj_verify_fetch(struct dc_obj_verify_args *dova)
 	dova->fetch_iov.iov_buf = dova->fetch_buf;
 	dova->fetch_iov.iov_buf_len = dova->fetch_buf_len;
 
-	dova->fetch_sgl.sg_nr = 1;
-	dova->fetch_sgl.sg_nr_out = 1;
-	dova->fetch_sgl.sg_iovs = &dova->fetch_iov;
+	dova->fetch_sgl.sg_nr     = 1;
+	dova->fetch_sgl.sg_nr_out = 0;
+	dova->fetch_sgl.sg_iovs   = &dova->fetch_iov;
 
 	shard = dc_obj_anchor2shard(&dova->dkey_anchor);
 	rc = dc_obj_fetch_task_create(dova->oh, dova->th, 0, &cursor->dkey, 1,
@@ -677,18 +678,18 @@ dc_obj_verify_ec_cb(struct dc_obj_enum_unpack_io *io, void *arg)
 			D_GOTO(out, rc = -DER_NOMEM);
 
 		d_iov_set(&iovs[idx], data, size);
-		sgls[idx].sg_nr = 1;
-		sgls[idx].sg_nr_out = 1;
-		sgls[idx].sg_iovs = &iovs[idx];
+		sgls[idx].sg_nr     = 1;
+		sgls[idx].sg_nr_out = 0;
+		sgls[idx].sg_iovs   = &iovs[idx];
 
 		D_ALLOC(data_verify, size);
 		if (data_verify == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
 		d_iov_set(&iovs_verify[idx], data_verify, size);
-		sgls_verify[idx].sg_nr = 1;
-		sgls_verify[idx].sg_nr_out = 1;
-		sgls_verify[idx].sg_iovs = &iovs_verify[idx];
+		sgls_verify[idx].sg_nr     = 1;
+		sgls_verify[idx].sg_nr_out = 0;
+		sgls_verify[idx].sg_iovs   = &iovs_verify[idx];
 		if (iod->iod_type == DAOS_IOD_ARRAY) {
 			rc = obj_recx_ec2_daos(obj_get_oca(obj), tgt_off, &iod->iod_recxs, NULL,
 					       &iod->iod_nr, true);
@@ -705,10 +706,13 @@ dc_obj_verify_ec_cb(struct dc_obj_enum_unpack_io *io, void *arg)
 		return 0;
 	}
 
-	/* Fetch by specific shard */
-	rc = dc_obj_fetch_task_create(dova->oh, dova->th, 0, &io->ui_dkey, idx,
-				      0, iods, sgls, NULL, &shard, NULL, NULL, NULL,
-				      &task);
+	/*
+	 * NOTE: Fetch data from data shard (including current one). The EC fetch task may touch
+	 *       multiple data shards. That is no matter as long as it does not trigger degraded
+	 *       fetch. Using DIOF_EC_NO_DEGRADE flag for such purpose.
+	 */
+	rc = dc_obj_fetch_task_create(dova->oh, dova->th, 0, &io->ui_dkey, idx, DIOF_EC_NO_DEGRADE,
+				      iods, sgls, NULL, &shard, NULL, NULL, NULL, &task);
 	if (rc != 0) {
 		D_ERROR(DF_OID" sgl num %u shard "DF_U64"\n",
 			DP_OID(obj->cob_md.omd_id), idx, shard);
@@ -731,10 +735,9 @@ dc_obj_verify_ec_cb(struct dc_obj_enum_unpack_io *io, void *arg)
 		D_GOTO(out, rc);
 	}
 
-	daos_fail_loc_set(DAOS_OBJ_FORCE_DEGRADE | DAOS_FAIL_ONCE);
 	rc = dc_obj_fetch_task_create(dova->oh, dova->th, 0, &io->ui_dkey, idx,
-				      0, iods, sgls_verify, NULL, &shard, NULL, NULL,
-				      NULL, &verify_task);
+				      DIOF_FOR_FORCE_DEGRADE, iods, sgls_verify, NULL, &shard, NULL,
+				      NULL, NULL, &verify_task);
 	if (rc != 0) {
 		D_ERROR(DF_OID" sgl num %u shard "DF_U64"\n",
 			DP_OID(obj->cob_md.omd_id), idx, shard);
@@ -756,7 +759,6 @@ dc_obj_verify_ec_cb(struct dc_obj_enum_unpack_io *io, void *arg)
 				io->ui_iods[i].iod_size, DP_RC(rc));
 		D_GOTO(out, rc);
 	}
-	daos_fail_loc_set(0);
 
 	for (i = 0; i < idx; i++) {
 		if (sgls[i].sg_iovs[0].iov_len != sgls_verify[i].sg_iovs[0].iov_len ||
@@ -810,10 +812,10 @@ dc_obj_verify_ec_rdg(struct dc_object *obj, struct dc_obj_verify_args *dova,
 		dc_obj_shard2anchor(&dova->dkey_anchor, start + i);
 		daos_anchor_set_flags(&dova->dkey_anchor, DIOF_TO_SPEC_SHARD |
 							  DIOF_WITH_SPEC_EPOCH);
-		dova->th = th;
-		dova->eof = 0;
-		dova->non_exist = 0;
-		dova->current_shard = i;
+		dova->th            = th;
+		dova->eof           = 0;
+		dova->non_exist     = 0;
+		dova->current_shard = start + i;
 		memset(cursor, 0, sizeof(*cursor));
 		cursor->iod.iod_nr = 1;
 		cursor->iod.iod_recxs = &cursor->recx;

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -32,7 +33,7 @@ rebuild_ec_internal(void **state, daos_oclass_id_t oclass, int kill_data_nr,
 	d_rank_t		extra_kill_ranks[4] = { -1 };
 	int			rc;
 
-	if (oclass == OC_EC_2P1G1 && !test_runable(arg, 4))
+	if (oclass == OC_EC_2P1GX && !test_runable(arg, 4))
 		return;
 	if (oclass == OC_EC_4P2G1 && !test_runable(arg, 8))
 		return;
@@ -69,7 +70,7 @@ rebuild_ec_internal(void **state, daos_oclass_id_t oclass, int kill_data_nr,
 	/*
 	 * let's kill extra data node to verify parity is correct.
 	 */
-	if (oclass == OC_EC_2P1G1) {
+	if (oclass == OC_EC_2P1GX) {
 		get_killing_rank_by_oid(arg, oid, 1, 0, extra_kill_ranks, NULL);
 		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[0], 1, true);
 	} else { /* oclass OC_EC_4P2G1 */
@@ -77,7 +78,7 @@ rebuild_ec_internal(void **state, daos_oclass_id_t oclass, int kill_data_nr,
 		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[0], 2, true);
 	}
 
-	if (oclass == OC_EC_2P1G1)
+	if (oclass == OC_EC_2P1GX)
 		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 1, true);
 	else /* oclass OC_EC_4P2G1 */
 		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 2, true);
@@ -314,49 +315,49 @@ rebuild_ec_6nodes_setup(void **state)
 static void
 rebuild_partial_fail_data(void **state)
 {
-	rebuild_ec_internal(state, OC_EC_2P1G1, 1, 0, PARTIAL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 1, 0, PARTIAL_UPDATE);
 }
 
 static void
 rebuild_partial_fail_parity(void **state)
 {
-	rebuild_ec_internal(state, OC_EC_2P1G1, 0, 1, PARTIAL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 0, 1, PARTIAL_UPDATE);
 }
 
 static void
 rebuild_full_fail_data(void **state)
 {
-	rebuild_ec_internal(state, OC_EC_2P1G1, 1, 0, FULL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 1, 0, FULL_UPDATE);
 }
 
 static void
 rebuild_full_fail_parity(void **state)
 {
-	rebuild_ec_internal(state, OC_EC_2P1G1, 0, 1, FULL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 0, 1, FULL_UPDATE);
 }
 
 static void
 rebuild_full_partial_fail_data(void **state)
 {
-	rebuild_ec_internal(state, OC_EC_2P1G1, 1, 0, FULL_PARTIAL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 1, 0, FULL_PARTIAL_UPDATE);
 }
 
 static void
 rebuild_full_partial_fail_parity(void **state)
 {
-	rebuild_ec_internal(state, OC_EC_2P1G1, 0, 1, FULL_PARTIAL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 0, 1, FULL_PARTIAL_UPDATE);
 }
 
 static void
 rebuild_partial_full_fail_data(void **state)
 {
-	rebuild_ec_internal(state, OC_EC_2P1G1, 1, 0, PARTIAL_FULL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 1, 0, PARTIAL_FULL_UPDATE);
 }
 
 static void
 rebuild_partial_full_fail_parity(void **state)
 {
-	rebuild_ec_internal(state, OC_EC_2P1G1, 0, 1, PARTIAL_FULL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_2P1GX, 0, 1, PARTIAL_FULL_UPDATE);
 }
 
 static void


### PR DESCRIPTION
Mainly include the following:

1. The old implementation sets dc_obj_verify_args::current_shard as the shard in the first EC redundancy group. It causes that we always verify the first EC redundancy group without others. That is wrong. We need to combine it with the group index.

2. New DIOF_EC_NO_DEGRADE flag for dc_obj_fetch task to guarantee reading data from the specified data shard. Otherwise, related read request maybe automatically converted as degraded reading from parity shard.

3. Replace DAOS_OBJ_FORCE_DEGRADE fail_loc as OBJ fetch API flag DIOF_FOR_FORCE_DEGRADE for EC verification logic. Then if the degraded fetch RPC is retried for some reason, the retry task will also be degraded fetch. That will avoid self-comparing.

4. Cleanup d_sg_list_t::sg_nr_out parameter for OBJ fetch task in object consistency verification logic.

5. For rebuild related test cases, if need to verify parity shard, then set fail_loc as DAOS_OBJ_FORCE_DEGRADE | DAOS_FAIL_ALWAYS, That will handle RPC retry cases properly.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
