### PR TITLE
DAOS-16766 container: rebuid and container destruction race (#15971)

### DIFF
--- a/src/common/lru.c
+++ b/src/common/lru.c
@@ -285,10 +285,10 @@ daos_lru_ref_release(struct daos_lru_cache *lcache, struct daos_llink *llink)
 	}
 }
 
-void
-daos_lru_ref_evict_wait(struct daos_lru_cache *lcache, struct daos_llink *llink)
+static void
+lru_ref_wait(struct daos_lru_cache *lcache, struct daos_llink *llink, bool evict)
 {
-	if (!llink->ll_evicted)
+	if (evict && !llink->ll_evicted)
 		daos_lru_ref_evict(lcache, llink);
 
 	if (lcache->dlc_ops->lop_wait && !daos_lru_is_last_user(llink)) {
@@ -302,4 +302,16 @@ daos_lru_ref_evict_wait(struct daos_lru_cache *lcache, struct daos_llink *llink)
 		lcache->dlc_ops->lop_wait(llink);
 		llink->ll_wait_evict = 0;
 	}
+}
+
+void
+daos_lru_ref_evict_wait(struct daos_lru_cache *lcache, struct daos_llink *llink)
+{
+	lru_ref_wait(lcache, llink, true);
+}
+
+void
+daos_lru_ref_noevict_wait(struct daos_lru_cache *lcache, struct daos_llink *llink)
+{
+	lru_ref_wait(lcache, llink, false);
 }

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1323,7 +1323,22 @@ cont_child_destroy_one(void *vin)
 	ABT_mutex_unlock(cont->sc_mutex);
 
 	/* nobody should see it again after eviction */
-	daos_lru_ref_evict_wait(tls->dt_cont_cache, &cont->sc_list);
+	/**
+	 * This function may yield, potentially creating a race condition with
+	 * rebuild operations. During rebuild migration, the container could be
+	 * reopened and restarted, which could result in EBUSY errors from
+	 * subsequent vos_cont_destroy() calls.
+	 *
+	 * To resolve this issue:
+	 * 1. We avoid container eviction during waiting periods
+	 * 2. Container lookup failures are guaranteed by checking the
+	 *    @sc_destroying flag before proceeding
+	 *
+	 * This design ensures consistency by preventing concurrent access
+	 * to containers marked for destruction.
+	 */
+	daos_lru_ref_noevict_wait(tls->dt_cont_cache, &cont->sc_list);
+	daos_lru_ref_evict(tls->dt_cont_cache, &cont->sc_list);
 	cont_child_put(tls->dt_cont_cache, cont);
 
 	D_DEBUG(DB_MD, DF_CONT": destroying vos container\n",

--- a/src/include/daos/lru.h
+++ b/src/include/daos/lru.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -129,6 +130,9 @@ daos_lru_ref_release(struct daos_lru_cache *lcache, struct daos_llink *llink);
 static inline void
 daos_lru_ref_evict(struct daos_lru_cache *lcache, struct daos_llink *llink)
 {
+	if (llink->ll_evicted)
+		return;
+
 	llink->ll_evicted = 1;
 	d_hash_rec_evict_at(&lcache->dlc_htable, &llink->ll_link);
 }
@@ -142,6 +146,15 @@ daos_lru_ref_evict(struct daos_lru_cache *lcache, struct daos_llink *llink)
  */
 void
 daos_lru_ref_evict_wait(struct daos_lru_cache *lcache, struct daos_llink *llink);
+
+/**
+ * Wait until the caller is the last one holds refcount.
+ *
+ * \param[in] lcache		DAOS LRU cache
+ * \param[in] llink		DAOS LRU item to be evicted
+ */
+void
+daos_lru_ref_noevict_wait(struct daos_lru_cache *lcache, struct daos_llink *llink);
 
 /**
  * Increase a usage reference to the LRU element


### PR DESCRIPTION
daos_lru_ref_evict_wait() may yield, potentially creating a race condition with rebuild operations. During rebuild migration, the container could be reopened and restarted, which could result in EBUSY errors from subsequent vos_cont_destroy() calls.

To resolve this issue:
  1. We avoid container eviction during waiting periods
  2. Container lookup failures are guaranteed by checking the @sc_destroying flag before proceeding This design ensures consistency by preventing concurrent access to containers marked for destruction.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
