### PR TITLE
DAOS-16774 client: expose env to support larger number of fd

### DIFF
--- a/docs/user/filesystem.md
+++ b/docs/user/filesystem.md
@@ -1039,6 +1039,10 @@ $ export D_IL_BYPASS_LIST="app_a:app_b:app_c:app_d"
 Fake file descriptor (FD) is used in regular mode in libpil4dfs.so for efficiency. open() returns fake fd to applications. In cases of some APIs are not intercepted, applications could crash with the error "Bad File Descriptor". Compatible mode is provided to work around such situations.
 Setting env "D_IL_COMPATIBLE=1" turns on compatible mode. Kernel fd allocated by dfuse instead of fake fd will be returned to applications. This mode provides better compatibility with degraded performance in open, openat, and opendir, etc. Please start dfuse with "--disable-caching" to disable caching before using compatible mode.
 
+### Increase the limit of the number of file descriptor for files and directories opened concurrently
+
+The default limit of the number of file descriptor for files and directories opened concurrently are 2048 and 512 respectively. They can be adjusted with env "D_IL_MAX_FD" and "D_IL_MAX_DIR".
+
 ### Directory caching
 
 To improve performance, directories are cached in a hash table.  The size of this hash table could

--- a/src/client/dfuse/SConscript
+++ b/src/client/dfuse/SConscript
@@ -34,7 +34,7 @@ OPS_SRC = ['create',
            'statfs']
 
 IOIL_SRC = ['int_posix.c', 'int_read.c', 'int_write.c']
-PIL4DFS_SRC = ['int_dfs.c', 'dfs_dcache.c', 'aio.c']
+PIL4DFS_SRC = ['int_dfs.c', 'dfs_dcache.c', 'aio.c', 'fd_pool.c']
 
 
 def build_common(env, files, is_shared):

--- a/src/client/dfuse/pil4dfs/fd_pool.c
+++ b/src/client/dfuse/pil4dfs/fd_pool.c
@@ -1,0 +1,83 @@
+/**
+ * (C) Copyright 2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+#define D_LOGFAC DD_FAC(il)
+
+#include <unistd.h>
+#include <errno.h>
+
+#include "pil4dfs_int.h"
+
+#define INVALID_IDX (-1)
+
+int
+fd_pool_create(int size, fd_pool_t *fd_pool)
+{
+	int i;
+
+	if (fd_pool == NULL || size == 0)
+		return EINVAL;
+
+	fd_pool->size     = 0;
+	fd_pool->capacity = size;
+	fd_pool->head     = 0;
+	fd_pool->next     = malloc(sizeof(int) * size);
+	if (fd_pool->next == NULL)
+		return ENOMEM;
+
+	/* initialize linked list */
+	fd_pool->next[size - 1] = INVALID_IDX;
+	for (i = 0; i < (size - 1); i++)
+		fd_pool->next[i] = i + 1;
+
+	return 0;
+}
+
+int
+fd_pool_alloc(fd_pool_t *fd_pool, int *idx)
+{
+	if (fd_pool == NULL || idx == NULL)
+		return EINVAL;
+
+	if (fd_pool->head < 0)
+		/* free list is empty. */
+		return EMFILE;
+	/* return the head of free list */
+	*idx          = fd_pool->head;
+	/* update the head of free list to point to the next node */
+	fd_pool->head = fd_pool->next[*idx];
+	fd_pool->size++;
+
+	return 0;
+}
+
+int
+fd_pool_free(fd_pool_t *fd_pool, int idx)
+{
+	if (fd_pool == NULL || (idx < 0) || (idx >= fd_pool->capacity) )
+		return EINVAL;
+
+	/* set the freed node as the head node */
+	fd_pool->next[idx] = fd_pool->head;
+	/* update head pointer to the newly freed node */
+	fd_pool->head      = idx;
+	fd_pool->size--;
+
+	return 0;
+}
+
+int
+fd_pool_destroy(fd_pool_t *fd_pool)
+{
+	if (fd_pool == NULL)
+		return EINVAL;
+
+	free(fd_pool->next);
+	return 0;
+}
+
+#undef INVALID_IDX

--- a/src/client/dfuse/pil4dfs/fd_pool.c
+++ b/src/client/dfuse/pil4dfs/fd_pool.c
@@ -47,7 +47,7 @@ fd_pool_alloc(fd_pool_t *fd_pool, int *idx)
 		/* free list is empty. */
 		return EMFILE;
 	/* return the head of free list */
-	*idx          = fd_pool->head;
+	*idx = fd_pool->head;
 	/* update the head of free list to point to the next node */
 	fd_pool->head = fd_pool->next[*idx];
 	fd_pool->size++;
