### PR TITLE
DAOS-17772 rebuild: avoid potential races between rebuild and EC aggregation

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1803,12 +1803,8 @@ cont_refresh_vos_agg_eph_one(void *data)
 		cont_child->sc_ec_agg_eph_boundary < arg->min_eph ? "update" : "ignore",
 		cont_child->sc_ec_agg_eph_boundary, arg->min_eph);
 
-	if (!cont_child->sc_ec_agg_eph_valid ||
-	    !cont_child->sc_pool->spc_pool->sp_rebuilding) {
-		/* don't refresh the boundary during rebuild */
-		if (cont_child->sc_ec_agg_eph_boundary < arg->min_eph)
-			cont_child->sc_ec_agg_eph_boundary = arg->min_eph;
-	}
+	if (cont_child->sc_ec_agg_eph_boundary < arg->min_eph)
+		cont_child->sc_ec_agg_eph_boundary = arg->min_eph;
 
 	cont_child->sc_ec_agg_eph_valid = 1;
 	ds_cont_child_put(cont_child);

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1803,8 +1803,12 @@ cont_refresh_vos_agg_eph_one(void *data)
 		cont_child->sc_ec_agg_eph_boundary < arg->min_eph ? "update" : "ignore",
 		cont_child->sc_ec_agg_eph_boundary, arg->min_eph);
 
-	if (cont_child->sc_ec_agg_eph_boundary < arg->min_eph)
-		cont_child->sc_ec_agg_eph_boundary = arg->min_eph;
+	if (!cont_child->sc_ec_agg_eph_valid ||
+	    !cont_child->sc_pool->spc_pool->sp_rebuilding) {
+		/* don't refresh the boundary during rebuild */
+		if (cont_child->sc_ec_agg_eph_boundary < arg->min_eph)
+			cont_child->sc_ec_agg_eph_boundary = arg->min_eph;
+	}
 
 	cont_child->sc_ec_agg_eph_valid = 1;
 	ds_cont_child_put(cont_child);

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -182,9 +182,9 @@ cont_aggregate_runnable(struct ds_cont_child *cont, struct sched_request *req,
 	}
 
 	if (ds_pool_is_rebuilding(pool) && !vos_agg) {
-		D_DEBUG(DB_EPC, DF_CONT": skip EC aggregation during rebuild %d, %d.\n",
-			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
-			pool->sp_rebuilding, pool->sp_rebuild_scan);
+		D_DEBUG(DB_EPC, DF_CONT ": skip EC aggregation during rebuild %d, %d.\n",
+			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid), pool->sp_rebuilding,
+			pool->sp_rebuild_scan);
 		return false;
 	}
 
@@ -499,8 +499,8 @@ next:
 		/* sleep 18 seconds for EC aggregation ULT if the pool is in rebuilding,
 		 * if no space pressure.
 		 */
-		if (ds_pool_is_rebuilding(cont->sc_pool->spc_pool) &&
-		    !param->ap_vos_agg && msecs != 200)
+		if (ds_pool_is_rebuilding(cont->sc_pool->spc_pool) && !param->ap_vos_agg &&
+		    msecs != 200)
 			msecs = 18000;
 
 		sched_req_sleep(req, msecs);
