### PR TITLE
DAOS-17639 test: Detect all server fabric_ifaces

### DIFF
--- a/src/tests/ftest/ior/small.yaml
+++ b/src/tests/ftest/ior/small.yaml
@@ -15,15 +15,11 @@ server_config:
     0:
       pinned_numa_node: 0
       nr_xs_helpers: 1
-      fabric_iface: ib0
-      fabric_iface_port: 31317
       log_file: daos_server0.log
       storage: auto
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
-      fabric_iface: ib1
-      fabric_iface_port: 31417
       log_file: daos_server1.log
       storage: auto
   transport_config:

--- a/src/tests/ftest/util/environment_utils.py
+++ b/src/tests/ftest/util/environment_utils.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -11,7 +12,7 @@ from ClusterShell.NodeSet import NodeSet
 # pylint: disable=import-error,no-name-in-module
 from util.host_utils import get_local_host
 from util.network_utils import (PROVIDER_ALIAS, SUPPORTED_PROVIDERS, NetworkException,
-                                get_common_provider, get_fastest_interface)
+                                get_common_provider, get_fastest_interfaces)
 from util.run_utils import run_remote
 
 
@@ -322,15 +323,15 @@ class TestEnvironment():
         Returns:
             str: the default interface; can be None
         """
-        interface = os.environ.get("D_INTERFACE")
-        if interface is None and hosts:
+        interfaces = list(filter(None, [os.environ.get("D_INTERFACE")]))
+        if not interfaces and hosts:
             # Find all the /sys/class/net interfaces on the launch node (excluding lo)
             logger.debug("Detecting network devices - D_INTERFACE not set")
             try:
-                interface = get_fastest_interface(logger, hosts | get_local_host())
+                interfaces = get_fastest_interfaces(logger, hosts | get_local_host())
             except NetworkException as error:
                 raise TestEnvironmentException("Error obtaining a default interface!") from error
-        return interface
+        return ",".join(interfaces)
 
     @property
     def provider(self):

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -486,8 +486,12 @@ class EngineYamlParameters(YamlParameters):
         super().__init__(os.path.join(*namespace))
 
         # Use environment variables to get default parameters
-        default_interface = os.environ.get("DAOS_TEST_FABRIC_IFACE", "eth0")
-        default_port = int(os.environ.get("D_PORT", 31416))
+        try:
+            _defaults = os.environ.get("DAOS_TEST_FABRIC_IFACE").split(",")
+            default_interface = list(filter(None, _defaults))[index]
+        except (AttributeError, IndexError):
+            default_interface = f"eth{index}"
+        default_port = int(os.environ.get("D_PORT", 31317 + (100 * index)))
 
         # All log files should be placed in the same directory on each host
         # to enable easy log file archiving by launch.py
@@ -505,7 +509,7 @@ class EngineYamlParameters(YamlParameters):
         self.targets = BasicParameter(None, 8)
         self.first_core = BasicParameter(None, 0)
         self.nr_xs_helpers = BasicParameter(None, 4)
-        self.fabric_iface = BasicParameter(None, default_interface)
+        self.fabric_iface = BasicParameter(None, default_interface[index])
         self.fabric_iface_port = BasicParameter(None, default_port)
         self.pinned_numa_node = BasicParameter(None)
         self.log_mask = BasicParameter(None, "INFO")


### PR DESCRIPTION
Launch.py will detect all of the fastest interfaces common to all the specified server hosts and use them to populate the engine fabric_iface entries if no overrides are provided in the test yaml.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: IorSmall

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
