### PR TITLE
DAOS-18286 client: Support dfuse startup before DAOS is fully operational

### DIFF
--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2015-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -33,6 +34,13 @@ daos_pool_connect(const char *pool, const char *sys, unsigned int flags,
 	args->pool	= pool;
 	args->grp	= sys;
 	args->flags	= flags;
+	/* Check for retry timeout from environment variable */
+	args->retry_timeout = DAOS_CLI_CONNECT_RETRY_TIMEOUT_DEFAULT;
+	char *retry_env     = NULL;
+	if (d_agetenv_str(&retry_env, "DAOS_CLI_CONNECT_RETRY_TIMEOUT") == 0) {
+		args->retry_timeout = atoi(retry_env);
+		d_freeenv_str(&retry_env);
+	}
 	args->poh	= poh;
 	args->info	= info;
 	uuid_clear(args->uuid);

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -91,6 +91,11 @@ struct dfuse_eq {
 	struct d_slab_type *de_read_slab;
 	struct d_slab_type *de_pre_read_slab;
 	struct d_slab_type *de_write_slab;
+
+	/* Adaptive polling state */
+	uint64_t            de_last_event_time;
+	uint32_t            de_consecutive_empty_polls;
+	uint64_t            de_last_poll_time;
 };
 
 /* Maximum size dfuse expects for read requests, this is not a limit but rather what is expected

--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -13,6 +13,7 @@
 #include <fused/fuse.h>
 #include <fused/fuse_lowlevel.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include <sys/types.h>
 #include <hwloc.h>
@@ -25,6 +26,7 @@
 #include <daos_fs.h>
 #include <daos_api.h>
 #include <daos_uns.h>
+#include <daos/common.h>
 
 #include <gurt/common.h>
 /* Signal handler for SIGCHLD, it doesn't need to do anything, but it's

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -1182,6 +1182,9 @@ daos_anchor_is_zero(daos_anchor_t *anchor)
 /* default debug log file */
 #define DAOS_LOG_DEFAULT	"/tmp/daos.log"
 
+/* default pool connect retry timeout in seconds (20 minutes) */
+#define DAOS_CLI_CONNECT_RETRY_TIMEOUT_DEFAULT 1200
+
 #ifdef NEED_EXPLICIT_BZERO
 /* Secure memory scrub */
 static inline void

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -156,6 +157,8 @@ typedef struct {
 	const char		*grp;
 	/** Connect mode represented by the DAOS_PC_ bits. */
 	unsigned int		 flags;
+	/** Retry timeout in seconds: 0=no retry, -1=indefinite, >0=retry for N seconds */
+	int                      retry_timeout;
 	/** Returned open handle. */
 	daos_handle_t		*poh;
 	/** Optional, returned pool information. */


### PR DESCRIPTION
Users may attempt to start dfuse before the DAOS server is fully initialized
 and ready. This PR adds support for such scenarios in the following cases:

DAOS agent started without cached information: When attach is called but the agent
hasn't cached any server information, it would previously return an error immediately
if servers weren't available.

Cached agent information with connection failures:

Even when the DAOS agent has cached server information,
dc_mgmt_init() may fail due to RPC protocol query failures when servers are unreachable.
Partial pool server availability: Pool connection attempts might fail when only some
pool servers are ready.

The implementation will retry connection attempts in the above scenarios until a
configurable timeout is reached (default: 20 minutes) Retry behavior is configurable via
DAOS_CLI_CONNECT_RETRY_TIMEOUT environment variable:

0: Disable retry (immediate failure)
-1: Infinite retry (no timeout)
0: Retry for specified number of seconds

Implement adaptive polling in dfuse progress thread with per-thread state tracking
consecutive empty polls and backing off sleep times up to 1 second when no events
are processed for extended periods

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
