### PR TITLE
DAOS-14523 client: intercept renameat()

### DIFF
--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -412,6 +412,8 @@ static int (*next_rmdir)(const char *path);
 
 static int (*next_rename)(const char *old_name, const char *new_name);
 
+static int (*next_renameat)(int olddirfd, const char *oldpath, int newdirfd, const char *newpath);
+
 static char *(*next_getcwd)(char *buf, size_t size);
 
 static int (*libc_unlink)(const char *path);
@@ -478,6 +480,10 @@ static int (*next_execvpe)(const char *filename, char *const argv[], char *const
 static int (*next_fexecve)(int fd, char *const argv[], char *const envp[]);
 
 static pid_t (*next_fork)(void);
+
+static int (*next_fchown)(int fd, uid_t uid, gid_t gid);
+static ssize_t (*next_fgetxattr)(int fd, char *name, void *value, size_t size);
+static int (*next_fsetxattr)(int fd, char *name, void *value, size_t size, int flags);
 
 /* start NOT supported by DAOS */
 static int (*next_posix_fadvise)(int fd, off_t offset, off_t len, int advice);
@@ -1971,6 +1977,15 @@ check_path_with_dirfd(int dirfd, char **full_path_out, const char *rel_path, int
 	int len_str, dirfd_directed;
 
 	*error = 0;
+
+	if (rel_path[0] == '/') {
+		/* an absolute path, dirfd should be ignored */
+		*full_path_out = strdup(rel_path);
+		if (*full_path_out == NULL)
+			goto out_oom;
+		return query_dfs_mount(*full_path_out);
+	}
+
 	*full_path_out = NULL;
 	dirfd_directed = d_get_fd_redirected(dirfd);
 
@@ -5025,6 +5040,53 @@ out_err:
 	return (-1);
 }
 
+int
+renameat(int olddirfd, const char *oldpath, int newdirfd, const char *newpath)
+{
+	int   error = 0;
+	int   rc;
+	char *full_path_old = NULL;
+	char *full_path_new = NULL;
+
+	if (next_renameat == NULL) {
+		next_renameat = dlsym(RTLD_NEXT, "renameat");
+		D_ASSERT(next_renameat != NULL);
+	}
+	if (!d_hook_enabled)
+		return next_renameat(olddirfd, oldpath, newdirfd, newpath);
+
+	if ((oldpath[0] == '/') && (newpath[0] == '/'))
+		/* fd is ignored for absolute path */
+		return rename(oldpath, newpath);
+
+	check_path_with_dirfd(olddirfd, &full_path_old, oldpath, &error);
+	if (error)
+		goto out_err;
+
+	check_path_with_dirfd(newdirfd, &full_path_new, newpath, &error);
+	if (error) {
+		if (full_path_old)
+			free(full_path_old);
+		goto out_err;
+	}
+	rc = rename(full_path_old, full_path_new);
+	/* save errno since free() may affect errno */
+	error = errno;
+	if (full_path_old) {
+		free(full_path_old);
+		errno = error;
+	}
+	if (full_path_new) {
+		free(full_path_new);
+		errno = error;
+	}
+	return rc;
+
+out_err:
+	errno = error;
+	return (-1);
+}
+
 char *
 getcwd(char *buf, size_t size)
 {
@@ -5667,6 +5729,119 @@ fchmodat(int dirfd, const char *path, mode_t mode, int flag)
 out_err:
 	errno = error;
 	return (-1);
+}
+
+int
+fchown(int fd, uid_t uid, gid_t gid)
+{
+	int rc, fd_directed;
+
+	if (next_fchown == NULL) {
+		next_fchown = dlsym(RTLD_NEXT, "fchown");
+		D_ASSERT(next_fchown != NULL);
+	}
+
+	if (!d_hook_enabled)
+		return next_fchown(fd, uid, gid);
+	fd_directed = d_get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
+		return next_fchown(fd, uid, gid);
+
+	if (fd_directed >= (FD_DIR_BASE + MAX_OPENED_DIR)) {
+		errno = EINVAL;
+		return (-1);
+	}
+
+	if (fd_directed >= FD_DIR_BASE)
+		/* Let dfuse handle this case. This function is not commonly used in applications.
+		 * There is no need for further optimization here at this time.
+		 */
+		return chown(dir_list[fd_directed - FD_DIR_BASE]->path, uid, gid);
+
+	/* regular file */
+	rc = dfs_chown(d_file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
+		       drec2obj(d_file_list[fd_directed - FD_FILE_BASE]->parent),
+		       d_file_list[fd_directed - FD_FILE_BASE]->item_name, uid, gid, 0);
+	if (rc) {
+		errno = rc;
+		return (-1);
+	}
+
+	return 0;
+}
+
+ssize_t
+fgetxattr(int fd, char *name, void *value, size_t size)
+{
+	int    rc, fd_directed;
+	size_t buf_size = size;
+
+	if (next_fgetxattr == NULL) {
+		next_fgetxattr = dlsym(RTLD_NEXT, "fgetxattr");
+		D_ASSERT(next_fgetxattr != NULL);
+	}
+
+	if (!d_hook_enabled)
+		return next_fgetxattr(fd, name, value, size);
+	fd_directed = d_get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
+		return next_fgetxattr(fd, name, value, size);
+
+	if (fd_directed >= (FD_DIR_BASE + MAX_OPENED_DIR)) {
+		errno = EINVAL;
+		return (-1);
+	}
+
+	if (fd_directed < FD_DIR_BASE)
+		rc = dfs_getxattr(d_file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
+				  d_file_list[fd_directed - FD_FILE_BASE]->file, name, value,
+				  &buf_size);
+	else
+		rc = dfs_getxattr(dir_list[fd_directed - FD_DIR_BASE]->dfs_mt->dfs,
+				  dir_list[fd_directed - FD_DIR_BASE]->dir, name, value, &buf_size);
+	if (rc) {
+		errno = rc;
+		return (-1);
+	}
+
+	return buf_size;
+}
+
+int
+fsetxattr(int fd, char *name, void *value, size_t size, int flags)
+{
+	int rc, fd_directed;
+
+	if (next_fsetxattr == NULL) {
+		next_fsetxattr = dlsym(RTLD_NEXT, "fsetxattr");
+		D_ASSERT(next_fsetxattr != NULL);
+	}
+
+	if (!d_hook_enabled)
+		return next_fsetxattr(fd, name, value, size, flags);
+	fd_directed = d_get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
+		return next_fsetxattr(fd, name, value, size, flags);
+
+	if (fd_directed >= (FD_DIR_BASE + MAX_OPENED_DIR)) {
+		errno = EINVAL;
+		return (-1);
+	}
+
+	if (fd_directed < FD_DIR_BASE)
+		rc = dfs_setxattr(d_file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
+				  d_file_list[fd_directed - FD_FILE_BASE]->file, name, value, size,
+				  flags);
+	else
+		rc = dfs_setxattr(dir_list[fd_directed - FD_DIR_BASE]->dfs_mt->dfs,
+				  dir_list[fd_directed - FD_DIR_BASE]->dir, name, value, size,
+				  flags);
+	if (rc) {
+		errno = rc;
+		return (-1);
+	}
+
+	return rc;
 }
 
 int


### PR DESCRIPTION
Ignore dirfd for an absolute path in check_path_with_dirfd()
Add utest for renameat()

Features: pil4dfs
Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