@@ -58,13 +58,13 @@ fd_pool_alloc(fd_pool_t *fd_pool, int *idx)
 int
 fd_pool_free(fd_pool_t *fd_pool, int idx)
 {
-	if (fd_pool == NULL || (idx < 0) || (idx >= fd_pool->capacity) )
+	if (fd_pool == NULL || (idx < 0) || (idx >= fd_pool->capacity))
 		return EINVAL;
 
 	/* set the freed node as the head node */
 	fd_pool->next[idx] = fd_pool->head;
 	/* update head pointer to the newly freed node */
-	fd_pool->head      = idx;
+	fd_pool->head = idx;
 	fd_pool->size--;
 
 	return 0;

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -95,23 +95,23 @@ static int                    fd_dummy = -1;
 #define DCACHE_GC_PERIOD      120
 
 /* reference count of fake fd duplicated by real fd with dup2() */
-static int                max_fd  = MAX_OPENED_FILE;
-static int                max_dir = MAX_OPENED_DIR;
+static int                    max_fd  = MAX_OPENED_FILE;
+static int                    max_dir = MAX_OPENED_DIR;
 
 /* fd_dir_base - The base number of the file descriptor for a directory.
  * The fd allocate from this lib is always larger than FD_FILE_BASE.
  */
-static int                fd_dir_base;
+static int                    fd_dir_base;
 
-static int               *dup_ref_count;
-struct file_obj         **d_file_list;
-static struct dir_obj   **dir_list;
-static struct mmap_obj    mmap_list[MAX_MMAP_BLOCK];
+static int                   *dup_ref_count;
+struct file_obj             **d_file_list;
+static struct dir_obj       **dir_list;
+static struct mmap_obj        mmap_list[MAX_MMAP_BLOCK];
 
 /* last_fd==-1 means the list is empty. No active fd in list. */
-static int                next_free_fd, last_fd       = -1, num_fd;
-static int                next_free_dirfd, last_dirfd = -1, num_dirfd;
-static int                next_free_map, last_map     = -1, num_map;
+static int                    next_free_fd, last_fd       = -1, num_fd;
+static int                    next_free_dirfd, last_dirfd = -1, num_dirfd;
+static int                    next_free_map, last_map     = -1, num_map;
 
 /* the number of low fd reserved */
 static uint16_t               low_fd_count;
@@ -4149,7 +4149,7 @@ out_readdir:
 		mydir->offset++;
 	len_str = asprintf(&full_path, "%s/%s",
 			   dir_list[mydir->fd - fd_dir_base]->path +
-			   dir_list[mydir->fd - fd_dir_base]->dfs_mt->len_fs_root,
+			       dir_list[mydir->fd - fd_dir_base]->dfs_mt->len_fs_root,
 			   mydir->ents[mydir->num_ents].d_name);
 	if (len_str >= DFS_MAX_PATH) {
 		D_DEBUG(DB_ANY, "path is too long: %d (%s)\n", ENAMETOOLONG,
@@ -6262,8 +6262,8 @@ new_fcntl(int fd, int cmd, ...)
 
 		if ((cmd == F_DUPFD) || (cmd == F_DUPFD_CLOEXEC)) {
 			if (fd_directed >= fd_dir_base) {
-				rc = find_next_available_dirfd(
-					dir_list[fd_directed - fd_dir_base], &next_dirfd);
+				rc = find_next_available_dirfd(dir_list[fd_directed - fd_dir_base],
+							       &next_dirfd);
 				if (rc) {
 					errno = rc;
 					return (-1);
@@ -7180,7 +7180,7 @@ init_myhook(void)
 	int      rc;
 	uint64_t eq_count_loc = 0;
 	float    libc_version;
-	uint32_t max_fd_loc = 0;
+	uint32_t max_fd_loc  = 0;
 	uint32_t max_dir_loc = 0;
 
 	/* get env for max number of fd and dir, then allocate memory for arrays */
@@ -7189,7 +7189,8 @@ init_myhook(void)
 		max_fd = (int)max_fd_loc;
 		if (max_fd > MAX_OPENED_FILE_LMT) {
 			max_fd = MAX_OPENED_FILE_LMT;
-			printf("D_IL_MAX_FD is set as %u, but is capped as %d\n", max_fd_loc, max_fd);
+			printf("D_IL_MAX_FD is set as %u, but is capped as %d\n", max_fd_loc,
+			       max_fd);
 		}
 	}
 	rc = d_getenv_uint("D_IL_MAX_DIR", &max_dir_loc);
@@ -7197,7 +7198,8 @@ init_myhook(void)
 		max_dir = (int)max_dir_loc;
 		if (max_dir > MAX_OPENED_DIR_LMT) {
 			max_dir = MAX_OPENED_DIR_LMT;
-			printf("D_IL_MAX_DIR is set as %u, but is capped as %d\n", max_dir_loc, max_dir);
+			printf("D_IL_MAX_DIR is set as %u, but is capped as %d\n", max_dir_loc,
+			       max_dir);
 		}
 	}
 	dup_ref_count = malloc(sizeof(int) * max_fd);

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -7440,7 +7440,7 @@ close_all_fd(void)
 {
 	int i;
 
-	for (i = 0; i <= max_fd; i++) {
+	for (i = 0; i < max_fd; i++) {
 		if (d_file_list[i])
 			free_fd(i, false);
 	}
@@ -7451,7 +7451,7 @@ close_all_dirfd(void)
 {
 	int i;
 
-	for (i = 0; i <= max_dir; i++) {
+	for (i = 0; i < max_dir; i++) {
 		if (dir_list[i])
 			free_dirfd(i);
 	}

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -95,23 +95,23 @@ static int                    fd_dummy = -1;
 #define DCACHE_GC_PERIOD      120
 
 /* reference count of fake fd duplicated by real fd with dup2() */
-static int                    max_fd  = MAX_OPENED_FILE;
-static int                    max_dir = MAX_OPENED_DIR;
+static int                     max_fd  = MAX_OPENED_FILE;
+static int                     max_dir = MAX_OPENED_DIR;
 
 /* fd_dir_base - The base number of the file descriptor for a directory.
  * The fd allocate from this lib is always larger than FD_FILE_BASE.
  */
-static int                    fd_dir_base;
+static int                     fd_dir_base;
 
-static int                   *dup_ref_count;
-struct file_obj             **d_file_list;
-static struct dir_obj       **dir_list;
-static struct mmap_obj        mmap_list[MAX_MMAP_BLOCK];
+static int                    *dup_ref_count;
+struct file_obj              **d_file_list;
+static struct dir_obj        **dir_list;
+static struct mmap_obj         mmap_list[MAX_MMAP_BLOCK];
 
 /* last_fd==-1 means the list is empty. No active fd in list. */
-static int                    next_free_fd, last_fd       = -1, num_fd;
-static int                    next_free_dirfd, last_dirfd = -1, num_dirfd;
-static int                    next_free_map, last_map     = -1, num_map;
+static int                     next_free_fd, last_fd       = -1, num_fd;
+static int                     next_free_dirfd, last_dirfd = -1, num_dirfd;
+static int                     next_free_map, last_map     = -1, num_map;
 
 /* the number of low fd reserved */
 static uint16_t               low_fd_count;

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -94,6 +94,25 @@ static int                    fd_dummy = -1;
 /* Default dir cache garbage collector time-out in seconds */
 #define DCACHE_GC_PERIOD      120
 
+/* reference count of fake fd duplicated by real fd with dup2() */
+static int                max_fd  = MAX_OPENED_FILE;
+static int                max_dir = MAX_OPENED_DIR;
+
+/* fd_dir_base - The base number of the file descriptor for a directory.
+ * The fd allocate from this lib is always larger than FD_FILE_BASE.
+ */
+static int                fd_dir_base;
+
+static int               *dup_ref_count;
+struct file_obj         **d_file_list;
+static struct dir_obj   **dir_list;
+static struct mmap_obj    mmap_list[MAX_MMAP_BLOCK];
+
+/* last_fd==-1 means the list is empty. No active fd in list. */
+static int                next_free_fd, last_fd       = -1, num_fd;
+static int                next_free_dirfd, last_dirfd = -1, num_dirfd;
+static int                next_free_map, last_map     = -1, num_map;
+
 /* the number of low fd reserved */
 static uint16_t               low_fd_count;
 /* the list of low fd reserved */
@@ -306,8 +325,8 @@ fd_rec_free(struct d_hash_table *htable, d_list_t *rlink)
 	struct ht_fd *fd = fd_obj(rlink);
 
 	/* close fake fd */
-	if (fd->fake_fd >= FD_DIR_BASE)
-		free_dirfd(fd->fake_fd - FD_DIR_BASE);
+	if (fd->fake_fd >= fd_dir_base)
+		free_dirfd(fd->fake_fd - fd_dir_base);
 	else
 		free_fd(fd->fake_fd - FD_FILE_BASE, false);
 
@@ -505,17 +524,6 @@ static int
 remove_dot_dot(char path[], int *len);
 static int
 remove_dot_and_cleanup(char szPath[], int len);
-
-/* reference count of fake fd duplicated by real fd with dup2() */
-static int                dup_ref_count[MAX_OPENED_FILE];
-struct file_obj          *d_file_list[MAX_OPENED_FILE];
-static struct dir_obj    *dir_list[MAX_OPENED_DIR];
-static struct mmap_obj    mmap_list[MAX_MMAP_BLOCK];
-
-/* last_fd==-1 means the list is empty. No active fd in list. */
-static int                next_free_fd, last_fd       = -1, num_fd;
-static int                next_free_dirfd, last_dirfd = -1, num_dirfd;
-static int                next_free_map, last_map     = -1, num_map;
 
 static int
 find_next_available_fd(struct file_obj *obj, int *new_fd);
@@ -1487,8 +1495,8 @@ init_fd_list(void)
 
 	/* fatal error above: failure to create mutexes. */
 
-	memset(d_file_list, 0, sizeof(struct file_obj *) * MAX_OPENED_FILE);
-	memset(dir_list, 0, sizeof(struct dir_obj *) * MAX_OPENED_DIR);
+	memset(d_file_list, 0, sizeof(struct file_obj *) * max_fd);
+	memset(dir_list, 0, sizeof(struct dir_obj *) * max_dir);
 	memset(mmap_list, 0, sizeof(struct mmap_obj) * MAX_MMAP_BLOCK);
 
 	next_free_fd    = 0;
@@ -1540,7 +1548,7 @@ find_next_available_fd(struct file_obj *obj, int *new_fd)
 		last_fd = next_free_fd;
 	next_free_fd = -1;
 
-	for (i = idx + 1; i < MAX_OPENED_FILE; i++) {
+	for (i = idx + 1; i < max_fd; i++) {
 		if (d_file_list[i] == NULL) {
 			/* available, then update next_free_fd */
 			next_free_fd = i;
@@ -1609,7 +1617,7 @@ find_next_available_dirfd(struct dir_obj *obj, int *new_dir_fd)
 
 	next_free_dirfd = -1;
 
-	for (i = idx + 1; i < MAX_OPENED_DIR; i++) {
+	for (i = idx + 1; i < max_dir; i++) {
 		if (dir_list[i] == NULL) {
 			/* available, then update next_free_dirfd */
 			next_free_dirfd = i;
@@ -1681,7 +1689,7 @@ free_fd(int idx, bool closing_dup_fd)
 	}
 	d_file_list[idx] = NULL;
 
-	if (idx < next_free_fd)
+	if (idx < next_free_fd || next_free_fd == -1)
 		next_free_fd = idx;
 
 	if (idx == last_fd) {
@@ -1729,7 +1737,7 @@ free_dirfd(int idx)
 		saved_obj = dir_list[idx];
 	dir_list[idx] = NULL;
 
-	if (idx < next_free_dirfd)
+	if (idx < next_free_dirfd || next_free_dirfd == -1)
 		next_free_dirfd = idx;
 
 	if (idx == last_dirfd) {
@@ -1985,9 +1993,9 @@ check_path_with_dirfd(int dirfd, char **full_path_out, const char *rel_path, int
 	*full_path_out = NULL;
 	dirfd_directed = d_get_fd_redirected(dirfd);
 
-	if (dirfd_directed >= FD_DIR_BASE) {
+	if (dirfd_directed >= fd_dir_base) {
 		len_str = asprintf(full_path_out, "%s/%s",
-				   dir_list[dirfd_directed - FD_DIR_BASE]->path, rel_path);
+				   dir_list[dirfd_directed - fd_dir_base]->path, rel_path);
 		if (len_str >= DFS_MAX_PATH)
 			goto out_toolong;
 		else if (len_str < 0)
@@ -2151,7 +2159,7 @@ open_common(int (*real_open)(const char *pathname, int oflags, ...), const char 
 			if (rc)
 				goto out_compatible_release;
 			dir_list[idx_dirfd]->dfs_mt   = dfs_mt;
-			dir_list[idx_dirfd]->fd       = idx_dirfd + FD_DIR_BASE;
+			dir_list[idx_dirfd]->fd       = idx_dirfd + fd_dir_base;
 			dir_list[idx_dirfd]->offset   = 0;
 			dir_list[idx_dirfd]->dir      = dfs_obj;
 			dir_list[idx_dirfd]->num_ents = 0;
@@ -2178,7 +2186,7 @@ open_common(int (*real_open)(const char *pathname, int oflags, ...), const char 
 				free_dirfd(idx_dirfd);
 				goto out_compatible;
 			}
-			fd_fake = idx_dirfd + FD_DIR_BASE;
+			fd_fake = idx_dirfd + fd_dir_base;
 			drec_decref(dfs_mt->dcache, parent);
 		} else {
 			/* not supposed to be here. If the object is neither a dir or a regular
@@ -2189,7 +2197,7 @@ open_common(int (*real_open)(const char *pathname, int oflags, ...), const char 
 		/* add fd_kernel to hash table */
 		D_ALLOC_PTR(fd_ht_obj);
 		if (fd_ht_obj == NULL) {
-			if (fd_fake >= FD_DIR_BASE)
+			if (fd_fake >= fd_dir_base)
 				free_dirfd(idx_dirfd);
 			else
 				free_fd(idx_fd, false);
@@ -2257,7 +2265,7 @@ open_common(int (*real_open)(const char *pathname, int oflags, ...), const char 
 			D_GOTO(out_error, rc);
 
 		dir_list[idx_dirfd]->dfs_mt      = dfs_mt;
-		dir_list[idx_dirfd]->fd          = idx_dirfd + FD_DIR_BASE;
+		dir_list[idx_dirfd]->fd          = idx_dirfd + fd_dir_base;
 		dir_list[idx_dirfd]->offset      = 0;
 		dir_list[idx_dirfd]->dir         = dfs_obj;
 		dir_list[idx_dirfd]->num_ents    = 0;
@@ -2289,7 +2297,7 @@ open_common(int (*real_open)(const char *pathname, int oflags, ...), const char 
 		drec_decref(dfs_mt->dcache, parent);
 		FREE(parent_dir);
 
-		return (idx_dirfd + FD_DIR_BASE);
+		return (idx_dirfd + fd_dir_base);
 	}
 
 	rc = find_next_available_fd(NULL, &idx_fd);
@@ -2451,9 +2459,9 @@ new_close_common(int (*next_close)(int fd), int fd)
 	}
 
 	fd_directed = d_get_fd_redirected(fd);
-	if (fd_directed >= FD_DIR_BASE) {
+	if (fd_directed >= fd_dir_base) {
 		/* directory */
-		free_dirfd(fd_directed - FD_DIR_BASE);
+		free_dirfd(fd_directed - fd_dir_base);
 		return 0;
 	} else if (fd_directed >= FD_FILE_BASE) {
 		/* This fd is a kernel fd. There was a duplicate fd created. */
@@ -3002,14 +3010,14 @@ new_fxstat(int vers, int fd, struct stat *buf)
 	if (fd_directed < FD_FILE_BASE)
 		return next_fxstat(vers, fd, buf);
 
-	if (fd_directed < FD_DIR_BASE) {
+	if (fd_directed < fd_dir_base) {
 		rc          = dfs_ostat(d_file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
 					d_file_list[fd_directed - FD_FILE_BASE]->file, buf);
 		buf->st_ino = d_file_list[fd_directed - FD_FILE_BASE]->st_ino;
 	} else {
-		rc          = dfs_ostat(dir_list[fd_directed - FD_DIR_BASE]->dfs_mt->dfs,
-					dir_list[fd_directed - FD_DIR_BASE]->dir, buf);
-		buf->st_ino = dir_list[fd_directed - FD_DIR_BASE]->st_ino;
+		rc          = dfs_ostat(dir_list[fd_directed - fd_dir_base]->dfs_mt->dfs,
+					dir_list[fd_directed - fd_dir_base]->dir, buf);
+		buf->st_ino = dir_list[fd_directed - fd_dir_base]->st_ino;
 	}
 
 	if (rc) {
@@ -3039,14 +3047,14 @@ fstat(int fd, struct stat *buf)
 	if (fd_directed < FD_FILE_BASE)
 		return next_fstat(fd, buf);
 
-	if (fd_directed < FD_DIR_BASE) {
+	if (fd_directed < fd_dir_base) {
 		rc          = dfs_ostat(d_file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
 					d_file_list[fd_directed - FD_FILE_BASE]->file, buf);
 		buf->st_ino = d_file_list[fd_directed - FD_FILE_BASE]->st_ino;
 	} else {
-		rc          = dfs_ostat(dir_list[fd_directed - FD_DIR_BASE]->dfs_mt->dfs,
-					dir_list[fd_directed - FD_DIR_BASE]->dir, buf);
-		buf->st_ino = dir_list[fd_directed - FD_DIR_BASE]->st_ino;
+		rc          = dfs_ostat(dir_list[fd_directed - fd_dir_base]->dfs_mt->dfs,
+					dir_list[fd_directed - fd_dir_base]->dir, buf);
+		buf->st_ino = dir_list[fd_directed - fd_dir_base]->st_ino;
 	}
 
 	if (rc) {
@@ -3202,7 +3210,7 @@ new_fxstatat(int ver, int dirfd, const char *path, struct stat *stat_buf, int fl
 			return new_xstat(1, path, stat_buf);
 	}
 
-	if (dirfd >= FD_FILE_BASE && dirfd < FD_DIR_BASE) {
+	if (dirfd >= FD_FILE_BASE && dirfd < fd_dir_base) {
 		if (path[0] == 0 && flags & AT_EMPTY_PATH)
 			/* same as fstat for a file. May need further work to handle flags */
 			return new_fxstat(ver, dirfd, stat_buf);
@@ -3260,7 +3268,7 @@ new_fstatat(int dirfd, const char *__restrict path, struct stat *__restrict stat
 			return new_xstat(1, path, stat_buf);
 	}
 
-	if (dirfd >= FD_FILE_BASE && dirfd < FD_DIR_BASE) {
+	if (dirfd >= FD_FILE_BASE && dirfd < fd_dir_base) {
 		if (path[0] == 0 && flags & AT_EMPTY_PATH)
 			/* same as fstat for a file. May need further work to handle flags */
 			return fstat(dirfd, stat_buf);
@@ -3398,7 +3406,7 @@ lseek_comm(off_t (*next_lseek)(int fd, off_t offset, int whence), int fd, off_t 
 	if (fd_directed < FD_FILE_BASE)
 		return next_lseek(fd, offset, whence);
 	/* seekdir() will handle by the following. */
-	if (fd < FD_FILE_BASE && fd_directed >= FD_DIR_BASE && d_compatible_mode)
+	if (fd < FD_FILE_BASE && fd_directed >= fd_dir_base && d_compatible_mode)
 		return next_lseek(fd, offset, whence);
 
 	atomic_fetch_add_relaxed(&num_seek, 1);
@@ -3521,10 +3529,10 @@ fstatfs(int fd, struct statfs *sfs)
 	if (fd_directed < FD_FILE_BASE)
 		return next_fstatfs(fd, sfs);
 
-	if (fd_directed < FD_DIR_BASE)
+	if (fd_directed < fd_dir_base)
 		dfs_mt = d_file_list[fd_directed - FD_FILE_BASE]->dfs_mt;
 	else
-		dfs_mt = dir_list[fd_directed - FD_DIR_BASE]->dfs_mt;
+		dfs_mt = dir_list[fd_directed - fd_dir_base]->dfs_mt;
 	rc = daos_pool_query(dfs_mt->poh, NULL, &info, NULL, NULL);
 	if (rc != 0) {
 		errno = rc;
@@ -3677,7 +3685,7 @@ opendir(const char *path)
 		D_GOTO(out_err, rc);
 
 	dir_list[idx_dirfd]->dfs_mt   = dfs_mt;
-	dir_list[idx_dirfd]->fd       = idx_dirfd + FD_DIR_BASE;
+	dir_list[idx_dirfd]->fd       = idx_dirfd + fd_dir_base;
 	dir_list[idx_dirfd]->offset   = 0;
 	dir_list[idx_dirfd]->dir      = dir_obj;
 	dir_list[idx_dirfd]->num_ents = 0;
@@ -3716,7 +3724,7 @@ opendir(const char *path)
 		}
 		fd_ht_obj->real_fd = dirfd(dirp_kernel);
 		D_ASSERT(fd_ht_obj->real_fd >= 0);
-		fd_ht_obj->fake_fd = idx_dirfd + FD_DIR_BASE;
+		fd_ht_obj->fake_fd = idx_dirfd + fd_dir_base;
 		rc = d_hash_rec_insert(fd_hash, &fd_ht_obj->real_fd, sizeof(int), &fd_ht_obj->entry,
 				       false);
 		D_ASSERT(rc == 0);
@@ -3757,14 +3765,14 @@ fdopendir(int fd)
 	if (!d_hook_enabled)
 		return next_fdopendir(fd);
 	fd_directed = d_get_fd_redirected(fd);
-	if (fd_directed < FD_DIR_BASE)
+	if (fd_directed < fd_dir_base)
 		return next_fdopendir(fd_directed);
-	if (fd < FD_FILE_BASE && fd_directed >= FD_DIR_BASE && d_compatible_mode)
+	if (fd < FD_FILE_BASE && fd_directed >= fd_dir_base && d_compatible_mode)
 		return next_fdopendir(fd);
 
 	atomic_fetch_add_relaxed(&num_opendir, 1);
 
-	return (DIR *)(dir_list[fd_directed - FD_DIR_BASE]);
+	return (DIR *)(dir_list[fd_directed - fd_dir_base]);
 }
 
 int
@@ -3919,8 +3927,8 @@ closedir(DIR *dirp)
 		}
 	}
 
-	if (fd >= FD_DIR_BASE) {
-		free_dirfd(fd - FD_DIR_BASE);
+	if (fd >= fd_dir_base) {
+		free_dirfd(fd - fd_dir_base);
 		return 0;
 	} else {
 		return next_closedir(dirp);
@@ -3940,10 +3948,10 @@ telldir(DIR *dirp)
 		return next_telldir(dirp);
 
 	fd = dirfd(dirp);
-	if (fd < FD_DIR_BASE)
+	if (fd < fd_dir_base)
 		return next_telldir(dirp);
 
-	return dir_list[fd - FD_DIR_BASE]->offset;
+	return dir_list[fd - fd_dir_base]->offset;
 }
 
 void
@@ -3959,10 +3967,10 @@ rewinddir(DIR *dirp)
 		return next_rewinddir(dirp);
 
 	fd = dirfd(dirp);
-	if (fd < FD_DIR_BASE)
+	if (fd < fd_dir_base)
 		return next_rewinddir(dirp);
 
-	idx                     = fd - FD_DIR_BASE;
+	idx                     = fd - fd_dir_base;
 	dir_list[idx]->offset   = 0;
 	dir_list[idx]->num_ents = 0;
 	memset(&dir_list[idx]->anchor, 0, sizeof(daos_anchor_t));
@@ -3988,10 +3996,10 @@ seekdir(DIR *dirp, long loc)
 		return next_seekdir(dirp, loc);
 
 	fd = dirfd(dirp);
-	if (fd < FD_DIR_BASE)
+	if (fd < fd_dir_base)
 		return next_seekdir(dirp, loc);
 
-	idx = fd - FD_DIR_BASE;
+	idx = fd - fd_dir_base;
 
 	/* need to compare loc with current offset & the number of cached entries */
 	if (loc <= OFFSET_BASE) {
@@ -4064,7 +4072,7 @@ scandirat(int dirfd, const char *restrict path, struct dirent ***restrict nameli
 	if (!d_hook_enabled)
 		return next_scandirat(dirfd, path, namelist, filter, compar);
 
-	if (dirfd < FD_DIR_BASE)
+	if (dirfd < fd_dir_base)
 		return next_scandirat(dirfd, path, namelist, filter, compar);
 
 	if (path[0] == '/')
@@ -4103,7 +4111,7 @@ new_readdir(DIR *dirp)
 	if (fd_directed < FD_FILE_BASE)
 		return next_readdir(dirp);
 
-	if (fd_directed < FD_DIR_BASE) {
+	if (fd_directed < fd_dir_base) {
 		/* Not suppose to be here */
 		D_DEBUG(DB_ANY, "readdir() failed: %d (%s)\n", EINVAL, strerror(EINVAL));
 		errno = EINVAL;
@@ -4111,7 +4119,7 @@ new_readdir(DIR *dirp)
 	}
 	if (d_compatible_mode)
 		/* dirp is from Linux kernel */
-		mydir = dir_list[fd_directed - FD_DIR_BASE];
+		mydir = dir_list[fd_directed - fd_dir_base];
 	atomic_fetch_add_relaxed(&num_readdir, 1);
 
 	if (mydir->num_ents)
@@ -4119,7 +4127,7 @@ new_readdir(DIR *dirp)
 
 	mydir->num_ents = READ_DIR_BATCH_SIZE;
 	while (!daos_anchor_is_eof(&mydir->anchor)) {
-		rc = dfs_readdir(dir_list[mydir->fd - FD_DIR_BASE]->dfs_mt->dfs, mydir->dir,
+		rc = dfs_readdir(dir_list[mydir->fd - fd_dir_base]->dfs_mt->dfs, mydir->dir,
 				 &mydir->anchor, &mydir->num_ents, mydir->ents);
 		if (rc != 0)
 			goto out_null_readdir;
@@ -4140,8 +4148,8 @@ out_readdir:
 	else
 		mydir->offset++;
 	len_str = asprintf(&full_path, "%s/%s",
-			   dir_list[mydir->fd - FD_DIR_BASE]->path +
-			   dir_list[mydir->fd - FD_DIR_BASE]->dfs_mt->len_fs_root,
+			   dir_list[mydir->fd - fd_dir_base]->path +
+			   dir_list[mydir->fd - fd_dir_base]->dfs_mt->len_fs_root,
 			   mydir->ents[mydir->num_ents].d_name);
 	if (len_str >= DFS_MAX_PATH) {
 		D_DEBUG(DB_ANY, "path is too long: %d (%s)\n", ENAMETOOLONG,
@@ -5310,7 +5318,7 @@ fchdir(int dirfd)
 		return next_fchdir(dirfd);
 
 	fd_directed = d_get_fd_redirected(dirfd);
-	if (fd_directed < FD_DIR_BASE)
+	if (fd_directed < fd_dir_base)
 		return next_fchdir(dirfd);
 
 	/* assume dfuse is running. call chdir() to update cwd. */
@@ -5318,11 +5326,11 @@ fchdir(int dirfd)
 		next_chdir = dlsym(RTLD_NEXT, "chdir");
 		D_ASSERT(next_chdir != NULL);
 	}
-	rc = next_chdir(dir_list[fd_directed - FD_DIR_BASE]->path);
+	rc = next_chdir(dir_list[fd_directed - fd_dir_base]->path);
 	if (rc)
 		return rc;
 
-	pt_end = stpncpy(cur_dir, dir_list[fd_directed - FD_DIR_BASE]->path, DFS_MAX_PATH - 1);
+	pt_end = stpncpy(cur_dir, dir_list[fd_directed - fd_dir_base]->path, DFS_MAX_PATH - 1);
 	if ((long int)(pt_end - cur_dir) >= DFS_MAX_PATH - 1) {
 		D_DEBUG(DB_ANY, "path is too long: %d (%s)\n", ENAMETOOLONG,
 			strerror(ENAMETOOLONG));
@@ -5476,7 +5484,7 @@ fsync(int fd)
 	if (fd_directed < FD_FILE_BASE)
 		return next_fsync(fd);
 
-	if (fd < FD_DIR_BASE && d_compatible_mode)
+	if (fd < fd_dir_base && d_compatible_mode)
 		return next_fsync(fd);
 
 	/* errno = ENOTSUP;
@@ -5501,7 +5509,7 @@ fdatasync(int fd)
 	if (fd_directed < FD_FILE_BASE)
 		return next_fdatasync(fd);
 
-	if (fd < FD_DIR_BASE && d_compatible_mode)
+	if (fd < fd_dir_base && d_compatible_mode)
 		return next_fdatasync(fd);
 
 	return 0;
@@ -5522,7 +5530,7 @@ ftruncate(int fd, off_t length)
 	if (fd_directed < FD_FILE_BASE)
 		return next_ftruncate(fd, length);
 
-	if (fd_directed >= FD_DIR_BASE) {
+	if (fd_directed >= fd_dir_base) {
 		errno = EINVAL;
 		return (-1);
 	}
@@ -5683,7 +5691,7 @@ fchmod(int fd, mode_t mode)
 	if (fd_directed < FD_FILE_BASE)
 		return next_fchmod(fd, mode);
 
-	if (fd_directed >= FD_DIR_BASE) {
+	if (fd_directed >= fd_dir_base) {
 		errno = EINVAL;
 		return (-1);
 	}
@@ -5753,16 +5761,16 @@ fchown(int fd, uid_t uid, gid_t gid)
 	if (fd_directed < FD_FILE_BASE)
 		return next_fchown(fd, uid, gid);
 
-	if (fd_directed >= (FD_DIR_BASE + MAX_OPENED_DIR)) {
+	if (fd_directed >= (fd_dir_base + max_dir)) {
 		errno = EINVAL;
 		return (-1);
 	}
 
-	if (fd_directed >= FD_DIR_BASE)
+	if (fd_directed >= fd_dir_base)
 		/* Let dfuse handle this case. This function is not commonly used in applications.
 		 * There is no need for further optimization here at this time.
 		 */
-		return chown(dir_list[fd_directed - FD_DIR_BASE]->path, uid, gid);
+		return chown(dir_list[fd_directed - fd_dir_base]->path, uid, gid);
 
 	/* regular file */
 	rc = dfs_chown(d_file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
@@ -5793,18 +5801,18 @@ fgetxattr(int fd, char *name, void *value, size_t size)
 	if (fd_directed < FD_FILE_BASE)
 		return next_fgetxattr(fd, name, value, size);
 
-	if (fd_directed >= (FD_DIR_BASE + MAX_OPENED_DIR)) {
+	if (fd_directed >= (fd_dir_base + max_dir)) {
 		errno = EINVAL;
 		return (-1);
 	}
 
-	if (fd_directed < FD_DIR_BASE)
+	if (fd_directed < fd_dir_base)
 		rc = dfs_getxattr(d_file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
 				  d_file_list[fd_directed - FD_FILE_BASE]->file, name, value,
 				  &buf_size);
 	else
-		rc = dfs_getxattr(dir_list[fd_directed - FD_DIR_BASE]->dfs_mt->dfs,
-				  dir_list[fd_directed - FD_DIR_BASE]->dir, name, value, &buf_size);
+		rc = dfs_getxattr(dir_list[fd_directed - fd_dir_base]->dfs_mt->dfs,
+				  dir_list[fd_directed - fd_dir_base]->dir, name, value, &buf_size);
 	if (rc) {
 		errno = rc;
 		return (-1);
@@ -5829,18 +5837,18 @@ fsetxattr(int fd, char *name, void *value, size_t size, int flags)
 	if (fd_directed < FD_FILE_BASE)
 		return next_fsetxattr(fd, name, value, size, flags);
 
-	if (fd_directed >= (FD_DIR_BASE + MAX_OPENED_DIR)) {
+	if (fd_directed >= (fd_dir_base + max_dir)) {
 		errno = EINVAL;
 		return (-1);
 	}
 
-	if (fd_directed < FD_DIR_BASE)
+	if (fd_directed < fd_dir_base)
 		rc = dfs_setxattr(d_file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
 				  d_file_list[fd_directed - FD_FILE_BASE]->file, name, value, size,
 				  flags);
 	else
-		rc = dfs_setxattr(dir_list[fd_directed - FD_DIR_BASE]->dfs_mt->dfs,
-				  dir_list[fd_directed - FD_DIR_BASE]->dir, name, value, size,
+		rc = dfs_setxattr(dir_list[fd_directed - fd_dir_base]->dfs_mt->dfs,
+				  dir_list[fd_directed - fd_dir_base]->dir, name, value, size,
 				  flags);
 	if (rc) {
 		errno = rc;
@@ -6236,8 +6244,8 @@ new_fcntl(int fd, int cmd, ...)
 		fd_directed = d_get_fd_redirected(fd);
 
 		if (cmd == F_GETFL) {
-			if (fd_directed >= FD_DIR_BASE)
-				return dir_list[fd_directed - FD_DIR_BASE]->open_flag;
+			if (fd_directed >= fd_dir_base)
+				return dir_list[fd_directed - fd_dir_base]->open_flag;
 			else if (fd_directed >= FD_FILE_BASE)
 				return d_file_list[fd_directed - FD_FILE_BASE]->open_flag;
 			else
@@ -6253,14 +6261,14 @@ new_fcntl(int fd, int cmd, ...)
 			OrgFunc = 0;
 
 		if ((cmd == F_DUPFD) || (cmd == F_DUPFD_CLOEXEC)) {
-			if (fd_directed >= FD_DIR_BASE) {
+			if (fd_directed >= fd_dir_base) {
 				rc = find_next_available_dirfd(
-					dir_list[fd_directed - FD_DIR_BASE], &next_dirfd);
+					dir_list[fd_directed - fd_dir_base], &next_dirfd);
 				if (rc) {
 					errno = rc;
 					return (-1);
 				}
-				return (next_dirfd + FD_DIR_BASE);
+				return (next_dirfd + fd_dir_base);
 			} else if (fd_directed >= FD_FILE_BASE) {
 				rc = find_next_available_fd(
 					d_file_list[fd_directed - FD_FILE_BASE], &next_fd);
@@ -6327,7 +6335,7 @@ ioctl(int fd, unsigned long request, ...)
 		return next_ioctl(fd, request, param);
 
 	fd_directed = d_get_fd_redirected(fd);
-	if ((fd_directed < FD_FILE_BASE) || (fd_directed >= (FD_DIR_BASE + MAX_OPENED_DIR)))
+	if ((fd_directed < FD_FILE_BASE) || (fd_directed >= (fd_dir_base + max_dir)))
 		return next_ioctl(fd, request, param);
 
 	if (request == FIOCLEX)
@@ -6383,7 +6391,7 @@ dup2(int oldfd, int newfd)
 		fd_directed = d_get_fd_redirected(oldfd);
 		if (fd_directed < FD_FILE_BASE) {
 			return fd_kernel;
-		} else if (fd_directed < FD_DIR_BASE) {
+		} else if (fd_directed < fd_dir_base) {
 			rc = find_next_available_fd(d_file_list[fd_directed - FD_FILE_BASE],
 						    &next_fd);
 			if (rc)
@@ -6391,21 +6399,21 @@ dup2(int oldfd, int newfd)
 				return fd_kernel;
 			fd_fake = next_fd + FD_FILE_BASE;
 		} else {
-			rc = find_next_available_dirfd(dir_list[fd_directed - FD_DIR_BASE],
+			rc = find_next_available_dirfd(dir_list[fd_directed - fd_dir_base],
 						       &next_dirfd);
 			if (rc)
 				/* still return the fd dup from kernel in
 				 * compatible mode
 				 */
 				return fd_kernel;
-			fd_fake = next_dirfd + FD_DIR_BASE;
+			fd_fake = next_dirfd + fd_dir_base;
 		}
 		if (fd_fake < 0)
 			return fd_kernel;
 		/* add fd_kernel to hash table */
 		D_ALLOC_PTR(fd_ht_obj);
 		if (fd_ht_obj == NULL) {
-			if (fd_fake >= FD_DIR_BASE)
+			if (fd_fake >= fd_dir_base)
 				free_dirfd(next_dirfd);
 			else
 				free_fd(next_fd, false);
@@ -7172,6 +7180,48 @@ init_myhook(void)
 	int      rc;
 	uint64_t eq_count_loc = 0;
 	float    libc_version;
+	uint32_t max_fd_loc = 0;
+	uint32_t max_dir_loc = 0;
+
+	/* get env for max number of fd and dir, then allocate memory for arrays */
+	rc = d_getenv_uint("D_IL_MAX_FD", &max_fd_loc);
+	if (rc != -DER_NONEXIST) {
+		max_fd = (int)max_fd_loc;
+		if (max_fd > MAX_OPENED_FILE_LMT) {
+			max_fd = MAX_OPENED_FILE_LMT;
+			printf("D_IL_MAX_FD is set as %u, but is capped as %d\n", max_fd_loc, max_fd);
+		}
+	}
+	rc = d_getenv_uint("D_IL_MAX_DIR", &max_dir_loc);
+	if (rc != -DER_NONEXIST) {
+		max_dir = (int)max_dir_loc;
+		if (max_dir > MAX_OPENED_DIR_LMT) {
+			max_dir = MAX_OPENED_DIR_LMT;
+			printf("D_IL_MAX_DIR is set as %u, but is capped as %d\n", max_dir_loc, max_dir);
+		}
+	}
+	dup_ref_count = malloc(sizeof(int) * max_fd);
+	if (dup_ref_count == NULL) {
+		printf("failed to allocate memory %ld bytes for dup_ref_count\n",
+		       sizeof(int) * max_fd);
+		return;
+	}
+	d_file_list = malloc(sizeof(struct file_obj *) * max_fd);
+	if (d_file_list == NULL) {
+		printf("failed to allocate memory %ld bytes for d_file_list\n",
+		       sizeof(struct file_obj *) * max_fd);
+		free(dup_ref_count);
+		return;
+	}
+	dir_list = malloc(sizeof(struct dir_obj *) * max_dir);
+	if (dir_list == NULL) {
+		printf("failed to allocate memory %ld bytes for dir_list\n",
+		       sizeof(struct dir_obj *) * max_dir);
+		free(dup_ref_count);
+		free(d_file_list);
+		return;
+	}
+	fd_dir_base = FD_FILE_BASE + max_fd;
 
 	/* D_IL_NO_BYPASS is ONLY for testing. It always keeps function interception enabled in
 	 * current process and children processes. This is needed to thoroughly test interception

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -113,7 +113,7 @@ static struct mmap_obj         mmap_list[MAX_MMAP_BLOCK];
 
 static int                     num_fd;
 static int                     num_dirfd;
-static int                     next_free_map, last_map     = -1, num_map;
+static int                     next_free_map, last_map = -1, num_map;
 
 /* the number of low fd reserved */
 static uint16_t               low_fd_count;
@@ -1512,8 +1512,8 @@ init_fd_list(void)
 static int
 find_next_available_fd(struct file_obj *obj, int *new_fd)
 {
-	bool	allocated = false;
-	int	rc, idx;
+	bool             allocated = false;
+	int              rc, idx;
 	struct file_obj *new_obj = NULL;
 
 	if (obj == NULL) {
@@ -1569,8 +1569,8 @@ dec_dup_ref_count(int fd)
 static int
 find_next_available_dirfd(struct dir_obj *obj, int *new_dir_fd)
 {
-	bool	allocated = false;
-	int	rc, idx;
+	bool            allocated = false;
+	int             rc, idx;
 	struct dir_obj *new_obj;
 
 	if (obj == NULL) {

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -2288,9 +2288,12 @@ org_func:
 		drec_decref(dfs_mt->dcache, parent);
 	FREE(parent_dir);
 	if (two_args)
-		return real_open(pathname, oflags);
+		fd_kernel = real_open(pathname, oflags);
 	else
-		return real_open(pathname, oflags, mode);
+		fd_kernel = real_open(pathname, oflags, mode);
+	if (fd_kernel >= FD_FILE_BASE && fd_kernel < (fd_dir_base + max_dir))
+		D_WARN("Large fd allocated by kernel may be conflicting with fake fd\n");
+	return fd_kernel;
 
 out_error:
 	if (dfs_mt != NULL)
@@ -2307,6 +2310,8 @@ out_compatible:
 	if (dfs_mt != NULL)
 		drec_decref(dfs_mt->dcache, parent);
 	FREE(parent_dir);
+	if (fd_kernel >= FD_FILE_BASE && fd_kernel < (fd_dir_base + max_dir))
+		D_WARN("Large fd allocated by kernel may be conflicting with fake fd\n");
 	return fd_kernel;
 }
 

--- a/src/client/dfuse/pil4dfs/pil4dfs_int.h
+++ b/src/client/dfuse/pil4dfs/pil4dfs_int.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/client/dfuse/pil4dfs/pil4dfs_int.h
+++ b/src/client/dfuse/pil4dfs/pil4dfs_int.h
@@ -14,9 +14,9 @@
 
 #define MAX_MMAP_BLOCK      (64)
 #define MAX_OPENED_FILE     (2048)
-#define MAX_OPENED_FILE_M1  ((MAX_OPENED_FILE)-1)
 #define MAX_OPENED_DIR      (512)
-#define MAX_OPENED_DIR_M1   ((MAX_OPENED_DIR)-1)
+#define MAX_OPENED_FILE_LMT (1024 * 1024)
+#define MAX_OPENED_DIR_LMT  (256 * 1024)
 
 #define MAX_EQ          64
 
@@ -26,11 +26,6 @@
  * The fd allocate from this lib is always larger than FD_FILE_BASE.
  */
 #define FD_FILE_BASE    (0x20000000)
-
-/* FD_FILE_BASE - The base number of the file descriptor for a directory.
- * The fd allocate from this lib is always larger than FD_FILE_BASE.
- */
-#define FD_DIR_BASE     (FD_FILE_BASE + MAX_OPENED_FILE)
 
 /* structure allocated for a FD for a file */
 struct file_obj {

--- a/src/client/dfuse/pil4dfs/pil4dfs_int.h
+++ b/src/client/dfuse/pil4dfs/pil4dfs_int.h
@@ -88,4 +88,32 @@ struct dfs_mt {
 	char            *fs_root;
 };
 
+/* structure of a fd pool based on linked list to manage fd/dirfd allocation/deallocation */
+typedef struct {
+	/* the number of allocated nodes */
+	int  size;
+	/* the max number of nodes */
+	int  capacity;
+	/* the index of the head of the link list of available nodes */
+	int  head;
+	/* array of next node for link list */
+	int *next;
+} fd_pool_t;
+
+/* create a fd pool */
+int
+fd_pool_create(int size, fd_pool_t *fd_pool);
+
+/* get a fd */
+int
+fd_pool_alloc(fd_pool_t *fd_pool, int *idx);
+
+/* free a fd */
+int
+fd_pool_free(fd_pool_t *fd_pool, int idx);
+
+/* free fd pool */
+int
+fd_pool_destroy(fd_pool_t *fd_pool);
+
 #endif

--- a/src/tests/ftest/daos_test/dfuse.py
+++ b/src/tests/ftest/daos_test/dfuse.py
@@ -95,6 +95,8 @@ class DaosCoreTestDfuse(TestWithServers):
             daos_test_env['DD_MASK'] = 'all'
             daos_test_env['DD_SUBSYS'] = 'all'
             daos_test_env['D_LOG_MASK'] = 'INFO,IL=DEBUG'
+            daos_test_env['D_IL_MAX_FD'] = '8192'
+            daos_test_env['D_IL_MAX_DIR'] = '8192'
 
             if il_lib == 'libpil4dfs.so':
                 daos_test_env['D_IL_MOUNT_POINT'] = mount_dir

--- a/src/tests/ftest/dfuse/bash.py
+++ b/src/tests/ftest/dfuse/bash.py
@@ -132,13 +132,13 @@ class DfuseBashCmd(TestWithServers):
             f"chmod u-r {fuse_root_dir}/lib.a.bz2",
             f"sed -i 's/abcd/bbcd/g' {fuse_root_dir}/src.c",
             'fio --readwrite=randwrite --name=test --size="2M" --directory '
-            f'{fuse_root_dir}/ --bs=1M --numjobs="4" --ioengine=psync --thread=0'
+            f'{fuse_root_dir}/ --bs=1M --numjobs="4" --ioengine=psync --thread=0 '
             "--group_reporting --exitall_on_error --continue_on_error=none",
             'fio --readwrite=randwrite --name=test --size="2M" --directory '
-            f'{fuse_root_dir}/ --bs=1M --numjobs="4" --ioengine=psync --thread=1'
+            f'{fuse_root_dir}/ --bs=1M --numjobs="4" --ioengine=psync --thread=1 '
             "--group_reporting --exitall_on_error --continue_on_error=none",
             'fio --readwrite=randwrite --name=test --size="2M" --directory '
-            f'{fuse_root_dir}/ --bs=1M --numjobs="1" --ioengine=libaio --iodepth=16'
+            f'{fuse_root_dir}/ --bs=1M --numjobs="1" --ioengine=libaio --iodepth=16 '
             '--group_reporting --exitall_on_error --continue_on_error=none',
             ('curl "https://jenkins.daos.hpc.amslabs.hpecorp.net" '
              f'-o {fuse_root_dir}/download.html')

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -215,6 +215,26 @@ is_fd_large(int fd)
 	return (fd > 100000);
 }
 
+/* randomize the elements in an array */
+static void
+randomize(int *list, int size, int num_exch)
+{
+        int i;
+        int idx_1;
+        int idx_2;
+        int tmp;
+
+        for (i = 0; i < num_exch; i++) {
+                idx_1 = rand() % size;
+                idx_2 = idx_1;
+                while (idx_2 == idx_1)
+                        idx_2 = rand() % size;
+                tmp = list[idx_1];
+                list[idx_1] = list[idx_2];
+                list[idx_2] = tmp;
+        }
+}
+
 #define MAX_FD (8192)
 
 extern int __open(const char *pathname, int flags, ...);
@@ -246,12 +266,26 @@ do_open(void **state)
 
 	fd_list = malloc(sizeof(int) * MAX_FD);
 	assert_true(fd_list != NULL);
+
 	for (i = 0; i < MAX_FD; i++) {
 		fd_list[i] = open(test_dir, O_PATH | O_DIRECTORY);
 		assert_true(fd_list[i] > 0);
 		if (with_pil4dfs && use_dfuse)
 			assert_true(is_fd_large(fd_list[i]));
 	}
+	randomize(fd_list, MAX_FD, MAX_FD);
+	for (i = 0; i < MAX_FD; i++) {
+		rc = close(fd_list[i]);
+		assert_true(rc == 0);
+	}
+
+	for (i = 0; i < MAX_FD; i++) {
+		fd_list[i] = open(test_dir, O_PATH | O_DIRECTORY);
+		assert_true(fd_list[i] > 0);
+		if (with_pil4dfs && use_dfuse)
+			assert_true(is_fd_large(fd_list[i]));
+	}
+	randomize(fd_list, MAX_FD, MAX_FD);
 	for (i = 0; i < MAX_FD; i++) {
 		rc = close(fd_list[i]);
 		assert_true(rc == 0);
@@ -288,6 +322,19 @@ do_open(void **state)
 		if (with_pil4dfs && use_dfuse)
 			assert_true(is_fd_large(fd_list[i]));
 	}
+	randomize(fd_list, MAX_FD, MAX_FD);
+	for (i = 0; i < MAX_FD; i++) {
+		rc = close(fd_list[i]);
+		assert_true(rc == 0);
+	}
+
+	for (i = 0; i < MAX_FD; i++) {
+		fd_list[i] = open(path, O_RDONLY);
+		assert_true(fd_list[i] > 0);
+		if (with_pil4dfs && use_dfuse)
+			assert_true(is_fd_large(fd_list[i]));
+	}
+	randomize(fd_list, MAX_FD, MAX_FD);
 	for (i = 0; i < MAX_FD; i++) {
 		rc = close(fd_list[i]);
 		assert_true(rc == 0);

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -229,7 +229,7 @@ randomize(int *list, int size, int num_exch)
 		idx_2 = idx_1;
 		while (idx_2 == idx_1)
 			idx_2 = rand() % size;
-		tmp = list[idx_1];
+		tmp         = list[idx_1];
 		list[idx_1] = list[idx_2];
 		list[idx_2] = tmp;
 	}

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -215,10 +215,13 @@ is_fd_large(int fd)
 	return (fd > 100000);
 }
 
+#define MAX_FD  (8192)
+
 extern int __open(const char *pathname, int flags, ...);
 void
 do_open(void **state)
 {
+	int   i;
 	int   fd;
 	int   rc;
 	int   len;
@@ -228,6 +231,7 @@ do_open(void **state)
 	bool  use_dfuse    = true;
 	/* "/tmp/dfuse-test" is assigned in src/tests/ftest/daos_test/dfuse.py */
 	char  native_mount_dir[] = "/tmp/dfuse-test";
+	int  *fd_list;
 
 	if (strstr(test_dir, native_mount_dir))
 		use_dfuse = false;
@@ -239,6 +243,19 @@ do_open(void **state)
 	if (strstr(env_ldpreload, "libpil4dfs.so") != NULL)
 		/* libioil cannot pass this test since low fds are only temporarily blocked */
 		with_pil4dfs = true;
+
+	fd_list = malloc(sizeof(int) * MAX_FD);
+	assert_true(fd_list != NULL);
+	for (i = 0; i < MAX_FD; i++) {
+		fd_list[i] = open(test_dir, O_PATH | O_DIRECTORY);
+		assert_true(fd_list[i] > 0);
+		if (with_pil4dfs && use_dfuse)
+			assert_true(is_fd_large(fd_list[i]));
+	}
+	for (i = 0; i < MAX_FD; i++) {
+		rc = close(fd_list[i]);
+		assert_true(rc == 0);
+	}
 
 	len = snprintf(path, sizeof(path) - 1, "%s/open_file", test_dir);
 	assert_true(len < (sizeof(path) - 1));
@@ -265,6 +282,17 @@ do_open(void **state)
 	rc = close(fd);
 	assert_return_code(rc, errno);
 
+	for (i = 0; i < MAX_FD; i++) {
+		fd_list[i] = open(path, O_RDONLY);
+		assert_true(fd_list[i] > 0);
+		if (with_pil4dfs && use_dfuse)
+			assert_true(is_fd_large(fd_list[i]));
+	}
+	for (i = 0; i < MAX_FD; i++) {
+		rc = close(fd_list[i]);
+		assert_true(rc == 0);
+	}
+
 	rc = unlink(path);
 	assert_return_code(rc, errno);
 
@@ -279,6 +307,8 @@ do_open(void **state)
 
 	rc = unlink(path);
 	assert_return_code(rc, errno);
+
+	free(fd_list);
 }
 
 void

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -215,7 +215,7 @@ is_fd_large(int fd)
 	return (fd > 100000);
 }
 
-#define MAX_FD  (8192)
+#define MAX_FD (8192)
 
 extern int __open(const char *pathname, int flags, ...);
 void

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -219,20 +219,20 @@ is_fd_large(int fd)
 static void
 randomize(int *list, int size, int num_exch)
 {
-        int i;
-        int idx_1;
-        int idx_2;
-        int tmp;
+	int i;
+	int idx_1;
+	int idx_2;
+	int tmp;
 
-        for (i = 0; i < num_exch; i++) {
-                idx_1 = rand() % size;
-                idx_2 = idx_1;
-                while (idx_2 == idx_1)
-                        idx_2 = rand() % size;
-                tmp = list[idx_1];
-                list[idx_1] = list[idx_2];
-                list[idx_2] = tmp;
-        }
+	for (i = 0; i < num_exch; i++) {
+		idx_1 = rand() % size;
+		idx_2 = idx_1;
+		while (idx_2 == idx_1)
+			idx_2 = rand() % size;
+		tmp = list[idx_1];
+		list[idx_1] = list[idx_2];
+		list[idx_2] = tmp;
+	}
 }
 
 #define MAX_FD (8192)


### PR DESCRIPTION
1. Expose env to allow users to adjust the limit of the number of file descriptor for files and directories opened concurrently.
2. Implement fd allocator based on linked list for better performance.
3. document env "D_IL_MAX_FD" and "D_IL_MAX_DIR".
4. check the range of the file descriptor allocated by kernel in open

Features: pil4dfs
Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
