### PR TITLE
DAOS-18161 object: refine EC aggregation processing

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -2110,7 +2110,8 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 			min_ec_agg_eph = eph_ldr->cte_rdb_ec_agg_eph;
 
 		if (min_ec_agg_eph == eph_ldr->cte_current_ec_agg_eph &&
-		    min_stable_eph == eph_ldr->cte_current_stable_eph)
+		    min_stable_eph == eph_ldr->cte_current_stable_eph &&
+		    eph_ldr->cte_current_ec_agg_eph != 0)
 			continue;
 
 		/**

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2706,10 +2706,6 @@ cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 			       DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
 			       cont->sc_ec_agg_eph_boundary);
 			cont->sc_ec_agg_eph = cont->sc_ec_agg_eph_boundary;
-		} else {
-			D_ASSERTF(cont->sc_ec_agg_eph >= cont->sc_ec_agg_eph_boundary,
-				  "bad sc_ec_agg_eph " DF_X64 " < sc_ec_agg_eph_boundary " DF_X64,
-				  cont->sc_ec_agg_eph, cont->sc_ec_agg_eph_boundary);
 		}
 	} else {
 		D_DEBUG(DB_EPC, DF_CONT ": pause EC aggregation for sc_ec_agg_eph_boundary.\n",
@@ -2807,18 +2803,18 @@ update_hae:
 	if (rc == 0) {
 		cont->sc_ec_agg_eph = max(cont->sc_ec_agg_eph, epr->epr_hi);
 		if (!cont->sc_stopping && cont->sc_query_ec_agg_eph) {
-			uint64_t orig, cur;
+			uint64_t orig, cur, cur_eph;
 
+			cur_eph = min(ec_agg_param->ap_min_unagg_eph, cont->sc_ec_agg_eph);
 			orig = d_hlc2sec(*cont->sc_query_ec_agg_eph);
-			cur = d_hlc2sec(cont->sc_ec_agg_eph);
+			cur     = d_hlc2sec(cur_eph);
 			if (orig && cur > orig && (cur - orig) >= 600)
 				D_WARN(DF_CONT" Sluggish EC boundary bumping: "
 				       ""DF_U64" -> "DF_U64", gap:"DF_U64"\n",
 				       DP_CONT(cont->sc_pool_uuid, cont->sc_uuid),
 				       orig, cur, cur - orig);
 
-			*cont->sc_query_ec_agg_eph = min(ec_agg_param->ap_min_unagg_eph,
-							 cont->sc_ec_agg_eph);
+			*cont->sc_query_ec_agg_eph = cur_eph;
 		}
 	}
 


### PR DESCRIPTION
1. After restart take the sc_ec_agg_eph_boundary as ec aggregation's min epoch to avoid scan from epoch 0.
2. Consume more credits for layout calculate in EC agg.
3. Don't bump sc_ec_agg_eph after it reset during EC agg, to avoid data corruption.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
