### PR TITLE
DAOS-17987 control: Log to DBG if ctx already has logger

### DIFF
--- a/src/control/drpc/drpc_server.go
+++ b/src/control/drpc/drpc_server.go
@@ -57,7 +57,7 @@ func (d *DomainSocketServer) listenSession(ctx context.Context, s *Session) {
 		// The most likely reason for this to happen is that a logger is already embedded in the
 		// context. If we shift to using loggers passed in context more generally on the server side,
 		// there's no need to do it here.
-		d.log.Errorf("failed to embed logger in context for dRPC session: %s", err.Error())
+		d.log.Debugf("failed to embed logger in context for dRPC session: %s", err.Error())
 		logCtx = ctx
 	}
 


### PR DESCRIPTION
Avoid confusing "logger already present in context" errors when a
client process contacts the agent by reducing the log level to DBG
as this is an expected situation with the current code level.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
