### PR TITLE
DAOS-17993 ci: New stage name causes missing RPMs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -505,7 +505,7 @@ pipeline {
                 expression { !skipStage() }
             }
             parallel {
-                stage('Build on EL 8.8') {
+                stage('Build RPM on EL 8') {
                     when {
                         beforeAgent true
                         expression { !params.CI_el8_NOBUILD && !skipStage() }
@@ -559,7 +559,7 @@ pipeline {
                         }
                     }
                 }
-                stage('Build on EL 9') {
+                stage('Build RPM on EL 9') {
                     when {
                         beforeAgent true
                         expression { !params.CI_el9_NOBUILD && !skipStage() }
@@ -613,7 +613,7 @@ pipeline {
                         }
                     }
                 }
-                stage('Build on Leap 15.5') {
+                stage('Build RPM on Leap 15.5') {
                     when {
                         beforeAgent true
                         expression { !params.CI_leap15_NOBUILD && !skipStage() }


### PR DESCRIPTION
There were several ways to disable regular builds but to keep RPM builds. For example CI_BUILD_PACKAGES_ONLY disable regular builds. Now regular builds are the only way to get RPMs. We have to use stage name dedicated to RPM builds as skipping mechanism relay of stage names.

Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
