### PR TITLE
DAOS-18015 dfuse: do not force foreground if run with MPI

### DIFF
--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -590,12 +590,6 @@ main(int argc, char **argv)
 		}
 	}
 
-	if (!dfuse_info->di_foreground && d_isenv_def("PMIX_RANK")) {
-		DFUSE_TRA_WARNING(dfuse_info,
-				  "Not running in background under orterun");
-		dfuse_info->di_foreground = true;
-	}
-
 	if (!dfuse_info->di_mountpoint) {
 		printf("Mountpoint is required\n");
 		show_help(argv[0]);


### PR DESCRIPTION
If using MPI to launch dfuse, we should not force running in the foreground as that introduces several limitations. MPI like clush should be able to launch and daemonize dfuse.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
