### PR TITLE
DAOS-17803 cq: fix actor name for Dependabot

### DIFF
--- a/.github/workflows/dependabot2jira.yml
+++ b/.github/workflows/dependabot2jira.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-if-dependabot:
-    if: github.actor == 'dependabot'
+    if: startsWith(github.actor, 'dependabot')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
The actual actor for Dependabot is `dependabot[bot]`, not just `dependabot`.

This causes the action not to be triggered:
https://github.com/daos-stack/daos/actions/runs/17719486886

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
