### PR TITLE
DAOS-15635 client: intercept creat() and creat64()

### DIFF
--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -2392,6 +2392,16 @@ new_open_pthread(const char *pathname, int oflags, ...)
 	return rc;
 }
 
+int
+creat(const char *path, mode_t mode)
+{
+	/* https://linux.die.net/man/3/creat */
+	return new_open_libc(path, O_WRONLY | O_CREAT | O_TRUNC, mode);
+}
+
+int
+creat64(const char *path, mode_t mode) __attribute__((alias("creat")));
+
 /* Search a fd in fd hash table. Remove it in case it is found. Also free the fake fd.
  * Return true if fd is found. Return false if fd is not found.
  */


### PR DESCRIPTION
Features: pil4dfs
Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
