### PR TITLE
DAOS-18310 rebuild: refine ds_iv_ns_reint_prep

### DIFF
--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -339,8 +339,8 @@ iv_entry_lookup_or_create(struct ds_iv_ns *ns, struct ds_iv_key *key,
 		entry->iv_ref++;
 		if (got != NULL)
 			*got = entry;
-		D_DEBUG(DB_TRACE, "Get entry %p/%d key %d\n",
-			entry, entry->iv_ref, key->class_id);
+		D_DEBUG(DB_TRACE, "Get entry %p, ref %d valid %d key %d\n", entry, entry->iv_ref,
+			entry->iv_valid, key->class_id);
 		return 0;
 	}
 
@@ -883,12 +883,39 @@ ds_iv_ns_cleanup(struct ds_iv_ns *ns)
 /* To prepare for reintegrate, cleanup some IVs' cache.
  * May add more types later when needed.
  */
-void
+int
 ds_iv_ns_reint_prep(struct ds_iv_ns *ns)
 {
 	struct ds_iv_entry *entry;
 	struct ds_iv_entry *tmp;
+	uint32_t            msec  = 100;
+	uint32_t            total = 0;
+	int                 rc;
 
+	/* iv_refcount is 1 after ns create,
+	 *                2 after ds_iv_ns_start.
+	 *              > 2 if with any in-flight IV operation.
+	 * here wait the in-flight IV operation for at most 30 seconds, if cannot finish within
+	 * 30 seconds return EBUSY so user can redo the reintegration. Should be very rare case
+	 * for 30 seconds IV timeout.
+	 */
+	while (ns->iv_refcount > 2) {
+		msec = min(5000, msec * 2);
+		dss_sleep(msec);
+		total += msec;
+		if (total > 30000) {
+			rc = -DER_BUSY;
+			DL_ERROR(
+			    rc, DF_UUID " timed out for wait IV, iv_refcount %d, waited %d seconds",
+			    DP_UUID(ns->iv_pool_uuid), ns->iv_refcount, min(1, total / 1000));
+			return rc;
+		} else {
+			D_INFO(DF_UUID " wait IV operation, iv_refcount %d, waited %d seconds",
+			       DP_UUID(ns->iv_pool_uuid), ns->iv_refcount, min(1, total / 1000));
+		}
+	}
+
+	/* no yield for the cleanup */
 	d_list_for_each_entry_safe(entry, tmp, &ns->iv_entry_list, iv_link) {
 		if (entry->iv_key.class_id == IV_CONT_TRACK_EPOCH ||
 		    entry->iv_key.class_id == IV_CONT_PROP ||
@@ -899,6 +926,8 @@ ds_iv_ns_reint_prep(struct ds_iv_ns *ns)
 			iv_entry_free(entry);
 		}
 	}
+
+	return 0;
 }
 
 void

--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -319,7 +319,8 @@ int ds_iv_ns_create(crt_context_t ctx, uuid_t pool_uuid, crt_group_t *grp,
 
 void ds_iv_ns_update(struct ds_iv_ns *ns, unsigned int master_rank, uint64_t term);
 void ds_iv_ns_cleanup(struct ds_iv_ns *ns);
-void ds_iv_ns_reint_prep(struct ds_iv_ns *ns);
+int
+	     ds_iv_ns_reint_prep(struct ds_iv_ns *ns);
 void ds_iv_ns_stop(struct ds_iv_ns *ns);
 void ds_iv_ns_leader_stop(struct ds_iv_ns *ns);
 void ds_iv_ns_start(struct ds_iv_ns *ns);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -6468,7 +6468,7 @@ shard_anchors_check_alloc_bufs(struct obj_auxi_args *obj_auxi, struct shard_anch
 		}
 
 		if (obj_args->recxs != NULL) {
-			if (sub_anchor->ssa_recxs != NULL && sub_anchors->sa_nr == nr)
+			if (sub_anchor->ssa_recxs != NULL && sub_anchors->sa_nr != nr)
 				D_FREE(sub_anchor->ssa_recxs);
 
 			if (sub_anchor->ssa_recxs == NULL) {

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -847,7 +847,8 @@ dc_rw_cb(tse_task_t *task, void *arg)
 		 * rec2big errors which can be expected.
 		 */
 		if (rc == -DER_REC2BIG || rc == -DER_NONEXIST || rc == -DER_NO_PERM ||
-		    rc == -DER_EXIST || rc == -DER_RF)
+		    rc == -DER_EXIST || rc == -DER_RF || rc == -DER_UPDATE_AGAIN ||
+		    rc == -DER_FETCH_AGAIN)
 			D_DEBUG(DB_IO, DF_UOID" rpc %p opc %d to rank %d tag %d: "DF_RC"\n",
 				DP_UOID(orw->orw_oid), rw_args->rpc, opc,
 				rw_args->rpc->cr_ep.ep_rank, rw_args->rpc->cr_ep.ep_tag, DP_RC(rc));

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -2798,7 +2798,7 @@ ds_pool_tgt_discard_handler(crt_rpc_t *rpc)
 	pool->sp_discard_status = 0;
 	rc = dss_ult_execute(ds_pool_tgt_discard_ult, arg, NULL, NULL, DSS_XS_SYS, 0, 0);
 	if (rc == 0)
-		ds_iv_ns_reint_prep(pool->sp_iv_ns); /* cleanup IV cache */
+		rc = ds_iv_ns_reint_prep(pool->sp_iv_ns); /* cleanup IV cache */
 
 	ds_pool_put(pool);
 out:
@@ -3120,7 +3120,7 @@ lock:
 	ABT_rwlock_unlock(pool->sp_recov_lock);
 
 	if (rc == 0)
-		ds_iv_ns_reint_prep(pool->sp_iv_ns); /* cleanup IV cache */
+		rc = ds_iv_ns_reint_prep(pool->sp_iv_ns); /* cleanup IV cache */
 
 out:
 	DL_CDEBUG(rc != 0, DLOG_ERR, DB_REBUILD, rc,


### PR DESCRIPTION
Cannot do the IV ns cleanup if with in-flight IV operation, wait IV operation's completion in ds_iv_ns_reint_prep before cleanup.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
