### PR TITLE
DAOS-17962 object: fix a memleak in EC data recovery

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -2056,8 +2056,7 @@ obj_ec_parity_check(struct obj_reasb_req *reasb_req,
 	D_MUTEX_LOCK(&reasb_req->orr_mutex);
 	parity_lists = reasb_req->orr_parity_lists;
 	if (parity_lists == NULL) {
-		reasb_req->orr_parity_lists =
-			daos_recx_ep_lists_dup(recx_lists, nr);
+		reasb_req->orr_parity_lists   = daos_recx_ep_lists_dup(recx_lists, nr);
 		reasb_req->orr_parity_list_nr = nr;
 		parity_lists = reasb_req->orr_parity_lists;
 		if (parity_lists == NULL)
@@ -2131,7 +2130,7 @@ obj_ec_fail_info_reset(struct obj_reasb_req *reasb_req)
 			       fail_info->efi_nrecx_lists);
 	fail_info->efi_recx_lists = NULL;
 	fail_info->efi_stripe_lists = NULL;
-	fail_info->efi_nrecx_lists = 0;
+	fail_info->efi_nrecx_lists  = 0;
 	daos_recx_ep_list_free(reasb_req->orr_parity_lists,
 			       reasb_req->orr_parity_list_nr);
 	reasb_req->orr_parity_lists = NULL;
@@ -2546,27 +2545,40 @@ out:
 }
 
 void
+obj_ec_recov_reset(struct obj_reasb_req *reasb_req)
+{
+	struct obj_ec_fail_info *fail_info = reasb_req->orr_fail;
+	int                      i;
+
+	for (i = 0; fail_info != NULL && i < fail_info->efi_recov_ntasks; i++) {
+		if (daos_handle_is_valid(fail_info->efi_recov_tasks[i].ert_th)) {
+			dc_tx_local_close(fail_info->efi_recov_tasks[i].ert_th);
+			fail_info->efi_recov_tasks[i].ert_th = DAOS_HDL_INVAL;
+		}
+	}
+	daos_recx_ep_list_free(reasb_req->orr_parity_lists, reasb_req->orr_parity_list_nr);
+	reasb_req->orr_parity_lists   = NULL;
+	reasb_req->orr_parity_list_nr = 0;
+}
+
+void
 obj_ec_fail_info_free(struct obj_reasb_req *reasb_req)
 {
 	struct obj_ec_fail_info *fail_info = reasb_req->orr_fail;
+
+	obj_ec_recov_reset(reasb_req);
 
 	if (fail_info == NULL || reasb_req->orr_fail_alloc == 0)
 		return;
 
 	obj_ec_recov_task_fini(reasb_req);
 	obj_ec_recov_codec_free(reasb_req);
-	daos_recx_ep_list_free(fail_info->efi_recx_lists,
-			       fail_info->efi_nrecx_lists);
-	daos_recx_ep_list_free(fail_info->efi_stripe_lists,
-			       fail_info->efi_nrecx_lists);
-	daos_recx_ep_list_free(reasb_req->orr_parity_lists,
-			       reasb_req->orr_parity_list_nr);
+	daos_recx_ep_list_free(fail_info->efi_recx_lists, fail_info->efi_nrecx_lists);
+	daos_recx_ep_list_free(fail_info->efi_stripe_lists, fail_info->efi_nrecx_lists);
 	D_FREE(fail_info->efi_tgt_list);
 	D_FREE(fail_info);
 	reasb_req->orr_fail = NULL;
 	reasb_req->orr_fail_alloc = 0;
-	reasb_req->orr_parity_lists = NULL;
-	reasb_req->orr_parity_list_nr = 0;
 }
 
 int

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5042,6 +5042,9 @@ obj_ec_comp_cb(struct obj_auxi_args *obj_auxi)
 
 		daos_obj_fetch_t *args = dc_task_get_args(task);
 
+		/* possibly due to previous EC recovery task failed and do the recovery again */
+		obj_ec_recov_reset(&obj_auxi->reasb_req);
+
 		task->dt_result = 0;
 		obj_bulk_fini(obj_auxi);
 		D_DEBUG(DB_IO, "opc %d init recover task for "DF_OID"\n",

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -1209,5 +1209,7 @@ int
 obj_pl_place(struct pl_map *map, uint16_t layout_ver, struct daos_obj_md *md,
 	     unsigned int mode, struct daos_obj_shard_md *shard_md,
 	     struct pl_obj_layout **layout_pp);
+void
+obj_ec_recov_reset(struct obj_reasb_req *reasb_req);
 
 #endif /* __DAOS_OBJ_INTENRAL_H__ */


### PR DESCRIPTION
EC data recovery possibly due to previous failed EC data recovery, in that case should do some cleanup to avoid memleak.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
