### PR TITLE
DAOS-17990 cart: Fix deadlines

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1221,6 +1221,11 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	opc_info = rpc_priv->crp_opc_info;
 	rpc_pub = &rpc_priv->crp_pub;
 
+	/* populate rpc_priv based on raw header values in rpc_tmp.
+	 * perform conversion to either a timeout or deadline based on header
+	 * feature flag and set rpc_priv fields accordingly
+	 * returns error if an rpc is determined to be expired already
+	 */
 	rc = crt_hg_process_header(&rpc_tmp, rpc_priv);
 	if (unlikely(rc != 0)) {
 		RPC_WARN(rpc_priv, "RPC expired. Deadline was %d\n", rpc_priv->crp_deadline_sec);

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -575,7 +575,15 @@ out:
 	return rc;
 }
 
-/* Process header */
+/* Process header.
+ * Populate 'out' fields of rpc_priv struct based on incoming rpc header 'in'
+ *
+ * Treat incoming 'cch_src_deadline_sec' header value as either a timeout or a
+ * deadline based on a feature flag set in the RPC header.
+ *
+ *
+ * Returns 0 on success or -DER_TIMEDOUT if RPC is determined to be expired already.
+ */
 int
 crt_hg_process_header(struct crt_rpc_priv *in, struct crt_rpc_priv *out)
 {

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -738,6 +738,7 @@ crt_req_set_timeout(crt_rpc_t *req, uint32_t timeout_sec)
 
 	rpc_priv = container_of(req, struct crt_rpc_priv, crp_pub);
 	rpc_priv->crp_timeout_sec = timeout_sec;
+	rpc_priv->crp_deadline_sec = crt_timeout_to_deadline(timeout_sec);
 
 	RPC_TRACE(DB_NET, rpc_priv, "Caller set explicit timeout to %d\n", timeout_sec);
 out:
@@ -1711,6 +1712,7 @@ crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx, bool srv
 	if (!srv_flag) {
 		rpc_priv->crp_timeout_sec = (ctx->cc_timeout_sec == 0 ? crt_gdata.cg_timeout :
 					     ctx->cc_timeout_sec);
+		rpc_priv->crp_deadline_sec = crt_timeout_to_deadline(rpc_priv->crp_timeout_sec);
 	}
 }
 

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -715,8 +715,10 @@ crt_set_timeout(struct crt_rpc_priv *rpc_priv)
 {
 	D_ASSERT(rpc_priv != NULL);
 
-	if (rpc_priv->crp_timeout_sec == 0)
+	if (rpc_priv->crp_timeout_sec == 0) {
 		rpc_priv->crp_timeout_sec = crt_gdata.cg_timeout;
+		rpc_priv->crp_deadline_sec = crt_timeout_to_deadline(rpc_priv->crp_timeout_sec);
+	}
 
 	rpc_priv->crp_timeout_ts = d_timeus_secdiff(rpc_priv->crp_timeout_sec);
 }


### PR DESCRIPTION
- Deadlines were not set for some internal RPCs due to conversion from timeout to deadline happening in an rpc tracking code. Some internal RPCs bypass rpc tracking

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
