### PR TITLE
DAOS-18012 vea: tune the VEA parameter

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -263,6 +263,7 @@ bio_nvme_init_ext(const char *nvme_conf, int numa_node, unsigned int mem_size,
 	bio_chk_cnt_max = DAOS_DMA_CHUNK_CNT_MAX;
 	bio_chk_sz = ((uint64_t)size_mb << 20) >> BIO_DMA_PAGE_SHIFT;
 
+	D_INFO("Revert e9083b0d0c69bd56bd01d0347e35c743fb089a2a\n");
 	d_getenv_bool("DAOS_SCM_RDMA_ENABLED", &bio_scm_rdma);
 	D_INFO("RDMA to SCM is %s\n", bio_scm_rdma ? "enabled" : "disabled");
 

--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -218,35 +218,35 @@ static struct pressure_ratio pressure_gauge[] = {
     {
 	/* free space > 30% */
 	.pr_free     = 30,
-	.pr_gc_ratio = 30,
+	.pr_gc_ratio = 20,
 	.pr_delay    = 4000, /* msecs */
 	.pr_pressure = 1,
     },
     {
 	/* free space > 20% */
 	.pr_free     = 20,
-	.pr_gc_ratio = 45,
+	.pr_gc_ratio = 30,
 	.pr_delay    = 6000, /* msecs */
 	.pr_pressure = 2,
     },
     {
 	/* free space > 10% */
 	.pr_free     = 10,
-	.pr_gc_ratio = 60,
+	.pr_gc_ratio = 40,
 	.pr_delay    = 8000, /* msecs */
 	.pr_pressure = 3,
     },
     {
 	/* free space > 5% */
 	.pr_free     = 5,
-	.pr_gc_ratio = 75,
+	.pr_gc_ratio = 50,
 	.pr_delay    = 10000, /* msecs */
 	.pr_pressure = 4,
     },
     {
 	/* free space <= 5% */
 	.pr_free     = 0,
-	.pr_gc_ratio = 90,
+	.pr_gc_ratio = 60,
 	.pr_delay    = 12000, /* msecs */
 	.pr_pressure = 5,
     },

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -242,9 +242,9 @@ flush_ult(void *arg)
 		} else if (rc) {	/* This pool doesn't have NVMe partition */
 			sleep_ms = 60000;
 		} else if (sched_req_space_check(child->spc_flush_req) == SCHED_SPACE_PRESS_NONE) {
-			sleep_ms = 500;
+			sleep_ms = 5000;
 		} else {
-			sleep_ms = (nr_flushed < nr_flush) ? 50 : 0;
+			sleep_ms = (nr_flushed < nr_flush) ? 1000 : 0;
 		}
 
 		if (dss_ult_exiting(child->spc_flush_req))

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -451,6 +451,7 @@ class EngineYamlParameters(YamlParameters):
             "D_LOG_FILE_APPEND_PID=1",
             "DAOS_POOL_RF=4",
             "CRT_EVENT_DELAY=1",
+            "DAOS_VOS_AGG_GAP=25",
             # pylint: disable-next=fixme
             # FIXME disable space cache since some tests need to verify instant pool space
             # changing, this global setting to individual test setting once in follow-on PR.

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -380,7 +380,7 @@ error:
 	return rc;
 }
 
-#define FLUSH_INTVL 2 /* seconds */
+#define FLUSH_INTVL 5 /* seconds */
 
 static inline bool
 need_aging_flush(struct vea_space_info *vsi, bool force)

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -767,7 +767,7 @@ aggregated_free(struct vea_space_info *vsi, struct vea_free_entry *vfe)
 	return 0;
 }
 
-#define EXPIRE_INTVL            3               /* seconds */
+#define EXPIRE_INTVL            6               /* seconds */
 #define UNMAP_SIZE_THRESH	(1UL << 20)	/* 1MB */
 
 static int

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -767,7 +767,7 @@ aggregated_free(struct vea_space_info *vsi, struct vea_free_entry *vfe)
 	return 0;
 }
 
-#define EXPIRE_INTVL            6               /* seconds */
+#define EXPIRE_INTVL            10              /* seconds */
 #define UNMAP_SIZE_THRESH	(1UL << 20)	/* 1MB */
 
 static int


### PR DESCRIPTION
### WARNING

This PR is a duplicate of the #17011 and is not intended to be merged.
The Goal is to produce some up to date RPMs and test them.

### Description

Change the expire interval of aging extent from 3 to 6 seconds.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
