### PR TITLE
DAOS-17751 test: online_rebuild_mdtest engine INFO logging

### DIFF
--- a/src/tests/ftest/erasurecode/online_rebuild_mdtest.yaml
+++ b/src/tests/ftest/erasurecode/online_rebuild_mdtest.yaml
@@ -21,7 +21,7 @@ server_config:
       fabric_iface: ib0
       fabric_iface_port: 31416
       log_file: daos_server0.log
-      log_mask: ERR
+      log_mask: INFO
       storage: auto
     1:
       pinned_numa_node: 1
@@ -29,7 +29,7 @@ server_config:
       fabric_iface: ib1
       fabric_iface_port: 31517
       log_file: daos_server1.log
-      log_mask: ERR
+      log_mask: INFO
       storage: auto
 pool:
   size: 93%


### PR DESCRIPTION
Change test's log_mask from ERR to INFO, generally a good idea, and better in this case for diagnosing a more frequently-failing CI test.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_ec_online_rebuild_mdtest

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
