### PR TITLE
DAOS-17358 rebuild: rebuilding test in obj_inflight_io_check

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2457,19 +2457,6 @@ obj_inflight_io_check(struct ds_cont_child *child, uint32_t opc,
 		return -DER_UPDATE_AGAIN;
 	}
 
-	/* All I/O during rebuilding, needs to wait for the rebuild fence to
-	 * be generated (see rebuild_prepare_one()), which will create a boundary
-	 * for rebuild, so the data after boundary(epoch) should not be rebuilt,
-	 * which otherwise might be written duplicately, which might cause
-	 * the failure in VOS.
-	 */
-	if ((flags & ORF_REBUILDING_IO) &&
-	    (is_pool_rebuild_allowed(child->sc_pool->spc_pool, false) &&
-	     child->sc_pool->spc_rebuild_fence == 0)) {
-		D_ERROR("rebuilding "DF_UUID" retry.\n", DP_UUID(child->sc_pool->spc_uuid));
-		return -DER_UPDATE_AGAIN;
-	}
-
 	return 0;
 }
 


### PR DESCRIPTION
This change removes the check of incoming client IO with the ORF_REBUILDING_IO flag set.

Before the change, the intent of the check was to temporarily disallow such IO while a rebuild was starting, when the PS leader engine first distributes a fence / epoch value to all engines. The check caused the IO to get an error -DER_UPDATE_AGAIN, causing the client to retry.

With forthcoming features like interactive/explicit rebuild control, the rebuild *stop* case is negatively affected by this test, causing all subsequent client IO after rebuild stops to block indefinitely, until the rebuild is restarted by the administrator.

Other intermittent test failures, unrelated to the new feature, are also being seen. Discussion with other developers have suggested that this test in the engine code is not required.

Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
