### PR TITLE
DAOS-17497 test: Adjust CR tests for md-on-ssd mode 1

### DIFF
--- a/src/tests/ftest/recovery/check_policy.py
+++ b/src/tests/ftest/recovery/check_policy.py
@@ -34,7 +34,7 @@ class DMGCheckPolicyTest(TestWithServers):
         Jira ID: DAOS-17706
 
         :avocado: tags=all,full_regression
-        :avocado: tags=vm
+        :avocado: tags=hw,medium
         :avocado: tags=recovery,cat_recov
         :avocado: tags=DMGCheckPolicyTest,test_check_policies
         """

--- a/src/tests/ftest/recovery/check_policy.yaml
+++ b/src/tests/ftest/recovery/check_policy.yaml
@@ -1,19 +1,27 @@
 hosts:
   test_servers: 1
 
-timeout: 180
+timeout: 5M
 
 server_config:
   name: daos_server
-  engines_per_host: 1
+  engines_per_host: 2
   engines:
     0:
-      targets: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      nr_xs_helpers: 1
       storage: auto
-  system_ram_reserved: 1
+    1:
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      nr_xs_helpers: 1
+      storage: auto
 
 pool:
-  size: 5G
+  size: 60G
 
 container:
   control_method: daos

--- a/src/tests/ftest/recovery/check_repair.py
+++ b/src/tests/ftest/recovery/check_repair.py
@@ -30,7 +30,7 @@ class DMGCheckRepairTest(TestWithServers):
         Jira ID: DAOS-17852
 
         :avocado: tags=all,full_regression
-        :avocado: tags=vm
+        :avocado: tags=hw,medium
         :avocado: tags=recovery,cat_recov
         :avocado: tags=DMGCheckRepairTest,test_check_repair_corner_case
         """

--- a/src/tests/ftest/recovery/check_repair.yaml
+++ b/src/tests/ftest/recovery/check_repair.yaml
@@ -5,12 +5,20 @@ timeout: 180
 
 server_config:
   name: daos_server
-  engines_per_host: 1
+  engines_per_host: 2
   engines:
     0:
-      targets: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      nr_xs_helpers: 1
       storage: auto
-  system_ram_reserved: 1
+    1:
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      nr_xs_helpers: 1
+      storage: auto
 
 pool:
-  size: 5G
+  size: 60G

--- a/src/tests/ftest/recovery/check_start_options.py
+++ b/src/tests/ftest/recovery/check_start_options.py
@@ -47,7 +47,7 @@ class DMGCheckStartOptionsTest(TestWithServers):
         Jira ID: DAOS-17623
 
         :avocado: tags=all,full_regression
-        :avocado: tags=vm
+        :avocado: tags=hw,medium
         :avocado: tags=recovery,cat_recov
         :avocado: tags=DMGCheckStartOptionsTest,test_check_start_reset
         """
@@ -161,7 +161,7 @@ class DMGCheckStartOptionsTest(TestWithServers):
         Jira ID: DAOS-17818
 
         :avocado: tags=all,full_regression
-        :avocado: tags=vm
+        :avocado: tags=hw,medium
         :avocado: tags=recovery,cat_recov
         :avocado: tags=DMGCheckStartOptionsTest,test_check_start_failout
         """
@@ -259,7 +259,7 @@ class DMGCheckStartOptionsTest(TestWithServers):
         Jira ID: DAOS-17819
 
         :avocado: tags=all,full_regression
-        :avocado: tags=vm
+        :avocado: tags=hw,medium
         :avocado: tags=recovery,cat_recov
         :avocado: tags=DMGCheckStartOptionsTest,test_check_start_find_orphans
         """

--- a/src/tests/ftest/recovery/check_start_options.yaml
+++ b/src/tests/ftest/recovery/check_start_options.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 1
   test_clients: 1
 
-timeout: 180
+timeout: 5M
 
 setup:
   start_servers_once: False
@@ -12,12 +12,14 @@ server_config:
   engines_per_host: 1
   engines:
     0:
-      targets: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      nr_xs_helpers: 1
       storage: auto
-  system_ram_reserved: 1
 
 pool:
-  size: 3G
+  size: 60G
 
 container:
   control_method: daos

--- a/src/tests/ftest/recovery/check_stop.py
+++ b/src/tests/ftest/recovery/check_stop.py
@@ -51,7 +51,7 @@ class DMGCheckStopTest(TestWithServers):
         Jira ID: DAOS-17785
 
         :avocado: tags=all,full_regression
-        :avocado: tags=vm
+        :avocado: tags=hw,medium
         :avocado: tags=recovery,cat_recov
         :avocado: tags=DMGCheckStopTest,test_stop_during_repair
         """
@@ -143,7 +143,7 @@ class DMGCheckStopTest(TestWithServers):
         Jira ID: DAOS-17785
 
         :avocado: tags=all,full_regression
-        :avocado: tags=vm
+        :avocado: tags=hw,medium
         :avocado: tags=recovery,cat_recov
         :avocado: tags=DMGCheckStopTest,test_disable_during_repair
         """

--- a/src/tests/ftest/recovery/check_stop.yaml
+++ b/src/tests/ftest/recovery/check_stop.yaml
@@ -2,19 +2,27 @@ hosts:
   test_servers: 1
   test_clients: 1
 
-timeout: 150
+timeout: 4M
 
 server_config:
   name: daos_server
-  engines_per_host: 1
+  engines_per_host: 2
   engines:
     0:
-      targets: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      nr_xs_helpers: 1
       storage: auto
-  system_ram_reserved: 1
+    1:
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      nr_xs_helpers: 1
+      storage: auto
 
 pool:
-  size: 3G
+  size: 60G
 
 container:
   type: POSIX


### PR DESCRIPTION
Update the checker-related tests that are using VM to use Hardware Medium so that they run on MD-on-SSD
cluster.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-medium: false
Test-tag: DMGCheckPolicyTest DMGCheckRepairTest DMGCheckStartOptionsTest DMGCheckStopTest

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
