### PR TITLE
DAOS-17772 rebuild: refine some rebuild/EC agg/EC deg fetch process

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1843,11 +1843,10 @@ crt_hdlr_iv_sync_aux(void *arg)
 	grp_ver = ivns_internal->cii_grp_priv->gp_membs_ver;
 	D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	if (grp_ver != input->ivs_grp_ver) {
-		D_DEBUG(DB_ALL,
-			"Group (%s) version mismatch. Local: %d Remote :%d\n",
-			ivns_id.ii_group_name, grp_ver,
-			input->ivs_grp_ver);
-		D_GOTO(exit, rc = -DER_GRPVER);
+		rc = -DER_GRPVER;
+		DL_INFO(rc, "Group (%s) version mismatch. Local: %d Remote :%d",
+			ivns_id.ii_group_name, grp_ver, input->ivs_grp_ver);
+		goto exit;
 	}
 
 	iv_ops = crt_iv_ops_get(ivns_internal, input->ivs_class_id);
@@ -1922,7 +1921,7 @@ exit:
 	if (need_put && iv_ops)
 		iv_ops->ivo_on_put(ivns_internal, NULL, user_priv);
 
-	output->rc = rc;
+	output->ivs_rc = rc;
 	crt_reply_send(rpc_req);
 
 	/* ADDREF done in lookup above */
@@ -2002,7 +2001,7 @@ crt_hdlr_iv_sync(crt_rpc_t *rpc_req)
 	IVNS_DECREF(ivns_internal);
 	return;
 exit:
-	output->rc = rc;
+	output->ivs_rc = rc;
 	crt_reply_send(rpc_req);
 
 	if (ivns_internal) {
@@ -2022,9 +2021,9 @@ crt_iv_sync_corpc_aggregate(crt_rpc_t *source, crt_rpc_t *result, void *arg)
 	output_result = crt_reply_get(result);
 
 	/* Only set new rc if so far rc is 0 */
-	if (output_result->rc == 0) {
-		if (output_source->rc != 0)
-			output_result->rc = output_source->rc;
+	if (output_result->ivs_rc == 0) {
+		if (output_source->ivs_rc != 0)
+			output_result->ivs_rc = output_source->ivs_rc;
 	}
 
 	return 0;
@@ -2163,14 +2162,16 @@ handle_ivsync_response(const struct crt_cb_info *cb_info)
 {
 	struct iv_sync_cb_info	*iv_sync = cb_info->cci_arg;
 	struct crt_iv_ops	*iv_ops;
+	crt_rpc_t               *rpc    = cb_info->cci_rpc;
+	struct crt_iv_sync_out  *output = crt_reply_get(rpc);
 
 	if (iv_sync->isc_bulk_hdl != CRT_BULK_NULL)
 		crt_bulk_free(iv_sync->isc_bulk_hdl);
 
 	/* do_callback is set based on sync value specified */
 	if (iv_sync->isc_do_callback) {
-		if (cb_info->cci_rc != 0)
-			iv_sync->isc_update_rc = cb_info->cci_rc;
+		if (cb_info->cci_rc || output->ivs_rc)
+			iv_sync->isc_update_rc = cb_info->cci_rc ? cb_info->cci_rc : output->ivs_rc;
 
 		iv_sync->isc_update_comp_cb(iv_sync->isc_ivns_internal,
 					    iv_sync->isc_class_id,
@@ -2412,7 +2413,7 @@ finalize_transfer_back(struct update_cb_info *cb_info, int rc)
 	struct crt_iv_update_out	*child_output;
 
 	child_output = crt_reply_get(cb_info->uci_child_rpc);
-	child_output->rc = rc;
+	child_output->ivo_rc = rc;
 
 	ivns = cb_info->uci_ivns_internal;
 	crt_reply_send(cb_info->uci_child_rpc);
@@ -2528,15 +2529,15 @@ handle_ivupdate_response(const struct crt_cb_info *cb_info)
 		if (iv_info->uci_bulk_hdl == CRT_BULK_NULL)
 			d_sgl_buf_copy(&iv_info->uci_iv_value, &output->ivo_iv_sgl);
 		iv_ops->ivo_on_refresh(iv_info->uci_ivns_internal, &input->ivu_key, 0,
-				       &iv_info->uci_iv_value, false, cb_info->cci_rc ?: output->rc,
-				       iv_info->uci_user_priv);
+				       &iv_info->uci_iv_value, false,
+				       cb_info->cci_rc ?: output->ivo_rc, iv_info->uci_user_priv);
 
 		if (input->ivu_iv_value_bulk == CRT_BULK_NULL &&
 		    iv_info->uci_child_rpc != NULL) {
 			child_output = crt_reply_get(iv_info->uci_child_rpc);
 			child_output->ivo_iv_sgl = iv_info->uci_iv_value;
 		}
-		transfer_back_to_child(&input->ivu_key, iv_info, cb_info->cci_rc ?: output->rc);
+		transfer_back_to_child(&input->ivu_key, iv_info, cb_info->cci_rc ?: output->ivo_rc);
 		D_GOTO(exit, 0);
 	}
 
@@ -2549,10 +2550,10 @@ handle_ivupdate_response(const struct crt_cb_info *cb_info)
 
 		iv_ops->ivo_on_put(iv_info->uci_ivns_internal, &iv_info->uci_iv_value,
 				   iv_info->uci_user_priv);
-		child_output->rc = output->rc;
+		child_output->ivo_rc = output->ivo_rc;
 
 		if (cb_info->cci_rc != 0)
-			child_output->rc = cb_info->cci_rc;
+			child_output->ivo_rc = cb_info->cci_rc;
 
 		/* Respond back to child; might fail if child is not alive */
 		if (crt_reply_send(iv_info->uci_child_rpc) != DER_SUCCESS)
@@ -2568,7 +2569,7 @@ handle_ivupdate_response(const struct crt_cb_info *cb_info)
 		else
 			tmp_iv_value = &iv_info->uci_iv_value;
 
-		rc = output->rc;
+		rc = output->ivo_rc;
 
 		if (cb_info->cci_rc != 0)
 			rc = cb_info->cci_rc;
@@ -2897,7 +2898,7 @@ bulk_update_transfer_done_aux(const struct crt_bulk_cb_info *info)
 			D_GOTO(exit, rc);
 		}
 		rc = crt_bulk_free(cb_info->buc_bulk_hdl);
-		output->rc = rc;
+		output->ivo_rc = rc;
 		iv_ops->ivo_on_put(ivns_internal, &cb_info->buc_iv_value, cb_info->buc_user_priv);
 
 		crt_reply_send(info->bci_bulk_desc->bd_rpc);
@@ -2913,7 +2914,7 @@ exit:
 
 send_error:
 	/* send back whatever error got us here */
-	output->rc = rc;
+	output->ivo_rc = rc;
 	rc         = crt_bulk_free(cb_info->buc_bulk_hdl);
 	if (rc != 0)
 		DL_ERROR(rc, "crt_bulk_free() failed");
@@ -3016,7 +3017,7 @@ bulk_update_transfer_done(const struct crt_bulk_cb_info *info)
 	return rc;
 
 send_error:
-	output->rc = rc;
+	output->ivo_rc = rc;
 	crt_reply_send(info->bci_bulk_desc->bd_rpc);
 
 	crt_bulk_free(cb_info->buc_bulk_hdl);
@@ -3121,7 +3122,7 @@ crt_iv_update_inline_hdlr(crt_rpc_t *rpc, struct crt_ivns_internal *ivns_interna
 			D_GOTO(exit, rc);
 		}
 	} else if (rc == 0) {
-		output->rc = rc;
+		output->ivo_rc = rc;
 		crt_reply_send(rpc);
 		iv_ops->ivo_on_put(ivns_internal, &iv_value, user_priv);
 	} else {
@@ -3136,7 +3137,7 @@ put_error:
 	iv_ops->ivo_on_put(ivns_internal, &iv_value, user_priv);
 
 send_error:
-	output->rc = rc;
+	output->ivo_rc = rc;
 	crt_reply_send(rpc);
 	if (update_cb_info)
 		D_FREE(update_cb_info);
@@ -3270,7 +3271,7 @@ crt_hdlr_iv_update(crt_rpc_t *rpc_req)
 			}
 
 		} else if (rc == 0) {
-			output->rc = rc;
+			output->ivo_rc = rc;
 			rc = crt_reply_send(rpc_req);
 		} else {
 			D_GOTO(send_error, rc);
@@ -3340,7 +3341,7 @@ exit:
 	return;
 
 send_error:
-	output->rc = rc;
+	output->ivo_rc = rc;
 	crt_reply_send(rpc_req);
 
 	if (put_needed)

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1843,10 +1843,9 @@ crt_hdlr_iv_sync_aux(void *arg)
 	grp_ver = ivns_internal->cii_grp_priv->gp_membs_ver;
 	D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	if (grp_ver != input->ivs_grp_ver) {
-		rc = -DER_GRPVER;
-		DL_INFO(rc, "Group (%s) version mismatch. Local: %d Remote :%d",
+		D_DEBUG(DB_ALL, "Group (%s) version mismatch. Local: %d Remote :%d",
 			ivns_id.ii_group_name, grp_ver, input->ivs_grp_ver);
-		goto exit;
+		D_GOTO(exit, rc = -DER_GRPVER);
 	}
 
 	iv_ops = crt_iv_ops_get(ivns_internal, input->ivs_class_id);

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -534,7 +534,7 @@ CRT_RPC_DECLARE(crt_iv_fetch, CRT_ISEQ_IV_FETCH, CRT_OSEQ_IV_FETCH)
 	((uint32_t)		(padding)		CRT_VAR)
 
 #define CRT_OSEQ_IV_UPDATE	/* output fields */		 \
-	((uint64_t)		(rc)			CRT_VAR) \
+	((uint64_t)		(ivo_rc)		CRT_VAR) \
 	((d_sg_list_t)		(ivo_iv_sgl)		CRT_VAR)
 
 CRT_RPC_DECLARE(crt_iv_update, CRT_ISEQ_IV_UPDATE, CRT_OSEQ_IV_UPDATE)
@@ -553,7 +553,7 @@ CRT_RPC_DECLARE(crt_iv_update, CRT_ISEQ_IV_UPDATE, CRT_OSEQ_IV_UPDATE)
 	((uint32_t)		(ivs_class_id)		CRT_VAR) \
 
 #define CRT_OSEQ_IV_SYNC	/* output fields */		 \
-	((int32_t)		(rc)			CRT_VAR)
+	((int32_t)		(ivs_rc)		CRT_VAR)
 
 CRT_RPC_DECLARE(crt_iv_sync, CRT_ISEQ_IV_SYNC, CRT_OSEQ_IV_SYNC)
 

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -219,15 +219,17 @@ free:
 }
 
 daos_size_t
-daos_sgl_data_len(d_sg_list_t *sgl)
+daos_sgl_data_len(d_sg_list_t *sgl, bool out)
 {
 	daos_size_t	len;
-	int		i;
+	uint32_t        sg_nr;
+	uint32_t        i;
 
 	if (sgl == NULL || sgl->sg_iovs == NULL)
 		return 0;
 
-	for (i = 0, len = 0; i < sgl->sg_nr; i++)
+	sg_nr = out ? sgl->sg_nr_out : sgl->sg_nr;
+	for (i = 0, len = 0; i < sg_nr; i++)
 		len += sgl->sg_iovs[i].iov_len;
 
 	return len;

--- a/src/common/tests_lib.c
+++ b/src/common/tests_lib.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2015-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -279,7 +280,7 @@ td_init(struct test_data *td, uint32_t iod_nr, struct td_init_args args)
 
 		/* Initialize and create some data */
 		dts_sgl_generate(sgl, 1, args.ca_data_size, 0xAB);
-		D_ASSERT(daos_sgl_data_len(sgl) == data_len);
+		D_ASSERT(daos_sgl_data_len(sgl, false) == data_len);
 
 		iod->iod_type = iod_types[i];
 		dts_iov_alloc_str(&iod->iod_name, "akey");

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -450,6 +450,7 @@ cont_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		  d_sg_list_t *dst, void **priv)
 {
 	struct cont_iv_entry	*src_iv;
+	struct cont_iv_entry     iv_entry = {0};
 	daos_handle_t		root_hdl;
 	d_iov_t			key_iov;
 	d_iov_t			val_iov;
@@ -497,7 +498,6 @@ again:
 				rc1 = ds_cont_hdl_rdb_lookup(entry->ns->iv_pool_uuid,
 							     civ_key->cont_uuid, &chdl);
 				if (rc1 == 0) {
-					struct cont_iv_entry	iv_entry = { 0 };
 					daos_prop_t		*prop = NULL;
 					struct daos_prop_entry	*prop_entry;
 					struct daos_co_status	stat = { 0 };
@@ -547,8 +547,40 @@ again:
 				} else {
 					rc = -DER_NONEXIST;
 				}
+			} else if (class_id == IV_CONT_TRACK_EPOCH) {
+				uint64_t ec_agg_eph;
+
+				rc = ds_cont_ec_agg_eph_rdb_lookup(entry->ns->iv_pool_uuid,
+								   civ_key->cont_uuid, &ec_agg_eph);
+				if (rc == 0) {
+					uuid_copy(iv_entry.cont_uuid, civ_key->cont_uuid);
+					iv_entry.iv_track_eph.ite_ec_agg_eph  = ec_agg_eph;
+					iv_entry.iv_track_eph.ite_rank = dss_self_rank();
+					d_iov_set(&val_iov, &iv_entry, sizeof(iv_entry));
+					rc = dbtree_update(root_hdl, &key_iov, &val_iov);
+					DL_CDEBUG(
+					    rc != 0, DLOG_ERR, DB_MD, rc,
+					    DF_CONT ": dbtree_update ec_agg_eph " DF_X64,
+					    DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid),
+					    ec_agg_eph);
+					if (rc)
+						goto failed;
+					/* on master node will not trigger on_refresh callback,
+					 * so need to explicitly refresh its own cont child's
+					 * sc_ec_agg_eph_boundary especially for the case of
+					 * restart that the value is zero.
+					 * pass zero stable epoch that won't refresh it, only to
+					 * fetch+refresh EC aggregation epoch.
+					 */
+					rc = ds_cont_tgt_refresh_track_eph(entry->ns->iv_pool_uuid,
+									   civ_key->cont_uuid,
+									   ec_agg_eph, 0);
+					if (rc == 0)
+						goto again;
+				}
 			}
 		}
