### PR TITLE
DAOS-18023 tests: Add rebuild scenario to interop testing under ftest

### DIFF
--- a/src/tests/ftest/interoperability/upgrade_downgrade_base.py
+++ b/src/tests/ftest/interoperability/upgrade_downgrade_base.py
@@ -432,7 +432,7 @@ class UpgradeDowngradeBase(IorTestBase):
         """
         # Make sure an upgrade isn't already in progress
         self.wait_for_pool_upgrade(pool, ["not started", "completed"], fail_on_status=["failed"])
-    
+
         self.log.info('Check the layout version before upgrading')
         response = self.get_dmg_command().pool_query(pool=pool.identifier)['response']
         pre_pool_layout_ver = int(response['pool_layout_ver'])
@@ -440,14 +440,14 @@ class UpgradeDowngradeBase(IorTestBase):
         if pre_pool_layout_ver == pre_upgrade_layout_ver:
             self.log.info('Pool does not need upgrade. Skipping.')
             return
-    
+
         if with_fault:
             # Stop a rank right before upgrade
             self.get_dmg_command().system_stop(force=True, ranks="1")
-    
+
         # Pool upgrade
         self.pool.upgrade()
-    
+
         if with_fault:
             # Upgrade should fail because a rank is stopped/stopping
             self.wait_for_pool_upgrade(pool, ["failed"], fail_on_status=["completed"])
@@ -455,10 +455,10 @@ class UpgradeDowngradeBase(IorTestBase):
             self.get_dmg_command().system_start(ranks="1")
             self.log.info("Sleeping for 30 seconds after system start")
             time.sleep(30)
-    
+
         # Verify pool upgrade completed
         self.wait_for_pool_upgrade(pool, ["completed"], fail_on_status=["failed"])
-    
+
         self.log.info('Sleep 5 seconds after upgrade is complete')
         time.sleep(5)
         self.log.info('Verify the layout version increased after upgrading')


### PR DESCRIPTION
Adding rebuild for interop test
Trigger rebuild after server/client upgrade
Wait for rebuild to complete
Perform read/write
Reintegrate the ranks
Wait for rebuild to complete again.

Skip-test: true

Signed-off-by: Saurabh Tandan <saurabh.tandan@hpe.com>

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
