### PR TITLE
DAOS-623 cq: remove conflicting xargs argument

### DIFF
--- a/utils/githooks/pre-commit.d/20-codespell.sh
+++ b/utils/githooks/pre-commit.d/20-codespell.sh
@@ -22,4 +22,4 @@ fi
 
 echo "Checking for spelling mistakes"
 # Convert file names to relative path format that codespell expects. I.e. "./path"
-_git_diff_cached_files | xargs -r -n 1 -I% echo "./%" | xargs -r codespell
+_git_diff_cached_files | xargs -r -I% echo "./%" | xargs -r codespell


### PR DESCRIPTION
'-n' and '-I' are mutually exclusive. When using '-I', '-n1' is implied.

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
