### PR TITLE
DAOS-18219 pool: refine pool IV err handling

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -742,6 +742,12 @@ cont_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		    d_sg_list_t *src, int ref_rc, void **priv)
 {
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	if (ref_rc != 0) {
+		DL_WARN(ref_rc, DF_UUID "bypass refresh, IV class id %d.",
+			DP_UUID(entry->ns->iv_pool_uuid), key->class_id);
+		return ref_rc;
+	}
+
 	return cont_iv_ent_update(entry, key, src, priv);
 }
 
@@ -1768,7 +1774,7 @@ ds_cont_find_hdl(uuid_t po_uuid, uuid_t coh_uuid, struct ds_cont_hdl **coh_p)
 	/* Return a retry-able error when the srv handle not propagated */
 	if (d_list_empty(&pool_child->spc_srv_cont_hdl)) {
 		struct copy_hdl_arg arg;
-		int                 rc;
+		int                 rc, ret;
 
 		/*
 		 * Sometimes the srv container handle failed to be propagated to the pool
@@ -1784,8 +1790,10 @@ ds_cont_find_hdl(uuid_t po_uuid, uuid_t coh_uuid, struct ds_cont_hdl **coh_p)
 			}
 		}
 		ds_pool_child_put(pool_child);
-		D_INFO(DF_UUID ": Server handle isn't propagated yet.\n", DP_UUID(po_uuid));
-		return -DER_STALE;
+		ret = -DER_STALE;
+		DL_INFO(ret, DF_UUID ": Server handle isn't propagated yet %d.", DP_UUID(po_uuid),
+			rc);
+		return ret;
 	}
 
 srv_hdl_ready:

--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -454,7 +454,7 @@ iv_on_update_internal(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 	struct ds_iv_ns		*ns = NULL;
 	struct ds_iv_entry	*entry;
 	struct ds_iv_key	key;
-	struct iv_priv_entry	*priv_entry = priv;
+	struct iv_priv_entry    *priv_entry = priv;
 	int			rc = 0;
 
 	rc = iv_ns_lookup_by_ivns(ivns, &ns);
@@ -473,17 +473,21 @@ iv_on_update_internal(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 	}
 
 	if (refresh) {
+		/* oid_iv_ent_refresh need to be called to unlock */
 		rc = refresh_iv_value(entry, &key, iv_value, ref_rc,
 				      priv_entry ? priv_entry->priv : NULL);
+		if (rc == 0)
+			rc = ref_rc;
 	} else {
 		D_ASSERT(iv_value != NULL);
+		D_ASSERT(ref_rc == 0);
+		D_ASSERT(!invalidate);
 		if (ns->iv_master_rank != key.rank) {
 			D_DEBUG(DB_MD, "key id %d master rank %u != %u: rc = %d\n",
 				key.class_id, ns->iv_master_rank, key.rank, -DER_GRPVER);
 			D_GOTO(output, rc = -DER_GRPVER);
 		}
-		rc = update_iv_value(entry, &key, iv_value,
-				     priv_entry ? priv_entry->priv : NULL);
+		rc = update_iv_value(entry, &key, iv_value, priv_entry ? priv_entry->priv : NULL);
 	}
 	if (rc != 0) {
 		D_DEBUG(DB_MD, "key id %d update failed: rc = " DF_RC "\n", key.class_id,

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -186,6 +186,13 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	if (rpt->rt_leader_term != src_iv->riv_leader_term)
 		goto out;
 
+	if (ref_rc != 0) {
+		rc = ref_rc;
+		DL_WARN(rc, DF_UUID "bypass refresh, IV class id %d.",
+			DP_UUID(entry->ns->iv_pool_uuid), key->class_id);
+		goto out;
+	}
+
 	uuid_copy(dst_iv->riv_pool_uuid, src_iv->riv_pool_uuid);
 	dst_iv->riv_master_rank = src_iv->riv_master_rank;
 	dst_iv->riv_global_done = src_iv->riv_global_done;


### PR DESCRIPTION
When the pool IV fetch failed (fetch IV_POOL_HDL failed as -DER_NOTLEADER for example), the refresh callback still will be called. In that case should not refresh/update to IV cache, also cannot set iv_valid as true, to avoid following IV fetch get invalid data.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
