### PR TITLE
DAOS-18170 object: more delay before retry obj rpc

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1717,35 +1717,43 @@ dc_obj_layout_refresh(daos_handle_t oh)
 }
 
 uint32_t
-dc_obj_retry_delay(tse_task_t *task, uint32_t opc, int err, uint16_t *retry_cnt,
-		   uint16_t *inprogress_cnt, uint32_t timeout_sec)
+dc_obj_retry_delay(tse_task_t *task, uint32_t opc, int err, uint32_t *retry_cnt,
+		   uint32_t timeout_sec, bool long_delay)
 {
 	uint32_t delay = 0;
 
-	if (err == -DER_INPROGRESS || err == -DER_UPDATE_AGAIN)
-		++(*inprogress_cnt);
-
-	if (++(*retry_cnt) > 1) {
+	/* Randomly delay [1,  max_delay - 5] for DER_OVERLOAD_RETRY case. */
+	if (err == -DER_OVERLOAD_RETRY) {
+		delay = daos_rpc_rand_delay(timeout_sec) << 20;
+	} else if (++(*retry_cnt) > 1) {
 		/* Randomly delay [31 ~ 1023] us if it is not the first retried object RPC. */
 		delay = (d_rand() | ((1 << 5) - 1)) & ((1 << 10) - 1);
 		/* Rebuild is being established on the server side, wait a bit longer */
-		if (err == -DER_UPDATE_AGAIN)
+		if (err == -DER_UPDATE_AGAIN || long_delay) {
 			delay <<= 10;
-		else if (opc == DAOS_OBJ_RPC_COLL_PUNCH)
-			/* 128 times of the delay for collective object RPC. */
-			delay <<= 7;
-		else if (opc == DAOS_OBJ_RPC_CPD)
-			/* 8 times of the delay for compounded RPC. */
-			delay <<= 3;
-		D_DEBUG(DB_IO, "Try to re-sched task %p (%u) for %u/%u times with %u us delay\n",
-			task, opc, *inprogress_cnt, *retry_cnt, delay);
+		} else {
+			switch (opc) {
+			case DAOS_OBJ_RPC_COLL_PUNCH:
+			case DAOS_OBJ_RPC_COLL_QUERY:
+				/* 256 times of the delay for collective object RPC. */
+				delay <<= 8;
+				break;
+			case DAOS_OBJ_RPC_CPD:
+				/* 8 times of the delay for compounded RPC. */
+				delay <<= 3;
+				break;
+			default:
+				break;
+			}
+
+			/* Increase delay after multiple times retry. */
+			if (*retry_cnt >= 5)
+				delay <<= 1;
+		}
 	}
 
-	/*
-	 * Randomly delay [1,  max_delay - 5] for DER_OVERLOAD_RETRY case.
-	 */
-	if (err == -DER_OVERLOAD_RETRY)
-		delay = daos_rpc_rand_delay(timeout_sec) << 20;
+	D_DEBUG(DB_IO, "Try to re-sched task %p (%u) for %u times with %u us delay\n", task, opc,
+		*retry_cnt, delay);
 
 	return delay;
 }
@@ -1755,10 +1763,12 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 	     struct obj_auxi_args *obj_auxi, bool pmap_stale,
 	     bool *io_task_reinited)
 {
-	tse_sched_t	 *sched = tse_task2sched(task);
-	tse_task_t       *pool_task = NULL;
-	int		  result = task->dt_result;
-	int		  rc;
+	tse_sched_t *sched     = tse_task2sched(task);
+	tse_task_t  *pool_task = NULL;
+	uint32_t     delay     = 0;
+	uint32_t     opc       = obj_auxi->opc;
+	int          result    = task->dt_result;
+	int          rc;
 
 	if (pmap_stale) {
 		rc = obj_pool_query_task(sched, obj, 0, &pool_task);
@@ -1767,8 +1777,6 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 	}
 
 	if (obj_auxi->io_retry) {
-		uint32_t delay = 0;
-
 		if (pool_task != NULL) {
 			rc = dc_task_depend(task, 1, &pool_task);
 			if (rc != 0) {
@@ -1778,19 +1786,24 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 			}
 		}
 
+		if (obj_is_modification_opc(opc) && result == -DER_TIMEDOUT)
+			obj_auxi->long_retry_delay = 1;
+		else if (result != -DER_INPROGRESS)
+			obj_auxi->long_retry_delay = 0;
+
 		if (!pmap_stale) {
 			uint32_t now = daos_gettime_coarse();
 
-			delay =
-			    dc_obj_retry_delay(task, obj_auxi->opc, result, &obj_auxi->retry_cnt,
-					       &obj_auxi->inprogress_cnt, obj_auxi->max_delay);
+			delay = dc_obj_retry_delay(task, opc, result, &obj_auxi->retry_cnt,
+						   obj_auxi->max_delay,
+						   obj_auxi->long_retry_delay == 1 ? true : false);
 			if (result == -DER_INPROGRESS &&
-			    ((obj_auxi->retry_warn_ts == 0 && obj_auxi->inprogress_cnt >= 10) ||
+			    ((obj_auxi->retry_warn_ts == 0 && obj_auxi->retry_cnt >= 10) ||
 			     (obj_auxi->retry_warn_ts > 0 && obj_auxi->retry_warn_ts + 10 < now))) {
 				obj_auxi->retry_warn_ts = now;
 				obj_auxi->flags |= ORF_MAYBE_STARVE;
 				D_WARN("The task %p has been retried for %u times, maybe starve\n",
-				       task, obj_auxi->inprogress_cnt);
+				       task, obj_auxi->retry_cnt);
 			}
 		}
 

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -464,40 +464,17 @@ struct obj_auxi_args {
 	 * ec_wait_recov -- obj fetch wait another EC recovery task,
 	 * ec_in_recov -- a EC recovery task
 	 */
-	uint32_t			 io_retry:1,
-					 args_initialized:1,
-					 to_leader:1,
-					 spec_shard:1,
-					 spec_group:1,
-					 req_reasbed:1,
-					 is_ec_obj:1,
-					 csum_retry:1,
-					 csum_report:1,
-					 tx_uncertain:1,
-					 nvme_io_err:1,
-					 no_retry:1,
-					 ec_wait_recov:1,
-					 ec_in_recov:1,
-					 new_shard_tasks:1,
-					 reset_param:1,
-					 force_degraded:1,
-					 shards_scheded:1,
-					 sub_anchors:1,
-					 ec_degrade_fetch:1,
-					 tx_convert:1,
-					 cond_modify:1,
-					 /* conf_fetch split to multiple sub-tasks */
-					 cond_fetch_split:1,
-					 reintegrating:1,
-					 tx_renew:1,
-					 rebuilding:1,
-					 for_migrate:1,
-					 req_dup_sgl:1;
+	uint32_t new_shard_tasks : 1, reset_param : 1, force_degraded : 1, shards_scheded : 1,
+	    io_retry : 1, args_initialized : 1, to_leader : 1, spec_shard : 1, spec_group : 1,
+	    req_reasbed : 1, is_ec_obj : 1, csum_retry : 1, csum_report : 1, tx_uncertain : 1,
+	    nvme_io_err : 1, no_retry : 1, ec_wait_recov : 1, ec_in_recov : 1, rebuilding : 1,
+	    sub_anchors : 1, ec_degrade_fetch : 1, long_retry_delay : 1, cond_fetch_split : 1,
+	    cond_modify : 1, reintegrating : 1, tx_renew : 1, tx_convert : 1, req_dup_sgl : 1,
+	    for_migrate : 1;
 	/* request flags. currently only: ORF_RESEND */
-	uint32_t			 specified_shard;
-	uint32_t			 flags;
-	uint16_t			 retry_cnt;
-	uint16_t			 inprogress_cnt;
+	uint32_t                         specified_shard;
+	uint32_t                         flags;
+	uint32_t                         retry_cnt;
 	/* Last timestamp (in second) when report retry warning message. */
 	uint32_t                         retry_warn_ts;
 	struct obj_req_tgts		 req_tgts;
@@ -925,8 +902,8 @@ void obj_decref(struct dc_object *obj);
 int obj_get_grp_size(struct dc_object *obj);
 struct dc_object *obj_hdl2ptr(daos_handle_t oh);
 uint32_t
-dc_obj_retry_delay(tse_task_t *task, uint32_t opc, int err, uint16_t *retry_cnt,
-		   uint16_t *inprogress_cnt, uint32_t timeout_secs);
+dc_obj_retry_delay(tse_task_t *task, uint32_t opc, int err, uint32_t *retry_cnt,
+		   uint32_t timeout_secs, bool long_delay);
 
 /* handles, pointers for handling I/O */
 struct obj_io_context {

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -101,8 +101,7 @@ struct dc_tx {
 	/** The read requests count */
 	uint32_t		 tx_read_cnt;
 
-	uint16_t		 tx_retry_cnt;
-	uint16_t		 tx_inprogress_cnt;
+	uint32_t                 tx_retry_cnt;
 	/* Last timestamp (in second) when report retry warning message. */
 	uint32_t                 tx_retry_warn_ts;
 	/** Pool map version when trigger first IO. */
@@ -1083,15 +1082,14 @@ dc_tx_commit_cb(tse_task_t *task, void *data)
 	if (rc != -DER_TX_RESTART) {
 		uint32_t now = daos_gettime_coarse();
 
-		delay = dc_obj_retry_delay(task, DAOS_OBJ_RPC_CPD, rc, &tx->tx_retry_cnt,
-					   &tx->tx_inprogress_cnt, 0);
+		delay = dc_obj_retry_delay(task, DAOS_OBJ_RPC_CPD, rc, &tx->tx_retry_cnt, 0, false);
 		if (rc == -DER_INPROGRESS &&
-		    ((tx->tx_retry_warn_ts == 0 && tx->tx_inprogress_cnt >= 10) ||
+		    ((tx->tx_retry_warn_ts == 0 && tx->tx_retry_cnt >= 10) ||
 		     (tx->tx_retry_warn_ts > 0 && tx->tx_retry_warn_ts + 10 < now))) {
 			tx->tx_retry_warn_ts = now;
 			tx->tx_maybe_starve  = 1;
 			D_WARN("The dist TX task %p has been retried for %u times, maybe starve\n",
-			       task, tx->tx_inprogress_cnt);
+			       task, tx->tx_retry_cnt);
 		}
 
 		rc1 = tse_task_reinit_with_delay(task, delay);
@@ -2588,7 +2586,6 @@ dc_tx_restart_begin(struct dc_tx *tx, uint32_t *backoff)
 		 */
 		tx->tx_status = TX_RESTARTING;
 		tx->tx_retry_cnt = 0;
-		tx->tx_inprogress_cnt = 0;
 
 		*backoff = d_backoff_seq_next(&tx->tx_backoff_seq);
 	}

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -5983,13 +5983,14 @@ ds_obj_coll_query_handler(crt_rpc_t *rpc)
 	rc = dtx_leader_end(dlh, ioc.ioc_coc, rc);
 
 out:
-	D_DEBUG(DB_IO, "Handled collective query RPC %p %s forwarding for obj "DF_UOID
-		" on rank %u XS %u/%u epc "DF_X64" pmv %u, with dti "DF_DTI", dct_nr %u, "
-		"forward width %u, forward depth %u\n: "DF_RC"\n", rpc,
-		ocqi->ocqi_tgts.ca_count <= 1 ? "without" : "with", DP_UOID(ocqi->ocqi_oid),
-		myrank, dmi->dmi_xs_id, tgt_id, ocqi->ocqi_epoch, ocqi->ocqi_map_ver,
-		DP_DTI(&ocqi->ocqi_xid), (unsigned int)ocqi->ocqi_tgts.ca_count,
-		ocqi->ocqi_disp_width, ocqi->ocqi_disp_depth, DP_RC(rc));
+	DL_CDEBUG(rc != 0 && rc != -DER_INPROGRESS, DLOG_ERR, DB_IO, rc,
+		  "Handled collective query RPC %p %s forwarding for obj " DF_UOID " on rank %u XS "
+		  "%u/%u epc " DF_X64 " pmv %u, with dti " DF_DTI ", dct_nr %u, forward width %u, "
+		  "forward depth %u",
+		  rpc, ocqi->ocqi_tgts.ca_count <= 1 ? "without" : "with", DP_UOID(ocqi->ocqi_oid),
+		  myrank, dmi->dmi_xs_id, tgt_id, ocqi->ocqi_epoch, ocqi->ocqi_map_ver,
+		  DP_DTI(&ocqi->ocqi_xid), (unsigned int)ocqi->ocqi_tgts.ca_count,
+		  ocqi->ocqi_disp_width, ocqi->ocqi_disp_depth);
 
 	obj_reply_set_status(rpc, rc);
 	obj_reply_map_version_set(rpc, version);


### PR DESCRIPTION
If an update RPC is timeout, it is unnecessary to retry the update RPC immediately. Because the original one maybe blocked on some of targets under some heave load cases. Under such case, the retried RPC will get -DER_INPROGRESS and cause RPC retry again and again. That will further increase server load and make the situation to be worse.

This patch introduces more delay before retrying RPC under such cases. It also add more delay for collective object RPC.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
