### PR TITLE
DAOS-18029 cq: do not run trivy on all prs

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -11,6 +11,13 @@ on:
     branches: ["master", "release/**"]
   pull_request:
     branches: ["master", "release/**"]
+    paths:
+      - utils/trivy/**
+      - utils/rpms/**
+      - requirements-*.txt
+      - utils/build.config
+      - src/client/java/**/pom.xml
+      - .github/workflows/trivy.yml
 
 # Declare default permissions as nothing.
 permissions: {}


### PR DESCRIPTION
Trivy often fails and is unrelated to most PRs. Only run it on PRs if relevant files are touched.

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
