### PR TITLE
DAOS-18103: container: fix compatibility for newer clients with older…

### DIFF
--- a/src/client/pydaos/raw/daos_cref.py
+++ b/src/client/pydaos/raw/daos_cref.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -51,7 +52,8 @@ class RebuildStatus(ctypes.Structure):
                 ("rs_seconds", ctypes.c_uint32),
                 ("rs_errno", ctypes.c_uint32),
                 ("rs_state", ctypes.c_uint32),
-                ("rs_padding32", ctypes.c_uint32),
+                ("rs_max_supported_layout_ver", ctypes.c_uint16),
+                ("rs_padding16", ctypes.c_uint16),
                 ("rs_fail_rank", ctypes.c_uint32),
                 ("rs_toberb_obj_nr", ctypes.c_uint64),
                 ("rs_obj_nr", ctypes.c_uint64),

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -216,8 +216,8 @@ daos_prop_has_entry(daos_prop_t *prop, uint32_t entry_type)
  * The newly allocated prop is expected to be freed by the cont create callback.
  */
 static int
-dup_cont_create_props(daos_handle_t poh, daos_prop_t **prop_out,
-		      daos_prop_t *prop_in)
+dup_cont_create_props(daos_handle_t poh, daos_prop_t **prop_out, daos_prop_t *prop_in,
+		      uint32_t co_ver)
 {
 	char				*owner = NULL;
 	char				*owner_grp = NULL;
@@ -227,8 +227,7 @@ dup_cont_create_props(daos_handle_t poh, daos_prop_t **prop_out,
 	uint32_t			entries;
 	int				rc = 0;
 	uid_t				uid = geteuid();
-	gid_t				gid = getegid();
-	uint32_t                         co_ver = 0;
+	gid_t                            gid = getegid();
 
 	entries = (prop_in == NULL) ? 0 : prop_in->dpp_nr;
 
@@ -264,8 +263,10 @@ dup_cont_create_props(daos_handle_t poh, daos_prop_t **prop_out,
 		entries++;
 	}
 	if (!daos_prop_has_entry(prop_in, DAOS_PROP_CO_OBJ_VERSION)) {
-		co_ver = DAOS_POOL_OBJ_VERSION_2;
-		entries++;
+		if (co_ver >= DAOS_POOL_OBJ_VERSION_2)
+			entries++;
+		else /* don't specify version if server is old */
+			co_ver = 0;
 	}
 
 	if (!daos_prop_has_entry(prop_in, DAOS_PROP_CO_ROOTS)) {
@@ -389,7 +390,8 @@ dc_cont_create(tse_task_t *task)
 		D_GOTO(err_task, rc = -DER_NO_HDL);
 
 	/** duplicate properties and add extra ones (e.g. ownership) */
-	rc = dup_cont_create_props(args->poh, &rpc_prop, args->prop);
+	rc = dup_cont_create_props(args->poh, &rpc_prop, args->prop,
+				   pool->dp_max_supported_layout_ver);
 	if (rc != 0)
 		D_GOTO(err_pool, rc);
 
@@ -1047,7 +1049,9 @@ dc_cont_open(tse_task_t *task)
 		if (tpriv->cont == NULL)
 			D_GOTO(err_pool, rc = -DER_NOMEM);
 		uuid_generate(tpriv->cont->dc_cont_hdl);
-		tpriv->cont->dc_capas = args->flags | DAOS_COO_NEW_LAYOUT;
+		tpriv->cont->dc_capas = args->flags;
+		if (pool->dp_max_supported_layout_ver >= DAOS_POOL_OBJ_VERSION_2)
+			tpriv->cont->dc_capas |= DAOS_COO_NEW_LAYOUT;
 	}
 
 	D_DEBUG(DB_MD, DF_UUID ":%s: opening: hdl=" DF_UUIDF " flags=%x\n", DP_UUID(pool->dp_pool),

--- a/src/include/daos/pool.h
+++ b/src/include/daos/pool.h
@@ -34,6 +34,7 @@
 /** pool query request bits */
 #define DAOS_PO_QUERY_SPACE			(1ULL << 0)
 #define DAOS_PO_QUERY_REBUILD_STATUS		(1ULL << 1)
+#define DAOS_PO_QUERY_REBULD_MAX_LAYOUT_VER     (1ULL << 2)
 #define PROP_BIT_START				16
 #define DAOS_PO_QUERY_PROP_BIT_START		PROP_BIT_START
 #define DAOS_PO_QUERY_PROP_LABEL		(1ULL << (PROP_BIT_START + 0))
@@ -136,6 +137,8 @@ struct dc_pool {
 
 	/* pool redunc factor */
 	uint32_t		dp_rf;
+	/* Maximum supported layout version */
+	uint16_t                dp_max_supported_layout_ver;
 };
 
 static inline unsigned int

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2020-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -121,8 +122,10 @@ struct daos_rebuild_status {
 		int32_t		rs_state;
 		int32_t		rs_done;
 	};
+	/** Maximum supported layout version */
+	uint16_t                rs_max_supported_layout_ver;
 	/** padding of rebuild status */
-	int32_t			rs_padding32;
+	int16_t                 rs_padding16;
 
 	/** Failure on which rank */
 	int32_t			rs_fail_rank;
@@ -164,6 +167,8 @@ enum daos_pool_info_bit {
 	DPI_ENGINES_DISABLED = 1ULL << 3,
 	/** true to include (in \a ranks) engines marked DEAD by SWIM. */
 	DPI_ENGINES_DEAD = 1ULL << 4,
+	/** true to query pool's maximum supported rebuild layout version */
+	DPI_REBUILD_MAX_LAYOUT_VER = 1ULL << 5,
 	/** query all above optional info */
 	DPI_ALL = -1,
 };

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1337,7 +1337,8 @@ out_task:
 struct dc_pool_glob {
 	/* magic number, DC_POOL_GLOB_MAGIC */
 	uint32_t	dpg_magic;
-	uint32_t	dpg_padding;
+	uint16_t        dpg_max_supported_layout_ver;
+	uint16_t        dpg_padding;
 	/* pool UUID, pool handle UUID, and capas */
 	uuid_t		dpg_pool;
 	uuid_t		dpg_pool_hdl;
@@ -1392,6 +1393,7 @@ swap_pool_glob(struct dc_pool_glob *pool_glob)
 
 	D_SWAP32S(&pool_glob->dpg_magic);
 	/* skip pool_glob->dpg_padding */
+	D_SWAP16S(&pool_glob->dpg_max_supported_layout_ver);
 	/* skip pool_glob->dpg_pool (uuid_t) */
 	/* skip pool_glob->dpg_pool_hdl (uuid_t) */
 	D_SWAP64S(&pool_glob->dpg_capas);
@@ -1459,6 +1461,7 @@ dc_pool_l2g(daos_handle_t poh, d_iov_t *glob)
 	/* init pool global handle */
 	pool_glob = (struct dc_pool_glob *)glob->iov_buf;
 	pool_glob->dpg_magic = DC_POOL_GLOB_MAGIC;
+	pool_glob->dpg_max_supported_layout_ver = pool->dp_max_supported_layout_ver;
 	uuid_copy(pool_glob->dpg_pool, pool->dp_pool);
 	uuid_copy(pool_glob->dpg_pool_hdl, pool->dp_pool_hdl);
 	pool_glob->dpg_capas = pool->dp_capas;
@@ -1529,6 +1532,7 @@ dc_pool_g2l(struct dc_pool_glob *pool_glob, size_t len, daos_handle_t *poh)
 	if (pool == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
+	pool->dp_max_supported_layout_ver = pool_glob->dpg_max_supported_layout_ver;
 	uuid_copy(pool->dp_pool, pool_glob->dpg_pool);
 	uuid_copy(pool->dp_pool_hdl, pool_glob->dpg_pool_hdl);
 	pool->dp_capas = pool_glob->dpg_capas;

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -929,8 +929,8 @@ pool_connect_cp(tse_task_t *task, void *data)
 
 	rs = &pco->pco_rebuild_st;
 	rc = process_query_reply(tpriv->pool, map_buf, pco->pco_op.po_map_version,
-				 pco->pco_op.po_hint.sh_rank, &pco->pco_space, rs,
-				 NULL /* tgts */, info, NULL, NULL, true);
+				 pco->pco_op.po_hint.sh_rank, &pco->pco_space, rs, NULL /* tgts */,
+				 info, NULL, NULL, true);
 	tpriv->pool->dp_max_supported_layout_ver = rs->rs_max_supported_layout_ver
 						       ? rs->rs_max_supported_layout_ver
 						       : DAOS_POOL_OBJ_VERSION_1;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4202,6 +4202,8 @@ pool_connect_handler(crt_rpc_t *rpc, int handler_version)
 		if (rc != 0)
 			D_GOTO(out_svc, rc);
 	}
+	if (query_bits & DAOS_PO_QUERY_REBULD_MAX_LAYOUT_VER)
+		out->pco_rebuild_st.rs_max_supported_layout_ver = DAOS_POOL_OBJ_VERSION;
 
 	rc = rdb_tx_begin(svc->ps_rsvc.s_db, svc->ps_rsvc.s_term, &tx);
 	if (rc != 0)

--- a/src/rebuild/README.md
+++ b/src/rebuild/README.md
@@ -204,8 +204,10 @@ struct daos_rebuild_status {
 		int32_t			rs_done;
 	};
 
-	/* padding of rebuild status */
-	int32_t			rs_padding32;
+	/** Maximum supported layout version */
+	uint16_t                rs_max_supported_layout_ver;
+	/** padding of rebuild status */
+	int16_t			rs_padding16;
 
 	/* Failure on which rank */
 	int32_t			rs_fail_rank;

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -961,7 +961,7 @@ class TestPool(TestDaosApiBase):
         return False
 
     def check_rebuild_status(self, rs_version=None, rs_seconds=None,
-                             rs_errno=None, rs_state=None, rs_padding32=None,
+                             rs_errno=None, rs_state=None, rs_padding16=None,
                              rs_fail_rank=None, rs_toberb_obj_nr=None,
                              rs_obj_nr=None, rs_rec_nr=None, rs_size=None):
         # pylint: disable=unused-argument
@@ -978,7 +978,7 @@ class TestPool(TestDaosApiBase):
             rs_seconds (int, optional): rebuild seconds. Defaults to None.
             rs_errno (int, optional): rebuild error number. Defaults to None.
             rs_state (int, optional): rebuild state flag. Defaults to None.
-            rs_padding32 (int, optional): padding. Defaults to None.
+            rs_padding16 (int, optional): padding. Defaults to None.
             rs_fail_rank (int, optional): rebuild fail target. Defaults to None.
             rs_toberb_obj_nr (int, optional): number of objects to be rebuilt.
                 Defaults to None.


### PR DESCRIPTION
… servers

Now the pool connection will return the server's maximum supported layout version, allowing the client to determine which version to use for container creation/open.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