+failed:
 		D_DEBUG(DB_MGMT, DF_CONT "lookup cont: rc " DF_RC "\n",
 			DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid), DP_RC(rc));
 		D_GOTO(out, rc);
@@ -653,8 +685,15 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 				D_GOTO(out, rc);
 		} else if (entry->iv_class->iv_class_id == IV_CONT_TRACK_EPOCH) {
 			rc = cont_iv_ent_track_eph_refresh(entry, key, src);
-			if (rc)
+			if (rc) {
+				if (rc == -DER_NONEXIST) {
+					DL_INFO(
+					    rc, DF_CONT " cont_iv_ent_agg_eph_refresh ignore",
+					    DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
+					rc = 0;
+				}
 				D_GOTO(out, rc);
+			}
 		}
 	}
 
@@ -1118,9 +1157,8 @@ int
 cont_iv_track_eph_refresh(void *ns, uuid_t cont_uuid, daos_epoch_t ec_agg_eph,
 			  daos_epoch_t stable_eph)
 {
-	return cont_iv_track_eph_update_internal(ns, cont_uuid, ec_agg_eph, stable_eph,
-						 0, CRT_IV_SYNC_LAZY,
-						 IV_CONT_TRACK_EPOCH);
+	return cont_iv_track_eph_update_internal(ns, cont_uuid, ec_agg_eph, stable_eph, 0,
+						 CRT_IV_SYNC_EAGER, IV_CONT_TRACK_EPOCH);
 }
 
 int

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1699,6 +1699,7 @@ cont_track_eph_leader_alloc(struct cont_svc *cont_svc, uuid_t cont_uuid,
 	uuid_copy(eph_ldr->cte_cont_uuid, cont_uuid);
 	eph_ldr->cte_servers_num = rank_nr;
 	eph_ldr->cte_current_ec_agg_eph = 0;
+	eph_ldr->cte_rdb_ec_agg_eph     = 0;
 	for (i = 0; i < rank_nr; i++) {
 		eph_ldr->cte_server_ephs[i].re_rank = doms[i].do_comp.co_rank;
 		eph_ldr->cte_server_ephs[i].re_ec_agg_eph = 0;
@@ -1824,6 +1825,8 @@ cont_refresh_track_eph_one(void *data)
 	if (cont_child->sc_ec_agg_eph_boundary < arg->min_ec_agg_eph)
 		cont_child->sc_ec_agg_eph_boundary = arg->min_ec_agg_eph;
 
+	cont_child->sc_ec_agg_eph_valid = 1;
+
 	/* Only should update local stable epoch if the target is in UPIN status */
 	if (cont_child->sc_global_stable_eph < arg->min_stable_eph &&
 	    (arg->tgt_status[idx] & PO_COMP_ST_UPIN)) {
@@ -1876,6 +1879,10 @@ ds_cont_tgt_refresh_track_eph(uuid_t pool_uuid, uuid_t cont_uuid,
 	rc = ds_pool_thread_collective(
 	    pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
 	    cont_refresh_track_eph_one, &arg, DSS_ULT_DEEP_STACK | DSS_ULT_FL_PERIODIC);
+	DL_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO, rc,
+		  DF_CONT ": refresh ec_agg_eph " DF_X64 ", "
+			  "stable_eph " DF_X64,
+		  DP_CONT(pool_uuid, cont_uuid), ec_agg_eph, stable_eph);
 
 out:
 	if (arg.tgt_status != NULL && arg.tgt_status != arg.tgt_status_inline)
@@ -1883,127 +1890,290 @@ out:
 	return rc;
 }
 
-#define TRACK_EPH_INTV	 (5ULL * 1000)	/* seconds interval to check*/
-static void
-cont_track_eph_leader_ult(void *arg)
+static int
+cont_agg_eph_load(struct cont_svc *svc, uuid_t cont_uuid, uint64_t *ec_agg_eph)
 {
-	struct cont_svc			*svc = arg;
-	struct ds_pool			*pool = svc->cs_pool;
+	struct rdb_tx tx;
+	struct cont  *cont = NULL;
+	uint64_t      agg_eph;
+	d_iov_t       value;
+	int           rc;
+
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0) {
+		DL_CDEBUG(rc != -DER_NOTLEADER, DLOG_ERR, DB_MD, rc,
+			  DF_CONT ": Failed to start rdb tx.",
+			  DP_CONT(svc->cs_pool_uuid, cont_uuid));
+		return rc;
+	}
+
+	ABT_rwlock_rdlock(svc->cs_lock);
+	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR(DF_CONT ": Failed to look container: %d\n",
+			DP_CONT(svc->cs_pool_uuid, cont_uuid), rc);
+		D_GOTO(out_lock, rc);
+	}
+
+	d_iov_set(&value, &agg_eph, sizeof(agg_eph));
+	rc = rdb_tx_lookup(&tx, &cont->c_prop, &ds_cont_prop_ec_agg_eph, &value);
+	DL_CDEBUG(rc != 0 && rc != -DER_NONEXIST && rc != -DER_NOTLEADER, DLOG_ERR, DB_MD, rc,
+		  DF_CONT ": rdb_tx_lookup ec_agg_eph " DF_X64,
+		  DP_CONT(svc->cs_pool_uuid, cont_uuid), agg_eph);
+	if (rc == -DER_NONEXIST) {
+		agg_eph = 0;
+		rc      = 0;
+	}
+	if (rc == 0)
+		*ec_agg_eph = agg_eph;
+	cont_put(cont);
+
+out_lock:
+	ABT_rwlock_unlock(svc->cs_lock);
+	rdb_tx_end(&tx);
+	return rc;
+}
+
+int
+ds_cont_ec_agg_eph_rdb_lookup(uuid_t pool_uuid, uuid_t cont_uuid, uint64_t *ec_agg_eph)
+{
+	struct cont_svc *svc;
+	int              rc;
+
+	rc = cont_svc_lookup_leader(pool_uuid, 0 /* id */, &svc, NULL);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_CONT ": find leader failed.", DP_CONT(pool_uuid, cont_uuid));
+		return rc;
+	}
+
+	rc = cont_agg_eph_load(svc, cont_uuid, ec_agg_eph);
+	cont_svc_put_leader(svc);
+	if (rc)
+		DL_ERROR(rc, DF_CONT ": cont_agg_eph_load failed.", DP_CONT(pool_uuid, cont_uuid));
+	return rc;
+}
+
+static int
+cont_agg_eph_store(struct cont_svc *svc, uuid_t cont_uuid, uint64_t ec_agg_eph, uint64_t *rdb_eph)
+{
+	struct rdb_tx tx;
+	struct cont  *cont = NULL;
+	d_iov_t       value;
+	uint64_t      old_eph;
+	int           rc;
+
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0) {
+		DL_CDEBUG(rc != -DER_NOTLEADER, DLOG_ERR, DB_MD, rc,
+			  DF_CONT ": Failed to start rdb tx.",
+			  DP_CONT(svc->cs_pool_uuid, cont_uuid));
+		return rc;
+	}
+
+	ABT_rwlock_wrlock(svc->cs_lock);
+	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR(DF_CONT ": Failed to look container: %d\n",
+			DP_CONT(svc->cs_pool_uuid, cont_uuid), rc);
+		D_GOTO(out_lock, rc);
+	}
+
+	d_iov_set(&value, &old_eph, sizeof(old_eph));
+	rc = rdb_tx_lookup(&tx, &cont->c_prop, &ds_cont_prop_ec_agg_eph, &value);
+	if (rc == -DER_NONEXIST) {
+		rc      = 0;
+		old_eph = 0;
+	}
+	if (rc != 0)
+		goto out;
+
+	*rdb_eph = old_eph;
+	if (ec_agg_eph > old_eph) {
+		d_iov_set(&value, &ec_agg_eph, sizeof(ec_agg_eph));
+		rc = rdb_tx_update(&tx, &cont->c_prop, &ds_cont_prop_ec_agg_eph, &value);
+		if (rc == 0)
+			rc = rdb_tx_commit(&tx);
+		if (rc == 0)
+			*rdb_eph = ec_agg_eph;
+	} else {
+		D_DEBUG(DB_MD,
+			DF_CONT ": bypass rdb update ec_agg_eph " DF_X64 ", in rdb eph " DF_X64,
+			DP_CONT(svc->cs_pool_uuid, cont_uuid), ec_agg_eph, old_eph);
+	}
+
+out:
+	DL_CDEBUG(rc != 0 && rc != -DER_NOTLEADER, DLOG_ERR, DB_MD, rc,
+		  DF_CONT ": rdb_tx_update ec_agg_eph " DF_X64,
+		  DP_CONT(svc->cs_pool_uuid, cont_uuid), ec_agg_eph);
+	cont_put(cont);
+out_lock:
+	ABT_rwlock_unlock(svc->cs_lock);
+	rdb_tx_end(&tx);
+	return rc;
+}
+
+static void
+cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
+{
+	d_rank_list_t                    fail_ranks = {0};
 	struct cont_track_eph_leader	*eph_ldr;
 	struct cont_track_eph_leader	*tmp;
 	uint64_t			 cur_eph, new_eph;
+	daos_epoch_t			 min_ec_agg_eph;
+	daos_epoch_t			 min_stable_eph;
+	int				 i;
 	int				 rc = 0;
+
+	rc = map_ranks_init(pool->sp_map, PO_COMP_ST_DOWNOUT | PO_COMP_ST_DOWN, &fail_ranks);
+	if (rc) {
+		D_ERROR(DF_UUID ": ranks init failed: %d\n", DP_UUID(pool->sp_uuid), rc);
+		return;
+	}
+
+	d_list_for_each_entry_safe(eph_ldr, tmp, &svc->cs_cont_ephs_leader_list, cte_list) {
+		if (eph_ldr->cte_deleted) {
+			d_list_del(&eph_ldr->cte_list);
+			D_FREE(eph_ldr->cte_server_ephs);
+			D_FREE(eph_ldr);
+			continue;
+		}
+
+		if (eph_ldr->cte_rdb_ec_agg_eph == 0) {
+			rc = cont_agg_eph_load(svc, eph_ldr->cte_cont_uuid,
+					       &eph_ldr->cte_rdb_ec_agg_eph);
+			if (rc)
+				DL_ERROR(rc, DF_CONT ": cont_agg_eph_load failed.",
+					 DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid));
+		}
+
+		min_ec_agg_eph = DAOS_EPOCH_MAX;
+		min_stable_eph = DAOS_EPOCH_MAX;
+		for (i = 0; i < eph_ldr->cte_servers_num; i++) {
+			d_rank_t rank = eph_ldr->cte_server_ephs[i].re_rank;
+
+			if (d_rank_in_rank_list(&fail_ranks, rank)) {
+				D_DEBUG(DB_MD, DF_CONT " skip %u\n",
+					DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid), rank);
+				continue;
+			}
+
+			if (eph_ldr->cte_server_ephs[i].re_ec_agg_eph < min_ec_agg_eph)
+				min_ec_agg_eph = eph_ldr->cte_server_ephs[i].re_ec_agg_eph;
+			if (eph_ldr->cte_server_ephs[i].re_stable_eph < min_stable_eph)
+				min_stable_eph = eph_ldr->cte_server_ephs[i].re_stable_eph;
+		}
+
+		/* for reboot case the ea_rdb_eph possibly higher than min_eph */
+		if (min_ec_agg_eph < eph_ldr->cte_rdb_ec_agg_eph)
+			min_ec_agg_eph = eph_ldr->cte_rdb_ec_agg_eph;
+
+		if (min_ec_agg_eph == eph_ldr->cte_current_ec_agg_eph &&
+		    min_stable_eph == eph_ldr->cte_current_stable_eph)
+			continue;
+
+		/**
+		 * NB: during extending or reintegration, the new
+		 * server might cause the minimum epoch is less than
+		 * cte_current_ec_agg_eph.
+		 */
+		D_DEBUG(DB_MD,
+			DF_CONT " min_ec_agg_eph " DF_X64 " current " DF_X64
+				", min_stable_eph " DF_X64 " current " DF_X64 ".\n",
+			DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid), min_ec_agg_eph,
+			eph_ldr->cte_current_ec_agg_eph, min_stable_eph,
+			eph_ldr->cte_current_stable_eph);
+
+		cur_eph = d_hlc2sec(eph_ldr->cte_current_ec_agg_eph);
+		new_eph = d_hlc2sec(min_ec_agg_eph);
+		if (cur_eph && new_eph > cur_eph && (new_eph - cur_eph) >= 600)
+			D_WARN(DF_CONT ": Sluggish EC boundary reporting. "
+				       "cur:" DF_U64 " new:" DF_U64 " gap:" DF_U64 "\n",
+			       DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid), cur_eph, new_eph,
+			       new_eph - cur_eph);
+
+		cur_eph = d_hlc2sec(eph_ldr->cte_current_stable_eph);
+		new_eph = d_hlc2sec(min_stable_eph);
+		if (cur_eph && new_eph > cur_eph && (new_eph - cur_eph) >= 600)
+			D_WARN(DF_CONT ": Sluggish stable epoch reporting. "
+				       "cur:" DF_U64 " new:" DF_U64 " gap:" DF_U64 "\n",
+			       DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid), cur_eph, new_eph,
+			       new_eph - cur_eph);
+
+		if (min_ec_agg_eph > eph_ldr->cte_rdb_ec_agg_eph) {
+			rc = cont_agg_eph_store(svc, eph_ldr->cte_cont_uuid, min_ec_agg_eph,
+						&eph_ldr->cte_rdb_ec_agg_eph);
+			if (rc)
+				DL_ERROR(rc,
+					 DF_CONT ": rdb_tx_update ec_agg_eph " DF_X64 " failed.",
+					 DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid),
+					 min_ec_agg_eph);
+		}
+
+		rc = cont_iv_track_eph_refresh(pool->sp_iv_ns, eph_ldr->cte_cont_uuid,
+					       min_ec_agg_eph, min_stable_eph);
+		if (rc) {
+			DL_CDEBUG(rc == -DER_NONEXIST, DLOG_INFO, DLOG_ERR, rc,
+				  DF_CONT ": refresh failed",
+				  DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid));
+
+			/* If there are network error or pool map inconsistency,
+			 * let's skip the following eph sync, which will fail
+			 * anyway.
+			 */
+			if (daos_crt_network_error(rc) || rc == -DER_GRPVER) {
+				D_INFO(DF_UUID ": skip refresh due to: " DF_RC "\n",
+				       DP_UUID(svc->cs_pool_uuid), DP_RC(rc));
+				break;
+			}
+
+			continue;
+		}
+		eph_ldr->cte_current_ec_agg_eph = min_ec_agg_eph;
+		eph_ldr->cte_current_stable_eph = min_stable_eph;
+		if (pool->sp_rebuilding)
+			break;
+	}
+
+	map_ranks_fini(&fail_ranks);
+}
+
+int
+ds_cont_svc_refresh_agg_eph(uuid_t pool_uuid)
+{
+	struct cont_svc *svc;
+	int              rc;
+
+	rc = cont_svc_lookup_leader(pool_uuid, 0 /* id */, &svc, NULL /* hint */);
+	if (rc != 0)
+		return rc;
+
+	cont_agg_eph_sync(svc->cs_pool, svc);
+
+	cont_svc_put_leader(svc);
+	return 0;
+}
+
+#define TRACK_EPH_INTV (5ULL * 1000) /* seconds interval to check*/
+static void
+cont_track_eph_leader_ult(void *arg)
+{
+	struct cont_svc              *svc  = arg;
+	struct ds_pool               *pool = svc->cs_pool;
+	struct cont_track_eph_leader *eph_ldr;
+	struct cont_track_eph_leader *tmp;
+	int                           rc = 0;
 
 	if (svc->cs_cont_ephs_leader_req == NULL)
 		goto out;
 
 	while (!dss_ult_exiting(svc->cs_cont_ephs_leader_req)) {
-		d_rank_list_t		fail_ranks = { 0 };
-
-		if (pool->sp_rebuilding) {
-			D_DEBUG(DB_MD, DF_UUID "skip during rebuilding.\n",
-				DP_UUID(pool->sp_uuid));
-			goto yield;
-		}
-
-		rc = map_ranks_init(pool->sp_map, PO_COMP_ST_DOWNOUT | PO_COMP_ST_DOWN,
-				    &fail_ranks);
-		if (rc) {
-			D_ERROR(DF_UUID": ranks init failed: %d\n",
-				DP_UUID(pool->sp_uuid), rc);
-			goto yield;
-		}
-
-		d_list_for_each_entry_safe(eph_ldr, tmp, &svc->cs_cont_ephs_leader_list, cte_list) {
-			daos_epoch_t min_ec_agg_eph = DAOS_EPOCH_MAX;
-			daos_epoch_t min_stable_eph = DAOS_EPOCH_MAX;
-			int	     i;
-
-			if (eph_ldr->cte_deleted) {
-				d_list_del(&eph_ldr->cte_list);
-				D_FREE(eph_ldr->cte_server_ephs);
-				D_FREE(eph_ldr);
-				continue;
-			}
-
-			for (i = 0; i < eph_ldr->cte_servers_num; i++) {
-				d_rank_t rank = eph_ldr->cte_server_ephs[i].re_rank;
-
-				if (d_rank_in_rank_list(&fail_ranks, rank)) {
-					D_DEBUG(DB_MD, DF_CONT" skip %u\n",
-						DP_CONT(svc->cs_pool_uuid,
-							eph_ldr->cte_cont_uuid),
-						rank);
-					continue;
-				}
-
-				if (eph_ldr->cte_server_ephs[i].re_ec_agg_eph < min_ec_agg_eph)
-					min_ec_agg_eph = eph_ldr->cte_server_ephs[i].re_ec_agg_eph;
-				if (eph_ldr->cte_server_ephs[i].re_stable_eph < min_stable_eph)
-					min_stable_eph = eph_ldr->cte_server_ephs[i].re_stable_eph;
-			}
-
-			if (min_ec_agg_eph == eph_ldr->cte_current_ec_agg_eph &&
-			    min_stable_eph == eph_ldr->cte_current_stable_eph)
-				continue;
-
-			/**
-			 * NB: during extending or reintegration, the new
-			 * server might cause the minimum epoch is less than
-			 * cte_current_ec_agg_eph.
-			 */
-			D_DEBUG(DB_MD, DF_CONT" min_ec_agg_eph "DF_X64" current "DF_X64
-				", min_stable_eph "DF_X64" current "DF_X64".\n",
-				DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid),
-				min_ec_agg_eph, eph_ldr->cte_current_ec_agg_eph,
-				min_stable_eph, eph_ldr->cte_current_stable_eph);
-
-			cur_eph = d_hlc2sec(eph_ldr->cte_current_ec_agg_eph);
-			new_eph = d_hlc2sec(min_ec_agg_eph);
-			if (cur_eph && new_eph > cur_eph && (new_eph - cur_eph) >= 600)
-				D_WARN(DF_CONT": Sluggish EC boundary reporting. "
-				       "cur:"DF_U64" new:"DF_U64" gap:"DF_U64"\n",
-				       DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid),
-				       cur_eph, new_eph, new_eph - cur_eph);
-
-			cur_eph = d_hlc2sec(eph_ldr->cte_current_stable_eph);
-			new_eph = d_hlc2sec(min_stable_eph);
-			if (cur_eph && new_eph > cur_eph && (new_eph - cur_eph) >= 600)
-				D_WARN(DF_CONT": Sluggish stable epoch reporting. "
-				       "cur:"DF_U64" new:"DF_U64" gap:"DF_U64"\n",
-				       DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid),
-				       cur_eph, new_eph, new_eph - cur_eph);
-
-			rc = cont_iv_track_eph_refresh(pool->sp_iv_ns, eph_ldr->cte_cont_uuid,
-						       min_ec_agg_eph, min_stable_eph);
-			if (rc) {
-				DL_CDEBUG(rc == -DER_NONEXIST, DLOG_INFO, DLOG_ERR, rc,
-					  DF_CONT ": refresh failed",
-					  DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid));
-
-				/* If there are network error or pool map inconsistency,
-				 * let's skip the following eph sync, which will fail
-				 * anyway.
-				 */
-				if (daos_crt_network_error(rc) || rc == -DER_GRPVER) {
-					D_INFO(DF_UUID": skip refresh due to: "DF_RC"\n",
-					       DP_UUID(svc->cs_pool_uuid), DP_RC(rc));
-					break;
-				}
-
-				continue;
-			}
-			eph_ldr->cte_current_ec_agg_eph = min_ec_agg_eph;
-			eph_ldr->cte_current_stable_eph = min_stable_eph;
-			if (pool->sp_rebuilding)
-				break;
-		}
-
-		map_ranks_fini(&fail_ranks);
+		cont_agg_eph_sync(pool, svc);
 
 		if (dss_ult_exiting(svc->cs_cont_ephs_leader_req))
 			break;