@@ -921,14 +921,14 @@ ds_cont_child_reset_ec_agg_eph_all(struct ds_pool_child *pool_child)
 void
 ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child)
 {
-	uint64_t	start_time = daos_wallclock_secs();
+	uint64_t start_time = daos_wallclock_secs();
 
-	D_DEBUG(DB_MD, DF_UUID"[%d]: wait for pausing EC aggregation\n",
+	D_DEBUG(DB_MD, DF_UUID "[%d]: wait for pausing EC aggregation\n",
 		DP_UUID(pool_child->spc_uuid), dss_get_module_info()->dmi_tgt_id);
 	while (1) {
 		struct ds_cont_child *coc;
-		bool wait = false;
-		int  waited;
+		bool                  wait = false;
+		int                   waited;
 
 		/* Wait for pausing aggregation
 		 * XXX: There is no global barrier so we always wait for at least 10 seconds to
@@ -947,7 +947,7 @@ ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child)
 
 		waited = daos_wallclock_secs() - start_time;
 		if (waited % 60 == 0) {
-			D_WARN(DF_UUID"[%d]: waited %d secs for EC aggregation to pause\n",
+			D_WARN(DF_UUID "[%d]: waited %d secs for EC aggregation to pause\n",
 			       DP_UUID(pool_child->spc_uuid), dss_get_module_info()->dmi_tgt_id,
 			       waited);
 		}

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -918,14 +918,14 @@ ds_cont_child_reset_ec_agg_eph_all(struct ds_pool_child *pool_child)
 		cont_child->sc_ec_agg_eph = cont_child->sc_ec_agg_eph_boundary;
 }
 
-#define WAIT_EC_PAUSE_MAX		600
+#define WAIT_EC_PAUSE_MAX 600
 
 void
 ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child, int wait_timeout)
 {
 	uint64_t start_time = daos_wallclock_secs();
-	int	 wait_intv  = 10;
-	int	 waited = 0;
+	int      wait_intv  = 10;
+	int      waited     = 0;
 
 	D_DEBUG(DB_MD, DF_UUID "[%d]: wait for pausing EC aggregation\n",
 		DP_UUID(pool_child->spc_uuid), dss_get_module_info()->dmi_tgt_id);

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -918,42 +918,53 @@ ds_cont_child_reset_ec_agg_eph_all(struct ds_pool_child *pool_child)
 		cont_child->sc_ec_agg_eph = cont_child->sc_ec_agg_eph_boundary;
 }
 
+#define WAIT_EC_PAUSE_MAX		600
+
 void
-ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child)
+ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child, int wait_timeout)
 {
 	uint64_t start_time = daos_wallclock_secs();
+	int	 wait_intv  = 10;
+	int	 waited = 0;
 
 	D_DEBUG(DB_MD, DF_UUID "[%d]: wait for pausing EC aggregation\n",
 		DP_UUID(pool_child->spc_uuid), dss_get_module_info()->dmi_tgt_id);
+
+	if (wait_timeout == 0 || wait_timeout > WAIT_EC_PAUSE_MAX)
+		wait_timeout = WAIT_EC_PAUSE_MAX; /* 10 minutes by default */
+
 	while (1) {
 		struct ds_cont_child *coc;
-		bool                  wait = false;
-		int                   waited;
+		bool                  paused = true;
 
 		/* Wait for pausing aggregation
 		 * XXX: There is no global barrier so we always wait for at least 10 seconds to
 		 * lower the chance that remote targets are still running EC aggregation.
 		 */
-		dss_sleep(10 * 1000);
+		if (wait_intv > wait_timeout - waited)
+			wait_intv = wait_timeout - waited;
+
+		dss_sleep(wait_intv * 1000);
 		d_list_for_each_entry(coc, &pool_child->spc_cont_list, sc_link) {
 			if (ds_cont_child_ec_aggregating(coc)) {
 				/* Aggregation is active on this container */
-				wait = true;
+				paused = false;
 				break;
 			}
 		}
-		if (!wait)
+		if (paused)
 			return;
 
 		waited = daos_wallclock_secs() - start_time;
+		if (waited >= wait_timeout) {
+			D_WARN("can't pause EC aggregation after %d seconds\n", waited);
+			return; /* XXX what can I do? */
+		}
+
 		if (waited % 60 == 0) {
 			D_WARN(DF_UUID "[%d]: waited %d secs for EC aggregation to pause\n",
 			       DP_UUID(pool_child->spc_uuid), dss_get_module_info()->dmi_tgt_id,
 			       waited);
-		}
-		if (waited > 600) {
-			D_ERROR("Waited for 10 minutes for EC aggregation to pause!\n");
-			return; /* XXX what can I do? */
 		}
 	}
 }

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -136,7 +136,7 @@ struct ds_cont_child {
 	d_list_t		 sc_dtx_batched_list;
 	/* the pool map version of updating DAOS_PROP_CO_STATUS prop */
 	uint32_t		 sc_status_pm_ver;
-	int			 sc_ec_agg_updates;
+	int                      sc_ec_agg_updates;
 };
 
 struct agg_param {
@@ -208,7 +208,7 @@ ds_cont_child_destroy(uuid_t pool_uuid, uuid_t cont_uuid);
 void
 ds_cont_child_reset_ec_agg_eph_all(struct ds_pool_child *pool_child);
 void
-ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child);
+     ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child);
 
 /** initialize a csummer based on container properties. Will retrieve the
  * checksum related properties from IV

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -207,8 +207,7 @@ ds_cont_child_destroy(uuid_t pool_uuid, uuid_t cont_uuid);
 
 void
 ds_cont_child_reset_ec_agg_eph_all(struct ds_pool_child *pool_child);
-void
-     ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child);
+void ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child, int wait_timeout);
 
 /** initialize a csummer based on container properties. Will retrieve the
  * checksum related properties from IV

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -207,7 +207,8 @@ ds_cont_child_destroy(uuid_t pool_uuid, uuid_t cont_uuid);
 
 void
 ds_cont_child_reset_ec_agg_eph_all(struct ds_pool_child *pool_child);
-void ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child, int wait_timeout);
+void
+     ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child, int wait_timeout);
 
 /** initialize a csummer based on container properties. Will retrieve the
  * checksum related properties from IV

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -149,6 +149,14 @@ struct agg_param {
 typedef int (*cont_aggregate_cb_t)(struct ds_cont_child *cont,
 				   daos_epoch_range_t *epr, uint32_t flags,
 				   struct agg_param *param);
+
+static inline bool
+ds_cont_child_ec_aggregating(struct ds_cont_child *cont)
+{
+	/* either I'm running aggregation, or someone else is writing to me for aggregation */
+	return cont->sc_ec_agg_updates || cont->sc_ec_agg_active;
+}
+
 void
 cont_aggregate_interval(struct ds_cont_child *cont, cont_aggregate_cb_t cb,
 			struct agg_param *param);
@@ -199,6 +207,9 @@ ds_cont_child_destroy(uuid_t pool_uuid, uuid_t cont_uuid);
 
 void
 ds_cont_child_reset_ec_agg_eph_all(struct ds_pool_child *pool_child);
