### PR TITLE
DAOS-16553 client: intercept ucs_init and memset ucs global variable after fork

### DIFF
--- a/src/client/dfuse/pil4dfs/hook.c
+++ b/src/client/dfuse/pil4dfs/hook.c
@@ -1240,9 +1240,16 @@ query_var_addr_size(const void *ref_func_addr, const char *ref_func_name, const 
 			}
 			num_sym = sections[i].sh_size / sections[i].sh_entsize;
 
+			/* i should be larger than 0 here given sections[i].sh_type == SHT_SYMTAB.
+			 * The range of [i-1, i+2) was set from my experience with several shared
+			 * libraries I have tried so far. In case this range does not work, we
+			 * could simply extend the search to the full range of [0, header->e_shnum).
+			 */
 			for (j = i - 1; j < i + 2; j++) {
-				if (sections[j].sh_type == SHT_STRTAB)
+				if (sections[j].sh_type == SHT_STRTAB) {
 					strtab_offset = (int)(sections[j].sh_offset);
+					break;
+				}
 			}
 
 			for (j = 0; j < num_sym; j++) {

--- a/src/client/dfuse/pil4dfs/hook.c
+++ b/src/client/dfuse/pil4dfs/hook.c
@@ -1,6 +1,7 @@
 /**
  * (C) Copyright 2018-2021 Lei Huang.
  * (C) Copyright 2023-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1182,8 +1183,8 @@ query_all_org_func_addr(void)
 }
 
 int
-query_func_var_addr_size(const void *ref_func_addr, const char *ref_func_name, const char *var_name,
-			 size_t *var_size, char **var_addr)
+query_var_addr_size(const void *ref_func_addr, const char *ref_func_name, const char *var_name,
+		    size_t *var_size, char **var_addr)
 {
 	int         fd, i, j, rc;
 	struct stat file_stat;

--- a/src/client/dfuse/pil4dfs/hook.h
+++ b/src/client/dfuse/pil4dfs/hook.h
@@ -1,6 +1,7 @@
 /**
  * (C) Copyright 2018-2021 Lei Huang.
  * (C) Copyright 2023-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -80,7 +81,7 @@ query_libc_version(void);
  *				otherwise	fail
  */
 int
-query_func_var_addr_size(const void *ref_func_addr, const char *ref_func_name, const char *var_name,
-			 size_t *var_size, char **var_addr);
+query_var_addr_size(const void *ref_func_addr, const char *ref_func_name, const char *var_name,
+		    size_t *var_size, char **var_addr);
 
 #endif

--- a/src/client/dfuse/pil4dfs/hook.h
+++ b/src/client/dfuse/pil4dfs/hook.h
@@ -68,7 +68,7 @@ float
 query_libc_version(void);
 
 /**
- * query the size of a variable and the relative offset of the variable to a reference function
+ * query the size and address of a variable in a loaded shared library with a reference function
  *
  * \param[in]	ref_func_addr	The address of a reference function
  * \param[in]	ref_func_name	The name of a reference function

--- a/src/client/dfuse/pil4dfs/hook.h
+++ b/src/client/dfuse/pil4dfs/hook.h
@@ -66,4 +66,21 @@ query_pil4dfs_path(void);
 float
 query_libc_version(void);
 
+/**
+ * query the size of a variable and the relative offset of the variable to a reference function
+ *
+ * \param[in]	ref_func_addr	The address of a reference function
+ * \param[in]	ref_func_name	The name of a reference function
+ * \param[in]	var_name	The variable name
+ *
+ * \param[out]	var_size	The size of this variable
+ * \param[out]	var_addr	The address of the variable
+ *
+ * \return			0		success
+ *				otherwise	fail
+ */
+int
+query_func_var_addr_size(const void *ref_func_addr, const char *ref_func_name, const char *var_name,
+			 size_t *var_size, char **var_addr);
+
 #endif

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -1095,8 +1095,8 @@ ucs_init(void)
 		next_ucs_init = dlsym(RTLD_NEXT, "ucs_init");
 		D_ASSERT(next_ucs_init != NULL);
 	}
-	rc = query_func_var_addr_size(next_ucs_init, "ucs_init", "ucs_async_thread_global_context",
-				      &ucs_global_var_size, &ucs_global_var_addr);
+	rc = query_var_addr_size(next_ucs_init, "ucs_init", "ucs_async_thread_global_context",
+				 &ucs_global_var_size, &ucs_global_var_addr);
 	if (rc == 0)
 		pthread_atfork(NULL, NULL, reset_ucs_global_variable_after_fork);
 


### PR DESCRIPTION

Features: pil4dfs

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
