### PR TITLE
DAOS-18110 rebuild: rebuid status query may return wrong status

### DIFF
--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -251,8 +251,8 @@ struct rebuild_pool_tls {
 	uint32_t	rebuild_pool_gen;
 	uint64_t	rebuild_pool_leader_term;
 	int		rebuild_pool_status;
-	unsigned int	rebuild_pool_scanning:1,
-			rebuild_pool_scan_done:1;
+	unsigned int    rebuild_pool_scan_prepping : 1, /* preparing scanner on each target */
+	    rebuild_pool_scan_running              : 1; /* scanner is running */
 };
 
 /* per thread structure to track rebuild status for all pools */

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -124,8 +124,8 @@ rebuild_pool_tls_create(uuid_t pool_uuid, uuid_t poh_uuid, uuid_t coh_uuid,
 	rebuild_pool_tls->rebuild_pool_ver = ver;
 	rebuild_pool_tls->rebuild_pool_gen = gen;
 	uuid_copy(rebuild_pool_tls->rebuild_pool_uuid, pool_uuid);
-	rebuild_pool_tls->rebuild_pool_scanning = 1;
-	rebuild_pool_tls->rebuild_pool_scan_done = 0;
+	rebuild_pool_tls->rebuild_pool_scan_prepping     = 1;
+	rebuild_pool_tls->rebuild_pool_scan_running      = 1;
 	rebuild_pool_tls->rebuild_pool_obj_count = 0;
 	rebuild_pool_tls->rebuild_pool_reclaim_obj_count = 0;
 	rebuild_pool_tls->rebuild_tree_hdl = DAOS_HDL_INVAL;
@@ -428,12 +428,12 @@ dss_rebuild_check_one(void *data)
 	if (pool_tls == NULL)
 		return 0;
 
-	D_DEBUG(DB_REBUILD, "%d scanning %d status: "DF_RC"\n", idx,
-		pool_tls->rebuild_pool_scanning,
+	D_DEBUG(DB_REBUILD, "%d scanning %d/%d status: " DF_RC "\n", idx,
+		pool_tls->rebuild_pool_scan_prepping, pool_tls->rebuild_pool_scan_running,
 		DP_RC(pool_tls->rebuild_pool_status));
 
 	ABT_mutex_lock(status->lock);
-	if (pool_tls->rebuild_pool_scanning)
+	if (pool_tls->rebuild_pool_scan_prepping || pool_tls->rebuild_pool_scan_running)
 		status->scanning = 1;
 	if (pool_tls->rebuild_pool_status != 0 && status->status == 0)
 		status->status = pool_tls->rebuild_pool_status;


### PR DESCRIPTION
The rebuild_scanner() function may be blocked or delayed before it creates any ULTs, for example, while waiting in functions like dtx_cleanup_orphan() or ds_cont_child_wait_ec_agg_pause(). Meanwhile, rebuild_scan_leader() might exit and set tls::rebuild_pool_scanning to false early—before rebuild_scanner() has a chance to create any ULTs. As a result, when rebuild_tgt_query() is called, it returns status::scanning = 0.

This leads rebuild_tgt_status_check_ult() to incorrectly interpret the rebuild process as “DONE,” even though it hasn’t actually started to run actual scann, or created any ULT for object/dkey migration.

To address this issue, rebuild_tgt_query() should also check whether the scanner is still running, not just rely on the scanning flag. This ensures that the rebuild status reflects the actual state of the scanner and avoids premature reporting of completion.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