+void
+ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child);
+
 /** initialize a csummer based on container properties. Will retrieve the
  * checksum related properties from IV
  */

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -136,6 +136,7 @@ struct ds_cont_child {
 	d_list_t		 sc_dtx_batched_list;
 	/* the pool map version of updating DAOS_PROP_CO_STATUS prop */
 	uint32_t		 sc_status_pm_ver;
+	int			 sc_ec_agg_updates;
 };
 
 struct agg_param {

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -91,8 +91,12 @@ struct ds_pool {
 	 * rebuild job.
 	 */
 	uint32_t		sp_rebuild_gen;
-
 	int			sp_rebuilding;
+	/**
+	 * someone has already messaged this pool to for rebuild scan,
+	 * NB: all xstreams can do lockless-write on it but it's OK
+	 */
+	int			sp_rebuild_scan;
 
 	int			sp_discard_status;
 	/** path to ephemeral metrics */
@@ -182,8 +186,7 @@ struct ds_pool_child {
 	ABT_eventual	spc_ref_eventual;
 
 	uint64_t	spc_discard_done:1,
-			spc_no_storage:1, /* The pool shard has no storage. */
-			spc_remote_scan:1; /* remote servers started scan for rebuild */
+			spc_no_storage:1; /* The pool shard has no storage. */
 
 	uint32_t	spc_reint_mode;
 	uint32_t	*spc_state;	/* Pointer to ds_pool->sp_states[i] */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -90,13 +90,13 @@ struct ds_pool {
 	/* pool_uuid + map version + leader term + rebuild generation define a
 	 * rebuild job.
 	 */
-	uint32_t		sp_rebuild_gen;
+	uint32_t                 sp_rebuild_gen;
 	int			sp_rebuilding;
 	/**
 	 * someone has already messaged this pool to for rebuild scan,
 	 * NB: all xstreams can do lockless-write on it but it's OK
 	 */
-	int			sp_rebuild_scan;
+	int                      sp_rebuild_scan;
 
 	int			sp_discard_status;
 	/** path to ephemeral metrics */
@@ -283,8 +283,9 @@ int
 int ds_pool_tgt_add_in(uuid_t pool_uuid, struct pool_target_id_list *list);
 
 int ds_pool_tgt_revert_rebuild(uuid_t pool_uuid, struct pool_target_id_list *list);
-int ds_pool_tgt_finish_rebuild(uuid_t pool_uuid, struct pool_target_id_list *list,
-			       uint32_t *reclaim_ver);
+int
+     ds_pool_tgt_finish_rebuild(uuid_t pool_uuid, struct pool_target_id_list *list,
+				uint32_t *reclaim_ver);
 int ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 			   unsigned int map_version);
 

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -273,7 +273,8 @@ int
 int ds_pool_tgt_add_in(uuid_t pool_uuid, struct pool_target_id_list *list);
 
 int ds_pool_tgt_revert_rebuild(uuid_t pool_uuid, struct pool_target_id_list *list);
-int ds_pool_tgt_finish_rebuild(uuid_t pool_uuid, struct pool_target_id_list *list);
+int ds_pool_tgt_finish_rebuild(uuid_t pool_uuid, struct pool_target_id_list *list,
+			       uint32_t *reclaim_ver);
 int ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 			   unsigned int map_version);
 

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -210,6 +210,12 @@ struct ds_pool_svc_op_val {
 	char ov_resvd[60];
 };
 
+static inline bool
+ds_pool_is_rebuilding(struct ds_pool *pool)
+{
+	return (pool->sp_rebuilding > 0 || pool->sp_rebuild_scan > 0);
+}
+
 /* encode metadata RPC operation key: HLC time first, in network order, for keys sorted by time.
  * allocates the byte-stream, caller must free with D_FREE().
  */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -182,7 +182,8 @@ struct ds_pool_child {
 	ABT_eventual	spc_ref_eventual;
 
 	uint64_t	spc_discard_done:1,
-			spc_no_storage:1; /* The pool shard has no storage. */
+			spc_no_storage:1, /* The pool shard has no storage. */
+			spc_remote_scan:1; /* remote servers started scan for rebuild */
 
 	uint32_t	spc_reint_mode;
 	uint32_t	*spc_state;	/* Pointer to ds_pool->sp_states[i] */

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -16,6 +16,7 @@
 
 #define REBUILD_ENV            "DAOS_REBUILD"
 #define REBUILD_ENV_DISABLED   "no"
+#define REBUILD_WAIT_EC_PAUSE_ENV	"DAOS_REBUILD_WAIT_EC_PAUSE"
 
 /**
  * Enum values to indicate the rebuild operation that should be applied to the

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -16,7 +16,7 @@
 
 #define REBUILD_ENV            "DAOS_REBUILD"
 #define REBUILD_ENV_DISABLED   "no"
-#define REBUILD_WAIT_EC_PAUSE_ENV	"DAOS_REBUILD_WAIT_EC_PAUSE"
+#define REBUILD_WAIT_EC_PAUSE_ENV "DAOS_REBUILD_WAIT_EC_PAUSE"
 
 /**
  * Enum values to indicate the rebuild operation that should be applied to the

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3771,9 +3771,9 @@ obj_shard_comp_cb(tse_task_t *task, struct shard_auxi_args *shard_auxi,
 	 * 2) if any shard failed, store it in obj_auxi->result, the
 	 *    un-retryable error with higher priority.
 	 */
+	if (obj_auxi->map_ver_reply < shard_auxi->map_ver)
+		obj_auxi->map_ver_reply = shard_auxi->map_ver;
 	if (ret == 0) {
-		if (obj_auxi->map_ver_reply < shard_auxi->map_ver)
-			obj_auxi->map_ver_reply = shard_auxi->map_ver;
 		if (obj_req_is_ec_cond_fetch(obj_auxi)) {
 			iter_arg->cond_fetch_exist = true;
 			if (obj_auxi->result == -DER_NONEXIST)

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1224,6 +1224,7 @@ agg_process_partial_stripe(struct ec_agg_entry *entry)
 				    entry->ae_cur_stripe.as_stripenum,
 				    &full_cell_cnt);
 
+	has_old_replicas = true; /* XXX force full recalculation */
 	if (full_cell_cnt >= k / 2 || cell_cnt == k || has_old_replicas) {
 		stripe_ud.asu_recalc = true;
 		cell_cnt = full_cell_cnt;

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -132,7 +132,7 @@ struct ec_agg_param {
 	daos_handle_t		 ap_cont_handle; /* VOS container handle */
 	int			(*ap_yield_func)(void *arg); /* yield function*/
 	void			*ap_yield_arg;   /* yield argument            */
-	struct ds_cont_child	*ap_cont;
+	struct ds_cont_child    *ap_cont;
 	uint32_t		 ap_credits_max; /* # of tight loops to yield */
 	uint32_t		 ap_credits;     /* # of tight loops          */
 	uint32_t		 ap_initialized:1; /* initialized flag */
@@ -787,12 +787,12 @@ agg_update_vos(struct ec_agg_param *agg_param, struct ec_agg_entry *entry,
 {
 	daos_recx_t		 recx = { 0 };
 	daos_epoch_range_t	 epoch_range = { 0 };
-	struct ec_agg_param	*ap;
+	struct ec_agg_param     *ap;
 	uint32_t		 len = ec_age2cs(entry);
 	uint32_t		 pidx = ec_age2pidx(entry);
 	struct daos_csummer	*csummer;
 	struct dcs_iod_csums	*iod_csums = NULL;
-	int			 err;
+	int                      err;
 	int			 rc = 0;
 
 	ap = container_of(entry, struct ec_agg_param, ap_agg_entry);
@@ -838,14 +838,14 @@ agg_update_vos(struct ec_agg_param *agg_param, struct ec_agg_entry *entry,
 		}
 	}
 
-	recx.rx_idx = entry->ae_cur_stripe.as_stripenum * ec_age2ss(entry);
-	recx.rx_nr  = ec_age2ss(entry);
+	recx.rx_idx        = entry->ae_cur_stripe.as_stripenum * ec_age2ss(entry);
+	recx.rx_nr         = ec_age2ss(entry);
 	epoch_range.epr_lo = ap->ap_epr.epr_lo;
 	epoch_range.epr_hi = entry->ae_cur_stripe.as_hi_epoch;
-	err = vos_obj_array_remove(ap->ap_cont_handle, entry->ae_oid, &epoch_range,
-				   &entry->ae_dkey, &entry->ae_akey, &recx);
+	err = vos_obj_array_remove(ap->ap_cont_handle, entry->ae_oid, &epoch_range, &entry->ae_dkey,
+				   &entry->ae_akey, &recx);
 	if (err)
-		D_ERROR("array_remove fails: "DF_RC"\n", DP_RC(err));
+		D_ERROR("array_remove fails: " DF_RC "\n", DP_RC(err));
 	if (!rc && err)
 		rc = err;
 out:
@@ -1282,19 +1282,19 @@ out:
 int
 agg_peer_check_avail(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 {
-	struct pool_target	*targets = NULL;
-	struct daos_shard_loc	*peer_loc;
-	uint32_t		 failed_tgts_cnt = 0;
-	uint32_t		 p = ec_age2p(entry);
-	uint32_t		 pidx = ec_age2pidx(entry);
-	int			 peer;
-	int			 i;
-	int			 rc;
+	struct pool_target    *targets = NULL;
+	struct daos_shard_loc *peer_loc;
+	uint32_t               failed_tgts_cnt = 0;
+	uint32_t               p               = ec_age2p(entry);
+	uint32_t               pidx            = ec_age2pidx(entry);
+	int                    peer;
+	int                    i;
+	int                    rc;
 
-	rc = pool_map_find_failed_tgts(agg_param->ap_pool_info.api_pool->sp_map,
-				       &targets, &failed_tgts_cnt);
+	rc = pool_map_find_failed_tgts(agg_param->ap_pool_info.api_pool->sp_map, &targets,
+				       &failed_tgts_cnt);
 	if (rc) {
-		D_ERROR(DF_UOID" pool_map_find_failed_tgts failed: "DF_RC"\n",
+		D_ERROR(DF_UOID " pool_map_find_failed_tgts failed: " DF_RC "\n",
 			DP_UOID(entry->ae_oid), DP_RC(rc));
 		return rc;
 	}
@@ -1311,9 +1311,11 @@ agg_peer_check_avail(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 			if (peer_loc->sd_rank == DAOS_TGT_IGNORE ||
 			    (targets[i].ta_comp.co_rank == peer_loc->sd_rank &&
 			     targets[i].ta_comp.co_index == peer_loc->sd_tgt_idx)) {
-				D_DEBUG(DB_EPC, DF_UOID" peer parity tgt failed rank %d, "
-					"tgt_idx %d.\n", DP_UOID(entry->ae_oid),
-					peer_loc->sd_rank, peer_loc->sd_tgt_idx);
+				D_DEBUG(DB_EPC,
+					DF_UOID " peer parity tgt failed rank %d, "
+						"tgt_idx %d.\n",
+					DP_UOID(entry->ae_oid), peer_loc->sd_rank,
+					peer_loc->sd_tgt_idx);
 				D_GOTO(out, rc = -DER_UNREACH);
 			}
 		}
@@ -1340,7 +1342,7 @@ agg_peer_update_ult(void *arg)
 	crt_endpoint_t		 tgt_ep = { 0 };
 	unsigned char		*buf = NULL;
 	struct obj_ec_agg_in	*ec_agg_in = NULL;
-	struct obj_ec_agg_out	*ec_agg_out = NULL;
+	struct obj_ec_agg_out   *ec_agg_out = NULL;
 	struct ec_agg_param	*agg_param;
 	crt_bulk_t		 bulk_hdl = NULL;
 	struct daos_csummer	*csummer = NULL;
@@ -1352,8 +1354,8 @@ agg_peer_update_ult(void *arg)
 	uint32_t		 peer, peer_shard;
 	struct dc_object	*obj = NULL;
 	crt_rpc_t		*rpc = NULL;
-	int			 peer_rc = 0, rc = 0;
-	int			 peer_updated = 0;
+	int                      peer_rc = 0, rc = 0;
+	int                      peer_updated = 0;
 	uint64_t		 enqueue_id;
 	uint32_t		 max_delay = 0;
 
@@ -1361,7 +1363,7 @@ agg_peer_update_ult(void *arg)
 		D_GOTO(out, rc = -DER_TIMEDOUT);
 
 	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
-	rc = agg_peer_check_avail(agg_param, entry);
+	rc        = agg_peer_check_avail(agg_param, entry);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -1377,7 +1379,7 @@ agg_peer_update_ult(void *arg)
 		tgt_ep.ep_rank = entry->ae_peer_pshards[peer].sd_rank;
 		tgt_ep.ep_tag = entry->ae_peer_pshards[peer].sd_tgt_idx;
 		enqueue_id = 0;
-	retry:
+retry:
 		rc = obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
 				    DAOS_OBJ_RPC_EC_AGGREGATE, &rpc);
 		if (rc) {
@@ -1427,7 +1429,7 @@ agg_peer_update_ult(void *arg)
 			rc = crt_bulk_create(dss_get_module_info()->dmi_ctx,
 					     &sgl, CRT_BULK_RW, &bulk_hdl);
 			if (rc) {
-				D_ERROR(DF_UOID" pidx %d to peer %d, crt_bulk_create "DF_RC"\n",
+				D_ERROR(DF_UOID " pidx %d to peer %d, crt_bulk_create " DF_RC "\n",
 					DP_UOID(entry->ae_oid), pidx, peer, DP_RC(rc));
 				goto next;
 			}
@@ -1437,7 +1439,7 @@ agg_peer_update_ult(void *arg)
 				rc = daos_csummer_calc_iods(csummer, &sgl, &iod, NULL, 1, false,
 							    NULL, 0, &iod_csums);
 				if (rc) {
-					D_ERROR("daos_csummer_calc_iods failed: "DF_RC"\n",
+					D_ERROR("daos_csummer_calc_iods failed: " DF_RC "\n",
 						DP_RC(rc));
 					goto next;
 				}
@@ -1450,19 +1452,19 @@ agg_peer_update_ult(void *arg)
 
 		rc = dss_rpc_send(rpc);
 		if (rc) {
-			D_ERROR(DF_UOID" pidx %d to parity[%d], dss_rpc_send "
-				DF_RC"\n", DP_UOID(entry->ae_oid), pidx, peer, DP_RC(rc));
+			D_ERROR(DF_UOID " pidx %d to parity[%d], dss_rpc_send " DF_RC "\n",
+				DP_UOID(entry->ae_oid), pidx, peer, DP_RC(rc));
 		} else {
 			crt_req_get_timeout(rpc, &max_delay);
 			ec_agg_out = crt_reply_get(rpc);
-			rc = ec_agg_out->ea_status;
+			rc         = ec_agg_out->ea_status;
 			enqueue_id = ec_agg_out->ea_comm_out.req_out_enqueue_id;
 			D_CDEBUG(rc == 0, DB_TRACE, DLOG_ERR,
-				 "update parity[%d] to %d:%d, status = "DF_RC"\n",
-				 peer, tgt_ep.ep_rank, tgt_ep.ep_tag, DP_RC(rc));
+				 "update parity[%d] to %d:%d, status = " DF_RC "\n", peer,
+				 tgt_ep.ep_rank, tgt_ep.ep_tag, DP_RC(rc));
 			peer_updated += rc == 0;
 		}
-	next:
+next:
 		if (bulk_hdl)
 			crt_bulk_free(bulk_hdl);
 		if (rpc)
@@ -1470,7 +1472,7 @@ agg_peer_update_ult(void *arg)
 		if (iod_csums != NULL)
 			daos_csummer_free_ic(csummer, &iod_csums);
 		rpc = NULL;
-		bulk_hdl = NULL;
+		bulk_hdl  = NULL;
 		iod_csums = NULL;
 		if (rc == -DER_OVERLOAD_RETRY) {
 			dss_sleep(daos_rpc_rand_delay(max_delay) << 10);
@@ -1495,12 +1497,11 @@ out:
 static int
 agg_peer_update(struct ec_agg_entry *entry, bool write_parity)
 {
-	struct ec_agg_stripe_ud	 stripe_ud = { 0 };
+	struct ec_agg_stripe_ud  stripe_ud = {0};
 	int			*status;
-	int			 tid, rc = 0;
+	int                      tid, rc = 0;
 
-	D_ASSERT(!write_parity ||
-		 entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf);
+	D_ASSERT(!write_parity || entry->ae_sgl.sg_iovs[AGG_IOV_PARITY].iov_buf);
 
 	rc = agg_get_obj_handle(entry, false);
 	if (rc) {
@@ -1541,7 +1542,7 @@ agg_process_holes_ult(void *arg)
 	struct ec_agg_stripe_ud	*stripe_ud = (struct ec_agg_stripe_ud *)arg;
 	daos_iod_t		*iod = &stripe_ud->asu_iod;
 	struct ec_agg_entry	*entry = stripe_ud->asu_agg_entry;
-	struct ec_agg_extent	*agg_extent;
+	struct ec_agg_extent    *agg_extent;
 	struct ec_agg_param	*agg_param;
 	struct obj_ec_rep_in	*ec_rep_in = NULL;
 	struct obj_ec_rep_out	*ec_rep_out = NULL;
@@ -1556,11 +1557,11 @@ agg_process_holes_ult(void *arg)
 					k * len;
 	uint64_t		 last_ext_end = 0;
 	uint64_t		 ext_cnt = 0;
-	uint64_t		 ext_tot_len = 0;
+	uint64_t                 ext_tot_len  = 0;
 	uint32_t		 pidx = ec_age2pidx(entry);
 	uint32_t		 peer;
-	int			 rc = 0, peer_rc = 0;
-	int			 peer_updated = 0;
+	int                      rc = 0, peer_rc = 0;
+	int                      peer_updated = 0;
 	uint32_t		 max_delay = 0;
 	uint64_t		 enqueue_id;
 
@@ -1575,8 +1576,8 @@ agg_process_holes_ult(void *arg)
 			stripe_ud->asu_valid_hole = true;
 		if (agg_extent->ae_recx.rx_idx - ss > last_ext_end) {
 			stripe_ud->asu_recxs[ext_cnt].rx_idx = ss + last_ext_end;
-			stripe_ud->asu_recxs[ext_cnt].rx_nr = agg_extent->ae_recx.rx_idx -
-							      ss - last_ext_end;
+			stripe_ud->asu_recxs[ext_cnt].rx_nr =
+			    agg_extent->ae_recx.rx_idx - ss - last_ext_end;
 			ext_tot_len += stripe_ud->asu_recxs[ext_cnt++].rx_nr;
 		}
 		last_ext_end = agg_extent->ae_recx.rx_idx +
@@ -1589,7 +1590,7 @@ agg_process_holes_ult(void *arg)
 		goto out;
 
 	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
-	rc = agg_peer_check_avail(agg_param, entry);
+	rc        = agg_peer_check_avail(agg_param, entry);
 	if (rc != 0)
 		goto out;
 
@@ -1654,7 +1655,7 @@ agg_process_holes_ult(void *arg)
 			continue;
 
 		enqueue_id = 0;
-	retry:
+retry:
 		D_ASSERT(entry->ae_peer_pshards[peer].sd_rank != DAOS_TGT_IGNORE);
 		tgt_ep.ep_rank = entry->ae_peer_pshards[peer].sd_rank;
 		tgt_ep.ep_tag = entry->ae_peer_pshards[peer].sd_tgt_idx;
@@ -1696,10 +1697,10 @@ agg_process_holes_ult(void *arg)
 		} else {
 			crt_req_get_timeout(rpc, &max_delay);
 			ec_rep_out = crt_reply_get(rpc);
-			rc = ec_rep_out->er_status;
+			rc         = ec_rep_out->er_status;
 			enqueue_id = ec_rep_out->er_comm_out.req_out_enqueue_id;
 			D_CDEBUG(rc == 0, DB_TRACE, DLOG_ERR,
-				 DF_UOID" parity[%d] er_status = "DF_RC"\n",
+				 DF_UOID " parity[%d] er_status = " DF_RC "\n",
 				 DP_UOID(entry->ae_oid), peer, DP_RC(rc));
 			peer_updated += rc == 0;
 		}
@@ -1842,9 +1843,9 @@ agg_process_stripe(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 	/* avoid race between EC aggregation and rebuild scanner */
 	agg_param->ap_cont->sc_ec_agg_updates++;
 	if (ds_pool_is_rebuilding(agg_param->ap_cont->sc_pool->spc_pool)) {
-		D_DEBUG(DB_EPC, DF_UOID" abort as rebuild started\n", DP_UOID(entry->ae_oid));
+		D_DEBUG(DB_EPC, DF_UOID " abort as rebuild started\n", DP_UOID(entry->ae_oid));
 		update_vos = false;
-		rc = -1;
+		rc         = -1;
 		goto out;
 	}
 
@@ -2633,7 +2634,7 @@ ec_agg_param_init(struct ds_cont_child *cont, struct agg_param *param)
 	uuid_copy(info->api_cont_uuid, cont->sc_uuid);
 	info->api_pool = cont->sc_pool->spc_pool;
 
-	agg_param->ap_cont		= cont;
+	agg_param->ap_cont              = cont;
 	agg_param->ap_cont_handle	= cont->sc_hdl;
 	agg_param->ap_yield_func	= agg_rate_ctl;
 	agg_param->ap_yield_arg		= param;

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -146,7 +146,7 @@ struct ec_agg_stripe_ud {
 	daos_recx_t		*asu_recxs;     /* For re-replicate      */
 	unsigned int		 asu_cell_cnt;  /* Count of cells        */
 	bool			 asu_recalc;    /* Should recalc parity  */
-	bool			 asu_write_par; /* Should write parity   */
+	bool                     asu_write_par; /* Should write parity   */
 	daos_iod_t		 asu_iod;
 	d_iov_t			 asu_csum_iov;
 	struct dcs_iod_csums	*asu_iod_csums; /* iod csums */
@@ -1381,14 +1381,14 @@ agg_peer_update_ult(void *arg)
 	iod.iod_size = entry->ae_rsize;
 	obj = obj_hdl2ptr(entry->ae_obj_hdl);
 	for (peer = 0; peer < p; peer++) {
-		uint64_t	enqueue_id = 0;
-		bool		overloaded;
+		uint64_t enqueue_id = 0;
+		bool     overloaded;
 
 		if (peer == pidx)
 			continue;
 		D_ASSERT(entry->ae_peer_pshards[peer].sd_rank != DAOS_TGT_IGNORE);
 		tgt_ep.ep_rank = entry->ae_peer_pshards[peer].sd_rank;
-		tgt_ep.ep_tag = entry->ae_peer_pshards[peer].sd_tgt_idx;
+		tgt_ep.ep_tag  = entry->ae_peer_pshards[peer].sd_tgt_idx;
 retry:
 		overloaded = false;
 		rc = obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
@@ -1577,7 +1577,7 @@ agg_process_holes_ult(void *arg)
 	uint32_t		 peer;
 	int                      rc = 0, peer_rc = 0;
 	int                      peer_updated = 0;
-	uint32_t		 max_delay = 0;
+	uint32_t                 max_delay    = 0;
 
 	stripe_ud->asu_valid_hole = false;
 	/* Process extent list to find what to re-replicate -- build recx array
@@ -1663,9 +1663,9 @@ agg_process_holes_ult(void *arg)
 
 	/* Invoke peer re-replicate */
 	for (peer = 0; peer < p; peer++) {
-		uint64_t	enqueue_id = 0;
-		uint32_t	peer_shard;
-		bool		overloaded;
+		uint64_t enqueue_id = 0;
+		uint32_t peer_shard;
+		bool     overloaded;
 
 		if (pidx == peer)
 			continue;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2653,7 +2653,7 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 		if (rc)
 			D_ERROR(DF_UOID " bio_iod_post failed: " DF_RC "\n", DP_UOID(oea->ea_oid),
 				DP_RC(rc));
-	end:
+end:
 		rc = vos_update_end(ioh, ioc.ioc_map_ver, dkey, rc, &ioc.ioc_io_size, NULL);
 		if (rc) {
 			if (rc == -DER_NO_PERM) {

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -3031,7 +3031,8 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 			 */
 			waited++;
 			dss_sleep(5000);
-			D_DEBUG(DB_REBUILD, DF_UOID "retry with %d \n", DP_UOID(arg->oid), rc);
+			D_DEBUG(DB_REBUILD, DF_UOID "retry %d secs with %d \n",
+				DP_UOID(arg->oid), waited * 5, rc);
 			rc = 0;
 			continue;
 		} else if (rc) {

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2865,7 +2865,7 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 	uint32_t		 minimum_nr;
 	uint32_t		 enum_flags;
 	uint32_t		 num;
-	int			 waited = 0;
+	int                       waited = 0;
 	int			 rc = 0;
 
 	D_DEBUG(DB_REBUILD, "migrate obj "DF_UOID" for shard %u eph "
@@ -3031,8 +3031,8 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 			 */
 			waited++;
 			dss_sleep(5000);
-			D_DEBUG(DB_REBUILD, DF_UOID "retry %d secs with %d \n",
-				DP_UOID(arg->oid), waited * 5, rc);
+			D_DEBUG(DB_REBUILD, DF_UOID "retry %d secs with %d \n", DP_UOID(arg->oid),
+				waited * 5, rc);
 			rc = 0;
 			continue;
 		} else if (rc) {

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -3008,14 +3008,6 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 				break;
 			}
 			continue;
-
-		} else if (rc == -DER_FETCH_AGAIN) {
-			waited++;
-			dss_sleep(5000);
-			D_DEBUG(DB_REBUILD,
-				"waited %d seconds for suspending EC aggregation\n", waited * 5);
-			continue;
-
 		} else if (rc && rc != -DER_SHUTDOWN &&
 			   daos_anchor_get_flags(&dkey_anchor) & DIOF_TO_LEADER) {
 			if (rc != -DER_INPROGRESS) {
@@ -3037,6 +3029,8 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 			/* -DER_UPDATE_AGAIN means the remote target does not parse EC
 			 * aggregation yet, so let's retry.
 			 */
+			waited++;
+			dss_sleep(5000);
 			D_DEBUG(DB_REBUILD, DF_UOID "retry with %d \n", DP_UOID(arg->oid), rc);
 			rc = 0;
 			continue;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7306,10 +7306,11 @@ ds_pool_tgt_add_in(uuid_t pool_uuid, struct pool_target_id_list *list)
 }
 
 int
-ds_pool_tgt_finish_rebuild(uuid_t pool_uuid, struct pool_target_id_list *list)
+ds_pool_tgt_finish_rebuild(uuid_t pool_uuid, struct pool_target_id_list *list,
+			   uint32_t *reclaim_ver)
 {
 	return pool_update_map_internal(pool_uuid, MAP_FINISH_REBUILD, false, list,
-					NULL, NULL, NULL, NULL, NULL, NULL);
+					NULL, NULL, NULL, NULL, reclaim_ver, NULL);
 }
 
 int

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7309,8 +7309,8 @@ int
 ds_pool_tgt_finish_rebuild(uuid_t pool_uuid, struct pool_target_id_list *list,
 			   uint32_t *reclaim_ver)
 {
-	return pool_update_map_internal(pool_uuid, MAP_FINISH_REBUILD, false, list,
-					NULL, NULL, NULL, NULL, reclaim_ver, NULL);
+	return pool_update_map_internal(pool_uuid, MAP_FINISH_REBUILD, false, list, NULL, NULL,
+					NULL, NULL, reclaim_ver, NULL);
 }
 
 int

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -217,7 +217,7 @@ struct rebuild_global {
 
 /* Per target structure to track the rebuild status */
 extern struct rebuild_global rebuild_gst;
-extern unsigned int rebuild_wait_ec_pause;
+extern unsigned int          rebuild_wait_ec_pause;
 
 struct rebuild_task {
 	d_list_t			dst_list;

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -217,6 +217,7 @@ struct rebuild_global {
 
 /* Per target structure to track the rebuild status */
 extern struct rebuild_global rebuild_gst;
+extern unsigned int rebuild_wait_ec_pause;
 
 struct rebuild_task {
 	d_list_t			dst_list;

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -1280,6 +1280,7 @@ tls_lookup:
 	}
 
 	rpt->rt_pool->sp_rebuilding++; /* reset in rebuild_tgt_fini */
+	dss_sleep(10 * 1000); /* XXX: time window for EC aggregation to pause */
 
 	rpt_get(rpt);
 	/* step-3: start scan leader */

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -1002,7 +1002,7 @@ rebuild_scanner(void *data)
 	if (child == NULL)
 		D_GOTO(out, rc = -DER_NONEXIST);
 
-	ds_cont_child_wait_ec_agg_pause(child);
+	ds_cont_child_wait_ec_agg_pause(child, rebuild_wait_ec_pause);
 
 	/* There maybe orphan DTX entries after DTX resync, let's cleanup before rebuild scan. */
 	rc = dtx_cleanup_orphan(rpt->rt_pool_uuid, rpt->rt_pool->sp_dtx_resync_version);

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -985,7 +985,7 @@ rebuild_scanner(void *data)
 {
 	struct rebuild_scan_arg		arg = { 0 };
 	struct rebuild_tgt_pool_tracker *rpt = data;
-	struct ds_pool_child		*child = NULL;
+	struct ds_pool_child            *child = NULL;
 	struct rebuild_pool_tls		*tls;
 	vos_iter_param_t		param = { 0 };
 	struct vos_iter_anchors		anchor = { 0 };
@@ -1043,7 +1043,6 @@ rebuild_scanner(void *data)
 			D_GOTO(out, rc);
 		}
 	}
-
 
 	param.ip_hdl = child->spc_hdl;
 	param.ip_flags = VOS_IT_FOR_MIGRATION;

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1472,8 +1472,8 @@ retry_rebuild_task(struct rebuild_task *task, int error, daos_rebuild_opc_t *opc
 
 static int
 rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
-			       struct rebuild_global_pool_tracker *rgt,
-			       uint32_t obj_reclaim_ver, int ret)
+			       struct rebuild_global_pool_tracker *rgt, uint32_t obj_reclaim_ver,
+			       int ret)
 {
 	int rc = 0;
 	int rc1;
@@ -1564,8 +1564,8 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 			rgt->rgt_status.rs_errno);
 
 		rc = ds_rebuild_schedule(pool, obj_reclaim_ver, rgt->rgt_reclaim_epoch,
-					 task->dst_new_layout_version,
-					 &task->dst_tgts, RB_OP_RECLAIM, 5);
+					 task->dst_new_layout_version, &task->dst_tgts,
+					 RB_OP_RECLAIM, 5);
 		if (rc != 0)
 			D_ERROR("reschedule reclaim, "DF_UUID" failed: "DF_RC"\n",
 				DP_UUID(task->dst_pool_uuid), DP_RC(rc));
@@ -1598,7 +1598,7 @@ rebuild_task_ult(void *arg)
 	struct rebuild_global_pool_tracker	*rgt = NULL;
 	d_rank_t				myrank;
 	uint64_t				cur_ts = 0;
-	uint32_t				obj_reclaim_ver = 0;
+	uint32_t                                 obj_reclaim_ver = 0;
 	int					rc;
 
 	cur_ts = daos_gettime_coarse();

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -2285,6 +2285,7 @@ rebuild_fini_one(void *arg)
 			rpt->rt_rebuild_fence, dpc->spc_rebuild_fence);
 	}
 
+	dpc->spc_remote_scan = 0;
 	ds_pool_child_put(dpc);
 
 	return 0;

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -25,6 +25,7 @@
 
 #define RBLD_CHECK_INTV	 2000	/* milliseconds interval to check*/
 struct rebuild_global	rebuild_gst;
+unsigned int		rebuild_wait_ec_pause = 0;
 
 struct pool_map *
 rebuild_pool_map_get(struct ds_pool *pool)
@@ -2740,6 +2741,10 @@ static int
 init(void)
 {
 	int rc;
+
+	rc = d_getenv_uint(REBUILD_WAIT_EC_PAUSE_ENV, &rebuild_wait_ec_pause);
+	if (rc == 0)
+		D_DEBUG(DB_REBUILD, "Set REBUILD_WAIT_EC_PAUSE to %u\n", rebuild_wait_ec_pause);
 
 	D_INIT_LIST_HEAD(&rebuild_gst.rg_tgt_tracker_list);
 	D_INIT_LIST_HEAD(&rebuild_gst.rg_global_tracker_list);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1564,6 +1564,8 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 			DP_UUID(task->dst_pool_uuid), task->dst_rebuild_op, task->dst_map_ver,
 			rgt->rgt_status.rs_errno);
 
+		/* NB: if pool map remains unchanged, ds_pool_tgt_finish_rebuild sets it to 0 */
+		obj_reclaim_ver = obj_reclaim_ver > 0 ? obj_reclaim_ver : task->dst_map_ver;
 		rc = ds_rebuild_schedule(pool, obj_reclaim_ver, rgt->rgt_reclaim_epoch,
 					 task->dst_new_layout_version, &task->dst_tgts,
 					 RB_OP_RECLAIM, 5);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1566,9 +1566,9 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 
 		/* NB: if pool map remains unchanged, ds_pool_tgt_finish_rebuild sets it to 0 */
 		obj_reclaim_ver = obj_reclaim_ver > 0 ? obj_reclaim_ver : task->dst_map_ver;
-		rc = ds_rebuild_schedule(pool, obj_reclaim_ver, rgt->rgt_reclaim_epoch,
-					 task->dst_new_layout_version, &task->dst_tgts,
-					 RB_OP_RECLAIM, 5);
+		rc              = ds_rebuild_schedule(pool, obj_reclaim_ver, rgt->rgt_reclaim_epoch,
+						      task->dst_new_layout_version, &task->dst_tgts,
+						      RB_OP_RECLAIM, 5);
 		if (rc != 0)
 			D_ERROR("reschedule reclaim, "DF_UUID" failed: "DF_RC"\n",
 				DP_UUID(task->dst_pool_uuid), DP_RC(rc));

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1472,7 +1472,8 @@ retry_rebuild_task(struct rebuild_task *task, int error, daos_rebuild_opc_t *opc
 
 static int
 rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
-			       struct rebuild_global_pool_tracker *rgt, int ret)
+			       struct rebuild_global_pool_tracker *rgt,
+			       uint32_t obj_reclaim_ver, int ret)
 {
 	int rc = 0;
 	int rc1;
@@ -1561,7 +1562,8 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		D_DEBUG(DB_REBUILD, DF_UUID" opc %u/%u, error %d, schedule RECLAIM.\n",
 			DP_UUID(task->dst_pool_uuid), task->dst_rebuild_op, task->dst_map_ver,
 			rgt->rgt_status.rs_errno);
-		rc = ds_rebuild_schedule(pool, task->dst_map_ver, rgt->rgt_reclaim_epoch,
+
+		rc = ds_rebuild_schedule(pool, obj_reclaim_ver, rgt->rgt_reclaim_epoch,
 					 task->dst_new_layout_version,
 					 &task->dst_tgts, RB_OP_RECLAIM, 5);
 		if (rc != 0)
@@ -1596,6 +1598,7 @@ rebuild_task_ult(void *arg)
 	struct rebuild_global_pool_tracker	*rgt = NULL;
 	d_rank_t				myrank;
 	uint64_t				cur_ts = 0;
+	uint32_t				obj_reclaim_ver = 0;
 	int					rc;
 
 	cur_ts = daos_gettime_coarse();
@@ -1724,7 +1727,8 @@ done:
 			goto iv_stop;
 
 		if (task->dst_rebuild_op == RB_OP_REBUILD)
-			rc = ds_pool_tgt_finish_rebuild(pool->sp_uuid, &task->dst_tgts);
+			rc = ds_pool_tgt_finish_rebuild(pool->sp_uuid, &task->dst_tgts,
+							&obj_reclaim_ver);
 		D_INFO("finish rebuild %d of " DF_UUID " "DF_RC"\n",
 		       task->dst_tgts.pti_ids[0].pti_id, DP_UUID(task->dst_pool_uuid), DP_RC(rc));
 	}
@@ -1748,7 +1752,7 @@ iv_stop:
 	}
 
 try_reschedule:
-	rebuild_task_complete_schedule(task, pool, rgt, rc);
+	rebuild_task_complete_schedule(task, pool, rgt, obj_reclaim_ver, rc);
 output:
 	rc = rebuild_notify_ras_end(&task->dst_pool_uuid, task->dst_map_ver,
 				    RB_OP_STR(task->dst_rebuild_op),

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -25,7 +25,7 @@
 
 #define RBLD_CHECK_INTV	 2000	/* milliseconds interval to check*/
 struct rebuild_global	rebuild_gst;
-unsigned int		rebuild_wait_ec_pause = 0;
+unsigned int            rebuild_wait_ec_pause = 0;
 
 struct pool_map *
 rebuild_pool_map_get(struct ds_pool *pool)

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -2285,9 +2285,7 @@ rebuild_fini_one(void *arg)
 			rpt->rt_rebuild_fence, dpc->spc_rebuild_fence);
 	}
 
-	dpc->spc_remote_scan = 0;
 	ds_pool_child_put(dpc);
-
 	return 0;
 }
 
@@ -2302,6 +2300,7 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 
 	D_ASSERT(rpt->rt_pool->sp_rebuilding > 0);
 	rpt->rt_pool->sp_rebuilding--;
+	rpt->rt_pool->sp_rebuild_scan = 0;
 
 	ABT_mutex_lock(rpt->rt_lock);
 	ABT_cond_signal(rpt->rt_global_dtx_wait_cond);

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -436,6 +436,7 @@ class EngineYamlParameters(YamlParameters):
         "common": [
             "D_LOG_FILE_APPEND_PID=1",
             "DAOS_POOL_RF=4",
+            "DAOS_REBUILD_WAIT_EC_PAUSE=1",
             "CRT_EVENT_DELAY=1",
             # pylint: disable-next=fixme
             # FIXME disable space cache since some tests need to verify instant pool space

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2676,7 +2677,9 @@ co_rf_simple(void **state)
 	daos_prop_val_2_co_status(entry->dpe_val, &stat);
 	assert_int_equal(stat.dcs_status, DAOS_PROP_CO_HEALTHY);
 
-	test_set_engine_fail_loc(arg, CRT_NO_RANK, DAOS_REBUILD_DELAY | DAOS_FAIL_ALWAYS);
+	/* Hang the rebuild */
+	test_set_engine_fail_loc(arg, CRT_NO_RANK,
+				 DAOS_REBUILD_TGT_REBUILD_HANG | DAOS_FAIL_ALWAYS);
 	if (arg->myrank == 0) {
 		unsigned int ranks[2];
 
@@ -2698,7 +2701,8 @@ co_rf_simple(void **state)
 	assert_rc_equal(rc, 0);
 
 	/* Hang the rebuild */
-	test_set_engine_fail_loc(arg, CRT_NO_RANK, DAOS_REBUILD_TGT_REBUILD_HANG | DAOS_FAIL_ALWAYS);
+	test_set_engine_fail_loc(arg, CRT_NO_RANK,
+				 DAOS_REBUILD_TGT_REBUILD_HANG | DAOS_FAIL_ALWAYS);
 	/* IO testing */
 	io_oid = daos_test_oid_gen(arg->coh, OC_RP_4G1, 0, 0, arg->myrank);
 	rc = daos_obj_open(arg->coh, io_oid, DAOS_OO_RW, &io_oh, NULL);


### PR DESCRIPTION
- Increment the map_version for reclaim tasks to ensure they operate on the latest
   pool map. Without this, reclaim tasks might act on an outdated pool map, potentially
   causing data corruption.

- Always recalculate parity for partial overwrites, disabling the optimized path to
   ensure data consistency.

- Ignore parity update errors during EC aggregation. This is a temporary workaround
   because DAOS does not use DTX to update parities during EC aggregation.
   Without DTX, parity shards may become inconsistent if an engine failure occurs
   alongside a rebuild. This approach significantly increases the likelihood of parity
   shards remaining consistent when EC aggregation interacts with rebuild operations.

- Standardize the parity target status checks for both full stripe and hole processing
   during EC aggregation.

- Introduce additional barriers to minimize the chances of overlapping EC aggregation
   and rebuild operations.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
