### PR TITLE
DAOS-17997 cq: Update hadoop from 3.4.1 to 3.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ utils/githooks/*.d/*-user-*
 .vscode
 src/include/daos_version.h
 utils/rpms/mock.cfg
+trivy-report-daos.txt

--- a/src/client/java/daos-java/pom.xml
+++ b/src/client/java/daos-java/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>4.1.115.Final</version>
+      <version>4.1.125.Final</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/src/client/java/hadoop-daos/pom.xml
+++ b/src/client/java/hadoop-daos/pom.xml
@@ -15,7 +15,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <hadoop.version>3.4.1</hadoop.version>
+    <hadoop.version>3.4.2</hadoop.version>
     <native.build.path>${project.basedir}/build</native.build.path>
     <daos.install.path>${project.basedir}/install</daos.install.path>
   </properties>

--- a/utils/trivy/.trivyignore
+++ b/utils/trivy/.trivyignore
@@ -1,28 +1,12 @@
-### Ignored hadoop 3.4.1 related CVEs
-## CVE-2023-39410,HIGH,7.5,"apache-avro: Apache Avro Java SDK: Memory when deserializing untrusted data in Avro Java SDK","org.apache.avro:avro","1.7.7","1.11.3",https://avd.aquasec.com/nvd/# CVE-2023-39410
-CVE-2023-39410
-
-## CVE-2024-47561,CRITICAL,,"apache-avro: Schema parsing may trigger Remote Code Execution (RCE)","org.apache.avro:avro","1.9.2","1.11.4",https://avd.aquasec.com/nvd/# CVE-2024-47561
-CVE-2024-47561
-
-## CVE-2025-24970,HIGH,,"io.netty:netty-handler: SslHandler doesn't correctly validate packets which can lead to native crash when using native SSLEngine","io.netty:netty-handler","4.1.100.Final","4.1.118.Final",https://avd.aquasec.com/nvd/# CVE-2025-24970
-CVE-2025-24970
-
-## CVE-2025-52999,HIGH,,"com.fasterxml.jackson.core/jackson-core: jackson-core Potential StackoverflowError","com.fasterxml.jackson.core:jackson-core","2.10.2","2.15.0",https://avd.aquasec.com/nvd/# CVE-2025-52999
+### Ignored hadoop 3.4.2 related CVEs
+## CVE-2025-52999,HIGH,,"com.fasterxml.jackson.core/jackson-core: jackson-core Potential StackoverflowError","com.fasterxml.jackson.core:jackson-core","2.10.2","2.15.0",https://avd.aquasec.com/nvd/cve-2025-52999
 CVE-2025-52999
 
-## CVE-2025-49128,MEDIUM,,"com.fasterxml.jackson.core/jackson-core: Jackson-core Memory Disclosure via Source Snippet in JsonLocation","com.fasterxml.jackson.core:jackson-core","2.10.2","2.13.0",https://avd.aquasec.com/nvd/# CVE-2025-49128
-CVE-2025-49128
-
-## CVE-2025-53864,MEDIUM,,"com.nimbusds/nimbus-jose-jwt: Uncontrolled recursion in Connect2id Nimbus JOSE + JWT","com.nimbusds:nimbus-jose-jwt","9.37.2","10.0.2",https://avd.aquasec.com/nvd/# CVE-2025-53864
+## CVE-2025-53864,MEDIUM,,"com.nimbusds/nimbus-jose-jwt: Uncontrolled recursion in Connect2id Nimbus JOSE + JWT","com.nimbusds:nimbus-jose-jwt","9.37.2","10.0.2",https://avd.aquasec.com/nvd/cve-2025-53864
 CVE-2025-53864
 
-## CVE-2025-48734,HIGH,,"commons-beanutils: Apache Commons BeanUtils: PropertyUtilsBean does not suppresses an enum's declaredClass property by default","commons-beanutils:commons-beanutils","1.9.4","1.11.0",https://avd.aquasec.com/nvd/# CVE-2025-48734
-CVE-2025-48734
-
-## CVE-2025-48924,MEDIUM,,"commons-lang/commons-lang: org.apache.commons/commons-lang3: Uncontrolled Recursion vulnerability in Apache Commons Lang","org.apache.commons:commons-lang3","3.12.0","3.18.0",https://avd.aquasec.com/nvd/# CVE-2025-48924
+## CVE-2025-48924,MEDIUM,,"commons-lang/commons-lang: org.apache.commons/commons-lang3: Uncontrolled Recursion vulnerability in Apache Commons Lang","org.apache.commons:commons-lang3","3.12.0","3.18.0",https://avd.aquasec.com/nvd/cve-2025-48924
 CVE-2025-48924
 
-### Ignored io.netty:netty-buffer:4.1.115.Final and hadoop-common:3.4.1 CVEs
-## CVE-2025-25193,MEDIUM,,"Netty, an asynchronous, event-driven network application framework, ha ...","io.netty:netty-common","4.1.115.Final","",https://avd.aquasec.com/nvd/# CVE-2025-25193
-CVE-2025-25193
+## CVE-2025-58057,MEDIUM,7.5,"netty-codec: netty-codec-compression: Netty's BrotliDecoder is vulnerable to DoS via zip bomb style attack","io.netty:netty-codec","4.1.100.Final","4.1.125.Final",https://avd.aquasec.com/nvd/cve-2025-58057
+CVE-2025-58057

--- a/utils/trivy/trivy.yaml
+++ b/utils/trivy/trivy.yaml
@@ -228,6 +228,7 @@ scan:
   # ignore all hadoop dependencies
   skip-dirs:
     ./src/client/java/hadoop-daos
+    ./build
   skip-files: []
   show-suppressed: true
 secret:


### PR DESCRIPTION
Hadoop 3.4.2 eliminates the following vulnerabilities:
CVE-2023-39410,HIGH,7.5,"apache-avro: Apache Avro Java SDK: Memory when deserializing untrusted data in Avro Java SDK","org.apache.avro:avro","1.7.7","1.11.3", https://avd.aquasec.com/nvd/cve-2023-39410

CVE-2024-47561,CRITICAL,,"apache-avro: Schema parsing may trigger Remote Code Execution (RCE)", "org.apache.avro:avro","1.9.2","1.11.4",https://avd.aquasec.com/nvd/cve-2024-47561

CVE-2025-24970,HIGH,,"io.netty:netty-handler: SslHandler doesn't correctly validate packets which can lead to native crash when using native SSLEngine","io.netty:netty-handler", "4.1.100.Final","4.1.118.Final",https://avd.aquasec.com/nvd/cve-2025-24970

CVE-2025-49128,MEDIUM,,"com.fasterxml.jackson.core/jackson-core: Jackson-core Memory Disclosure via Source Snippet in JsonLocation","com.fasterxml.jackson.core:jackson-core", "2.10.2","2.13.0",https://avd.aquasec.com/nvd/cve-2025-49128

CVE-2025-48734,HIGH,,"commons-beanutils: Apache Commons BeanUtils: PropertyUtilsBean does not suppresses an enum's declaredClass property by default", "commons-beanutils:commons-beanutils","1.9.4","1.11.0", https://avd.aquasec.com/nvd/cve-2025-48734

CVE-2025-25193,MEDIUM,,"Netty, an asynchronous, event-driven network application framework, ha ...","io.netty:netty-common","4.1.115.Final","",https://avd.aquasec.com/nvd/cve-2025-25193

This PR also updates io.netty.netty-buffer from 4.1.115 to 4.1.125 to eliminate the following vulnerability:
CVE-2025-58057,MEDIUM,7.5,"netty-codec: netty-codec-compression: Netty's BrotliDecoder is vulnerable to DoS via zip bomb style attack","io.netty:netty-codec","4.1.100.Final", "4.1.125.Final",https://avd.aquasec.com/nvd/cve-2025-58057

NOTICE:
Hadoop 3.4.2 introduces new vulnerability:
CVE-2025-58057,MEDIUM,7.5,"netty-codec: netty-codec-compression: Netty's BrotliDecoder is vulnerable to DoS via zip bomb style attack","io.netty:netty-codec","4.1.100.Final", "4.1.125.Final",https://avd.aquasec.com/nvd/cve-2025-58057

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
