### PR TITLE
DAOS-17988 client: Include padding space during memory allocation

### DIFF
--- a/src/gurt/shm_dict.c
+++ b/src/gurt/shm_dict.c
@@ -669,6 +669,7 @@ shm_ht_rec_find_insert(d_shm_ht_loc_t shm_ht_loc, const char *key, const int len
 	d_shm_ht_rec_t  rec_next = NULL;
 	char           *value    = NULL;
 	int             rc;
+	int             padding;
 	d_shm_ht_head_t ht_head;
 
 	if (created)
@@ -717,21 +718,22 @@ shm_ht_rec_find_insert(d_shm_ht_loc_t shm_ht_loc, const char *key, const int len
 			off_next = rec->next;
 		}
 	}
+	/* add padding space to make sure value is aligned by SHM_MEM_ALIGN */
+	padding =
+	    (len_key & (SHM_MEM_ALIGN - 1)) ? (SHM_MEM_ALIGN - (len_key & (SHM_MEM_ALIGN - 1))) : 0;
 	/* record is not found. Insert it at the very beginning of the link list. */
-	rec = (d_shm_ht_rec_t)shm_memalign(SHM_MEM_ALIGN,
-					   sizeof(struct d_shm_ht_rec) + len_key + len_value);
+	rec = (d_shm_ht_rec_t)shm_memalign(SHM_MEM_ALIGN, sizeof(struct d_shm_ht_rec) + len_key +
+							      len_value + padding);
 	if (rec == NULL) {
 		*err = ENOMEM;
 		goto err;
 	}
-	rec->len_key = len_key;
-	/* add padding space to make sure value is aligned by SHM_MEM_ALIGN */
-	rec->len_padding =
-	    (len_key & (SHM_MEM_ALIGN - 1)) ? (SHM_MEM_ALIGN - (len_key & (SHM_MEM_ALIGN - 1))) : 0;
-	rec->len_value = len_value;
-	rec->next      = INVALID_OFFSET;
+	rec->len_key     = len_key;
+	rec->len_padding = padding;
+	rec->len_value   = len_value;
+	rec->next        = INVALID_OFFSET;
 	memcpy((char *)rec + sizeof(struct d_shm_ht_rec), key, len_key);
-	value = (char *)rec + sizeof(struct d_shm_ht_rec) + len_key + rec->len_padding;
+	value = (char *)rec + sizeof(struct d_shm_ht_rec) + len_key + padding;
 
 	if (strcmp(val, INIT_KEY_VALUE_MUTEX) == 0) {
 		/* value holds a mutex */


### PR DESCRIPTION
Robust mutex needs the address of lock is 4-byte aligned. Otherwise, it cannot work as expected. This was observed on x86_64 platform. It has not been checked on other platforms yet. Since proper alignment normally is a good idea performance-wise, we enforce 4-byte alignment for the data stored in hash table record in shared memory to avoid such mis-alignment related issues. During the memory allocation for hash table record, the space used for padding needs to be included.

Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
