### PR TITLE
DAOS-18157 container: treat rank as failed if all tgts failed for con…

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1992,7 +1992,7 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 	int                 i;
 	int                 rc;
 
-	rc = map_ranks_init(pool->sp_map, PO_COMP_ST_DOWNOUT | PO_COMP_ST_DOWN, &fail_ranks);
+	rc = map_ranks_failed(pool->sp_map, &fail_ranks);
 	if (rc) {
 		D_ERROR(DF_UUID ": ranks init failed: %d\n", DP_UUID(pool->sp_uuid), rc);
 		return;

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -371,7 +371,8 @@ ds_pool_child_map_refresh_async(struct ds_pool_child *dpc);
 
 int
 map_ranks_init(const struct pool_map *map, unsigned int status, d_rank_list_t *ranks);
-
+int
+map_ranks_failed(const struct pool_map *map, d_rank_list_t *ranks);
 void
 map_ranks_fini(d_rank_list_t *ranks);
 

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -2056,8 +2056,7 @@ obj_ec_parity_check(struct obj_reasb_req *reasb_req,
 	D_MUTEX_LOCK(&reasb_req->orr_mutex);
 	parity_lists = reasb_req->orr_parity_lists;
 	if (parity_lists == NULL) {
-		reasb_req->orr_parity_lists =
-			daos_recx_ep_lists_dup(recx_lists, nr);
+		reasb_req->orr_parity_lists   = daos_recx_ep_lists_dup(recx_lists, nr);
 		reasb_req->orr_parity_list_nr = nr;
 		parity_lists = reasb_req->orr_parity_lists;
 		if (parity_lists == NULL)
@@ -2131,7 +2130,7 @@ obj_ec_fail_info_reset(struct obj_reasb_req *reasb_req)
 			       fail_info->efi_nrecx_lists);
 	fail_info->efi_recx_lists = NULL;
 	fail_info->efi_stripe_lists = NULL;
-	fail_info->efi_nrecx_lists = 0;
+	fail_info->efi_nrecx_lists  = 0;
 	daos_recx_ep_list_free(reasb_req->orr_parity_lists,
 			       reasb_req->orr_parity_list_nr);
 	reasb_req->orr_parity_lists = NULL;
@@ -2546,27 +2545,40 @@ out:
 }
 
 void
+obj_ec_recov_reset(struct obj_reasb_req *reasb_req)
+{
+	struct obj_ec_fail_info *fail_info = reasb_req->orr_fail;
+	int                      i;
+
+	for (i = 0; fail_info != NULL && i < fail_info->efi_recov_ntasks; i++) {
+		if (daos_handle_is_valid(fail_info->efi_recov_tasks[i].ert_th)) {
+			dc_tx_local_close(fail_info->efi_recov_tasks[i].ert_th);
+			fail_info->efi_recov_tasks[i].ert_th = DAOS_HDL_INVAL;
+		}
+	}
+	daos_recx_ep_list_free(reasb_req->orr_parity_lists, reasb_req->orr_parity_list_nr);
+	reasb_req->orr_parity_lists   = NULL;
+	reasb_req->orr_parity_list_nr = 0;
+}
+
+void
 obj_ec_fail_info_free(struct obj_reasb_req *reasb_req)
 {
 	struct obj_ec_fail_info *fail_info = reasb_req->orr_fail;
+
+	obj_ec_recov_reset(reasb_req);
 
 	if (fail_info == NULL || reasb_req->orr_fail_alloc == 0)
 		return;
 
 	obj_ec_recov_task_fini(reasb_req);
 	obj_ec_recov_codec_free(reasb_req);
-	daos_recx_ep_list_free(fail_info->efi_recx_lists,
-			       fail_info->efi_nrecx_lists);
-	daos_recx_ep_list_free(fail_info->efi_stripe_lists,
-			       fail_info->efi_nrecx_lists);
-	daos_recx_ep_list_free(reasb_req->orr_parity_lists,
-			       reasb_req->orr_parity_list_nr);
+	daos_recx_ep_list_free(fail_info->efi_recx_lists, fail_info->efi_nrecx_lists);
+	daos_recx_ep_list_free(fail_info->efi_stripe_lists, fail_info->efi_nrecx_lists);
 	D_FREE(fail_info->efi_tgt_list);
 	D_FREE(fail_info);
 	reasb_req->orr_fail = NULL;
 	reasb_req->orr_fail_alloc = 0;
-	reasb_req->orr_parity_lists = NULL;
-	reasb_req->orr_parity_list_nr = 0;
 }
 
 int

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5042,6 +5042,9 @@ obj_ec_comp_cb(struct obj_auxi_args *obj_auxi)
 
 		daos_obj_fetch_t *args = dc_task_get_args(task);
 
+		/* possibly due to previous EC recovery task failed and do the recovery again */
+		obj_ec_recov_reset(&obj_auxi->reasb_req);
+
 		task->dt_result = 0;
 		obj_bulk_fini(obj_auxi);
 		D_DEBUG(DB_IO, "opc %d init recover task for "DF_OID"\n",

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5338,7 +5338,10 @@ args_fini:
 			 */
 			obj_rw_csum_destroy(obj, obj_auxi);
 
-			if (daos_handle_is_valid(obj_auxi->th) &&
+			/* for EC recovery fetch task, need not cache the tx as it only fetch from
+			 * committed full-stripe.
+			 */
+			if (daos_handle_is_valid(obj_auxi->th) && !obj_auxi->ec_in_recov &&
 			    !(args->extra_flags & DIOF_CHECK_EXISTENCE) &&
 			    (task->dt_result == 0 || task->dt_result == -DER_NONEXIST))
 				/* Cache transactional read if exist or not. */

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -1209,5 +1209,7 @@ int
 obj_pl_place(struct pl_map *map, uint16_t layout_ver, struct daos_obj_md *md,
 	     unsigned int mode, struct daos_obj_shard_md *shard_md,
 	     struct pl_obj_layout **layout_pp);
+void
+obj_ec_recov_reset(struct obj_reasb_req *reasb_req);
 
 #endif /* __DAOS_OBJ_INTENRAL_H__ */

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -57,6 +58,69 @@ map_ranks_init(const struct pool_map *map, unsigned int status, d_rank_list_t *r
 			D_ASSERT(n < ranks->rl_nr);
 			ranks->rl_ranks[n] = domains[i].do_comp.co_rank;
 			n++;
+		}
+	}
+	D_ASSERTF(n == ranks->rl_nr, "%d != %u\n", n, ranks->rl_nr);
+
+	return 0;
+}
+
+static bool
+all_tgts_match(struct pool_domain *rank_dom, unsigned int status)
+{
+	int i;
+
+	for (i = 0; i < rank_dom->do_target_nr; i++) {
+		if ((status & rank_dom->do_targets[i].ta_comp.co_status) == 0)
+			return false;
+	}
+
+	return true;
+}
+
+/* Build failed rank list, treats the rank as DOWN if all its targets are DOWN . */
+int
+map_ranks_failed(const struct pool_map *map, d_rank_list_t *ranks)
+{
+	struct pool_domain *domains = NULL;
+	unsigned int        status  = PO_COMP_ST_DOWNOUT | PO_COMP_ST_DOWN;
+	int                 nranks;
+	int                 n = 0;
+	int                 i;
+	d_rank_t           *rs;
+
+	nranks = pool_map_find_ranks((struct pool_map *)map, PO_COMP_ID_ALL, &domains);
+	if (nranks == 0) {
+		D_ERROR("no nodes in pool map\n");
+		return -DER_IO;
+	}
+
+	for (i = 0; i < nranks; i++) {
+		if ((status & domains[i].do_comp.co_status) || all_tgts_match(&domains[i], status))
+			n++;
+	}
+
+	if (n == 0) {
+		ranks->rl_nr    = 0;
+		ranks->rl_ranks = NULL;
+		return 0;
+	}
+
+	D_ALLOC_ARRAY(rs, n);
+	if (rs == NULL)
+		return -DER_NOMEM;
+
+	ranks->rl_nr    = n;
+	ranks->rl_ranks = rs;
+
+	n = 0;
+	for (i = 0; i < nranks; i++) {
+		if ((status & domains[i].do_comp.co_status) ||
+		    all_tgts_match(&domains[i], status)) {
+			D_ASSERT(n < ranks->rl_nr);
+			ranks->rl_ranks[n] = domains[i].do_comp.co_rank;
+			n++;
+			continue;
 		}
 	}
 	D_ASSERTF(n == ranks->rl_nr, "%d != %u\n", n, ranks->rl_nr);


### PR DESCRIPTION
…t_agg_eph_sync

The “pool exclude” does not set rank’s domain status as DOWN, so in cont_agg_eph_sync() the “map_ranks_init(pool->sp_map, PO_COMP_ST_DOWNOUT | PO_COMP_ST_DOWN, &fail_ranks)” cannot get the excluded ranks and cause the EC aggregation boundary epoch cannot be synced to other engines correctly.
This patch treats rank as failed if all its targets failed to fix it.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
