### PR TITLE
DAOS-18040 test: use size percentage for cont/boundary test

### DIFF
--- a/src/tests/ftest/container/boundary.yaml
+++ b/src/tests/ftest/container/boundary.yaml
@@ -28,7 +28,7 @@ server_config:
       storage: auto
 
 pool:
-  scm_size: 200M
+  size: 1%
   label: pool
   set_logmasks: False
 


### PR DESCRIPTION
test_container_boundary creates various numbers of pools with a set size. We can run out of disk space if the drives are not large enough. Set the pool size as a percentage of the total storage available.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_container_boundary

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
