### PR TITLE
DAOS-18383 object: Fix potential use-after-free in migrate_pool_tls_c…

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -533,16 +533,12 @@ migrate_pool_tls_create(uuid_t pool_uuid, unsigned int version, unsigned int gen
 	d_list_add(&pool_tls->mpt_list, &obj_tls->ot_pool_list);
 	migrate_pool_tls_get(pool_tls);
 out:
-	if (rc && pool_tls)
-		migrate_pool_tls_destroy(pool_tls);
-
 	if (pool_child != NULL)
 		ds_pool_child_put(pool_child);
 
 	D_DEBUG(DB_TRACE, "create tls " DF_UUID ": " DF_RC "\n", DP_UUID(pool_uuid), DP_RC(rc));
 	if (rc != 0) {
-		if (pool_tls != NULL)
-			migrate_pool_tls_put(pool_tls);
+		migrate_pool_tls_put(pool_tls);
 	} else {
 		*p_tls = pool_tls;
 	}


### PR DESCRIPTION
…reate()

In migrate_pool_tls_create(), error handling could result in both migrate_pool_tls_destroy() and migrate_pool_tls_put() being called on the same pool_tls object, leading to a possible double free/use-after-free.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
