### PR TITLE
DAOS-17758 test: add some sleep in dfuse mtime check to accomodate CI…

### DIFF
--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -439,6 +439,7 @@ do_mtime(void **state)
 	/* Open a file and sanity check the mtime */
 	fd = openat(root, "mtime_file", O_RDWR | O_CREAT | O_EXCL, S_IWUSR | S_IRUSR);
 	assert_return_code(fd, errno);
+	usleep(10000);
 
 	rc = fstatfs(root, &fs);
 	assert_return_code(fd, errno);
@@ -458,6 +459,7 @@ do_mtime(void **state)
 	}
 
 	/* Write to the file and verify mtime is newer */
+	usleep(10000);
 	rc = write(fd, input_buf, sizeof(input_buf));
 	assert_return_code(rc, errno);
 	rc = fstat(fd, &stbuf);
@@ -474,6 +476,7 @@ do_mtime(void **state)
 	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
 
 	/* Truncate the file and verify mtime is newer */
+	usleep(10000);
 	rc = ftruncate(fd, 0);
 	assert_return_code(rc, errno);
 	rc = fstat(fd, &stbuf);
@@ -489,6 +492,7 @@ do_mtime(void **state)
 	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
 
 	/* Set and verify mtime set in the past */
+	usleep(10000);
 	times[0]         = now;
 	times[1].tv_sec  = now.tv_sec - 10;
 	times[1].tv_nsec = 20;
@@ -502,6 +506,7 @@ do_mtime(void **state)
 	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
 
 	/* Repeat the write test again */
+	usleep(10000);
 	rc = write(fd, input_buf, sizeof(input_buf));
 	assert_return_code(rc, errno);
 	rc = fstat(fd, &stbuf);


### PR DESCRIPTION
… (#16866)

Similar to DAOS-16817, the same workaround needs to be applied to the dfuse test.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
