### PR TITLE
DAOS-17772 rebuild: refine some rebuild/EC agg/EC deg fetch process

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1843,11 +1843,10 @@ crt_hdlr_iv_sync_aux(void *arg)
 	grp_ver = ivns_internal->cii_grp_priv->gp_membs_ver;
 	D_RWLOCK_UNLOCK(&ivns_internal->cii_grp_priv->gp_rwlock);
 	if (grp_ver != input->ivs_grp_ver) {
-		D_DEBUG(DB_ALL,
-			"Group (%s) version mismatch. Local: %d Remote :%d\n",
-			ivns_id.ii_group_name, grp_ver,
-			input->ivs_grp_ver);
-		D_GOTO(exit, rc = -DER_GRPVER);
+		rc = -DER_GRPVER;
+		DL_INFO(rc, "Group (%s) version mismatch. Local: %d Remote :%d",
+			ivns_id.ii_group_name, grp_ver, input->ivs_grp_ver);
+		goto exit;
 	}
 
 	iv_ops = crt_iv_ops_get(ivns_internal, input->ivs_class_id);
@@ -1922,7 +1921,7 @@ exit:
 	if (need_put && iv_ops)
 		iv_ops->ivo_on_put(ivns_internal, NULL, user_priv);
 
-	output->rc = rc;
+	output->ivs_rc = rc;
 	crt_reply_send(rpc_req);
 
 	/* ADDREF done in lookup above */
@@ -2002,7 +2001,7 @@ crt_hdlr_iv_sync(crt_rpc_t *rpc_req)
 	IVNS_DECREF(ivns_internal);
 	return;
 exit:
-	output->rc = rc;
+	output->ivs_rc = rc;
 	crt_reply_send(rpc_req);
 
 	if (ivns_internal) {
@@ -2022,9 +2021,9 @@ crt_iv_sync_corpc_aggregate(crt_rpc_t *source, crt_rpc_t *result, void *arg)
 	output_result = crt_reply_get(result);
 
 	/* Only set new rc if so far rc is 0 */
-	if (output_result->rc == 0) {
-		if (output_source->rc != 0)
-			output_result->rc = output_source->rc;
+	if (output_result->ivs_rc == 0) {
+		if (output_source->ivs_rc != 0)
+			output_result->ivs_rc = output_source->ivs_rc;
 	}
 
 	return 0;
@@ -2163,14 +2162,16 @@ handle_ivsync_response(const struct crt_cb_info *cb_info)
 {
 	struct iv_sync_cb_info	*iv_sync = cb_info->cci_arg;
 	struct crt_iv_ops	*iv_ops;
+	crt_rpc_t               *rpc    = cb_info->cci_rpc;
+	struct crt_iv_sync_out  *output = crt_reply_get(rpc);
 
 	if (iv_sync->isc_bulk_hdl != CRT_BULK_NULL)
 		crt_bulk_free(iv_sync->isc_bulk_hdl);
 
 	/* do_callback is set based on sync value specified */
 	if (iv_sync->isc_do_callback) {
-		if (cb_info->cci_rc != 0)
-			iv_sync->isc_update_rc = cb_info->cci_rc;
+		if (cb_info->cci_rc || output->ivs_rc)
+			iv_sync->isc_update_rc = cb_info->cci_rc ? cb_info->cci_rc : output->ivs_rc;
 
 		iv_sync->isc_update_comp_cb(iv_sync->isc_ivns_internal,
 					    iv_sync->isc_class_id,
@@ -2412,7 +2413,7 @@ finalize_transfer_back(struct update_cb_info *cb_info, int rc)
 	struct crt_iv_update_out	*child_output;
 
 	child_output = crt_reply_get(cb_info->uci_child_rpc);
-	child_output->rc = rc;
+	child_output->ivo_rc = rc;
 
 	ivns = cb_info->uci_ivns_internal;
 	crt_reply_send(cb_info->uci_child_rpc);
@@ -2528,15 +2529,15 @@ handle_ivupdate_response(const struct crt_cb_info *cb_info)
 		if (iv_info->uci_bulk_hdl == CRT_BULK_NULL)
 			d_sgl_buf_copy(&iv_info->uci_iv_value, &output->ivo_iv_sgl);
 		iv_ops->ivo_on_refresh(iv_info->uci_ivns_internal, &input->ivu_key, 0,
-				       &iv_info->uci_iv_value, false, cb_info->cci_rc ?: output->rc,
-				       iv_info->uci_user_priv);
+				       &iv_info->uci_iv_value, false,
+				       cb_info->cci_rc ?: output->ivo_rc, iv_info->uci_user_priv);
 
 		if (input->ivu_iv_value_bulk == CRT_BULK_NULL &&
 		    iv_info->uci_child_rpc != NULL) {
 			child_output = crt_reply_get(iv_info->uci_child_rpc);
 			child_output->ivo_iv_sgl = iv_info->uci_iv_value;
 		}
-		transfer_back_to_child(&input->ivu_key, iv_info, cb_info->cci_rc ?: output->rc);
+		transfer_back_to_child(&input->ivu_key, iv_info, cb_info->cci_rc ?: output->ivo_rc);
 		D_GOTO(exit, 0);
 	}
 
@@ -2549,10 +2550,10 @@ handle_ivupdate_response(const struct crt_cb_info *cb_info)
 
 		iv_ops->ivo_on_put(iv_info->uci_ivns_internal, &iv_info->uci_iv_value,
 				   iv_info->uci_user_priv);
-		child_output->rc = output->rc;
+		child_output->ivo_rc = output->ivo_rc;
 
 		if (cb_info->cci_rc != 0)
-			child_output->rc = cb_info->cci_rc;
+			child_output->ivo_rc = cb_info->cci_rc;
 
 		/* Respond back to child; might fail if child is not alive */
 		if (crt_reply_send(iv_info->uci_child_rpc) != DER_SUCCESS)
@@ -2568,7 +2569,7 @@ handle_ivupdate_response(const struct crt_cb_info *cb_info)
 		else
 			tmp_iv_value = &iv_info->uci_iv_value;
 
-		rc = output->rc;
+		rc = output->ivo_rc;
 
 		if (cb_info->cci_rc != 0)
 			rc = cb_info->cci_rc;
@@ -2897,7 +2898,7 @@ bulk_update_transfer_done_aux(const struct crt_bulk_cb_info *info)
 			D_GOTO(exit, rc);
 		}
 		rc = crt_bulk_free(cb_info->buc_bulk_hdl);
-		output->rc = rc;
+		output->ivo_rc = rc;
 		iv_ops->ivo_on_put(ivns_internal, &cb_info->buc_iv_value, cb_info->buc_user_priv);
 
 		crt_reply_send(info->bci_bulk_desc->bd_rpc);
@@ -2913,7 +2914,7 @@ exit:
 
 send_error:
 	/* send back whatever error got us here */
-	output->rc = rc;
+	output->ivo_rc = rc;
 	rc         = crt_bulk_free(cb_info->buc_bulk_hdl);
 	if (rc != 0)
 		DL_ERROR(rc, "crt_bulk_free() failed");
@@ -3016,7 +3017,7 @@ bulk_update_transfer_done(const struct crt_bulk_cb_info *info)
 	return rc;
 
 send_error:
-	output->rc = rc;
+	output->ivo_rc = rc;
 	crt_reply_send(info->bci_bulk_desc->bd_rpc);
 
 	crt_bulk_free(cb_info->buc_bulk_hdl);
@@ -3121,7 +3122,7 @@ crt_iv_update_inline_hdlr(crt_rpc_t *rpc, struct crt_ivns_internal *ivns_interna
 			D_GOTO(exit, rc);
 		}
 	} else if (rc == 0) {
-		output->rc = rc;
+		output->ivo_rc = rc;
 		crt_reply_send(rpc);
 		iv_ops->ivo_on_put(ivns_internal, &iv_value, user_priv);
 	} else {
@@ -3136,7 +3137,7 @@ put_error:
 	iv_ops->ivo_on_put(ivns_internal, &iv_value, user_priv);
 
 send_error:
-	output->rc = rc;
+	output->ivo_rc = rc;
 	crt_reply_send(rpc);
 	if (update_cb_info)
 		D_FREE(update_cb_info);
@@ -3270,7 +3271,7 @@ crt_hdlr_iv_update(crt_rpc_t *rpc_req)
 			}
 
 		} else if (rc == 0) {
-			output->rc = rc;
+			output->ivo_rc = rc;
 			rc = crt_reply_send(rpc_req);
 		} else {
 			D_GOTO(send_error, rc);
@@ -3340,7 +3341,7 @@ exit:
 	return;
 
 send_error:
-	output->rc = rc;
+	output->ivo_rc = rc;
 	crt_reply_send(rpc_req);
 
 	if (put_needed)

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -534,7 +534,7 @@ CRT_RPC_DECLARE(crt_iv_fetch, CRT_ISEQ_IV_FETCH, CRT_OSEQ_IV_FETCH)
 	((uint32_t)		(padding)		CRT_VAR)
 
 #define CRT_OSEQ_IV_UPDATE	/* output fields */		 \
-	((uint64_t)		(rc)			CRT_VAR) \
+	((uint64_t)		(ivo_rc)		CRT_VAR) \
 	((d_sg_list_t)		(ivo_iv_sgl)		CRT_VAR)
 
 CRT_RPC_DECLARE(crt_iv_update, CRT_ISEQ_IV_UPDATE, CRT_OSEQ_IV_UPDATE)
@@ -553,7 +553,7 @@ CRT_RPC_DECLARE(crt_iv_update, CRT_ISEQ_IV_UPDATE, CRT_OSEQ_IV_UPDATE)
 	((uint32_t)		(ivs_class_id)		CRT_VAR) \
 
 #define CRT_OSEQ_IV_SYNC	/* output fields */		 \
-	((int32_t)		(rc)			CRT_VAR)
+	((int32_t)		(ivs_rc)		CRT_VAR)
 
 CRT_RPC_DECLARE(crt_iv_sync, CRT_ISEQ_IV_SYNC, CRT_OSEQ_IV_SYNC)
 

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -219,15 +219,17 @@ free:
 }
 
 daos_size_t
