### PR TITLE
DAOS-18013 test: Update D_LOG_FILE_APPEND_PID to engine env_vars

### DIFF
--- a/src/tests/ftest/control/config_generate_run.py
+++ b/src/tests/ftest/control/config_generate_run.py
@@ -74,6 +74,9 @@ class ConfigGenerateRun(TestWithServers):
         for engine in engines:
             engine["log_file"] = os.path.join(
                 self.test_env.log_dir, os.path.basename(engine["log_file"]))
+            if "env_vars" not in engine:
+                engine["env_vars"] = []
+            engine["env_vars"].append("D_LOG_FILE_APPEND_PID=1")
 
         # Stop and restart daos_server. self.start_server_managers() has the
         # server start-up check built into it, so if there's something wrong,


### PR DESCRIPTION
Update control/config_generate_run.py D_LOG_FILE_APPEND_PID=1

Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
