### PR TITLE
DAOS-18110 rebuild: rebuid status query may return wrong status

### DIFF
--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -282,8 +282,8 @@ struct rebuild_pool_tls {
 	uint32_t	rebuild_pool_gen;
 	uint64_t	rebuild_pool_leader_term;
 	int		rebuild_pool_status;
-	unsigned int	rebuild_pool_scanning:1,
-			rebuild_pool_scan_done:1;
+	unsigned int    rebuild_pool_scan_prepping : 1, /* preparing scanner on each target */
+	    rebuild_pool_scan_running              : 1; /* scanner is running */
 };
 
 /* per thread structure to track rebuild status for all pools */

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -300,7 +300,7 @@ rebuild_objects_send_ult(void *data)
 	arg.ephs = ephs;
 	arg.punched_ephs = punched_ephs;
 	arg.rpt = rpt;
-	while (!tls->rebuild_pool_scan_done || !dbtree_is_empty(tls->rebuild_tree_hdl)) {
+	while (tls->rebuild_pool_scan_running || !dbtree_is_empty(tls->rebuild_tree_hdl)) {
 		if (rpt->rt_stable_epoch == 0) {
 			dss_sleep(0);
 			continue;
@@ -340,7 +340,7 @@ out:
 }
 
 static int
-rebuild_scan_done(void *data)
+rebuild_scan_prepared(void *data)
 {
 	struct rebuild_tgt_pool_tracker *rpt = data;
 	struct rebuild_pool_tls *tls;
@@ -348,7 +348,7 @@ rebuild_scan_done(void *data)
 	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
 				      rpt->rt_rebuild_gen);
 	if (tls != NULL)
-		tls->rebuild_pool_scanning = 0;
+		tls->rebuild_pool_scan_prepping = 0;
 
 	return 0;
 }
@@ -1056,7 +1056,7 @@ rebuild_scanner(void *data)
 put:
 	ds_pool_child_put(child);
 out:
-	tls->rebuild_pool_scan_done = 1;
+	tls->rebuild_pool_scan_running = 0;
 	if (ult_send != ABT_THREAD_NULL)
 		ABT_thread_free(&ult_send);
 
@@ -1118,8 +1118,9 @@ rebuild_scan_leader(void *data)
 		D_DEBUG(DB_REBUILD, DF_RB "rebuild scan collective done\n", DP_RB_RPT(rpt));
 
 	ABT_mutex_lock(rpt->rt_lock);
-	rc = ds_pool_task_collective(rpt->rt_pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN |
-				     PO_COMP_ST_DOWNOUT, rebuild_scan_done, rpt, 0);
+	rc = ds_pool_task_collective(rpt->rt_pool_uuid,
+				     PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
+				     rebuild_scan_prepared, rpt, 0);
 	ABT_mutex_unlock(rpt->rt_lock);
 	if (rc) {
 		DL_ERROR(rc, DF_RB " send rebuild object list failed", DP_RB_RPT(rpt));

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -125,8 +125,8 @@ rebuild_pool_tls_create(struct rebuild_tgt_pool_tracker *rpt)
 	rebuild_pool_tls->rebuild_pool_ver = rpt->rt_rebuild_ver;
 	rebuild_pool_tls->rebuild_pool_gen = rpt->rt_rebuild_gen;
 	uuid_copy(rebuild_pool_tls->rebuild_pool_uuid, rpt->rt_pool_uuid);
-	rebuild_pool_tls->rebuild_pool_scanning = 1;
-	rebuild_pool_tls->rebuild_pool_scan_done = 0;
+	rebuild_pool_tls->rebuild_pool_scan_prepping     = 1;
+	rebuild_pool_tls->rebuild_pool_scan_running      = 1;
 	rebuild_pool_tls->rebuild_pool_obj_count = 0;
 	rebuild_pool_tls->rebuild_pool_reclaim_obj_count = 0;
 	rebuild_pool_tls->rebuild_tree_hdl = DAOS_HDL_INVAL;
@@ -624,11 +624,12 @@ dss_rebuild_check_one(void *data)
 	if (pool_tls == NULL)
 		return 0;
 
-	D_DEBUG(DB_REBUILD, DF_RB " scanning %d status: " DF_RC "\n", DP_RB_RPT(rpt),
-		pool_tls->rebuild_pool_scanning, DP_RC(pool_tls->rebuild_pool_status));
+	D_DEBUG(DB_REBUILD, DF_RB " scanning %d/%d status: " DF_RC "\n", DP_RB_RPT(rpt),
+		pool_tls->rebuild_pool_scan_prepping, pool_tls->rebuild_pool_scan_running,
+		DP_RC(pool_tls->rebuild_pool_status));
 
 	ABT_mutex_lock(status->lock);
-	if (pool_tls->rebuild_pool_scanning)
+	if (pool_tls->rebuild_pool_scan_prepping || pool_tls->rebuild_pool_scan_running)
 		status->scanning = 1;
 	if (pool_tls->rebuild_pool_status != 0 && status->status == 0)
 		status->status = pool_tls->rebuild_pool_status;

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2676,7 +2677,9 @@ co_rf_simple(void **state)
 	daos_prop_val_2_co_status(entry->dpe_val, &stat);
 	assert_int_equal(stat.dcs_status, DAOS_PROP_CO_HEALTHY);
 
-	test_set_engine_fail_loc(arg, CRT_NO_RANK, DAOS_REBUILD_DELAY | DAOS_FAIL_ALWAYS);
+	/* Hang the rebuild */
+	test_set_engine_fail_loc(arg, CRT_NO_RANK,
+				 DAOS_REBUILD_TGT_REBUILD_HANG | DAOS_FAIL_ALWAYS);
 	if (arg->myrank == 0) {
 		unsigned int ranks[2];
 
@@ -2697,8 +2700,6 @@ co_rf_simple(void **state)
 	rc = daos_cont_close(coh, NULL);
 	assert_rc_equal(rc, 0);
 
-	/* Hang the rebuild */
-	test_set_engine_fail_loc(arg, CRT_NO_RANK, DAOS_REBUILD_TGT_REBUILD_HANG | DAOS_FAIL_ALWAYS);
 	/* IO testing */
 	io_oid = daos_test_oid_gen(arg->coh, OC_RP_4G1, 0, 0, arg->myrank);
 	rc = daos_obj_open(arg->coh, io_oid, DAOS_OO_RW, &io_oh, NULL);
@@ -3107,7 +3108,8 @@ co_redun_lvl(void **state)
 	/* exclude two engined on same node, as redun_lvl set as DAOS_PROP_CO_REDUN_NODE,
 	 * should not cause RF broken.
 	 */
-	test_set_engine_fail_loc(arg, CRT_NO_RANK, DAOS_REBUILD_DELAY | DAOS_FAIL_ALWAYS);
+	test_set_engine_fail_loc(arg, CRT_NO_RANK,
+				 DAOS_REBUILD_TGT_REBUILD_HANG | DAOS_FAIL_ALWAYS);
 	if (arg->myrank == 0) {
 		arg->no_rebuild = 1;
 		rebuild_pools_ranks(&arg, 1, ranks, 2, false);
@@ -3148,7 +3150,6 @@ co_redun_lvl(void **state)
 		assert_rc_equal(rc, -DER_INVAL);
 	}
 
-	test_set_engine_fail_loc(arg, CRT_NO_RANK, DAOS_REBUILD_TGT_REBUILD_HANG | DAOS_FAIL_ALWAYS);
 	print_message("obj update should success before RF broken\n");
 	io_oid = daos_test_oid_gen(arg->coh, OC_EC_2P2G1, 0, 0, arg->myrank);
 	rc = daos_obj_open(arg->coh, io_oid, DAOS_OO_RW, &io_oh, NULL);


### PR DESCRIPTION
The rebuild_scanner() function may be blocked or delayed before it creates any ULTs, for example, while waiting in functions like dtx_cleanup_orphan() or ds_cont_child_wait_ec_agg_pause(). Meanwhile, rebuild_scan_leader() might exit and set tls::rebuild_pool_scanning to false early—before rebuild_scanner() has a chance to create any ULTs. As a result, when rebuild_tgt_query() is called, it returns status::scanning = 0.

This leads rebuild_tgt_status_check_ult() to incorrectly interpret the rebuild process as “DONE,” even though it hasn’t actually started to run actual scann, or created any ULT for object/dkey migration.

To address this issue, rebuild_tgt_query() should also check whether the scanner is still running, not just rely on the scanning flag. This ensures that the rebuild status reflects the actual state of the scanner and avoids premature reporting of completion.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
