### PR TITLE
DAOS-18192 rebuild: global resource control for rebuild

### DIFF
--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -77,16 +77,13 @@ struct migrate_pool_tls {
 	 */
 	uint32_t                 mpt_tgt_obj_ult_cnt;
 	uint32_t                 mpt_tgt_dkey_ult_cnt;
+	/* The current in-flight data size */
 	uint64_t                 mpt_inflight_size;
 
 	struct migr_res_manager *mpt_rmg;
 
 	/* reference count for the structure */
-	uint64_t		mpt_refcount;
-
-	/* The current in-flight iod, mainly used for controlling
-	 * rebuild in-flight rate to avoid the DMA buffer overflow.
-	 */
+	uint64_t                 mpt_refcount;
 	uint32_t		mpt_opc;
 
 	/* The new layout version for upgrade job */

--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -26,6 +26,8 @@
 
 extern struct dss_module_key obj_module_key;
 
+struct migr_res_manager;
+
 /* Per pool attached to the migrate tls(per xstream) */
 struct migrate_pool_tls {
 	/* POOL UUID and pool to be migrated */
@@ -75,6 +77,9 @@ struct migrate_pool_tls {
 	 */
 	uint32_t                 mpt_tgt_obj_ult_cnt;
 	uint32_t                 mpt_tgt_dkey_ult_cnt;
+	uint64_t                 mpt_inflight_size;
+
+	struct migr_res_manager *mpt_rmg;
 
 	/* reference count for the structure */
 	uint64_t		mpt_refcount;
@@ -82,11 +87,6 @@ struct migrate_pool_tls {
 	/* The current in-flight iod, mainly used for controlling
 	 * rebuild in-flight rate to avoid the DMA buffer overflow.
 	 */
-	uint64_t		mpt_inflight_size;
-	uint64_t		mpt_inflight_max_size;
-	ABT_cond		mpt_inflight_cond;
-	ABT_mutex		mpt_inflight_mutex;
-	uint32_t		mpt_inflight_max_ult;
 	uint32_t		mpt_opc;
 
 	/* The new layout version for upgrade job */
@@ -147,6 +147,10 @@ struct obj_tgt_punch_args {
 
 void
 migrate_pool_tls_destroy(struct migrate_pool_tls *tls);
+int
+obj_migrate_init(void);
+void
+obj_migrate_fini(void);
 
 struct obj_tls {
 	d_sg_list_t		ot_echo_sgl;

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -40,9 +40,16 @@ obj_mod_init(void)
 		D_ERROR("failed to obj_ec_codec_init\n");
 		goto out_class;
 	}
+	rc = obj_migrate_init();
+	if (rc) {
+		D_ERROR("failed to init migration resource managers\n");
+		goto out_ec;
+	}
 
 	return 0;
 
+out_ec:
+	obj_ec_codec_fini();
 out_class:
 	obj_class_fini();
 out_utils:
@@ -55,6 +62,7 @@ out:
 static int
 obj_mod_fini(void)
 {
+	obj_migrate_fini();
 	obj_ec_codec_fini();
 	obj_class_fini();
 	obj_utils_fini();

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1846,7 +1846,7 @@ migrate_res_hold(struct migrate_pool_tls *tls, int res_type, long units, bool *y
 			  (int)(tls->mpt_rmg - &migr_eng_res.er_rmgs[0]));
 	}
 
-	res = &rmg->rmg_resources[res_type];
+	res     = &rmg->rmg_resources[res_type];
 	is_hulk = migr_res_is_hulk(res_type, units);
 	while (1) {
 		if (tls->mpt_fini) {

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -3058,8 +3058,6 @@ migrate_fini_one_ult(void *data)
 		for (i = 0; i < MIGR_MAX; i++)
 			ABT_cond_broadcast(rmg->rmg_resources[i].res_cond);
 		ABT_mutex_unlock(rmg->rmg_mutex);
-
-		tls->mpt_rmg = NULL;
 	}
 
 	migrate_pool_tls_put(tls); /* lookup */


### PR DESCRIPTION
Previously, the resource controls within the rebuild system—such as the limits on ULT (user-level thread) counts and DMA buffer usage—were scoped per pool.

This meant that when rebuild or migration operations occurred across multiple pools, each pool operated within its own local resource boundaries. As a result, simultaneous rebuilds in several pools could lead to excessive system-wide consumption of threads and memory, potentially impacting performance and system stability.

This patch reworks the rebuild migration resource management to introduce global limits on the number of ULTs and DMA buffers the rebuild system can use across all pools. A centralized migration resource manager is established per target to coordinate these resources across all active pools, preventing overallocation and minimizing resource contention.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
