### PR TITLE
SRE-3150 test: Fix running server storage verification

### DIFF
--- a/src/tests/ftest/util/collection_utils.py
+++ b/src/tests/ftest/util/collection_utils.py
@@ -178,7 +178,7 @@ def check_server_storage(logger, test, test_result, stage):
     }
     logger.debug("-" * 80)
     logger.debug(f"Verifying server storage during the {stage.lower()} stage for \'{test}\'")
-    if "check_server_storage" in test.yaml_info and not test.yaml_info["check_server_storage"]:
+    if "check_server_storage" in test.yaml_info and test.yaml_info["check_server_storage"] is False:
         logger.debug(" - Test requested skip via 'check_server_storage' yaml entry")
         return status
     for key, command in commands.items():


### PR DESCRIPTION
Fix faulty logic resulting in storage verification being skipped for all functional tests.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: StorageTiers CPUUsage IorSmall

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