-daos_sgl_data_len(d_sg_list_t *sgl)
+daos_sgl_data_len(d_sg_list_t *sgl, bool out)
 {
 	daos_size_t	len;
-	int		i;
+	uint32_t        sg_nr;
+	uint32_t        i;
 
 	if (sgl == NULL || sgl->sg_iovs == NULL)
 		return 0;
 
-	for (i = 0, len = 0; i < sgl->sg_nr; i++)
+	sg_nr = out ? sgl->sg_nr_out : sgl->sg_nr;
+	for (i = 0, len = 0; i < sg_nr; i++)
 		len += sgl->sg_iovs[i].iov_len;
 
 	return len;

--- a/src/common/tests_lib.c
+++ b/src/common/tests_lib.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2015-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -279,7 +280,7 @@ td_init(struct test_data *td, uint32_t iod_nr, struct td_init_args args)
 
 		/* Initialize and create some data */
 		dts_sgl_generate(sgl, 1, args.ca_data_size, 0xAB);
-		D_ASSERT(daos_sgl_data_len(sgl) == data_len);
+		D_ASSERT(daos_sgl_data_len(sgl, false) == data_len);
 
 		iod->iod_type = iod_types[i];
 		dts_iov_alloc_str(&iod->iod_name, "akey");

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -450,6 +450,7 @@ cont_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		  d_sg_list_t *dst, void **priv)
 {
 	struct cont_iv_entry	*src_iv;
+	struct cont_iv_entry     iv_entry = {0};
 	daos_handle_t		root_hdl;
 	d_iov_t			key_iov;
 	d_iov_t			val_iov;
@@ -497,7 +498,6 @@ again:
 				rc1 = ds_cont_hdl_rdb_lookup(entry->ns->iv_pool_uuid,
 							     civ_key->cont_uuid, &chdl);
 				if (rc1 == 0) {
-					struct cont_iv_entry	iv_entry = { 0 };
 					daos_prop_t		*prop = NULL;
 					struct daos_prop_entry	*prop_entry;
 					struct daos_co_status	stat = { 0 };
@@ -541,8 +541,40 @@ again:
 				} else {
 					rc = -DER_NONEXIST;
 				}
+			} else if (class_id == IV_CONT_TRACK_EPOCH) {
+				uint64_t ec_agg_eph;
+
+				rc = ds_cont_ec_agg_eph_rdb_lookup(entry->ns->iv_pool_uuid,
+								   civ_key->cont_uuid, &ec_agg_eph);
+				if (rc == 0) {
+					uuid_copy(iv_entry.cont_uuid, civ_key->cont_uuid);
+					iv_entry.iv_track_eph.ite_ec_agg_eph  = ec_agg_eph;
+					iv_entry.iv_track_eph.ite_rank = dss_self_rank();
+					d_iov_set(&val_iov, &iv_entry, sizeof(iv_entry));
+					rc = dbtree_update(root_hdl, &key_iov, &val_iov);
+					DL_CDEBUG(
+					    rc != 0, DLOG_ERR, DB_MD, rc,
+					    DF_CONT ": dbtree_update ec_agg_eph " DF_X64,
+					    DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid),
+					    ec_agg_eph);
+					if (rc)
+						goto failed;
+					/* on master node will not trigger on_refresh callback,
+					 * so need to explicitly refresh its own cont child's
+					 * sc_ec_agg_eph_boundary especially for the case of
+					 * restart that the value is zero.
+					 * pass zero stable epoch that won't refresh it, only to
+					 * fetch+refresh EC aggregation epoch.
+					 */
+					rc = ds_cont_tgt_refresh_track_eph(entry->ns->iv_pool_uuid,
+									   civ_key->cont_uuid,
+									   ec_agg_eph, 0);
+					if (rc == 0)
+						goto again;
+				}
 			}
 		}
