### PR TITLE
DAOS-16501 build: Support of Gperftools Heap Profiler

### DIFF
--- a/ci/unit/required_packages.sh
+++ b/ci/unit/required_packages.sh
@@ -29,6 +29,7 @@ pkgs="$(utils/rpms/package_version.sh argobots lib)                  \
       $(utils/rpms/package_version.sh pmdk debug pmem)               \
       fuse3                                                          \
       gotestsum                                                      \
+      gperftools-devel                                               \
       hwloc-devel                                                    \
       libasan                                                        \
       libipmctl-devel                                                \

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.7.101-18) unstable; urgency=medium
+  [ Cedric Koch-Hofer]
+  * Add support of the Google Performance tools
+
+ -- Cedric Koch-Hofer <cedric.koch-hofer@hpe.com>  Mon, 27 Oct 2025 14:12:00 +0100
+
 daos (2.7.101-17) unstable; urgency=medium
   [ Cedric Koch-Hofer]
   * Add support of the libasan to the mercury dependencies

--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,8 @@ Build-Depends: debhelper (>= 10),
                libaio-dev,
                libcapstone-dev,
                libpci-dev,
-               libasan5
+               libasan5,
+               libgoogle-perftools-dev
 Standards-Version: 4.1.2
 Homepage: https://docs.daos.io/
 Vcs-Git: https://github.com/daos-stack/daos.git

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -174,6 +174,32 @@ ASan support in DAOS is still experimental and has the following known issues:
    ASan is not fully integrated with the DAOS regression testing framework. Some tests, such as
    those using Valgrind, may fail due to false positives.
 
+### Heap Profiler
+
+To debug memory leaks which are properly deleted when the application stop, the
+[Gperftools Heap Profiler](https://gperftools.github.io/gperftools/heapprofile.html) can be used.
+This heap profiler mostly rely on the [TCMalloc](https://github.com/google/tcmalloc) memory
+allocator.  This memory allocator can either be linked to DAOS executables or loaded at runtime
+thanks to `LD_PRELOAD`.
+
+To profile heap allocation of the `daos_engine` with `LD_PRELOAD`, the following entries can be
+added to the `env_vars` section of the `daos_server.yml` configuration file:
+```yaml
+engines:
+- ...
+  env_vars:
+  ...
+  - LD_PRELOAD=/usr/lib64/libtcmalloc.so.4
+  - HEAPPROFILE=/var/daos/hprof/daos_engine.1.hprof
+  - HEAP_PROFILE_INUSE_INTERVAL=1073741824
+  - HEAP_PROFILE_ALLOCATION_INTERVAL=0
+  - HEAP_PROFILE_TIME_INTERVAL=0
+```
+
+To link DAOS executabls with the TCMalloc memory allocator, use the `HEAP_PROFILER=true` flag with
+the `scons` command.  To profile the daos engien heap allocation, the same `daos_server.yml`
+configuration can be used without setting the `LD_PRELOAD` environment variable.
+
 ## Go dependencies
 
 Developers contributing Go code may need to change the external dependencies

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -518,6 +518,8 @@ class PreReqComponent():
         opts.Add(EnumVariable('WARNING_LEVEL', "Set default warning level", 'error',
                               ['warning', 'warn', 'error'], ignorecase=2))
         opts.Add(('SANITIZERS', 'Instrument C code with Google Sanitizers', None))
+        opts.Add(BoolVariable('HEAP_PROFILER', 'Instrument C code with Gperftools Heap Profiler',
+                              False))
 
         opts.Update(self.__env)
 

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -25,7 +25,7 @@
 
 Name:          daos
 Version:       2.7.101
-Release:       17%{?relval}%{?dist}
+Release:       18%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -136,6 +136,7 @@ BuildRequires: libasan
 %if (0%{?suse_version} > 0)
 BuildRequires: libasan8
 %endif
+BuildRequires: gperftools-devel
 
 Requires: openssl
 # This should only be temporary until we can get a stable upstream release
@@ -659,6 +660,9 @@ fi
 %endif
 
 %changelog
+* Mon Oct 27 2025  Cedric Koch-Hofer <cedric.koch-hofer@hpe.com> 2.7.101-18
+- Add support of the Google Performance tools
+
 * Mon Oct 27 2025  Cedric Koch-Hofer <cedric.koch-hofer@hpe.com> 2.7.101-17
 - Add support of the libasan to the mercury dependencies
 

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -36,6 +36,7 @@ dnf --nodocs install ${dnf_install_args} \
     git \
     glibc-langpack-en \
     golang \
+    gperftools-devel \
     graphviz \
     help2man \
     hdf5-devel \

--- a/utils/scripts/install-el9.sh
+++ b/utils/scripts/install-el9.sh
@@ -34,6 +34,7 @@ dnf --nodocs install ${dnf_install_args} \
     git \
     glibc-langpack-en \
     golang \
+    gperftools-devel \
     graphviz \
     help2man \
     hdf5-devel \

--- a/utils/scripts/install-leap15.sh
+++ b/utils/scripts/install-leap15.sh
@@ -31,6 +31,7 @@ dnf --nodocs install ${dnf_install_args} \
     git \
     go \
     go-race \
+    gperftools-devel \
     graphviz \
     gzip \
     hdf5-devel \

--- a/utils/scripts/install-ubuntu.sh
+++ b/utils/scripts/install-ubuntu.sh
@@ -36,6 +36,7 @@ apt-get install ${apt_get_install_args} \
     libcunit1-dev \
     libdaxctl-dev \
     libfuse3-dev \
+    libgoogle-perftools-dev \
     libhwloc-dev \
     libibverbs-dev \
     libjson-c-dev \


### PR DESCRIPTION
### Description

Add scons build options HEAP_PROFILER allowing to use Gperftools Heap Profiler with using tcmalloc memory allocator.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
