### PR TITLE
DAOS-17865 control: Prevent duplicate pool props

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -337,7 +337,7 @@ func (cmd *poolCreateCmd) Execute(args []string) error {
 		User:       cmd.UserName.String(),
 		UserGroup:  cmd.GroupName.String(),
 		NumSvcReps: cmd.NumSvcReps,
-		Properties: cmd.Properties.ToSet,
+		Properties: cmd.Properties.ToSet.Slice(),
 		Ranks:      cmd.RankList.Ranks(),
 	}
 
@@ -832,7 +832,7 @@ func (cmd *poolSetPropCmd) Execute(_ []string) error {
 
 	req := &control.PoolSetPropReq{
 		ID:         cmd.PoolID().String(),
-		Properties: cmd.Args.Props.ToSet,
+		Properties: cmd.Args.Props.ToSet.Slice(),
 	}
 
 	err := control.PoolSetProp(cmd.MustLogCtx(), cmd.ctlInvoker, req)

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -602,9 +602,9 @@ func TestPoolCommands(t *testing.T) {
 			strings.Join([]string{
 				printRequest(t, &control.PoolCreateReq{
 					Properties: []*daos.PoolProperty{
+						propWithVal("label", "label"),
 						propWithVal("scrub", "timed"),
 						propWithVal("scrub_freq", "1"),
-						propWithVal("label", "label"),
 					},
 					User:      eUsr.Username + "@",
 					UserGroup: eGrp.Name + "@",
@@ -613,6 +613,30 @@ func TestPoolCommands(t *testing.T) {
 				}),
 			}, " "),
 			nil,
+		},
+		{
+			"Create pool with properties specified separately",
+			fmt.Sprintf("pool create label --scm-size %s --properties scrub:timed --properties scrub_freq:1", testSizeStr),
+			strings.Join([]string{
+				printRequest(t, &control.PoolCreateReq{
+					Properties: []*daos.PoolProperty{
+						propWithVal("label", "label"),
+						propWithVal("scrub", "timed"),
+						propWithVal("scrub_freq", "1"),
+					},
+					User:      eUsr.Username + "@",
+					UserGroup: eGrp.Name + "@",
+					Ranks:     []ranklist.Rank{},
+					TierBytes: []uint64{uint64(testSize), 0},
+				}),
+			}, " "),
+			nil,
+		},
+		{
+			"Create pool with duplicate properties specified separately",
+			fmt.Sprintf("pool create label --scm-size %s --properties scrub:timed --properties scrub:timed,scrub_freq:1", testSizeStr),
+			"",
+			errors.New("more than once"),
 		},
 		// Exclude testing with multiple ranks is verified at the control API layer.
 		{

--- a/src/control/lib/ui/prop_flags.go
+++ b/src/control/lib/ui/prop_flags.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2023 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -157,6 +158,9 @@ func (f *SetPropertiesFlag) UnmarshalFlag(fv string) error {
 		}
 		if len(value) == 0 {
 			return propError("value must not be empty")
+		}
+		if _, set := f.ParsedProps[key]; set {
+			return propError("%q: same key was specified more than once", key)
 		}
 
 		f.ParsedProps[key] = value

--- a/src/control/lib/ui/prop_flags_test.go
+++ b/src/control/lib/ui/prop_flags_test.go
@@ -47,6 +47,11 @@ func TestUI_SetPropertiesFlag_UnmarshalFlag(t *testing.T) {
 			fv:     strings.Repeat("x", ui.MaxPropKeyLen+1) + ":value",
 			expErr: errors.New("key too long"),
 		},
+		"duplicated properties": {
+			settable: []string{"a", "b"},
+			fv:       "a:c,b:d,a:d",
+			expErr:   errors.New("more than once"),
+		},
 		"valid properties": {
 			settable: []string{"a", "b"},
 			fv:       "b:d,a:c",

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -143,6 +143,8 @@ enum daos_pool_props {
 	DAOS_PROP_PO_MAX,
 };
 
+#define DAOS_PROP_PO_NUM                (DAOS_PROP_PO_MAX - DAOS_PROP_PO_MIN - 1)
+
 #define DAOS_PROP_PO_EC_CELL_SZ_MIN	(1UL << 10)
 #define DAOS_PROP_PO_EC_CELL_SZ_MAX	(1UL << 30)
 

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -600,7 +600,13 @@ ds_mgmt_pool_set_prop(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 	int              rc;
 
 	if (prop == NULL || prop->dpp_entries == NULL || prop->dpp_nr < 1) {
-		D_ERROR("invalid property list\n");
+		D_ERROR("no properties in prop list\n");
+		rc = -DER_INVAL;
+		goto out;
+	}
+
+	if (!daos_prop_valid(prop, true, true)) {
+		D_ERROR("invalid properties\n");
 		rc = -DER_INVAL;
 		goto out;
 	}

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -402,6 +402,11 @@ pool_prop_default_copy(daos_prop_t *prop_def, daos_prop_t *prop)
 	if (prop == NULL || prop->dpp_nr == 0 || prop->dpp_entries == NULL)
 		return 0;
 
+	if (!daos_prop_valid(prop, true, true)) {
+		D_ERROR("invalid pool property\n");
+		return -DER_INVAL;
+	}
+
 	for (i = 0; i < prop->dpp_nr; i++) {
 		entry = &prop->dpp_entries[i];
 		entry_def = daos_prop_entry_get(prop_def, entry->dpe_type);


### PR DESCRIPTION
Due to a bug in parsing props, it was possible to crash the daos_engine by entering the same pool property twice during pool create by using the --properties flag twice. A prop could also be duplicated within the --properties flag without causing an error.

This patch checks for duplication at three different points:
- Within all props set within a --properties flag.
- Within different property strings, if --properties was used multiple times.
- At the engine level.

Features: control pool

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