-yield:
+
 		sched_req_sleep(svc->cs_cont_ephs_leader_req, TRACK_EPH_INTV);
 	}
 

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -69,6 +69,7 @@ struct cont_track_eph_leader {
 	uuid_t			cte_cont_uuid;
 	daos_epoch_t		cte_current_ec_agg_eph;
 	daos_epoch_t		cte_current_stable_eph;
+	daos_epoch_t             cte_rdb_ec_agg_eph; /* EC agg epoch in RDB */
 	struct rank_eph		*cte_server_ephs;
 	d_list_t		cte_list;
 	int			cte_servers_num;
@@ -315,4 +316,7 @@ int cont_child_gather_oids(struct ds_cont_child *cont, uuid_t coh_uuid,
 
 int ds_cont_hdl_rdb_lookup(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 			   struct container_hdl *chdl);
+int
+ds_cont_ec_agg_eph_rdb_lookup(uuid_t pool_uuid, uuid_t cont_uuid, uint64_t *ec_agg_eph);
+
 #endif /* __CONTAINER_SRV_INTERNAL_H__ */

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -54,6 +55,7 @@ RDB_STRING_KEY(ds_cont_prop_, scrubber_disabled);
 RDB_STRING_KEY(ds_cont_prop_, co_md_times);
 RDB_STRING_KEY(ds_cont_prop_, cont_obj_version);
 RDB_STRING_KEY(ds_cont_prop_, nhandles);
+RDB_STRING_KEY(ds_cont_prop_, ec_agg_eph);
 
 /* dummy value for container roots, avoid malloc on demand */
 static struct daos_prop_co_roots dummy_roots;

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -137,6 +138,7 @@ extern d_iov_t ds_cont_prop_co_md_times;	/* co_md_times */
 extern d_iov_t ds_cont_prop_cont_obj_version;	/* uint32_t */
 extern d_iov_t ds_cont_prop_nhandles;		/* uint32_t */
 extern d_iov_t ds_cont_prop_oit_oids;		/* snapshot OIT OID KVS */
+extern d_iov_t ds_cont_prop_ec_agg_eph;         /* uint64_t */
 /* Please read the IMPORTANT notes above before adding new keys. */
 
 struct co_md_times {

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -387,7 +387,10 @@ int daos_sgl_copy_data(d_sg_list_t *dst, d_sg_list_t *src);
 int daos_sgl_alloc_copy_data(d_sg_list_t *dst, d_sg_list_t *src);
 int daos_sgls_alloc(d_sg_list_t *dst, d_sg_list_t *src, int nr);
 int daos_sgl_merge(d_sg_list_t *dst, d_sg_list_t *src);
-daos_size_t daos_sgl_data_len(d_sg_list_t *sgl);
+daos_size_t
+daos_sgl_data_len(d_sg_list_t *sgl, bool out);
+daos_size_t
+	    daos_sgl_out_data_len(d_sg_list_t *sgl);
 daos_size_t daos_sgl_buf_size(d_sg_list_t *sgl);
 daos_size_t daos_sgls_buf_size(d_sg_list_t *sgls, int nr);
 daos_size_t daos_sgls_packed_size(d_sg_list_t *sgls, int nr,

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -37,6 +37,8 @@ void ds_cont_svc_step_down(struct cont_svc *svc);
 int
     ds_cont_svc_set_prop(uuid_t pool_uuid, const char *cont_id, d_rank_list_t *ranks,
 			 daos_prop_t *prop);
+int
+    ds_cont_svc_refresh_agg_eph(uuid_t pool_uuid);
 int ds_cont_list(uuid_t pool_uuid, struct daos_pool_cont_info **conts, uint64_t *ncont);
 int ds_cont_filter(uuid_t pool_uuid, daos_pool_cont_filter_t *filt,
 		   struct daos_pool_cont_info2 **conts, uint64_t *ncont);
@@ -72,7 +74,9 @@ struct ds_cont_child {
 	    sc_dtx_delay_reset : 1, sc_dtx_registered : 1, sc_props_fetched : 1, sc_stopping : 1,
 	    sc_destroying : 1, sc_vos_agg_active : 1, sc_ec_agg_active : 1,
 	    /* flag of CONT_CAPA_READ_DATA/_WRITE_DATA disabled */
-	    sc_rw_disabled : 1, sc_scrubbing : 1, sc_rebuilding : 1, sc_open_initializing : 1;
+	    sc_rw_disabled : 1, sc_scrubbing : 1, sc_rebuilding : 1, sc_open_initializing : 1,
+	    /* flag of sc_ec_agg_eph_boundary valid */
+	    sc_ec_agg_eph_valid : 1;
 	/* Tracks the schedule request for aggregation ULT */
 	struct sched_request	*sc_agg_req;
 

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -83,8 +83,14 @@ typedef enum {
 	DP_UUID((mro)->mo_pool_uuid), (mro)->mo_pool_tls_version, (mro)->mo_generation,            \
 	    RB_OP_STR((mro)->mo_opc)
 
+static inline uint64_t
+ds_rebuild_get_upbound_eph()
+{
+	return d_hlc_get() + d_hlc_epsilon_get();
+}
+
 int
-     ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, daos_epoch_t stable_eph,
+     ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, daos_epoch_t upbound_eph,
 			 uint32_t layout_version, struct pool_target_id_list *tgts,
 			 daos_rebuild_opc_t rebuild_op, daos_rebuild_opc_t retry_rebuild_op,
 			 uint32_t retry_map_ver, bool stop_admin, uint64_t delay_sec);
@@ -92,7 +98,7 @@ void ds_rebuild_restart_if_rank_wip(uuid_t pool_uuid, d_rank_t rank);
 int ds_rebuild_query(uuid_t pool_uuid,
 		     struct daos_rebuild_status *status);
 void ds_rebuild_running_query(uuid_t pool_uuid, uint32_t opc, uint32_t *rebuild_ver,
-			      daos_epoch_t *current_eph, uint32_t *rebuild_gen);
+			      daos_epoch_t *upbound_eph, uint32_t *rebuild_gen);
 int
      ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop, uint64_t sys_self_heal,
 				uint64_t delay_sec);

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -94,7 +94,8 @@ int ds_rebuild_query(uuid_t pool_uuid,
 void ds_rebuild_running_query(uuid_t pool_uuid, uint32_t opc, uint32_t *rebuild_ver,
 			      daos_epoch_t *current_eph, uint32_t *rebuild_gen);
 int
-     ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop, uint64_t sys_self_heal);
+     ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop, uint64_t sys_self_heal,
+				uint64_t delay_sec);
 void ds_rebuild_leader_stop_all(void);
 void ds_rebuild_abort(uuid_t pool_uuid, unsigned int version, uint32_t rebuild_gen,
 		      uint64_t term);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -921,16 +921,18 @@ dc_rw_cb(tse_task_t *task, void *arg)
 						 orwo->orw_rels.ca_arrays,
 						 orwo->orw_rels.ca_count);
 			if (rc) {
-				D_ERROR(DF_UOID " obj_ec_parity_check failed, " DF_RC "\n",
-					DP_UOID(orw->orw_oid), DP_RC(rc));
+				DL_ERROR(rc, DF_CONT ", " DF_UOID " obj_ec_parity_check failed",
+					 DP_CONT(orw->orw_pool_uuid, orw->orw_co_uuid),
+					 DP_UOID(orw->orw_oid));
 				goto out;
 			}
 		}
 
 		rc = dc_shard_update_size(rw_args, 0);
 		if (rc) {
-			D_ERROR(DF_UOID " dc_shard_update_size failed, " DF_RC "\n",
-				DP_UOID(orw->orw_oid), DP_RC(rc));
+			DL_ERROR(rc, DF_CONT ", " DF_UOID " dc_shard_update_size failed",
+				 DP_CONT(orw->orw_pool_uuid, orw->orw_co_uuid),
+				 DP_UOID(orw->orw_oid));
 			goto out;
 		}
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1085,6 +1085,7 @@ agg_update_parity(struct ec_agg_entry *entry, uint8_t *bit_map,
 			goto out;
 		while (!isset(bit_map, j))
 			j++;
+		D_ASSERTF(j < k, "bad cell_idx %d, number of data shards %d\n", j, k);
 		agg_diff_preprocess(entry, diff, j);
 		ec_encode_data_update(cell_bytes, k, p, j,
 				      entry->ae_codec->ec_gftbls, diff,
@@ -1951,15 +1952,15 @@ out:
 			/* offload of ds_obj_update to push remote parity */
 			rc = agg_peer_update(entry, write_parity);
 			if (rc)
-				D_ERROR("agg_peer_update fail: "DF_RC"\n",
-					DP_RC(rc));
+				DL_ERROR(rc, "agg_peer_update failed, write_parity %d\n",
+					 write_parity);
 		}
 
 		if (rc == 0) {
 			rc = agg_update_vos(agg_param, entry, write_parity);
 			if (rc)
-				D_ERROR("agg_update_vos failed: "DF_RC"\n",
-					DP_RC(rc));
+				DL_ERROR(rc, "agg_update_vos failed, write_parity %d\n",
+					 write_parity);
 		}
 	}
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1074,7 +1074,7 @@ agg_update_parity(struct ec_agg_entry *entry, uint8_t *bit_map,
 	buf  = entry->ae_sgl.sg_iovs[AGG_IOV_DATA].iov_buf;
 	diff = entry->ae_sgl.sg_iovs[AGG_IOV_DIFF].iov_buf;
 
-	for (i = 0, j = 0; i < cell_cnt; i++) {
+	for (i = 0, j = 0; i < cell_cnt; i++, j++) {
 		old = &obuf[i * cell_bytes];
 		new = &buf[i * cell_bytes];
 		vects[0] = old;

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1952,14 +1952,14 @@ out:
 			/* offload of ds_obj_update to push remote parity */
 			rc = agg_peer_update(entry, write_parity);
 			if (rc)
-				DL_ERROR(rc, "agg_peer_update failed, write_parity %d\n",
+				DL_ERROR(rc, "agg_peer_update failed, write_parity %d",
 					 write_parity);
 		}
 
 		if (rc == 0) {
 			rc = agg_update_vos(agg_param, entry, write_parity);
 			if (rc)
-				DL_ERROR(rc, "agg_update_vos failed, write_parity %d\n",
+				DL_ERROR(rc, "agg_update_vos failed, write_parity %d",
 					 write_parity);
 		}
 	}

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1362,6 +1362,25 @@ obj_rw_recx_list_post(struct obj_rw_in *orw, struct obj_rw_out *orwo, uint8_t *s
 	return rc;
 }
 
+struct ec_agg_boundary_arg {
+	struct ds_pool *eab_pool;
+	uuid_t          eab_co_uuid;
+};
+
+static int
+obj_fetch_ec_agg_boundary(void *data)
+{
+	struct ec_agg_boundary_arg *arg = data;
+	int                         rc;
+
+	rc = ds_cont_fetch_ec_agg_boundary(arg->eab_pool->sp_iv_ns, arg->eab_co_uuid);
+	if (rc)
+		DL_ERROR(rc, DF_CONT ", ds_cont_fetch_ec_agg_boundary failed.",
+			 DP_CONT(arg->eab_pool->sp_uuid, arg->eab_co_uuid));
+
+	return rc;
+}
+
 static int
 obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc, daos_iod_t *iods,
 		      struct dcs_iod_csums *iod_csums, uint64_t *offs, uint8_t *skips,
@@ -1481,6 +1500,32 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc, daos_iod_t *io
 			is_parity_shard = is_ec_parity_shard_by_tgt_off(tgt_off, &ioc->ioc_oca);
 			get_parity_list = ec_recov && is_parity_shard &&
 					  ((orw->orw_flags & ORF_EC_RECOV_SNAP) == 0);
+		}
+		if ((ec_deg_fetch || (ec_recov && get_parity_list)) &&
+		    ioc->ioc_coc->sc_ec_agg_eph_valid == 0) {
+			struct ec_agg_boundary_arg arg;
+
+			arg.eab_pool = ioc->ioc_coc->sc_pool->spc_pool;
+			uuid_copy(arg.eab_co_uuid, ioc->ioc_coc->sc_uuid);
+			rc = dss_ult_execute(obj_fetch_ec_agg_boundary, &arg, NULL, NULL,
+					     DSS_XS_SYS, 0, 0);
+			if (rc) {
+				DL_ERROR(rc, DF_CONT ", " DF_UOID " fetch ec_agg_boundary failed.",
+					 DP_CONT(ioc->ioc_coc->sc_pool_uuid, ioc->ioc_coc->sc_uuid),
+					 DP_UOID(orw->orw_oid));
+				goto out;
+			}
+			if (ioc->ioc_coc->sc_ec_agg_eph_valid == 0) {
+				rc = -DER_FETCH_AGAIN;
+				DL_INFO(rc, DF_CONT ", " DF_UOID " zero ec_agg_boundary.",
+					DP_CONT(ioc->ioc_coc->sc_pool_uuid, ioc->ioc_coc->sc_uuid),
+					DP_UOID(orw->orw_oid));
+				goto out;
+			}
+			D_DEBUG(DB_IO,
+				DF_CONT ", " DF_UOID " fetched ec_agg_eph_boundary " DF_X64 "\n",
+				DP_CONT(ioc->ioc_coc->sc_pool_uuid, ioc->ioc_coc->sc_uuid),
+				DP_UOID(orw->orw_oid), ioc->ioc_coc->sc_ec_agg_eph_boundary);
 		}
 		if (get_parity_list) {
 			D_ASSERT(!ec_deg_fetch);

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -802,7 +802,7 @@ mrone_obj_fetch_internal(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_
 retry:
 	rc = dsc_obj_fetch(oh, eph, &mrone->mo_dkey, iod_num, iods, sgls, NULL, flags, extra_arg,
 			   csum_iov_fetch);
-	if (rc == -DER_TIMEDOUT &&
+	if ((rc == -DER_TIMEDOUT || rc == -DER_FETCH_AGAIN) &&
 	    tls->mpt_version + 1 >= tls->mpt_pool->spc_map_version) {
 		if (tls->mpt_fini) {
 			DL_ERROR(rc, DF_RB ": dsc_obj_fetch " DF_UOID "failed when mpt_fini",

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1364,12 +1364,12 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 			 * the rebuild and retry.
 			 */
 			rc = -DER_DATA_LOSS;
-			D_DEBUG(DB_REBUILD,
+			DL_INFO(rc,
 				DF_RB ": " DF_UOID " %p dkey " DF_KEY " " DF_KEY
-				      " nr %d/%d eph " DF_U64 " " DF_RC "\n",
+				      " nr %d/%d eph " DF_U64,
 				DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid), mrone,
 				DP_KEY(&mrone->mo_dkey), DP_KEY(&mrone->mo_iods[i].iod_name),
-				mrone->mo_iod_num, i, mrone->mo_epoch, DP_RC(rc));
+				mrone->mo_iod_num, i, mrone->mo_epoch);
 			D_GOTO(out, rc);
 		}
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2430,7 +2430,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	struct pool_iv_conns   *iv_hdls            = NULL;
 	bool			cont_svc_up = false;
 	bool			events_initialized = false;
-	d_rank_t		rank = dss_self_rank();
+	d_rank_t                rank               = dss_self_rank();
 	int			rc;
 
 	D_ASSERTF(svc->ps_error == 0, "ps_error: " DF_RC "\n", DP_RC(svc->ps_error));
@@ -2552,7 +2552,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	if (rc != 0)
 		goto out;
 
-	rc = ds_rebuild_regenerate_task(svc->ps_pool, prop, sys_self_heal);
+	rc = ds_rebuild_regenerate_task(svc->ps_pool, prop, sys_self_heal, 0);
 	if (rc != 0)
 		goto out;
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2431,6 +2431,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	bool			cont_svc_up = false;
 	bool			events_initialized = false;
 	d_rank_t                rank               = dss_self_rank();
+	uint64_t                age_sec, delay;
 	int			rc;
 
 	D_ASSERTF(svc->ps_error == 0, "ps_error: " DF_RC "\n", DP_RC(svc->ps_error));
@@ -2552,7 +2553,9 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	if (rc != 0)
 		goto out;
 
-	rc = ds_rebuild_regenerate_task(svc->ps_pool, prop, sys_self_heal, 0);
+	age_sec = d_hlc_age2sec(dss_get_start_epoch());
+	delay   = age_sec < 200 ? (200 - age_sec) : 0;
+	rc = ds_rebuild_regenerate_task(svc->ps_pool, prop, sys_self_heal, delay);
 	if (rc != 0)
 		goto out;
 
@@ -6394,7 +6397,6 @@ static int
 pool_check_upgrade_object_layout(struct rdb_tx *tx, struct pool_svc *svc,
 				 bool *scheduled_layout_upgrade)
 {
-	daos_epoch_t	upgrade_eph = d_hlc_get();
 	d_iov_t		value;
 	uint32_t	current_layout_ver = 0;
 	int		rc = 0;
@@ -6407,10 +6409,11 @@ pool_check_upgrade_object_layout(struct rdb_tx *tx, struct pool_svc *svc,
 		current_layout_ver = 0;
 
 	if (current_layout_ver < DAOS_POOL_OBJ_VERSION) {
-		rc = ds_rebuild_schedule(svc->ps_pool, svc->ps_pool->sp_map_version, upgrade_eph,
-					 DAOS_POOL_OBJ_VERSION, NULL, RB_OP_UPGRADE,
-					 RB_OP_NONE /* retry_rebuild_op */, 0 /* retry_map_ver */,
-					 false /* stop_admin */, 0);
+		/* pass zero upbound_eph, will select it before rebuild_leader_start() */
+		rc = ds_rebuild_schedule(svc->ps_pool, svc->ps_pool->sp_map_version,
+					 0 /* upbound_eph */, DAOS_POOL_OBJ_VERSION, NULL,
+					 RB_OP_UPGRADE, RB_OP_NONE /* retry_rebuild_op */,
+					 0 /* retry_map_ver */, false /* stop_admin */, 0);
 		if (rc == 0)
 			*scheduled_layout_upgrade = true;
 	}
@@ -7674,8 +7677,7 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 	uint32_t                         tgt_map_ver = 0;
 	bool				updated;
 	int				rc;
-	char				*env;
-	daos_epoch_t			rebuild_eph = d_hlc_get();
+	char                            *env;
 	uint64_t			delay = 2;
 	bool                             sys_self_heal_applicable;
 	uint64_t                         sys_self_heal = 0;
@@ -7756,8 +7758,10 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 		tgt_map_ver);
 
 	if (tgt_map_ver != 0) {
-		rc = ds_rebuild_schedule(svc->ps_pool, tgt_map_ver, rebuild_eph, 0, &target_list,
-					 RB_OP_REBUILD, RB_OP_NONE /* retry_rebuild_op */,
+		/* pass zero upbound_eph, will select it before rebuild_leader_start() */
+		rc = ds_rebuild_schedule(svc->ps_pool, tgt_map_ver, 0 /* upbound_eph */,
+					 0, &target_list, RB_OP_REBUILD,
+					 RB_OP_NONE /* retry_rebuild_op */,
 					 0 /* retry_map_ver */, false /* stop_admin */, delay);
 		if (rc != 0) {
 			D_ERROR("rebuild fails rc: "DF_RC"\n", DP_RC(rc));

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -72,16 +72,15 @@ struct rebuild_tgt_pool_tracker {
 	/* reported # rebuilt objs */
 	uint64_t		rt_reported_obj_cnt;
 	uint64_t		rt_reported_rec_cnt;
-	uint64_t		rt_reported_size;
-	/* global stable epoch to use for rebuilding the data */
-	uint64_t		rt_stable_epoch;
+	uint64_t                 rt_reported_size;
 
-	/* Only used by reclaim job to discard those half-rebuild data */
-	uint64_t		rt_reclaim_epoch;
-	/* local rebuild epoch mainly to constrain the VOS aggregation
-	 * to make sure aggregation will not cross the epoch
+	/* Upper bound epoch for the rebuild -
+	 * 1) Global consistent epoch for rebuild, and
+	 * 2) reclaim epoch of the rebuild, which is used to discard
+	 *    the half-rebuild data if rebuild fails.
+	 * And to constrain the VOS aggregation will not cross the epoch.
 	 */
-	uint64_t		rt_rebuild_fence;
+	uint64_t                 rt_upbound_eph;
 
 	uint32_t		rt_leader_rank;
 
@@ -149,15 +148,12 @@ struct rebuild_global_pool_tracker {
 
 	uint64_t	rgt_time_start;
 
-	/* Stable epoch of the rebuild, the minimum epoch from
-	 * all rebuilding targets
+	/* Upper bound epoch for the rebuild -
+	 * 1) Global consistent epoch for rebuild, and
+	 * 2) reclaim epoch of the rebuild, which is used to discard
+	 *    the half-rebuild data if rebuild fails.
 	 */
-	uint64_t	rgt_stable_epoch;
-
-	/* reclaim epoch of the rebuild, which is used to discard
-	 * the half-rebuild data if rebuild fails
-	 */
-	uint64_t	rgt_reclaim_epoch;
+	uint64_t                        rgt_upbound_eph;
 
 	ABT_mutex	rgt_lock;
 	/* The current rebuild is done on the leader */
@@ -233,10 +229,12 @@ struct rebuild_task {
 	struct pool_target_id_list	dst_tgts;
 	daos_rebuild_opc_t		dst_rebuild_op;
 
-	/* Epoch to use for reclaim job for discarding the data
-	 * of half-rebuild/reintegrated job.
+	/* Upper bound epoch for the rebuild task. Used as
+	 * 1) Stable epoch for rebuild, and
+	 * 2) Epoch to use for reclaim job for discarding the data
+	 *    of half-rebuild/reintegrated job.
 	 */
-	daos_epoch_t			dst_reclaim_eph;
+	daos_epoch_t                    dst_upbound_eph;
 	uint64_t			dst_schedule_time;
 	uint32_t			dst_map_ver;
 	uint32_t			dst_new_layout_version;

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -201,12 +201,10 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			dst_iv->riv_global_scan_done, dst_iv->riv_global_done,
 			dst_iv->riv_stable_epoch, dst_iv->riv_global_dtx_resyc_version);
 
-		if (rpt->rt_stable_epoch == 0)
-			rpt->rt_stable_epoch = dst_iv->riv_stable_epoch;
-		else if (rpt->rt_stable_epoch != dst_iv->riv_stable_epoch)
-			D_WARN("leader change stable epoch from "DF_U64" to "
-			       DF_U64 "\n", rpt->rt_stable_epoch,
-			       dst_iv->riv_stable_epoch);
+		D_ASSERT(rpt->rt_upbound_eph != 0);
+		if (rpt->rt_upbound_eph != dst_iv->riv_stable_epoch)
+			D_WARN("leader change stable epoch from " DF_U64 " to " DF_U64 "\n",
+			       rpt->rt_upbound_eph, dst_iv->riv_stable_epoch);
 		rpt->rt_global_done = dst_iv->riv_global_done;
 		rpt->rt_global_scan_done = dst_iv->riv_global_scan_done;
 		old_ver = rpt->rt_global_dtx_resync_version;

--- a/src/rebuild/rpc.h
+++ b/src/rebuild/rpc.h
@@ -47,7 +47,7 @@ extern struct crt_proto_format rebuild_proto_fmt;
 #define DAOS_ISEQ_REBUILD_SCAN	/* input fields */		 \
 	((uuid_t)		(rsi_pool_uuid)		CRT_VAR) \
 	((uint64_t)		(rsi_leader_term)	CRT_VAR) \
-	((uint64_t)		(rsi_reclaim_epoch)	CRT_VAR) \
+	((uint64_t)		(rsi_upbound_epoch)	CRT_VAR) \
 	((int32_t)		(rsi_rebuild_op)	CRT_VAR) \
 	((uint32_t)		(rsi_tgts_num)		CRT_VAR) \
 	((uint32_t)		(rsi_ns_id)		CRT_VAR) \
@@ -57,7 +57,7 @@ extern struct crt_proto_format rebuild_proto_fmt;
 	((uint32_t)		(rsi_layout_ver)	CRT_VAR)
 
 #define DAOS_OSEQ_REBUILD_SCAN	/* output fields */		 \
-	((uint64_t)		(rso_stable_epoch)	CRT_VAR) \
+	((uint64_t)		(rso_reserved)		CRT_VAR) \
 	((int32_t)		(rso_status)		CRT_VAR)
 
 CRT_RPC_DECLARE(rebuild_scan, DAOS_ISEQ_REBUILD_SCAN, DAOS_OSEQ_REBUILD_SCAN)

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -112,15 +112,15 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 		D_GOTO(out, rc = -DER_IO);
 
 	D_DEBUG(DB_REBUILD,
-		DF_RB " send rebuild objects to tgt %d cnt %d stable epoch " DF_U64 "\n",
-		DP_RB_RPT(rpt), arg->tgt_id, arg->count, rpt->rt_stable_epoch);
+		DF_RB " send rebuild objects to tgt %d cnt %d upbound epoch " DF_X64 "\n",
+		DP_RB_RPT(rpt), arg->tgt_id, arg->count, rpt->rt_upbound_eph);
 	while (1) {
 		enqueue_id = 0;
 		max_delay = 0;
 		rc = ds_object_migrate_send(rpt->rt_pool, rpt->rt_poh_uuid,
 					    rpt->rt_coh_uuid, arg->cont_uuid,
 					    arg->tgt_id, rpt->rt_rebuild_ver,
-					    rpt->rt_rebuild_gen, rpt->rt_stable_epoch,
+					    rpt->rt_rebuild_gen, rpt->rt_upbound_eph,
 					    arg->oids, arg->ephs, arg->punched_ephs, arg->shards,
 					    arg->count, rpt->rt_new_layout_ver, rpt->rt_rebuild_op,
 					    &enqueue_id, &max_delay);
@@ -301,11 +301,7 @@ rebuild_objects_send_ult(void *data)
 	arg.punched_ephs = punched_ephs;
 	arg.rpt = rpt;
 	while (!tls->rebuild_pool_scan_done || !dbtree_is_empty(tls->rebuild_tree_hdl)) {
-		if (rpt->rt_stable_epoch == 0) {
-			dss_sleep(0);
-			continue;
-		}
-
+		D_ASSERT(rpt->rt_upbound_eph != 0);
 		if (dbtree_is_empty(tls->rebuild_tree_hdl)) {
 			dss_sleep(0);
 			continue;
@@ -542,7 +538,7 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 	D_ASSERT(tls != NULL);
 	tls->rebuild_pool_reclaim_obj_count++;
 
-	discard_epr.epr_hi = rpt->rt_reclaim_epoch;
+	discard_epr.epr_hi = rpt->rt_upbound_eph;
 	discard_epr.epr_lo = 0;
 	/*
 	 * It's possible this object might still be being
@@ -588,7 +584,7 @@ rebuild_obj_ult(void *data)
 	struct rebuild_tgt_pool_tracker	*rpt = arg->rpt;
 
 	ds_migrate_object(rpt->rt_pool, rpt->rt_poh_uuid, rpt->rt_coh_uuid, arg->co_uuid,
-			  rpt->rt_rebuild_ver, rpt->rt_rebuild_gen, rpt->rt_stable_epoch,
+			  rpt->rt_rebuild_ver, rpt->rt_rebuild_gen, rpt->rt_upbound_eph,
 			  rpt->rt_rebuild_op, &arg->oid, &arg->epoch, &arg->punched_epoch,
 			  &arg->shard, 1, arg->tgt_index, rpt->rt_new_layout_ver);
 	rpt_put(rpt);
@@ -911,7 +907,7 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		}
 	}
 
-	epoch.oe_value = rpt->rt_stable_epoch;
+	epoch.oe_value = rpt->rt_upbound_eph;
 	rc = dtx_begin(coh, &dti, &epoch, 0, rpt->rt_rebuild_ver,
 		       &oid, NULL, 0, DTX_IGNORE_UNCOMMITTED, NULL, &dth);
 	D_ASSERT(rc == 0);
@@ -1282,7 +1278,6 @@ out:
 	}
 	rout = crt_reply_get(rpc);
 	rout->rso_status = rc;
-	rout->rso_stable_epoch = d_hlc_get();
 	dss_rpc_reply(rpc, DAOS_REBUILD_DROP_SCAN);
 }
 
@@ -1295,10 +1290,6 @@ rebuild_tgt_scan_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 
 	if (dst->rso_status == 0)
 		dst->rso_status = src->rso_status;
-
-	if (src->rso_status == 0 &&
-	    dst->rso_stable_epoch < src->rso_stable_epoch)
-		dst->rso_stable_epoch = src->rso_stable_epoch;
 
 	return 0;
 }

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1951,7 +1951,7 @@ rebuild_task_ult(void *arg)
 	if (rc) {
 		D_ERROR(DF_UUID ": ds_cont_svc_refresh_agg_eph failed, " DF_RC "\n",
 			DP_UUID(task->dst_pool_uuid), DP_RC(rc));
-		goto out_task;
+		goto out_pool;
 	}
 
 	while (1) {

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -698,22 +698,22 @@ out:
 
 void
 ds_rebuild_running_query(uuid_t pool_uuid, uint32_t opc, uint32_t *upper_ver,
-			 daos_epoch_t *stable_eph, uint32_t *generation)
+			 daos_epoch_t *upbound_eph, uint32_t *generation)
 {
 	struct rebuild_tgt_pool_tracker	*rpt;
 
 	if (upper_ver)
 		*upper_ver = 0;
-	if (stable_eph)
-		*stable_eph = 0;
+	if (upbound_eph)
+		*upbound_eph = 0;
 	if (generation)
 		*generation = -1;
 	rpt = rpt_lookup(pool_uuid, opc, -1 /* ver */, -1 /* gen */);
 	if (rpt != NULL && !rpt->rt_global_done && !rpt->rt_abort) {
 		D_DEBUG(DB_REBUILD, DF_RB " rebuild %p running eph " DF_X64 "\n", DP_RB_RPT(rpt),
-			rpt, rpt->rt_stable_epoch);
-		if (stable_eph)
-			*stable_eph = rpt->rt_stable_epoch;
+			rpt, rpt->rt_upbound_eph);
+		if (upbound_eph)
+			*upbound_eph = rpt->rt_upbound_eph;
 		if (upper_ver)
 			*upper_ver = rpt->rt_rebuild_ver;
 		if (generation)
@@ -849,7 +849,7 @@ rebuild_leader_status_notify(struct rebuild_global_pool_tracker *rgt, struct ds_
 	iv.riv_leader_term	= rgt->rgt_leader_term;
 	iv.riv_rebuild_gen	= rgt->rgt_rebuild_gen;
 	iv.riv_seconds          = rgt->rgt_status.rs_seconds;
-	iv.riv_stable_epoch	= rgt->rgt_stable_epoch;
+	iv.riv_stable_epoch         = rgt->rgt_upbound_eph;
 	iv.riv_sync = 1;
 	rgt->rgt_dtx_resync_version = iv.riv_global_dtx_resyc_version =
 				rebuild_get_global_dtx_resync_ver(rgt);
@@ -1039,11 +1039,11 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 		snprintf(sbuf, RBLD_SBUF_LEN,
 			 DF_RB " [%s] (leader %u dtx_gl %u toberb_obj=" DF_U64 ", rb_obj=" DF_U64
 			       ", rec=" DF_U64 ", size=" DF_U64 " done %d status %d/%d "
-			       "stable " DF_X64 " reclaim " DF_X64 " duration=%d secs)\n",
+			       "upbound_eph " DF_X64 " duration=%d secs)\n",
 			 DP_RB_RGT(rgt), str, myrank, rgt->rgt_dtx_resync_version,
 			 rs->rs_toberb_obj_nr, rs->rs_obj_nr, rs->rs_rec_nr, rs->rs_size,
-			 rs->rs_state, rs->rs_errno, rs->rs_fail_rank, rgt->rgt_stable_epoch,
-			 rgt->rgt_reclaim_epoch, rs->rs_seconds);
+			 rs->rs_state, rs->rs_errno, rs->rs_fail_rank, rgt->rgt_upbound_eph,
+			 rs->rs_seconds);
 
 		D_INFO("%s", sbuf);
 		if (rs->rs_state == DRS_COMPLETED || rebuild_gst.rg_abort || rgt->rgt_abort) {
@@ -1089,8 +1089,8 @@ rebuild_global_pool_tracker_destroy(struct rebuild_global_pool_tracker *rgt)
 
 static int
 rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver, uint32_t rebuild_gen,
-				   uint64_t leader_term, daos_epoch_t reclaim_eph,
-				   uint32_t opc, struct rebuild_global_pool_tracker **p_rgt)
+				   uint64_t leader_term, daos_epoch_t upbound_eph, uint32_t opc,
+				   struct rebuild_global_pool_tracker **p_rgt)
 {
 	struct rebuild_global_pool_tracker *rgt;
 	int rank_nr;
@@ -1141,7 +1141,7 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver, uint32_t 
 	rgt->rgt_leader_term = leader_term;
 	rgt->rgt_rebuild_gen = rebuild_gen;
 	rgt->rgt_time_start = d_timeus_secdiff(0);
-	rgt->rgt_reclaim_epoch = reclaim_eph;
+	rgt->rgt_upbound_eph       = upbound_eph;
 	rgt->rgt_opc = opc;
 	d_list_add(&rgt->rgt_list, &rebuild_gst.rg_global_tracker_list);
 	*p_rgt = rgt;
@@ -1192,12 +1192,9 @@ rebuild_global_pool_tracker_lookup(const uuid_t pool_uuid, unsigned int ver, uns
  * 0: does not need to rebuild.
  */
 static int
-rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
-		uint32_t rebuild_gen, uint64_t leader_term,
-		daos_epoch_t reclaim_eph,
-		struct pool_target_id_list *tgts,
-		daos_rebuild_opc_t rebuild_op,
-		struct rebuild_global_pool_tracker **rgt)
+rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver, uint32_t rebuild_gen,
+		uint64_t leader_term, daos_epoch_t upbound_eph, struct pool_target_id_list *tgts,
+		daos_rebuild_opc_t rebuild_op, struct rebuild_global_pool_tracker **rgt)
 {
 	int	rc = 0;
 
@@ -1244,7 +1241,7 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 
 		/* Update pool iv ns for the pool */
 		ret = rebuild_global_pool_tracker_create(pool, rebuild_ver, rebuild_gen,
-							leader_term, reclaim_eph, rebuild_op, rgt);
+							 leader_term, upbound_eph, rebuild_op, rgt);
 		if (ret) {
 			rc = ret;
 			DL_ERROR(rc, DF_RB " rebuild_global_pool_tracker create failed",
@@ -1335,10 +1332,9 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 	rsi->rsi_leader_term = rgt->rgt_leader_term;
 	rsi->rsi_rebuild_ver = rgt->rgt_rebuild_ver;
 	rsi->rsi_rebuild_gen = rgt->rgt_rebuild_gen;
-	if (rebuild_op == RB_OP_RECLAIM || rebuild_op == RB_OP_FAIL_RECLAIM)
-		D_ASSERT(rgt->rgt_reclaim_epoch != 0);
+	D_ASSERT(rgt->rgt_upbound_eph != 0);
 
-	rsi->rsi_reclaim_epoch = rgt->rgt_reclaim_epoch;
+	rsi->rsi_upbound_epoch = rgt->rgt_upbound_eph;
 	rsi->rsi_layout_ver = layout_version;
 	rsi->rsi_tgts_num = tgts_failed->pti_number;
 	rsi->rsi_rebuild_op = rebuild_op;
@@ -1350,9 +1346,8 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 		rc = rso->rso_status;
 
 	rgt->rgt_init_scan = 1;
-	rgt->rgt_stable_epoch = rso->rso_stable_epoch;
-	D_DEBUG(DB_REBUILD, DF_RB " " DF_RC " got stable/reclaim epoch " DF_X64 "/" DF_X64 "\n",
-		DP_RB_RGT(rgt), DP_RC(rc), rgt->rgt_stable_epoch, rgt->rgt_reclaim_epoch);
+	D_DEBUG(DB_REBUILD, DF_RB " " DF_RC " upbound_eph " DF_X64 "\n",
+		DP_RB_RGT(rgt), DP_RC(rc), rgt->rgt_upbound_eph);
 	crt_req_decref(rpc);
 out:
 	if (excluded)
@@ -1658,9 +1653,8 @@ rebuild_leader_start(struct ds_pool *pool, struct rebuild_task *task,
 	if (version < task->dst_map_ver)
 		generation = ++pool->sp_rebuild_gen;
 
-	rc = rebuild_prepare(pool, task->dst_map_ver, generation,
-			     leader_term, task->dst_reclaim_eph, &task->dst_tgts,
-			     task->dst_rebuild_op, p_rgt);
+	rc = rebuild_prepare(pool, task->dst_map_ver, generation, leader_term,
+			     task->dst_upbound_eph, &task->dst_tgts, task->dst_rebuild_op, p_rgt);
 	if (rc <= 0)
 		return rc;
 
@@ -1778,7 +1772,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 			return 0;
 		}
 
-		rc = ds_rebuild_schedule(pool, task->dst_map_ver, task->dst_reclaim_eph,
+		rc = ds_rebuild_schedule(pool, task->dst_map_ver, task->dst_upbound_eph,
 					 task->dst_new_layout_version, &task->dst_tgts,
 					 task->dst_rebuild_op, task->dst_retry_rebuild_op,
 					 task->dst_retry_map_ver, task->dst_stop_admin, delay_sec);
@@ -1811,7 +1805,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		/* reclaim or fail_reclaim failed - retry */
 		if (task->dst_rebuild_op == RB_OP_RECLAIM ||
 		    task->dst_rebuild_op == RB_OP_FAIL_RECLAIM) {
-			rc = ds_rebuild_schedule(pool, task->dst_map_ver, rgt->rgt_stable_epoch,
+			rc = ds_rebuild_schedule(pool, task->dst_map_ver, rgt->rgt_upbound_eph,
 						 task->dst_new_layout_version, &task->dst_tgts,
 						 task->dst_rebuild_op, task->dst_retry_rebuild_op,
 						 task->dst_retry_map_ver, task->dst_stop_admin,
@@ -1832,7 +1826,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 			 * (reclaim - 1 see obj_reclaim()), but keep the in-flight I/O data.
 			 */
 			rc = ds_rebuild_schedule(
-			    pool, task->dst_reclaim_ver - 1 /* map_ver */, rgt->rgt_stable_epoch,
+			    pool, task->dst_reclaim_ver - 1 /* map_ver */, rgt->rgt_upbound_eph,
 			    task->dst_new_layout_version, &task->dst_tgts, RB_OP_FAIL_RECLAIM,
 			    retry_opc /* retry_rebuild_op */, task->dst_map_ver /* retry_map_ver */,
 			    rgt->rgt_stop_admin, delay_sec);
@@ -1855,7 +1849,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		if (retry_opc == RB_OP_NONE)
 			D_GOTO(complete, rc);
 
-		rc = ds_rebuild_schedule(pool, task->dst_map_ver, rgt->rgt_stable_epoch,
+		rc = ds_rebuild_schedule(pool, task->dst_map_ver, rgt->rgt_upbound_eph,
 					 task->dst_new_layout_version, &task->dst_tgts,
 					 retry_opc /* rebuild_op*/, 0 /* retry_rebuild_op */,
 					 0 /* retry_map_ver */, false /* stop_admin */, delay_sec);
@@ -1868,7 +1862,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		 * (exclude/drain/reintegrate/extend/upgrade). */
 		rgt->rgt_status.rs_state = DRS_IN_PROGRESS;
 
-		rc = ds_rebuild_schedule(pool, task->dst_map_ver, rgt->rgt_reclaim_epoch,
+		rc = ds_rebuild_schedule(pool, task->dst_map_ver, rgt->rgt_upbound_eph,
 					 task->dst_new_layout_version, &task->dst_tgts,
 					 RB_OP_RECLAIM, RB_OP_NONE /* retry_rebuild_op */,
 					 0 /* retry_map_ver */, false /* stop_admin */, delay_sec);
@@ -1906,7 +1900,7 @@ complete:
 		   (task->dst_retry_rebuild_op != RB_OP_NONE)) {
 		/* Fail_reclaim done (and a stop command wasn't received during) - retry original
 		 * rebuild */
-		rc1 = ds_rebuild_schedule(pool, task->dst_retry_map_ver, rgt->rgt_reclaim_epoch,
+		rc1 = ds_rebuild_schedule(pool, task->dst_retry_map_ver, rgt->rgt_upbound_eph,
 					  task->dst_new_layout_version, &task->dst_tgts,
 					  task->dst_retry_rebuild_op,
 					  RB_OP_NONE /* retry_rebuild_op */, 0 /* retry_map_ver */,
@@ -1984,6 +1978,17 @@ rebuild_task_ult(void *arg)
 	if (rc)
 		D_ERROR(DF_UUID": failed to send RAS event\n",
 			DP_UUID(task->dst_pool_uuid));
+
+	/* as above ds_pool_svc_query_map_dist() ensures latest pool map on PS leader has already
+	 * been distributed to all engines (ds_pool_iv_map_update works in CRT_IV_SYNC_EAGER mode),
+	 * it is safe to select the rebuild upbound_eph now.
+	 */
+	if (task->dst_upbound_eph == 0) {
+		task->dst_upbound_eph = ds_rebuild_get_upbound_eph();
+		D_INFO("%s (pool " DF_UUID "), set upbound_eph " DF_X64 "\n",
+		       RB_OP_STR(task->dst_rebuild_op), DP_UUID(task->dst_pool_uuid),
+		       task->dst_upbound_eph);
+	}
 
 	rc = rebuild_leader_start(pool, task, &rgt);
 	if (rc == 0) {
@@ -2355,7 +2360,7 @@ rebuild_print_list_update(const uuid_t uuid, const uint32_t map_ver,
  * pool.
  */
 int
-ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, daos_epoch_t reclaim_eph,
+ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, daos_epoch_t upbound_eph,
 		    uint32_t layout_version, struct pool_target_id_list *tgts,
 		    daos_rebuild_opc_t rebuild_op, daos_rebuild_opc_t retry_rebuild_op,
 		    uint32_t retry_map_ver, bool stop_admin, uint64_t delay_sec)
@@ -2403,7 +2408,7 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, daos_epoch_t reclaim
 	new_task->dst_map_ver = map_ver;
 	new_task->dst_reclaim_ver = map_ver;
 	new_task->dst_rebuild_op = rebuild_op;
-	new_task->dst_reclaim_eph = reclaim_eph;
+	new_task->dst_upbound_eph        = upbound_eph;
 	new_task->dst_new_layout_version = layout_version;
 	if (rebuild_op == RB_OP_FAIL_RECLAIM) {
 		new_task->dst_retry_map_ver    = retry_map_ver;
@@ -2481,7 +2486,6 @@ static int
 regenerate_task_internal(struct ds_pool *pool, struct pool_target *tgts,
 			 unsigned int tgts_cnt, uint64_t delay)
 {
-	daos_epoch_t	eph = d_hlc_get();
 	daos_epoch_t	current_eph;
 	unsigned int	i;
 	int		rc;
@@ -2499,15 +2503,16 @@ regenerate_task_internal(struct ds_pool *pool, struct pool_target *tgts,
 		id_list.pti_ids = &tgt_id;
 		id_list.pti_number = 1;
 
+		/* if current_eph is zero, will select upbound_eph before rebuild_leader_start() */
 		if (tgt->ta_comp.co_status & (PO_COMP_ST_DOWN | PO_COMP_ST_DRAIN)) {
 			rc = ds_rebuild_schedule(
-			    pool, tgt->ta_comp.co_fseq, current_eph == 0 ? eph : current_eph, 0,
+			    pool, tgt->ta_comp.co_fseq, current_eph, 0,
 			    &id_list, RB_OP_REBUILD, RB_OP_NONE /* retry_rebuild_op */,
 			    0 /* retry_map_ver */, false /* stop_admin */, delay);
 		} else {
 			D_ASSERT(tgt->ta_comp.co_status == PO_COMP_ST_UP);
 			rc = ds_rebuild_schedule(
-			    pool, tgt->ta_comp.co_in_ver, current_eph == 0 ? eph : current_eph, 0,
+			    pool, tgt->ta_comp.co_in_ver, current_eph, 0,
 			    &id_list, RB_OP_REBUILD, RB_OP_NONE /* retry_rebuild_op */,
 			    0 /* retry_map_ver */, false /* stop_admin */, delay);
 		}
@@ -2661,17 +2666,17 @@ rebuild_fini_one(void *arg)
 	/* Reset rebuild epoch, then reset the aggregation epoch, so
 	 * it can aggregate the rebuild epoch.
 	 */
-	D_ASSERT(rpt->rt_rebuild_fence != 0);
-	if (rpt->rt_rebuild_fence == dpc->spc_rebuild_fence) {
+	D_ASSERT(rpt->rt_upbound_eph != 0);
+	if (rpt->rt_upbound_eph == dpc->spc_rebuild_fence) {
 		dpc->spc_rebuild_fence = 0;
-		dpc->spc_rebuild_end_hlc = d_hlc_get();
-		D_DEBUG(DB_REBUILD, DF_RB ": Reset aggregation end hlc " DF_U64 "\n",
+		dpc->spc_rebuild_end_hlc = rpt->rt_upbound_eph;
+		D_DEBUG(DB_REBUILD, DF_RB ": Reset aggregation end hlc " DF_X64 "\n",
 			DP_RB_RPT(rpt), dpc->spc_rebuild_end_hlc);
 	} else {
 		D_DEBUG(DB_REBUILD,
-			DF_RB ": pool is still being rebuilt rt_rebuild_fence " DF_U64
+			DF_RB ": pool is still being rebuilt rt_upbound_eph " DF_X64
 			      " spc_rebuild_fence " DF_U64 "\n",
-			DP_RB_RPT(rpt), rpt->rt_rebuild_fence, dpc->spc_rebuild_fence);
+			DP_RB_RPT(rpt), rpt->rt_upbound_eph, dpc->spc_rebuild_fence);
 	}
 
 	ds_pool_child_put(dpc);
@@ -2905,10 +2910,13 @@ rebuild_prepare_one(void *data)
 	/* Set the rebuild epoch per VOS container, so VOS aggregation will not
 	 * cross the epoch to cause problem.
 	 */
-	D_ASSERT(rpt->rt_rebuild_fence != 0);
-	dpc->spc_rebuild_fence = rpt->rt_rebuild_fence;
-	D_DEBUG(DB_REBUILD, DF_RB " open local container " DF_UUID " rebuild eph " DF_X64 "\n",
-		DP_RB_RPT(rpt), DP_UUID(rpt->rt_coh_uuid), rpt->rt_rebuild_fence);
+	D_ASSERT(rpt->rt_upbound_eph != 0);
+	dpc->spc_rebuild_fence = rpt->rt_upbound_eph;
+	D_DEBUG(DB_REBUILD,
+		"open local container " DF_UUID "/" DF_UUID " rebuild upbound epoch " DF_X64
+		" " DF_RC "\n",
+		DP_UUID(rpt->rt_pool_uuid), DP_UUID(rpt->rt_coh_uuid), rpt->rt_upbound_eph,
+		DP_RC(rc));
 
 put:
 	ds_pool_child_put(dpc);
@@ -2917,9 +2925,8 @@ put:
 }
 
 static int
-rpt_create(struct ds_pool *pool, uint32_t master_rank, uint32_t pm_ver,
-	   uint64_t leader_term, uint32_t rebuild_gen, uint32_t layout_ver,
-	   uint64_t reclaim_epoch, uint32_t tgts_num,
+rpt_create(struct ds_pool *pool, uint32_t master_rank, uint32_t pm_ver, uint64_t leader_term,
+	   uint32_t rebuild_gen, uint32_t layout_ver, uint64_t upbound_epoch, uint32_t tgts_num,
 	   struct rebuild_tgt_pool_tracker **p_rpt)
 {
 	struct rebuild_tgt_pool_tracker	*rpt;
@@ -2953,7 +2960,7 @@ rpt_create(struct ds_pool *pool, uint32_t master_rank, uint32_t pm_ver,
 	rpt->rt_leader_term = leader_term;
 	rpt->rt_rebuild_gen = rebuild_gen;
 	rpt->rt_tgts_num = tgts_num;
-	rpt->rt_reclaim_epoch = reclaim_epoch;
+	rpt->rt_upbound_eph          = upbound_epoch;
 	crt_group_rank(pool->sp_group, &rank);
 	rpt->rt_rank = rank;
 	rpt->rt_leader_rank = master_rank;
@@ -3011,9 +3018,8 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 		D_GOTO(out, rc);
 
 	/* Create rpt for the target */
-	rc = rpt_create(pool, rsi->rsi_master_rank, rsi->rsi_rebuild_ver,
-			rsi->rsi_leader_term, rsi->rsi_rebuild_gen,
-			rsi->rsi_layout_ver, rsi->rsi_reclaim_epoch,
+	rc = rpt_create(pool, rsi->rsi_master_rank, rsi->rsi_rebuild_ver, rsi->rsi_leader_term,
+			rsi->rsi_rebuild_gen, rsi->rsi_layout_ver, rsi->rsi_upbound_epoch,
 			rsi->rsi_tgts_num, &rpt);
 	if (rc)
 		D_GOTO(out, rc);
@@ -3050,12 +3056,13 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 	if (pool_tls == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	rpt->rt_rebuild_fence = d_hlc_get();
-	rc                    = ds_pool_task_collective(rpt->rt_pool_uuid,
-							PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
-							rebuild_prepare_one, rpt, 0);
+	D_ASSERTF(rpt->rt_upbound_eph != 0 && rsi->rsi_upbound_epoch == rpt->rt_upbound_eph,
+		  "bad epoch " DF_X64 ", " DF_X64 "\n", rsi->rsi_upbound_epoch,
+		  rpt->rt_upbound_eph);
+	rc = ds_pool_task_collective(rpt->rt_pool_uuid,
+				     PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
+				     rebuild_prepare_one, rpt, 0);
 	if (rc) {
-		rpt->rt_rebuild_fence = 0;
 		rebuild_pool_tls_destroy(pool_tls);
 		D_GOTO(out, rc);
 	}

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1104,11 +1105,41 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 			holes += lo - index;
 		}
 
-		/* Hole extent, with_shadow case only used for EC obj */
-		if (bio_addr_is_hole(&ent->en_addr) ||
-		    (with_shadow && (ent->en_epoch < shadow_ep))) {
+		if ((with_shadow && (ent->en_epoch < shadow_ep))) {
 			index = lo + nr;
 			holes += nr;
+			continue;
+		}
+
+		/* Hole extent, with_shadow case only used for EC obj */
+		if (bio_addr_is_hole(&ent->en_addr)) {
+			if (with_shadow) {
+				if (holes != 0) {
+					/* process the prev hole */
+					rc = save_recx(ioc, lo - holes, holes, shadow_ep, inob,
+						       DRT_SHADOW);
+					if (rc != 0)
+						goto failed;
+					biov_set_hole(&biov, holes * inob);
+					/* skip the hole */
+					rc = iod_fetch(ioc, &biov);
+					if (rc != 0)
+						goto failed;
+					holes = 0;
+				}
+				/* process this punch ext, for degraded fetch just skip it */
+				index = lo + nr;
+				holes = nr;
+				biov_set_hole(&biov, holes * inob);
+				/* skip the hole */
+				rc = iod_fetch(ioc, &biov);
+				if (rc != 0)
+					goto failed;
+				holes = 0;
+			} else {
+				index = lo + nr;
+				holes += nr;
+			}
 			continue;
 		}
 


### PR DESCRIPTION
1. add container RDB KV ds_cont_prop_ec_agg_eph for EC aggregation epoch boundary, store it when bump and load it after restart.
2. synchronize the ec agg boundary before rebuild
3. change ec agg boundary IV refresh to be EAGER sync
4. wait discard's completion in ds_pool_tgt_discard_handler()
5. fix a cart IV sync bug that ignored GRP_VER err case's err code
6. fetch ec agg boundary IV in fetch RPC handler when it is zero
7. fix an EC agg partial update stripe processing bug
8. fix a sgl sg_nr_out and iov_len process bug
9. fix a EC degraded fetch bug related with punch extent
10. some refines for rebuild upbound epoch
- rename rebuild stable epoch to rebuild upbound epoch
- select "current hlc + epsilon" (ds_rebuild_get_upbound_eph()) as the rebuild upbound epoch.
- use the global consistent rebuild upbound epoch as rebuild fence to avoid VOS aggregation cross the epoch.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
