### PR TITLE
DAOS-18219 pool: refine pool IV err handling

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -745,6 +745,12 @@ cont_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		    d_sg_list_t *src, int ref_rc, void **priv)
 {
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	if (ref_rc != 0) {
+		DL_WARN(ref_rc, DF_UUID "bypass refresh, IV class id %d.",
+			DP_UUID(entry->ns->iv_pool_uuid), key->class_id);
+		return ref_rc;
+	}
+
 	return cont_iv_ent_update(entry, key, src, priv);
 }
 

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -799,10 +799,11 @@ pool_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		 * not be fully initialized yet.
 		 */
 		if (!entry->iv_valid) {
-			D_INFO(DF_UUID" master %u is still stepping up: %d.\n",
-			       DP_UUID(entry->ns->iv_pool_uuid), entry->ns->iv_master_rank,
-			       -DER_NOTLEADER);
-			return -DER_NOTLEADER;
+			rc = -DER_NOTLEADER;
+			DL_INFO(rc, DF_UUID " iv class id %d, master %u is still stepping up.",
+				DP_UUID(entry->ns->iv_pool_uuid), key->class_id,
+				entry->ns->iv_master_rank);
+			return rc;
 		}
 	}
 
@@ -985,6 +986,13 @@ pool_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	struct pool_iv_entry	*src_iv;
 	struct ds_pool		*pool = 0;
 	int			rc;
+
+	if (ref_rc != 0) {
+		rc = ref_rc;
+		DL_WARN(rc, DF_UUID "bypass refresh, IV class id %d.",
+			DP_UUID(entry->ns->iv_pool_uuid), key->class_id);
+		goto out_put;
+	}
 
 	if (src == NULL)
 		rc = ds_pool_lookup_internal(entry->ns->iv_pool_uuid, &pool);

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -186,6 +186,13 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	if (rpt->rt_leader_term != src_iv->riv_leader_term)
 		goto out;
 
+	if (ref_rc != 0) {
+		rc = ref_rc;
+		DL_WARN(rc, DF_UUID "bypass refresh, IV class id %d.",
+			DP_UUID(entry->ns->iv_pool_uuid), key->class_id);
+		goto out;
+	}
+
 	uuid_copy(dst_iv->riv_pool_uuid, src_iv->riv_pool_uuid);
 	dst_iv->riv_master_rank = src_iv->riv_master_rank;
 	dst_iv->riv_global_done = src_iv->riv_global_done;


### PR DESCRIPTION
When the pool IV fetch failed (fetch IV_POOL_HDL failed as -DER_NOTLEADER for example), the refresh callback still will be called. In that case should not refresh/update to IV cache, also cannot set iv_valid as true, to avoid following IV fetch get invalid data.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