+failed:
 		D_DEBUG(DB_MGMT, DF_CONT "lookup cont: rc " DF_RC "\n",
 			DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid), DP_RC(rc));
 		D_GOTO(out, rc);
@@ -647,8 +679,15 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 				D_GOTO(out, rc);
 		} else if (entry->iv_class->iv_class_id == IV_CONT_TRACK_EPOCH) {
 			rc = cont_iv_ent_track_eph_refresh(entry, key, src);
-			if (rc)
+			if (rc) {
+				if (rc == -DER_NONEXIST) {
+					DL_INFO(
+					    rc, DF_CONT " cont_iv_ent_agg_eph_refresh ignore",
+					    DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
+					rc = 0;
+				}
 				D_GOTO(out, rc);
+			}
 		}
 	}
 
@@ -1117,9 +1156,8 @@ int
 cont_iv_track_eph_refresh(void *ns, uuid_t cont_uuid, daos_epoch_t ec_agg_eph,
 			  daos_epoch_t stable_eph)
 {
-	return cont_iv_track_eph_update_internal(ns, cont_uuid, ec_agg_eph, stable_eph,
-						 0, CRT_IV_SYNC_LAZY,
-						 IV_CONT_TRACK_EPOCH);
+	return cont_iv_track_eph_update_internal(ns, cont_uuid, ec_agg_eph, stable_eph, 0,
+						 CRT_IV_SYNC_EAGER, IV_CONT_TRACK_EPOCH);
 }
 
 int

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1699,6 +1699,7 @@ cont_track_eph_leader_alloc(struct cont_svc *cont_svc, uuid_t cont_uuid,
 	uuid_copy(eph_ldr->cte_cont_uuid, cont_uuid);
 	eph_ldr->cte_servers_num = rank_nr;
 	eph_ldr->cte_current_ec_agg_eph = 0;
+	eph_ldr->cte_rdb_ec_agg_eph     = 0;
 	for (i = 0; i < rank_nr; i++) {
 		eph_ldr->cte_server_ephs[i].re_rank = doms[i].do_comp.co_rank;
 		eph_ldr->cte_server_ephs[i].re_ec_agg_eph = 0;
@@ -1824,6 +1825,8 @@ cont_refresh_track_eph_one(void *data)
 	if (cont_child->sc_ec_agg_eph_boundary < arg->min_ec_agg_eph)
 		cont_child->sc_ec_agg_eph_boundary = arg->min_ec_agg_eph;
 
+	cont_child->sc_ec_agg_eph_valid = 1;
+
 	/* Only should update local stable epoch if the target is in UPIN status */
 	if (cont_child->sc_global_stable_eph < arg->min_stable_eph &&
 	    (arg->tgt_status[idx] & PO_COMP_ST_UPIN)) {
@@ -1876,6 +1879,10 @@ ds_cont_tgt_refresh_track_eph(uuid_t pool_uuid, uuid_t cont_uuid,
 	rc = ds_pool_thread_collective(
 	    pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
 	    cont_refresh_track_eph_one, &arg, DSS_ULT_DEEP_STACK | DSS_ULT_FL_PERIODIC);
+	DL_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO, rc,
+		  DF_CONT ": refresh ec_agg_eph " DF_X64 ", "
+			  "stable_eph " DF_X64,
+		  DP_CONT(pool_uuid, cont_uuid), ec_agg_eph, stable_eph);
 
 out:
 	if (arg.tgt_status != NULL && arg.tgt_status != arg.tgt_status_inline)
@@ -1883,127 +1890,290 @@ out:
 	return rc;
 }
 
-#define TRACK_EPH_INTV	 (5ULL * 1000)	/* seconds interval to check*/
-static void
-cont_track_eph_leader_ult(void *arg)
+static int
+cont_agg_eph_load(struct cont_svc *svc, uuid_t cont_uuid, uint64_t *ec_agg_eph)
 {
-	struct cont_svc			*svc = arg;
-	struct ds_pool			*pool = svc->cs_pool;
+	struct rdb_tx tx;
+	struct cont  *cont = NULL;
+	uint64_t      agg_eph;
+	d_iov_t       value;
+	int           rc;
+
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0) {
+		DL_CDEBUG(rc != -DER_NOTLEADER, DLOG_ERR, DB_MD, rc,
+			  DF_CONT ": Failed to start rdb tx.",
+			  DP_CONT(svc->cs_pool_uuid, cont_uuid));
+		return rc;
+	}
+
+	ABT_rwlock_rdlock(svc->cs_lock);
+	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR(DF_CONT ": Failed to look container: %d\n",
+			DP_CONT(svc->cs_pool_uuid, cont_uuid), rc);
+		D_GOTO(out_lock, rc);
+	}
+
+	d_iov_set(&value, &agg_eph, sizeof(agg_eph));
+	rc = rdb_tx_lookup(&tx, &cont->c_prop, &ds_cont_prop_ec_agg_eph, &value);
+	DL_CDEBUG(rc != 0 && rc != -DER_NONEXIST && rc != -DER_NOTLEADER, DLOG_ERR, DB_MD, rc,
+		  DF_CONT ": rdb_tx_lookup ec_agg_eph " DF_X64,
+		  DP_CONT(svc->cs_pool_uuid, cont_uuid), agg_eph);
+	if (rc == -DER_NONEXIST) {
+		agg_eph = 0;
+		rc      = 0;
+	}
+	if (rc == 0)
+		*ec_agg_eph = agg_eph;
+	cont_put(cont);
+
+out_lock:
+	ABT_rwlock_unlock(svc->cs_lock);
+	rdb_tx_end(&tx);
+	return rc;
+}
+
+int
+ds_cont_ec_agg_eph_rdb_lookup(uuid_t pool_uuid, uuid_t cont_uuid, uint64_t *ec_agg_eph)
+{
+	struct cont_svc *svc;
+	int              rc;
+
+	rc = cont_svc_lookup_leader(pool_uuid, 0 /* id */, &svc, NULL);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_CONT ": find leader failed.", DP_CONT(pool_uuid, cont_uuid));
+		return rc;
+	}
+
+	rc = cont_agg_eph_load(svc, cont_uuid, ec_agg_eph);
+	cont_svc_put_leader(svc);
+	if (rc)
+		DL_ERROR(rc, DF_CONT ": cont_agg_eph_load failed.", DP_CONT(pool_uuid, cont_uuid));
+	return rc;
+}
+
+static int
+cont_agg_eph_store(struct cont_svc *svc, uuid_t cont_uuid, uint64_t ec_agg_eph, uint64_t *rdb_eph)
+{
+	struct rdb_tx tx;
+	struct cont  *cont = NULL;
+	d_iov_t       value;
+	uint64_t      old_eph;
+	int           rc;
+
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0) {
+		DL_CDEBUG(rc != -DER_NOTLEADER, DLOG_ERR, DB_MD, rc,
+			  DF_CONT ": Failed to start rdb tx.",
+			  DP_CONT(svc->cs_pool_uuid, cont_uuid));
+		return rc;
+	}
+
+	ABT_rwlock_wrlock(svc->cs_lock);
+	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR(DF_CONT ": Failed to look container: %d\n",
+			DP_CONT(svc->cs_pool_uuid, cont_uuid), rc);
+		D_GOTO(out_lock, rc);
+	}
+
+	d_iov_set(&value, &old_eph, sizeof(old_eph));
+	rc = rdb_tx_lookup(&tx, &cont->c_prop, &ds_cont_prop_ec_agg_eph, &value);
+	if (rc == -DER_NONEXIST) {
+		rc      = 0;
+		old_eph = 0;
+	}
+	if (rc != 0)
+		goto out;
+
+	*rdb_eph = old_eph;
+	if (ec_agg_eph > old_eph) {
+		d_iov_set(&value, &ec_agg_eph, sizeof(ec_agg_eph));
+		rc = rdb_tx_update(&tx, &cont->c_prop, &ds_cont_prop_ec_agg_eph, &value);
+		if (rc == 0)
+			rc = rdb_tx_commit(&tx);
+		if (rc == 0)
+			*rdb_eph = ec_agg_eph;
+	} else {
+		D_DEBUG(DB_MD,
+			DF_CONT ": bypass rdb update ec_agg_eph " DF_X64 ", in rdb eph " DF_X64,
+			DP_CONT(svc->cs_pool_uuid, cont_uuid), ec_agg_eph, old_eph);
+	}
+
+out:
+	DL_CDEBUG(rc != 0 && rc != -DER_NOTLEADER, DLOG_ERR, DB_MD, rc,
+		  DF_CONT ": rdb_tx_update ec_agg_eph " DF_X64,
+		  DP_CONT(svc->cs_pool_uuid, cont_uuid), ec_agg_eph);
+	cont_put(cont);
+out_lock:
+	ABT_rwlock_unlock(svc->cs_lock);
+	rdb_tx_end(&tx);
+	return rc;
+}
+
+static void
+cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
+{
+	d_rank_list_t                    fail_ranks = {0};
 	struct cont_track_eph_leader	*eph_ldr;
 	struct cont_track_eph_leader	*tmp;
 	uint64_t			 cur_eph, new_eph;
+	daos_epoch_t			 min_ec_agg_eph;
+	daos_epoch_t			 min_stable_eph;
+	int				 i;
 	int				 rc = 0;
+
+	rc = map_ranks_init(pool->sp_map, PO_COMP_ST_DOWNOUT | PO_COMP_ST_DOWN, &fail_ranks);
+	if (rc) {
+		D_ERROR(DF_UUID ": ranks init failed: %d\n", DP_UUID(pool->sp_uuid), rc);
+		return;
+	}
+
+	d_list_for_each_entry_safe(eph_ldr, tmp, &svc->cs_cont_ephs_leader_list, cte_list) {
+		if (eph_ldr->cte_deleted) {
+			d_list_del(&eph_ldr->cte_list);
+			D_FREE(eph_ldr->cte_server_ephs);
+			D_FREE(eph_ldr);
+			continue;
+		}
+
+		if (eph_ldr->cte_rdb_ec_agg_eph == 0) {
+			rc = cont_agg_eph_load(svc, eph_ldr->cte_cont_uuid,
+					       &eph_ldr->cte_rdb_ec_agg_eph);
+			if (rc)
+				DL_ERROR(rc, DF_CONT ": cont_agg_eph_load failed.",
+					 DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid));
+		}
+
+		min_ec_agg_eph = DAOS_EPOCH_MAX;
+		min_stable_eph = DAOS_EPOCH_MAX;
+		for (i = 0; i < eph_ldr->cte_servers_num; i++) {
+			d_rank_t rank = eph_ldr->cte_server_ephs[i].re_rank;
+
+			if (d_rank_in_rank_list(&fail_ranks, rank)) {
+				D_DEBUG(DB_MD, DF_CONT " skip %u\n",
+					DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid), rank);
+				continue;
+			}
+
+			if (eph_ldr->cte_server_ephs[i].re_ec_agg_eph < min_ec_agg_eph)
+				min_ec_agg_eph = eph_ldr->cte_server_ephs[i].re_ec_agg_eph;
+			if (eph_ldr->cte_server_ephs[i].re_stable_eph < min_stable_eph)
+				min_stable_eph = eph_ldr->cte_server_ephs[i].re_stable_eph;
+		}
+
+		/* for reboot case the ea_rdb_eph possibly higher than min_eph */
+		if (min_ec_agg_eph < eph_ldr->cte_rdb_ec_agg_eph)
+			min_ec_agg_eph = eph_ldr->cte_rdb_ec_agg_eph;
+
+		if (min_ec_agg_eph == eph_ldr->cte_current_ec_agg_eph &&
+		    min_stable_eph == eph_ldr->cte_current_stable_eph)
+			continue;
+
+		/**
+		 * NB: during extending or reintegration, the new
+		 * server might cause the minimum epoch is less than
+		 * cte_current_ec_agg_eph.
+		 */
+		D_DEBUG(DB_MD,
+			DF_CONT " min_ec_agg_eph " DF_X64 " current " DF_X64
+				", min_stable_eph " DF_X64 " current " DF_X64 ".\n",
+			DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid), min_ec_agg_eph,
+			eph_ldr->cte_current_ec_agg_eph, min_stable_eph,
+			eph_ldr->cte_current_stable_eph);
+
+		cur_eph = d_hlc2sec(eph_ldr->cte_current_ec_agg_eph);
+		new_eph = d_hlc2sec(min_ec_agg_eph);
+		if (cur_eph && new_eph > cur_eph && (new_eph - cur_eph) >= 600)
+			D_WARN(DF_CONT ": Sluggish EC boundary reporting. "
+				       "cur:" DF_U64 " new:" DF_U64 " gap:" DF_U64 "\n",
+			       DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid), cur_eph, new_eph,
+			       new_eph - cur_eph);
+
+		cur_eph = d_hlc2sec(eph_ldr->cte_current_stable_eph);
+		new_eph = d_hlc2sec(min_stable_eph);
+		if (cur_eph && new_eph > cur_eph && (new_eph - cur_eph) >= 600)
+			D_WARN(DF_CONT ": Sluggish stable epoch reporting. "
+				       "cur:" DF_U64 " new:" DF_U64 " gap:" DF_U64 "\n",
+			       DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid), cur_eph, new_eph,
+			       new_eph - cur_eph);
+
+		if (min_ec_agg_eph > eph_ldr->cte_rdb_ec_agg_eph) {
+			rc = cont_agg_eph_store(svc, eph_ldr->cte_cont_uuid, min_ec_agg_eph,
+						&eph_ldr->cte_rdb_ec_agg_eph);
+			if (rc)
+				DL_ERROR(rc,
+					 DF_CONT ": rdb_tx_update ec_agg_eph " DF_X64 " failed.",
+					 DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid),
+					 min_ec_agg_eph);
+		}
+
+		rc = cont_iv_track_eph_refresh(pool->sp_iv_ns, eph_ldr->cte_cont_uuid,
+					       min_ec_agg_eph, min_stable_eph);
+		if (rc) {
+			DL_CDEBUG(rc == -DER_NONEXIST, DLOG_INFO, DLOG_ERR, rc,
+				  DF_CONT ": refresh failed",
+				  DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid));
+
+			/* If there are network error or pool map inconsistency,
+			 * let's skip the following eph sync, which will fail
+			 * anyway.
+			 */
+			if (daos_crt_network_error(rc) || rc == -DER_GRPVER) {
+				D_INFO(DF_UUID ": skip refresh due to: " DF_RC "\n",
+				       DP_UUID(svc->cs_pool_uuid), DP_RC(rc));
+				break;
+			}
+
+			continue;
+		}
+		eph_ldr->cte_current_ec_agg_eph = min_ec_agg_eph;
+		eph_ldr->cte_current_stable_eph = min_stable_eph;
+		if (pool->sp_rebuilding)
+			break;
+	}
+
+	map_ranks_fini(&fail_ranks);
+}
+
+int
+ds_cont_svc_refresh_agg_eph(uuid_t pool_uuid)
+{
+	struct cont_svc *svc;
+	int              rc;
+
+	rc = cont_svc_lookup_leader(pool_uuid, 0 /* id */, &svc, NULL /* hint */);
+	if (rc != 0)
+		return rc;
+
+	cont_agg_eph_sync(svc->cs_pool, svc);
+
+	cont_svc_put_leader(svc);
+	return 0;
+}
+
+#define TRACK_EPH_INTV (5ULL * 1000) /* seconds interval to check*/
+static void
+cont_track_eph_leader_ult(void *arg)
+{
+	struct cont_svc              *svc  = arg;
+	struct ds_pool               *pool = svc->cs_pool;
+	struct cont_track_eph_leader *eph_ldr;
+	struct cont_track_eph_leader *tmp;
+	int                           rc = 0;
 
 	if (svc->cs_cont_ephs_leader_req == NULL)
 		goto out;
 
 	while (!dss_ult_exiting(svc->cs_cont_ephs_leader_req)) {
-		d_rank_list_t		fail_ranks = { 0 };
-
-		if (pool->sp_rebuilding) {
-			D_DEBUG(DB_MD, DF_UUID "skip during rebuilding.\n",
-				DP_UUID(pool->sp_uuid));
-			goto yield;
-		}
-
-		rc = map_ranks_init(pool->sp_map, PO_COMP_ST_DOWNOUT | PO_COMP_ST_DOWN,
-				    &fail_ranks);
-		if (rc) {
-			D_ERROR(DF_UUID": ranks init failed: %d\n",
-				DP_UUID(pool->sp_uuid), rc);
-			goto yield;
-		}
-
-		d_list_for_each_entry_safe(eph_ldr, tmp, &svc->cs_cont_ephs_leader_list, cte_list) {
-			daos_epoch_t min_ec_agg_eph = DAOS_EPOCH_MAX;
-			daos_epoch_t min_stable_eph = DAOS_EPOCH_MAX;
-			int	     i;
-
-			if (eph_ldr->cte_deleted) {
-				d_list_del(&eph_ldr->cte_list);
-				D_FREE(eph_ldr->cte_server_ephs);
-				D_FREE(eph_ldr);
-				continue;
-			}
-
-			for (i = 0; i < eph_ldr->cte_servers_num; i++) {
-				d_rank_t rank = eph_ldr->cte_server_ephs[i].re_rank;
-
-				if (d_rank_in_rank_list(&fail_ranks, rank)) {
-					D_DEBUG(DB_MD, DF_CONT" skip %u\n",
-						DP_CONT(svc->cs_pool_uuid,
-							eph_ldr->cte_cont_uuid),
-						rank);
-					continue;
-				}
-
-				if (eph_ldr->cte_server_ephs[i].re_ec_agg_eph < min_ec_agg_eph)
-					min_ec_agg_eph = eph_ldr->cte_server_ephs[i].re_ec_agg_eph;
-				if (eph_ldr->cte_server_ephs[i].re_stable_eph < min_stable_eph)
-					min_stable_eph = eph_ldr->cte_server_ephs[i].re_stable_eph;
-			}
-
-			if (min_ec_agg_eph == eph_ldr->cte_current_ec_agg_eph &&
-			    min_stable_eph == eph_ldr->cte_current_stable_eph)
-				continue;
-
-			/**
-			 * NB: during extending or reintegration, the new
-			 * server might cause the minimum epoch is less than
-			 * cte_current_ec_agg_eph.
-			 */
-			D_DEBUG(DB_MD, DF_CONT" min_ec_agg_eph "DF_X64" current "DF_X64
-				", min_stable_eph "DF_X64" current "DF_X64".\n",
-				DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid),
-				min_ec_agg_eph, eph_ldr->cte_current_ec_agg_eph,
-				min_stable_eph, eph_ldr->cte_current_stable_eph);
-
-			cur_eph = d_hlc2sec(eph_ldr->cte_current_ec_agg_eph);
-			new_eph = d_hlc2sec(min_ec_agg_eph);
-			if (cur_eph && new_eph > cur_eph && (new_eph - cur_eph) >= 600)
-				D_WARN(DF_CONT": Sluggish EC boundary reporting. "
-				       "cur:"DF_U64" new:"DF_U64" gap:"DF_U64"\n",
-				       DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid),
-				       cur_eph, new_eph, new_eph - cur_eph);
-
-			cur_eph = d_hlc2sec(eph_ldr->cte_current_stable_eph);
-			new_eph = d_hlc2sec(min_stable_eph);
-			if (cur_eph && new_eph > cur_eph && (new_eph - cur_eph) >= 600)
-				D_WARN(DF_CONT": Sluggish stable epoch reporting. "
-				       "cur:"DF_U64" new:"DF_U64" gap:"DF_U64"\n",
-				       DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid),
-				       cur_eph, new_eph, new_eph - cur_eph);
-
-			rc = cont_iv_track_eph_refresh(pool->sp_iv_ns, eph_ldr->cte_cont_uuid,
-						       min_ec_agg_eph, min_stable_eph);
-			if (rc) {
-				DL_CDEBUG(rc == -DER_NONEXIST, DLOG_INFO, DLOG_ERR, rc,
-					  DF_CONT ": refresh failed",
-					  DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid));
-
-				/* If there are network error or pool map inconsistency,
-				 * let's skip the following eph sync, which will fail
-				 * anyway.
-				 */
-				if (daos_crt_network_error(rc) || rc == -DER_GRPVER) {
-					D_INFO(DF_UUID": skip refresh due to: "DF_RC"\n",
-					       DP_UUID(svc->cs_pool_uuid), DP_RC(rc));
-					break;
-				}
-
-				continue;
-			}
-			eph_ldr->cte_current_ec_agg_eph = min_ec_agg_eph;
-			eph_ldr->cte_current_stable_eph = min_stable_eph;
-			if (pool->sp_rebuilding)
-				break;
-		}
-
-		map_ranks_fini(&fail_ranks);
+		cont_agg_eph_sync(pool, svc);
 
 		if (dss_ult_exiting(svc->cs_cont_ephs_leader_req))
 			break;
