### PR TITLE
DAOS-17820 test: CR Automate Test - Check start corner cases - Single…

### DIFF
--- a/src/tests/ftest/recovery/check_start_corner_case.py
+++ b/src/tests/ftest/recovery/check_start_corner_case.py
@@ -1,0 +1,65 @@
+"""
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+import time
+
+from apricot import TestWithServers
+from exception_utils import CommandFailure
+
+
+class DMGCheckStartCornerCaseTest(TestWithServers):
+    """Test dmg check start corner cases.
+
+    :avocado: recursive
+    """
+
+    def test_start_single_pool(self):
+        """Test dmg check start corner cases with single healthy pool.
+
+        1. Create a pool and enable checker.
+        2. Start with the pool label. It shouldn’t detect any fault.
+        3. Start with non-existing pool label. Verify error message.
+
+        Jira ID: DAOS-17820
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=recovery,cat_recov
+        :avocado: tags=DMGCheckStartCornerCaseTest,test_start_single_pool
+        """
+        # 1. Create a pool and enable checker.
+        self.log_step("Create a pool and enable checker.")
+        pool = self.get_pool(connect=False)
+        dmg_command = self.get_dmg_command()
+        dmg_command.check_enable()
+
+        # 2. Start with the pool label. It shouldn’t detect any fault.
+        self.log_step("Start with the pool label. It shouldn’t detect any fault.")
+        dmg_command.check_start(pool=pool.identifier)
+        query_reports = None
+        for _ in range(8):
+            check_query_out = dmg_command.check_query()
+            if check_query_out["response"]["status"] == "COMPLETED":
+                query_reports = check_query_out["response"]["reports"]
+                break
+            time.sleep(5)
+        if query_reports:
+            msg = (f"dmg check start with healthy pool detected inconsistency! "
+                   f"{query_reports}")
+            self.fail(msg)
+
+        # 3. Start with non-existing pool label. Verify error message.
+        self.log_step("Start with non-existing pool label. Verify error message.")
+        try:
+            dmg_command.check_start(pool="invalid_label")
+            self.fail("dmg check start invalid_label worked!")
+        except CommandFailure as command_failure:
+            if "unable to find pool service" not in str(command_failure):
+                msg = (f"dmg check start invalid_label didn't return expected message! "
+                       f"{command_failure}")
+                self.fail(msg)
+            self.log.info("dmg check start invalid_label failed as expected.")
+
+        dmg_command.check_disable()

--- a/src/tests/ftest/recovery/check_start_corner_case.py
+++ b/src/tests/ftest/recovery/check_start_corner_case.py
@@ -19,7 +19,7 @@ class DMGCheckStartCornerCaseTest(TestWithServers):
         """Test dmg check start corner cases with single healthy pool.
 
         1. Create a pool and enable checker.
-        2. Start with the pool label. It shouldn’t detect any fault.
+        2. Start with the pool label. It should not detect any fault.
         3. Start with non-existing pool label. Verify error message.
 
         Jira ID: DAOS-17820
@@ -35,8 +35,8 @@ class DMGCheckStartCornerCaseTest(TestWithServers):
         dmg_command = self.get_dmg_command()
         dmg_command.check_enable()
 
-        # 2. Start with the pool label. It shouldn’t detect any fault.
-        self.log_step("Start with the pool label. It shouldn’t detect any fault.")
+        # 2. Start with the pool label. It should not detect any fault.
+        self.log_step("Start with the pool label. It should not detect any fault.")
         dmg_command.check_start(pool=pool.identifier)
         query_reports = None
         for _ in range(8):

--- a/src/tests/ftest/recovery/check_start_corner_case.yaml
+++ b/src/tests/ftest/recovery/check_start_corner_case.yaml
@@ -1,0 +1,21 @@
+hosts:
+  test_servers: 1
+  test_clients: 1
+
+timeout: 150
+
+server_config:
+  name: daos_server
+  engines_per_host: 1
+  engines:
+    0:
+      targets: 1
+      storage: auto
+  system_ram_reserved: 1
+
+pool:
+  size: 3G
+
+container:
+  type: POSIX
+  control_method: daos


### PR DESCRIPTION
… healthy pool

Test dmg check start corner cases with single healthy pool.

1. Create a pool and enable checker.
2. Start with the pool label. It shouldn’t detect any fault.
3. Start with non-existing pool label. Verify error message.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_start_single_pool

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
