### PR TITLE
DAOS-17497 test: Adjust CR tests for md-on-ssd mode 2

### DIFF
--- a/src/tests/ftest/recovery/check_start_corner_case.py
+++ b/src/tests/ftest/recovery/check_start_corner_case.py
@@ -26,7 +26,7 @@ class DMGCheckStartCornerCaseTest(TestWithServers):
         Jira ID: DAOS-17820
 
         :avocado: tags=all,full_regression
-        :avocado: tags=vm
+        :avocado: tags=hw,medium
         :avocado: tags=recovery,cat_recov
         :avocado: tags=DMGCheckStartCornerCaseTest,test_start_single_pool
         """
@@ -82,7 +82,7 @@ class DMGCheckStartCornerCaseTest(TestWithServers):
         Jira ID: DAOS-17860
 
         :avocado: tags=all,full_regression
-        :avocado: tags=vm
+        :avocado: tags=hw,medium
         :avocado: tags=recovery,cat_recov
         :avocado: tags=DMGCheckStartCornerCaseTest,test_start_back_to_back
         """

--- a/src/tests/ftest/recovery/check_start_corner_case.yaml
+++ b/src/tests/ftest/recovery/check_start_corner_case.yaml
@@ -2,19 +2,27 @@ hosts:
   test_servers: 1
   test_clients: 1
 
-timeout: 150
+timeout: 4M
 
 server_config:
   name: daos_server
-  engines_per_host: 1
+  engines_per_host: 2
   engines:
     0:
-      targets: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      nr_xs_helpers: 1
       storage: auto
-  system_ram_reserved: 1
+    1:
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      nr_xs_helpers: 1
+      storage: auto
 
 pool:
-  size: 3G
+  size: 60G
 
 container:
   type: POSIX


### PR DESCRIPTION
Update check_start_corner_case.py/yaml to use
Hardware Medium so that they run on MD-on-SSD
cluster.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-medium: false
Test-tag: DMGCheckStartCornerCaseTest

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
