### PR TITLE
DAOS-18196 object: use large stack for collective object RPC ULT

### DIFF
--- a/src/dtx/dtx_coll.c
+++ b/src/dtx/dtx_coll.c
@@ -426,7 +426,7 @@ dtx_coll_local_exec(uuid_t po_uuid, uuid_t co_uuid, struct dtx_id *xid, daos_epo
 	coll_args.ca_tgt_bitmap_sz = bitmap_sz;
 	coll_args.ca_tgt_bitmap = bitmap;
 
-	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, DSS_USE_CURRENT_ULT);
+	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, 0);
 	D_CDEBUG(rc < 0, DLOG_ERR, DB_TRACE,
 		 "Locally exec collective DTX PRC %u for "DF_DTI": "DF_RC"\n",
 		 opc, DP_DTI(xid), DP_RC(rc));

--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -92,18 +92,16 @@ dss_collective_reduce_internal(struct dss_coll_ops *ops,
 			       struct dss_coll_args *args, bool create_ult,
 			       unsigned int flags)
 {
-	struct collective_arg		carg;
-	struct dss_coll_stream_args	*stream_args;
-	struct dss_stream_arg_type	*stream;
-	struct aggregator_arg_type	aggregator;
-	struct dss_xstream		*dx;
-	ABT_future			future;
-	int				xs_nr;
-	int				rc;
-	int				tid;
-	int				tgt_id = dss_get_module_info()->dmi_tgt_id;
-	uint32_t			bm_len;
-	bool				self = false;
+	struct dss_coll_stream_args *stream_args;
+	struct dss_stream_arg_type  *stream;
+	struct dss_xstream          *dx;
+	struct collective_arg        carg;
+	struct aggregator_arg_type   aggregator;
+	ABT_future                   future;
+	uint32_t                     bm_len;
+	int                          xs_nr;
+	int                          rc;
+	int                          tid;
 
 	if (ops == NULL || args == NULL || ops->co_func == NULL) {
 		D_DEBUG(DB_MD, "mandatory args missing dss_collective_reduce");
@@ -171,11 +169,6 @@ dss_collective_reduce_internal(struct dss_coll_ops *ops,
 				D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
 				continue;
 			}
-
-			if (tgt_id == tid && flags & DSS_USE_CURRENT_ULT) {
-				self = true;
-				continue;
-			}
 		}
 
 		dx = dss_get_xstream(DSS_MAIN_XS_ID(tid));
@@ -214,12 +207,6 @@ next:
 			rc = ABT_future_set(future, (void *)stream);
 			D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
 		}
-	}
-
-	if (self) {
-		stream = &stream_args->csa_streams[tgt_id];
-		stream->st_coll_args = &carg;
-		collective_func(stream);
 	}
 
 	ABT_future_wait(future);

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -453,11 +453,9 @@ int dss_parameters_set(unsigned int key_id, uint64_t value);
 
 enum dss_ult_flags {
 	/* Periodically created ULTs */
-	DSS_ULT_FL_PERIODIC	= (1 << 0),
+	DSS_ULT_FL_PERIODIC = (1 << 0),
 	/* Use DSS_DEEP_STACK_SZ as the stack size */
-	DSS_ULT_DEEP_STACK	= (1 << 1),
-	/* Use current ULT (instead of creating new one) for the task. */
-	DSS_USE_CURRENT_ULT	= (1 << 2),
+	DSS_ULT_DEEP_STACK = (1 << 1),
 };
 
 int dss_ult_create(void (*func)(void *), void *arg, int xs_type, int tgt_id,

--- a/src/object/srv_coll.c
+++ b/src/object/srv_coll.c
@@ -70,7 +70,7 @@ obj_coll_local(crt_rpc_t *rpc, struct daos_coll_shard *shards, struct dtx_coll_e
 	coll_args.ca_tgt_bitmap = dce->dce_bitmap;
 	coll_args.ca_tgt_bitmap_sz = dce->dce_bitmap_sz;
 
-	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, DSS_USE_CURRENT_ULT);
+	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, DSS_ULT_DEEP_STACK);
 
 out:
 	if (octa.octa_versions != NULL) {


### PR DESCRIPTION
To avoid potential ULT stack overflow.

Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
