### PR TITLE
DAOS-18113 common: don't retry for bad target error

### DIFF
--- a/src/common/rsvc.c
+++ b/src/common/rsvc.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -275,6 +276,10 @@ rsvc_client_complete_rpc(struct rsvc_client *client, const crt_endpoint_t *ep,
 	} else if (rc_crt == -DER_UNREG) {
 		D_DEBUG(DB_MD, "rank %u RPC or protocol version not registered\n",
 			ep->ep_rank);
+		rsvc_client_process_error(client, rc_crt, ep);
+		return RSVC_CLIENT_PROCEED;
+	} else if (rc_crt == -DER_BAD_TARGET) {
+		D_DEBUG(DB_MD, "rank %u RPC to wrong target\n", ep->ep_rank);
 		rsvc_client_process_error(client, rc_crt, ep);
 		return RSVC_CLIENT_PROCEED;
 	} else if (rc_crt != 0) {


### PR DESCRIPTION
If a server is reformatted, clients might have stale applications that try to disconnect pools using stale URIs which might be rejected by the server. The current RSVC retries this error forever which might pollute the server logs.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
