### PR TITLE
DAOS-17860 test: CR Automate Test - Check start corner cases - Back to back

### DIFF
--- a/src/tests/ftest/recovery/check_start_corner_case.py
+++ b/src/tests/ftest/recovery/check_start_corner_case.py
@@ -114,10 +114,12 @@ class DMGCheckStartCornerCaseTest(TestWithServers):
 
         # 5. Immediately after starting the first pool, start the second pool.
         self.log_step("Immediately after starting the first pool, start the second pool.")
+        pool_2_started = False
         for count in range(8):
             try:
                 dmg_command.check_start(pool=pool_2.identifier)
                 self.log.info("dmg check start pool_2 worked. - %d", count)
+                pool_2_started = True
                 break
             except CommandFailure as command_failure:
                 # Starting back to back may cause Operation already performed error. In
@@ -126,6 +128,7 @@ class DMGCheckStartCornerCaseTest(TestWithServers):
                 self.log.info(
                     "dmg check start pool_2 failed. - %d; %s", count, command_failure)
             time.sleep(5)
+        self.assertTrue(pool_2_started, "dmg check start pool_2 failed after 40 sec!")
 
         # 6. Query checker and verify that they’re fixed.
         self.log_step("Query checker and verify that they’re fixed.")


### PR DESCRIPTION
1. Create two pools and a container.
2. Inject fault on both containers.
3. Enable checker.
4. Start with the first pool.
5. Immediately after starting the first pool, start the second pool. This may
result in Operation already performed error. In that case, repeat. When the first
pool is fixed, the second start should work.
6. Query checker and verify that they’re fixed.
7. Disable checker and start system.
8. Verify that the faults are actually fixed.
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
