### PR TITLE
DAOS-16766 container: don't create for cont lookup (#15670)

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -856,6 +856,8 @@ cont_child_stop(struct ds_cont_child *cont_child)
 {
 	struct ds_cont_hdl	*hdl;
 
+	D_ASSERT(cont_child->sc_stopping == 0);
+	cont_child->sc_stopping = 1;
 	while ((hdl = d_list_pop_entry(&cont_child->sc_open_hdls,
 				       struct ds_cont_hdl, sch_link)) != NULL) {
 		D_DEBUG(DB_MD, "Force closing container open handle "DF_UUID"/"DF_UUID"\n",
@@ -864,29 +866,22 @@ cont_child_stop(struct ds_cont_child *cont_child)
 		cont_close_hdl(hdl->sch_uuid);
 	}
 
-	/* Some ds_cont_child will only created by ds_cont_child_lookup().
-	 * never be started at all
-	 */
-	cont_child->sc_stopping = 1;
-
 	/* Stop DTX reindex by force. */
 	stop_dtx_reindex_ult(cont_child, true);
 
-	if (cont_child_started(cont_child)) {
-		D_DEBUG(DB_MD, DF_CONT"[%d]: Stopping container\n",
-			DP_CONT(cont_child->sc_pool->spc_uuid,
-				cont_child->sc_uuid),
-			dss_get_module_info()->dmi_tgt_id);
+	D_DEBUG(DB_MD, DF_CONT "[%d]: Stopping container\n",
+		DP_CONT(cont_child->sc_pool->spc_uuid, cont_child->sc_uuid),
+		dss_get_module_info()->dmi_tgt_id);
 
-		d_list_del_init(&cont_child->sc_link);
+	d_list_del_init(&cont_child->sc_link);
 
-		dtx_cont_deregister(cont_child);
-		D_ASSERT(cont_child->sc_dtx_registered == 0);
+	dtx_cont_deregister(cont_child);
+	D_ASSERT(cont_child->sc_dtx_registered == 0);
 
-		/* cont_stop_agg() may yield */
-		cont_stop_agg(cont_child);
-		ds_cont_child_put(cont_child);
-	}
+	/* cont_stop_agg() may yield */
+	cont_stop_agg(cont_child);
+	D_ASSERT(cont_child_started(cont_child) == false);
+	ds_cont_child_put(cont_child);
 }
 
 void
@@ -1431,8 +1426,8 @@ ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
 	struct dsm_tls		*tls = dsm_tls_get();
 	int			 rc;
 
-	rc = cont_child_lookup(tls->dt_cont_cache, cont_uuid, pool_uuid,
-			       true /* create */, ds_cont);
+	rc = cont_child_lookup(tls->dt_cont_cache, cont_uuid, pool_uuid, false /* create */,
+			       ds_cont);
 	if (rc != 0)
 		return rc;
 
@@ -1706,7 +1701,10 @@ err_cont:
 			DP_CONT(pool_uuid, cont_uuid));
 
 		D_ASSERT(hdl != NULL);
-		cont_hdl_delete(&tls->dt_cont_hdl_hash, hdl);
+		if (added)
+			cont_hdl_delete(&tls->dt_cont_hdl_hash, hdl);
+		else
+			D_FREE(hdl);
 		hdl = NULL;
 
 		D_ASSERT(cont != NULL);


### PR DESCRIPTION
If container is not found from LRU, that means it was evicted from cache. This should only happens on container stopped or destroyed. don't create it again to avoid any race.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
