### PR TITLE
DAOS-18159 object: refine EC recovery task process

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5341,7 +5341,10 @@ args_fini:
 			 */
 			obj_rw_csum_destroy(obj, obj_auxi);
 
-			if (daos_handle_is_valid(obj_auxi->th) &&
+			/* for EC recovery fetch task, need not cache the tx as it only fetch from
+			 * committed full-stripe.
+			 */
+			if (daos_handle_is_valid(obj_auxi->th) && !obj_auxi->ec_in_recov &&
 			    !(args->extra_flags & DIOF_CHECK_EXISTENCE) &&
 			    (task->dt_result == 0 || task->dt_result == -DER_NONEXIST))
 				/* Cache transactional read if exist or not. */


### PR DESCRIPTION
    1. EC recovery fetch need not dc_tx_attach as it reads from committed
       existed full-stripe.
    2. refine the fail info cleanup process.

Test-tag: test_daos_ec_io
Test-repeat: 10

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