-yield:
+
 		sched_req_sleep(svc->cs_cont_ephs_leader_req, TRACK_EPH_INTV);
 	}
 

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -69,6 +69,7 @@ struct cont_track_eph_leader {
 	uuid_t			cte_cont_uuid;
 	daos_epoch_t		cte_current_ec_agg_eph;
 	daos_epoch_t		cte_current_stable_eph;
+	daos_epoch_t             cte_rdb_ec_agg_eph; /* EC agg epoch in RDB */
 	struct rank_eph		*cte_server_ephs;
 	d_list_t		cte_list;
 	int			cte_servers_num;
@@ -315,4 +316,7 @@ int cont_child_gather_oids(struct ds_cont_child *cont, uuid_t coh_uuid,
 
 int ds_cont_hdl_rdb_lookup(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 			   struct container_hdl *chdl);
+int
+ds_cont_ec_agg_eph_rdb_lookup(uuid_t pool_uuid, uuid_t cont_uuid, uint64_t *ec_agg_eph);
+
 #endif /* __CONTAINER_SRV_INTERNAL_H__ */

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -54,6 +55,7 @@ RDB_STRING_KEY(ds_cont_prop_, scrubber_disabled);
 RDB_STRING_KEY(ds_cont_prop_, co_md_times);
 RDB_STRING_KEY(ds_cont_prop_, cont_obj_version);
 RDB_STRING_KEY(ds_cont_prop_, nhandles);
+RDB_STRING_KEY(ds_cont_prop_, ec_agg_eph);
 
 /* dummy value for container roots, avoid malloc on demand */
 static struct daos_prop_co_roots dummy_roots;

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -137,6 +138,7 @@ extern d_iov_t ds_cont_prop_co_md_times;	/* co_md_times */
 extern d_iov_t ds_cont_prop_cont_obj_version;	/* uint32_t */
 extern d_iov_t ds_cont_prop_nhandles;		/* uint32_t */
 extern d_iov_t ds_cont_prop_oit_oids;		/* snapshot OIT OID KVS */
+extern d_iov_t ds_cont_prop_ec_agg_eph;         /* uint64_t */
 /* Please read the IMPORTANT notes above before adding new keys. */
 
 struct co_md_times {

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -387,7 +387,10 @@ int daos_sgl_copy_data(d_sg_list_t *dst, d_sg_list_t *src);
 int daos_sgl_alloc_copy_data(d_sg_list_t *dst, d_sg_list_t *src);
 int daos_sgls_alloc(d_sg_list_t *dst, d_sg_list_t *src, int nr);
 int daos_sgl_merge(d_sg_list_t *dst, d_sg_list_t *src);
-daos_size_t daos_sgl_data_len(d_sg_list_t *sgl);
+daos_size_t
+daos_sgl_data_len(d_sg_list_t *sgl, bool out);
+daos_size_t
+	    daos_sgl_out_data_len(d_sg_list_t *sgl);
 daos_size_t daos_sgl_buf_size(d_sg_list_t *sgl);
 daos_size_t daos_sgls_buf_size(d_sg_list_t *sgls, int nr);
 daos_size_t daos_sgls_packed_size(d_sg_list_t *sgls, int nr,

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -37,6 +37,8 @@ void ds_cont_svc_step_down(struct cont_svc *svc);
 int
     ds_cont_svc_set_prop(uuid_t pool_uuid, const char *cont_id, d_rank_list_t *ranks,
 			 daos_prop_t *prop);
+int
+    ds_cont_svc_refresh_agg_eph(uuid_t pool_uuid);
 int ds_cont_list(uuid_t pool_uuid, struct daos_pool_cont_info **conts, uint64_t *ncont);
 int ds_cont_filter(uuid_t pool_uuid, daos_pool_cont_filter_t *filt,
 		   struct daos_pool_cont_info2 **conts, uint64_t *ncont);
@@ -78,7 +80,9 @@ struct ds_cont_child {
 	    sc_dtx_delay_reset : 1, sc_dtx_registered : 1, sc_props_fetched : 1, sc_stopping : 1,
 	    sc_destroying : 1, sc_vos_agg_active : 1, sc_ec_agg_active : 1,
 	    /* flag of CONT_CAPA_READ_DATA/_WRITE_DATA disabled */
-	    sc_rw_disabled : 1, sc_scrubbing : 1, sc_rebuilding : 1;
+	    sc_rw_disabled : 1, sc_scrubbing : 1, sc_rebuilding : 1,
+	    /* flag of sc_ec_agg_eph_boundary valid */
+	    sc_ec_agg_eph_valid : 1;
 	/* Tracks the schedule request for aggregation ULT */
 	struct sched_request	*sc_agg_req;
 

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -94,7 +94,8 @@ int ds_rebuild_query(uuid_t pool_uuid,
 void ds_rebuild_running_query(uuid_t pool_uuid, uint32_t opc, uint32_t *rebuild_ver,
 			      daos_epoch_t *current_eph, uint32_t *rebuild_gen);
 int
-     ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop, uint64_t sys_self_heal);
+     ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop, uint64_t sys_self_heal,
+				uint64_t delay_sec);
 void ds_rebuild_leader_stop_all(void);
 void ds_rebuild_abort(uuid_t pool_uuid, unsigned int version, uint32_t rebuild_gen,
 		      uint64_t term);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -921,16 +921,18 @@ dc_rw_cb(tse_task_t *task, void *arg)
 						 orwo->orw_rels.ca_arrays,
 						 orwo->orw_rels.ca_count);
 			if (rc) {
-				D_ERROR(DF_UOID " obj_ec_parity_check failed, " DF_RC "\n",
-					DP_UOID(orw->orw_oid), DP_RC(rc));
+				DL_ERROR(rc, DF_CONT ", " DF_UOID " obj_ec_parity_check failed",
+					 DP_CONT(orw->orw_pool_uuid, orw->orw_co_uuid),
+					 DP_UOID(orw->orw_oid));
 				goto out;
 			}
 		}
 
 		rc = dc_shard_update_size(rw_args, 0);
 		if (rc) {
-			D_ERROR(DF_UOID " dc_shard_update_size failed, " DF_RC "\n",
-				DP_UOID(orw->orw_oid), DP_RC(rc));
+			DL_ERROR(rc, DF_CONT ", " DF_UOID " dc_shard_update_size failed",
+				 DP_CONT(orw->orw_pool_uuid, orw->orw_co_uuid),
+				 DP_UOID(orw->orw_oid));
 			goto out;
 		}
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1085,6 +1085,7 @@ agg_update_parity(struct ec_agg_entry *entry, uint8_t *bit_map,
 			goto out;
 		while (!isset(bit_map, j))
 			j++;
+		D_ASSERTF(j < k, "bad cell_idx %d, number of data shards %d\n", j, k);
 		agg_diff_preprocess(entry, diff, j);
 		ec_encode_data_update(cell_bytes, k, p, j,
 				      entry->ae_codec->ec_gftbls, diff,
@@ -1951,15 +1952,15 @@ out:
 			/* offload of ds_obj_update to push remote parity */
 			rc = agg_peer_update(entry, write_parity);
 			if (rc)
-				D_ERROR("agg_peer_update fail: "DF_RC"\n",
-					DP_RC(rc));
+				DL_ERROR(rc, "agg_peer_update failed, write_parity %d",
+					 write_parity);
 		}
 
 		if (rc == 0) {
 			rc = agg_update_vos(agg_param, entry, write_parity);
 			if (rc)
-				D_ERROR("agg_update_vos failed: "DF_RC"\n",
-					DP_RC(rc));
+				DL_ERROR(rc, "agg_update_vos failed, write_parity %d",
+					 write_parity);
 		}
 	}
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1074,7 +1074,7 @@ agg_update_parity(struct ec_agg_entry *entry, uint8_t *bit_map,
 	buf  = entry->ae_sgl.sg_iovs[AGG_IOV_DATA].iov_buf;
 	diff = entry->ae_sgl.sg_iovs[AGG_IOV_DIFF].iov_buf;
 
-	for (i = 0, j = 0; i < cell_cnt; i++) {
+	for (i = 0, j = 0; i < cell_cnt; i++, j++) {
 		old = &obuf[i * cell_bytes];
 		new = &buf[i * cell_bytes];
 		vects[0] = old;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1362,6 +1362,25 @@ obj_rw_recx_list_post(struct obj_rw_in *orw, struct obj_rw_out *orwo, uint8_t *s
 	return rc;
 }
 
+struct ec_agg_boundary_arg {
+	struct ds_pool *eab_pool;
+	uuid_t          eab_co_uuid;
+};
+
+static int
+obj_fetch_ec_agg_boundary(void *data)
+{
+	struct ec_agg_boundary_arg *arg = data;
+	int                         rc;
+
+	rc = ds_cont_fetch_ec_agg_boundary(arg->eab_pool->sp_iv_ns, arg->eab_co_uuid);
+	if (rc)
+		DL_ERROR(rc, DF_CONT ", ds_cont_fetch_ec_agg_boundary failed.",
+			 DP_CONT(arg->eab_pool->sp_uuid, arg->eab_co_uuid));
+
+	return rc;
+}
+
 static int
 obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc, daos_iod_t *iods,
 		      struct dcs_iod_csums *iod_csums, uint64_t *offs, uint8_t *skips,
@@ -1481,6 +1500,32 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc, daos_iod_t *io
 			is_parity_shard = is_ec_parity_shard_by_tgt_off(tgt_off, &ioc->ioc_oca);
 			get_parity_list = ec_recov && is_parity_shard &&
 					  ((orw->orw_flags & ORF_EC_RECOV_SNAP) == 0);
+		}
+		if ((ec_deg_fetch || (ec_recov && get_parity_list)) &&
+		    ioc->ioc_coc->sc_ec_agg_eph_valid == 0) {
+			struct ec_agg_boundary_arg arg;
+
+			arg.eab_pool = ioc->ioc_coc->sc_pool->spc_pool;
+			uuid_copy(arg.eab_co_uuid, ioc->ioc_coc->sc_uuid);
+			rc = dss_ult_execute(obj_fetch_ec_agg_boundary, &arg, NULL, NULL,
+					     DSS_XS_SYS, 0, 0);
+			if (rc) {
+				DL_ERROR(rc, DF_CONT ", " DF_UOID " fetch ec_agg_boundary failed.",
+					 DP_CONT(ioc->ioc_coc->sc_pool_uuid, ioc->ioc_coc->sc_uuid),
+					 DP_UOID(orw->orw_oid));
+				goto out;
+			}
+			if (ioc->ioc_coc->sc_ec_agg_eph_valid == 0) {
+				rc = -DER_FETCH_AGAIN;
+				DL_INFO(rc, DF_CONT ", " DF_UOID " zero ec_agg_boundary.",
+					DP_CONT(ioc->ioc_coc->sc_pool_uuid, ioc->ioc_coc->sc_uuid),
+					DP_UOID(orw->orw_oid));
+				goto out;
+			}
+			D_DEBUG(DB_IO,
+				DF_CONT ", " DF_UOID " fetched ec_agg_eph_boundary " DF_X64 "\n",
+				DP_CONT(ioc->ioc_coc->sc_pool_uuid, ioc->ioc_coc->sc_uuid),
+				DP_UOID(orw->orw_oid), ioc->ioc_coc->sc_ec_agg_eph_boundary);
 		}
 		if (get_parity_list) {
 			D_ASSERT(!ec_deg_fetch);

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -802,7 +802,7 @@ mrone_obj_fetch_internal(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_
 retry:
 	rc = dsc_obj_fetch(oh, eph, &mrone->mo_dkey, iod_num, iods, sgls, NULL, flags, extra_arg,
 			   csum_iov_fetch);
-	if (rc == -DER_TIMEDOUT &&
+	if ((rc == -DER_TIMEDOUT || rc == -DER_FETCH_AGAIN) &&
 	    tls->mpt_version + 1 >= tls->mpt_pool->spc_map_version) {
 		if (tls->mpt_fini) {
 			DL_ERROR(rc, DF_RB ": dsc_obj_fetch " DF_UOID "failed when mpt_fini",

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2435,7 +2435,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	struct pool_iv_conns   *iv_hdls            = NULL;
 	bool			cont_svc_up = false;
 	bool			events_initialized = false;
-	d_rank_t		rank = dss_self_rank();
+	d_rank_t                rank               = dss_self_rank();
 	int			rc;
 
 	D_ASSERTF(svc->ps_error == 0, "ps_error: " DF_RC "\n", DP_RC(svc->ps_error));
@@ -2555,7 +2555,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	if (rc != 0)
 		goto out;
 
-	rc = ds_rebuild_regenerate_task(svc->ps_pool, prop, sys_self_heal);
+	rc = ds_rebuild_regenerate_task(svc->ps_pool, prop, sys_self_heal, 0);
 	if (rc != 0)
 		goto out;
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -2568,8 +2568,13 @@ cont_discard_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 
 put:
 	ds_cont_child_put(cont);
+	/* don't destroy vos container, to avoid ds_cont_tgt_refresh_agg_eph() failure,
+	 * later depend on container recovery process to handle it.
+	 */
+#if 0
 	if (rc == 0)
 		rc = ds_cont_child_destroy(arg->tgt_discard->pool_uuid, entry->ie_couuid);
+#endif
 	return rc;
 }
 
@@ -2730,7 +2735,7 @@ ds_pool_task_collective(uuid_t pool_uuid, uint32_t ex_status, int (*coll_func)(v
 }
 
 /* Discard the objects by epoch in this pool */
-static void
+static int
 ds_pool_tgt_discard_ult(void *data)
 {
 	struct ds_pool		*pool;
@@ -2757,6 +2762,7 @@ ds_pool_tgt_discard_ult(void *data)
 	ds_pool_put(pool);
 free:
 	tgt_discard_arg_free(arg);
+	return rc;
 }
 
 void
@@ -2789,7 +2795,7 @@ ds_pool_tgt_discard_handler(crt_rpc_t *rpc)
 
 	pool->sp_need_discard = 1;
 	pool->sp_discard_status = 0;
-	rc = dss_ult_create(ds_pool_tgt_discard_ult, arg, DSS_XS_SYS, 0, 0, NULL);
+	rc = dss_ult_execute(ds_pool_tgt_discard_ult, arg, NULL, NULL, DSS_XS_SYS, 0, 0);
 
 	ds_pool_put(pool);
 out:

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1930,8 +1930,7 @@ rebuild_task_ult(void *arg)
 	cur_ts = daos_gettime_coarse();
 	D_ASSERT(task->dst_schedule_time != (uint64_t)-1);
 	if (cur_ts < task->dst_schedule_time) {
-		D_DEBUG(DB_REBUILD, "rebuild task sleep "DF_U64" second\n",
-			task->dst_schedule_time - cur_ts);
+		D_INFO("rebuild task sleep " DF_U64 " second\n", task->dst_schedule_time - cur_ts);
 		dss_sleep((task->dst_schedule_time - cur_ts) * 1000);
 	}
 
@@ -1940,6 +1939,13 @@ rebuild_task_ult(void *arg)
 		D_ERROR(DF_UUID": failed to look up pool: %d\n",
 			DP_UUID(task->dst_pool_uuid), rc);
 		D_GOTO(out_task, rc = -DER_NONEXIST);
+	}
+
+	rc = ds_cont_svc_refresh_agg_eph(task->dst_pool_uuid);
+	if (rc) {
+		D_ERROR(DF_UUID ": ds_cont_svc_refresh_agg_eph failed, " DF_RC "\n",
+			DP_UUID(task->dst_pool_uuid), DP_RC(rc));
+		goto out_task;
 	}
 
 	while (1) {
@@ -2579,7 +2585,8 @@ regenerate_task_of_type(struct ds_pool *pool, pool_comp_state_t match_states, ui
 
 /* Regenerate the rebuild tasks when changing the leader. */
 int
-ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop, uint64_t sys_self_heal)
+ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop, uint64_t sys_self_heal,
+			   uint64_t delay_sec)
 {
 	struct daos_prop_entry *entry;
 	char                   *env;
@@ -2614,11 +2621,12 @@ ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop, uint64_t sys
 	if (entry->dpe_val & (DAOS_SELF_HEAL_AUTO_REBUILD | DAOS_SELF_HEAL_DELAY_REBUILD) &&
 	    !pool->sp_disable_rebuild) {
 		rc = regenerate_task_of_type(
-		    pool, PO_COMP_ST_DOWN, entry->dpe_val & DAOS_SELF_HEAL_DELAY_REBUILD ? -1 : 0);
+		    pool, PO_COMP_ST_DOWN,
+		    entry->dpe_val & DAOS_SELF_HEAL_DELAY_REBUILD ? -1 : delay_sec);
 		if (rc != 0)
 			return rc;
 
-		rc = regenerate_task_of_type(pool, PO_COMP_ST_DRAIN, 0);
+		rc = regenerate_task_of_type(pool, PO_COMP_ST_DRAIN, delay_sec);
 		if (rc != 0)
 			return rc;
 	} else {
@@ -2636,7 +2644,7 @@ ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop, uint64_t sys
 	 * discarding on an empty targets is harmless. So it is ok to use REINT to
 	 * do EXTEND here.
 	 */
-	rc = regenerate_task_of_type(pool, PO_COMP_ST_UP, 0);
+	rc = regenerate_task_of_type(pool, PO_COMP_ST_UP, delay_sec);
 	if (rc != 0)
 		return rc;
 
@@ -2659,7 +2667,7 @@ ds_rebuild_admin_start(struct ds_pool *pool)
 		goto out;
 	}
 
-	rc = ds_rebuild_regenerate_task(pool, &prop, DS_MGMT_SELF_HEAL_ALL);
+	rc = ds_rebuild_regenerate_task(pool, &prop, DS_MGMT_SELF_HEAL_ALL, 0);
 	daos_prop_fini(&prop);
 	if (rc)
 		DL_ERROR(rc, DF_UUID ": regenerate rebuild task failed", DP_UUID(pool->sp_uuid));

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1945,7 +1945,7 @@ rebuild_task_ult(void *arg)
 	if (rc) {
 		D_ERROR(DF_UUID ": ds_cont_svc_refresh_agg_eph failed, " DF_RC "\n",
 			DP_UUID(task->dst_pool_uuid), DP_RC(rc));
-		goto out_task;
+		goto out_pool;
 	}
 
 	while (1) {

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1104,11 +1105,41 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 			holes += lo - index;
 		}
 
-		/* Hole extent, with_shadow case only used for EC obj */
-		if (bio_addr_is_hole(&ent->en_addr) ||
-		    (with_shadow && (ent->en_epoch < shadow_ep))) {
+		if ((with_shadow && (ent->en_epoch < shadow_ep))) {
 			index = lo + nr;
 			holes += nr;
+			continue;
+		}
+
+		/* Hole extent, with_shadow case only used for EC obj */
+		if (bio_addr_is_hole(&ent->en_addr)) {
+			if (with_shadow) {
+				if (holes != 0) {
+					/* process the prev hole */
+					rc = save_recx(ioc, lo - holes, holes, shadow_ep, inob,
+						       DRT_SHADOW);
+					if (rc != 0)
+						goto failed;
+					biov_set_hole(&biov, holes * inob);
+					/* skip the hole */
+					rc = iod_fetch(ioc, &biov);
+					if (rc != 0)
+						goto failed;
+					holes = 0;
+				}
+				/* process this punch ext, for degraded fetch just skip it */
+				index = lo + nr;
+				holes = nr;
+				biov_set_hole(&biov, holes * inob);
+				/* skip the hole */
+				rc = iod_fetch(ioc, &biov);
+				if (rc != 0)
+					goto failed;
+				holes = 0;
+			} else {
+				index = lo + nr;
+				holes += nr;
+			}
 			continue;
 		}
 


### PR DESCRIPTION
1. add container RDB KV ds_cont_prop_ec_agg_eph for EC aggregation epoch boundary, store it when bump and load it after restart.
2. synchronize the ec agg boundary before rebuild
3. change ec agg boundary IV refresh to be EAGER sync
4. wait discard's completion in ds_pool_tgt_discard_handler()
5. fix a cart IV sync bug that ignored GRP_VER err case's err code
6. fetch ec agg boundary IV in fetch RPC handler when it is zero
7. fix an EC agg partial update stripe processing bug
8. fix a sgl sg_nr_out and iov_len process bug
9. fix a EC degraded fetch bug related with punch extent

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
