### PR TITLE
DAOS-18003 vos: more log message when hit in-aborting DTX entry

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -286,8 +286,11 @@ dtx_act_ent_update(struct btr_instance *tins, struct btr_record *rec,
 	D_ASSERT(dae_old != dae_new);
 
 	if (unlikely(dae_old->dae_aborting)) {
-		D_ERROR("Hit former in-aborting DTX entry %p "DF_DTI"\n",
-			dae_old, DP_DTI(&DAE_XID(dae_old)));
+		D_ERROR("Hit former in-aborting DTX entry %p: ID " DF_DTI ", LID %u, flags %x, "
+			"attached %s, status bits: preparing %d, prepared %d, aborted %d.\n",
+			dae_old, DP_DTI(&DAE_XID(dae_old)), DAE_LID(dae_old), DAE_FLAGS(dae_old),
+			dae_old->dae_dth != NULL ? "yes" : "no", dae_old->dae_preparing ? 1 : 0,
+			dae_old->dae_prepared ? 1 : 0, dae_old->dae_aborted ? 1 : 0);
 		return -DER_INPROGRESS;
 	}
 


### PR DESCRIPTION
It will be helpful to understand the DTX status when hit in-aborting DTX entry during update.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
