### PR TITLE
DAOS-17928 rebuild: migrate object processing from system xstream to main xstream

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -183,8 +183,8 @@ cont_aggregate_runnable(struct ds_cont_child *cont, struct sched_request *req,
 
 	if (ds_pool_is_rebuilding(pool) && !vos_agg) {
 		D_DEBUG(DB_EPC, DF_CONT ": skip EC aggregation during rebuild %d, %d.\n",
-			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid), pool->sp_rebuilding,
-			pool->sp_rebuild_scan);
+			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
+			atomic_load(&pool->sp_rebuilding), pool->sp_rebuild_scan);
 		return false;
 	}
 

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -707,7 +707,7 @@ ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_u
 		       uint32_t new_gl_ver, unsigned int migrate_opc, uint64_t *enqueue_id,
 		       uint32_t *max_delay);
 int
-ds_migrate_object(struct ds_pool *pool, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_uuid,
+ds_migrate_object(uuid_t pool_uuid, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_uuid,
 		  uint32_t version, uint32_t generation, uint64_t max_eph, uint32_t opc,
 		  daos_unit_oid_t *oids, daos_epoch_t *epochs, daos_epoch_t *punched_epochs,
 		  unsigned int *shards, uint32_t count, unsigned int tgt_idx, uint32_t new_gl_ver);

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -707,10 +707,10 @@ ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_u
 		       uint32_t new_gl_ver, unsigned int migrate_opc, uint64_t *enqueue_id,
 		       uint32_t *max_delay);
 int
-ds_migrate_object(uuid_t pool_uuid, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_uuid,
-		  uint32_t version, uint32_t generation, uint64_t max_eph, uint32_t opc,
-		  daos_unit_oid_t *oids, daos_epoch_t *epochs, daos_epoch_t *punched_epochs,
-		  unsigned int *shards, uint32_t count, unsigned int tgt_idx, uint32_t new_gl_ver);
+ds_migrate_object(uuid_t pool_uuid, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_uuid, uint32_t version,
+		  uint32_t generation, uint64_t max_eph, uint32_t opc, daos_unit_oid_t *oids,
+		  daos_epoch_t *epochs, daos_epoch_t *punched_epochs, unsigned int *shards,
+		  uint32_t count, unsigned int tgt_idx, uint32_t new_gl_ver);
 void
 ds_migrate_stop(struct ds_pool *pool, uint32_t ver, unsigned int generation);
 

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -25,6 +25,7 @@
 #include <daos_pool.h>
 #include <daos_security.h>
 #include <gurt/telemetry_common.h>
+#include <gurt/atomic.h>
 #include <daos_srv/rdb.h>
 
 /* Pool service (opaque) */
@@ -91,7 +92,7 @@ struct ds_pool {
 	 * rebuild job.
 	 */
 	uint32_t                 sp_rebuild_gen;
-	int			sp_rebuilding;
+	ATOMIC int               sp_rebuilding;
 	/**
 	 * someone has already messaged this pool to for rebuild scan,
 	 * NB: all xstreams can do lockless-write on it but it's OK
@@ -213,7 +214,7 @@ struct ds_pool_svc_op_val {
 static inline bool
 ds_pool_is_rebuilding(struct ds_pool *pool)
 {
-	return (pool->sp_rebuilding > 0 || pool->sp_rebuild_scan > 0);
+	return (atomic_load(&pool->sp_rebuilding) > 0 || pool->sp_rebuild_scan > 0);
 }
 
 /* encode metadata RPC operation key: HLC time first, in network order, for keys sorted by time.

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2288,9 +2288,9 @@ ec_aggregate_yield(struct ec_agg_param *agg_param)
 	int	rc;
 
 	if (ds_pool_is_rebuilding(agg_param->ap_pool_info.api_pool)) {
-		D_INFO(DF_UUID": abort ec aggregation, sp_rebuilding %d\n",
+		D_INFO(DF_UUID ": abort ec aggregation, sp_rebuilding %d\n",
 		       DP_UUID(agg_param->ap_pool_info.api_pool->sp_uuid),
-		       agg_param->ap_pool_info.api_pool->sp_rebuilding);
+		       atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding));
 		return true;
 	}
 
@@ -2494,10 +2494,10 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	 * (see obj_inflight_io_check()).
 	 */
 	if (ds_pool_is_rebuilding(agg_param->ap_pool_info.api_pool)) {
-		D_INFO(DF_CONT" abort as rebuild started, sp_rebuilding %d\n",
-			DP_CONT(agg_param->ap_pool_info.api_pool_uuid,
-				agg_param->ap_pool_info.api_cont_uuid),
-			agg_param->ap_pool_info.api_pool->sp_rebuilding);
+		D_INFO(DF_CONT " abort as rebuild started, sp_rebuilding %d\n",
+		       DP_CONT(agg_param->ap_pool_info.api_pool_uuid,
+			       agg_param->ap_pool_info.api_cont_uuid),
+		       atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding));
 		return -1;
 	}
 
@@ -2522,9 +2522,9 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	}
 
 	if (rc < 0) {
-		D_ERROR(DF_UUID" EC aggregation (rebuilding %d) failed: "DF_RC"\n",
+		D_ERROR(DF_UUID " EC aggregation (rebuilding %d) failed: " DF_RC "\n",
 			DP_UUID(agg_param->ap_pool_info.api_pool->sp_uuid),
-			agg_param->ap_pool_info.api_pool->sp_rebuilding, DP_RC(rc));
+			atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding), DP_RC(rc));
 		return rc;
 	}
 

--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -92,8 +93,7 @@ struct migrate_pool_tls {
 	uint32_t		mpt_new_layout_ver;
 
 	/* migrate leader ULT */
-	unsigned int		mpt_ult_running:1,
-				mpt_fini:1;
+	unsigned int             mpt_ult_running : 1, mpt_fini : 1;
 
 	/* migration init error */
 	int			mpt_init_err;

--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -72,12 +72,8 @@ struct migrate_pool_tls {
 	/* The ULT number on each target xstream, which actually refer
 	 * back to the item within mpt_obj/dkey_ult_cnts array.
 	 */
-	ATOMIC uint32_t		*mpt_tgt_obj_ult_cnt;
-	ATOMIC uint32_t		*mpt_tgt_dkey_ult_cnt;
-
-	/* ULT count array from all targets, obj: enumeration, dkey:fetch/update */
-	ATOMIC uint32_t		*mpt_obj_ult_cnts;
-	ATOMIC uint32_t		*mpt_dkey_ult_cnts;
+	uint32_t                 mpt_tgt_obj_ult_cnt;
+	uint32_t                 mpt_tgt_dkey_ult_cnt;
 
 	/* reference count for the structure */
 	uint64_t		mpt_refcount;
@@ -92,15 +88,11 @@ struct migrate_pool_tls {
 	uint32_t		mpt_inflight_max_ult;
 	uint32_t		mpt_opc;
 
-	ABT_cond		mpt_init_cond;
-	ABT_mutex		mpt_init_mutex;
-
 	/* The new layout version for upgrade job */
 	uint32_t		mpt_new_layout_ver;
 
 	/* migrate leader ULT */
 	unsigned int		mpt_ult_running:1,
-				mpt_init_tls:1,
 				mpt_fini:1;
 
 	/* migration init error */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2425,9 +2425,9 @@ obj_inflight_io_check(struct ds_cont_child *child, uint32_t opc,
 	if (opc == DAOS_OBJ_RPC_ENUMERATE && flags & ORF_FOR_MIGRATION) {
 		/* EC aggregation is still inflight, rebuild should wait until it's paused */
 		if (ds_cont_child_ec_aggregating(child)) {
-			D_ERROR(DF_CONT" ec aggregate still active, rebuilding %d\n",
+			D_ERROR(DF_CONT " ec aggregate still active, rebuilding %d\n",
 				DP_CONT(child->sc_pool->spc_uuid, child->sc_uuid),
-				child->sc_pool->spc_pool->sp_rebuilding);
+				atomic_load(&child->sc_pool->spc_pool->sp_rebuilding));
 			return -DER_UPDATE_AGAIN;
 		}
 	}
@@ -2435,7 +2435,7 @@ obj_inflight_io_check(struct ds_cont_child *child, uint32_t opc,
 	if (!obj_is_modification_opc(opc) && (opc != DAOS_OBJ_RPC_CPD || flags & ORF_CPD_RDONLY))
 		return 0;
 
-	if (child->sc_pool->spc_pool->sp_rebuilding) {
+	if (atomic_load(&child->sc_pool->spc_pool->sp_rebuilding)) {
 		uint32_t version;
 
 		ds_rebuild_running_query(child->sc_pool_uuid, RB_OP_REBUILD,

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -525,16 +525,12 @@ migrate_pool_tls_create(uuid_t pool_uuid, unsigned int version, unsigned int gen
 	d_list_add(&pool_tls->mpt_list, &obj_tls->ot_pool_list);
 	migrate_pool_tls_get(pool_tls);
 out:
-	if (rc && pool_tls)
-		migrate_pool_tls_destroy(pool_tls);
-
 	if (pool_child != NULL)
 		ds_pool_child_put(pool_child);
 
 	D_DEBUG(DB_TRACE, "create tls " DF_UUID ": " DF_RC "\n", DP_UUID(pool_uuid), DP_RC(rc));
  	if (rc != 0) {
-		if (pool_tls != NULL)
-			migrate_pool_tls_put(pool_tls);
+		migrate_pool_tls_put(pool_tls);
 	} else {
 		*p_tls = pool_tls;
 	}

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -519,9 +519,10 @@ migrate_pool_tls_create(uuid_t pool_uuid, unsigned int version, unsigned int gen
 			D_GOTO(out, rc);
 	}
 
-	D_DEBUG(DB_REBUILD, "TLS %p create for "DF_UUID" "DF_UUID"/"DF_UUID
-		" ver %d "DF_RC"\n", pool_tls, DP_UUID(pool_tls->mpt_pool_uuid),
-		DP_UUID(pool_hdl_uuid), DP_UUID(co_hdl_uuid), version, DP_RC(rc));
+	D_DEBUG(DB_REBUILD,
+		"TLS %p create for " DF_UUID " " DF_UUID "/" DF_UUID " ver %d " DF_RC "\n",
+		pool_tls, DP_UUID(pool_tls->mpt_pool_uuid), DP_UUID(pool_hdl_uuid),
+		DP_UUID(co_hdl_uuid), version, DP_RC(rc));
 	d_list_add(&pool_tls->mpt_list, &obj_tls->ot_pool_list);
 	migrate_pool_tls_get(pool_tls);
 out:
@@ -529,7 +530,7 @@ out:
 		ds_pool_child_put(pool_child);
 
 	D_DEBUG(DB_TRACE, "create tls " DF_UUID ": " DF_RC "\n", DP_UUID(pool_uuid), DP_RC(rc));
- 	if (rc != 0) {
+	if (rc != 0) {
 		migrate_pool_tls_put(pool_tls);
 	} else {
 		*p_tls = pool_tls;
@@ -1782,7 +1783,7 @@ migrate_tgt_enter(struct migrate_pool_tls *tls, int ult_type, bool *yielded)
 	ult_cnt = migrate_tgt_ult_cnt(tls, ult_type);
 	while (tls->mpt_inflight_max_ult / 2 <= ult_cnt) {
 		D_DEBUG(DB_REBUILD, "tgt %u max %u\n", ult_cnt, tls->mpt_inflight_max_ult);
- 
+
 		if (yielded)
 			*yielded = true;
 		ABT_mutex_lock(tls->mpt_inflight_mutex);
@@ -3212,10 +3213,11 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, daos_epoch_t punched_e
 
 	d_iov_set(&val_iov, &val, sizeof(struct migrate_obj_val));
 	rc = obj_tree_insert(toh, cont_arg->cont_uuid, -1, oid, &val_iov);
-	D_DEBUG(DB_REBUILD, "Insert "DF_UUID"/"DF_UUID"/"DF_UOID": ver %u "
-		"ult %u/%u "DF_RC"\n", DP_UUID(tls->mpt_pool_uuid),
-		DP_UUID(cont_arg->cont_uuid), DP_UOID(oid), tls->mpt_version,
-		tls->mpt_tgt_obj_ult_cnt, tls->mpt_tgt_dkey_ult_cnt, DP_RC(rc));
+	D_DEBUG(DB_REBUILD,
+		"Insert " DF_UUID "/" DF_UUID "/" DF_UOID ": ver %u "
+		"ult %u/%u " DF_RC "\n",
+		DP_UUID(tls->mpt_pool_uuid), DP_UUID(cont_arg->cont_uuid), DP_UOID(oid),
+		tls->mpt_version, tls->mpt_tgt_obj_ult_cnt, tls->mpt_tgt_dkey_ult_cnt, DP_RC(rc));
 
 	return 0;
 free:
@@ -3775,7 +3777,7 @@ struct migrate_query_arg {
 	ABT_mutex status_lock;
 	struct ds_migrate_status dms;
 	uint32_t version;
-	uint32_t ult_running;
+	uint32_t                 ult_running;
 	uint32_t total_ult_cnt;
 	uint32_t generation;
 };
@@ -3799,9 +3801,9 @@ migrate_check_one(void *data)
 	arg->total_ult_cnt = tls->mpt_tgt_obj_ult_cnt + tls->mpt_tgt_dkey_ult_cnt;
 	arg->ult_running += tls->mpt_ult_running;
 	ABT_mutex_unlock(arg->status_lock);
-	D_DEBUG(DB_REBUILD, "status %d/%d/ ult %u/%u  rec/obj/size "
-		DF_U64"/"DF_U64"/"DF_U64"\n", tls->mpt_status,
-		arg->dms.dm_status, tls->mpt_tgt_obj_ult_cnt,
+	D_DEBUG(DB_REBUILD,
+		"status %d/%d/ ult %u/%u  rec/obj/size " DF_U64 "/" DF_U64 "/" DF_U64 "\n",
+		tls->mpt_status, arg->dms.dm_status, tls->mpt_tgt_obj_ult_cnt,
 		tls->mpt_tgt_dkey_ult_cnt, tls->mpt_rec_count, tls->mpt_obj_count, tls->mpt_size);
 
 	migrate_pool_tls_put(tls);
@@ -3812,7 +3814,7 @@ int
 ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, unsigned int generation,
 			struct ds_migrate_status *dms)
 {
-	struct migrate_query_arg	arg = { 0 };
+	struct migrate_query_arg        arg = {0};
 	int				rc;
 
 	uuid_copy(arg.pool_uuid, pool_uuid);

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -382,10 +382,6 @@ migrate_pool_tls_destroy(struct migrate_pool_tls *tls)
 	if (daos_handle_is_valid(tls->mpt_pool_hdl))
 		dsc_pool_close(tls->mpt_pool_hdl);
 
-	if (tls->mpt_obj_ult_cnts)
-		D_FREE(tls->mpt_obj_ult_cnts);
-	if (tls->mpt_dkey_ult_cnts)
-		D_FREE(tls->mpt_dkey_ult_cnts);
 	d_list_del(&tls->mpt_list);
 	D_DEBUG(DB_REBUILD, "TLS destroy for "DF_UUID" ver %d\n",
 		DP_UUID(tls->mpt_pool_uuid), tls->mpt_version);
@@ -399,10 +395,6 @@ migrate_pool_tls_destroy(struct migrate_pool_tls *tls)
 		ABT_cond_free(&tls->mpt_inflight_cond);
 	if (tls->mpt_inflight_mutex)
 		ABT_mutex_free(&tls->mpt_inflight_mutex);
-	if (tls->mpt_init_cond)
-		ABT_cond_free(&tls->mpt_init_cond);
-	if (tls->mpt_init_mutex)
-		ABT_mutex_free(&tls->mpt_init_mutex);
 	if (daos_handle_is_valid(tls->mpt_root_hdl))
 		obj_tree_destroy(tls->mpt_root_hdl);
 	if (daos_handle_is_valid(tls->mpt_migrated_root_hdl))
@@ -452,50 +444,31 @@ migrate_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver, uint32_t gen)
 	return found;
 }
 
-struct migrate_pool_tls_create_arg {
-	uuid_t	pool_uuid;
-	uuid_t	pool_hdl_uuid;
-	uuid_t  co_hdl_uuid;
-	d_rank_list_t *svc_list;
-	ATOMIC uint32_t *obj_ult_cnts;
-	ATOMIC uint32_t *dkey_ult_cnts;
-	uint64_t max_eph;
-	unsigned int version;
-	unsigned int generation;
-	uint32_t opc;
-	uint32_t new_layout_ver;
-	uint32_t max_ult_cnt;
-};
-
-int
-migrate_pool_tls_create_one(void *data)
+static int
+migrate_pool_tls_create(uuid_t pool_uuid, unsigned int version, unsigned int generation,
+			uuid_t pool_hdl_uuid, uuid_t co_hdl_uuid, uint64_t max_eph,
+			uint32_t new_layout_ver, uint32_t opc, struct migrate_pool_tls **p_tls,
+			d_rank_list_t *svc_list)
 {
-	struct migrate_pool_tls_create_arg *arg = data;
-	struct obj_tls			   *tls = obj_tls_get();
-	struct migrate_pool_tls		   *pool_tls;
+	uint32_t                            max_migrate_ult = MIGRATE_DEFAULT_MAX_ULT;
+	struct obj_tls                     *obj_tls         = obj_tls_get();
+	struct migrate_pool_tls            *pool_tls        = NULL;
 	struct ds_pool_child		   *pool_child = NULL;
 	int				    rc = 0;
 
-	pool_tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
-	if (pool_tls != NULL) {
-		/* Some one else already created, because collective function
-		 * might yield xstream.
-		 */
-		migrate_pool_tls_put(pool_tls);
-		return 0;
-	}
+	d_getenv_uint(ENV_MIGRATE_ULT_CNT, &max_migrate_ult);
+	D_ASSERT(generation != (unsigned int)(-1));
 
-	pool_child = ds_pool_child_lookup(arg->pool_uuid);
+	pool_child = ds_pool_child_lookup(pool_uuid);
 	if (pool_child == NULL) {
 		/* Local ds_pool_child isn't started yet, return a retry-able error */
 		if (dss_get_module_info()->dmi_xs_id != 0) {
-			D_INFO(DF_UUID ": Local VOS pool isn't ready yet.\n",
-			       DP_UUID(arg->pool_uuid));
+			D_INFO(DF_UUID ": Local VOS pool isn't ready yet.\n", DP_UUID(pool_uuid));
 			return -DER_STALE;
 		}
 	} else if (unlikely(pool_child->spc_no_storage)) {
-		D_DEBUG(DB_REBUILD, DF_UUID" "DF_UUID" lost pool shard, ver %d, skip.\n",
-			DP_UUID(arg->pool_uuid), DP_UUID(arg->pool_hdl_uuid), arg->version);
+		D_DEBUG(DB_REBUILD, DF_UUID " " DF_UUID " lost pool shard, ver %d, skip.\n",
+			DP_UUID(pool_uuid), DP_UUID(pool_hdl_uuid), version);
 		D_GOTO(out, rc = 0);
 	}
 
@@ -519,56 +492,38 @@ migrate_pool_tls_create_one(void *data)
 	if (rc != ABT_SUCCESS)
 		D_GOTO(out, rc = dss_abterr2der(rc));
 
-	uuid_copy(pool_tls->mpt_pool_uuid, arg->pool_uuid);
-	uuid_copy(pool_tls->mpt_poh_uuid, arg->pool_hdl_uuid);
-	uuid_copy(pool_tls->mpt_coh_uuid, arg->co_hdl_uuid);
-	pool_tls->mpt_version = arg->version;
-	pool_tls->mpt_generation = arg->generation;
+	uuid_copy(pool_tls->mpt_pool_uuid, pool_uuid);
+	uuid_copy(pool_tls->mpt_poh_uuid, pool_hdl_uuid);
+	uuid_copy(pool_tls->mpt_coh_uuid, co_hdl_uuid);
+	pool_tls->mpt_version        = version;
+	pool_tls->mpt_generation     = generation;
 	pool_tls->mpt_rec_count = 0;
 	pool_tls->mpt_obj_count = 0;
 	pool_tls->mpt_size = 0;
 	pool_tls->mpt_root_hdl = DAOS_HDL_INVAL;
-	pool_tls->mpt_max_eph = arg->max_eph;
-	pool_tls->mpt_new_layout_ver = arg->new_layout_ver;
-	pool_tls->mpt_opc = arg->opc;
-	if (dss_get_module_info()->dmi_xs_id == 0) {
-		int i;
-
-		pool_tls->mpt_inflight_max_size = MIGRATE_MAX_SIZE;
-		pool_tls->mpt_inflight_max_ult = arg->max_ult_cnt;
-		D_ALLOC_ARRAY(pool_tls->mpt_obj_ult_cnts, dss_tgt_nr);
-		D_ALLOC_ARRAY(pool_tls->mpt_dkey_ult_cnts, dss_tgt_nr);
-		if (pool_tls->mpt_obj_ult_cnts == NULL || pool_tls->mpt_dkey_ult_cnts == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-		for (i = 0; i < dss_tgt_nr; i++) {
-			atomic_init(&pool_tls->mpt_obj_ult_cnts[i], 0);
-			atomic_init(&pool_tls->mpt_dkey_ult_cnts[i], 0);
-		}
-	} else {
-		int tgt_id = dss_get_module_info()->dmi_tgt_id;
-
-		pool_tls->mpt_pool = ds_pool_child_lookup(arg->pool_uuid);
-		if (pool_tls->mpt_pool == NULL)
-			D_GOTO(out, rc = -DER_NO_HDL);
-		pool_tls->mpt_inflight_max_size = MIGRATE_MAX_SIZE / dss_tgt_nr;
-		pool_tls->mpt_inflight_max_ult = arg->max_ult_cnt / dss_tgt_nr;
-		pool_tls->mpt_tgt_obj_ult_cnt = &arg->obj_ult_cnts[tgt_id];
-		pool_tls->mpt_tgt_dkey_ult_cnt = &arg->dkey_ult_cnts[tgt_id];
-	}
-
+	pool_tls->mpt_max_eph        = max_eph;
+	pool_tls->mpt_new_layout_ver = new_layout_ver;
+	pool_tls->mpt_opc            = opc;
+	pool_tls->mpt_pool           = ds_pool_child_lookup(pool_uuid);
+	if (pool_tls->mpt_pool == NULL)
+		D_GOTO(out, rc = -DER_NO_HDL);
+	pool_tls->mpt_inflight_max_size = MIGRATE_MAX_SIZE / dss_tgt_nr;
+	pool_tls->mpt_inflight_max_ult  = max_migrate_ult / dss_tgt_nr;
+	pool_tls->mpt_tgt_obj_ult_cnt   = 0;
+	pool_tls->mpt_tgt_dkey_ult_cnt  = 0;
 	pool_tls->mpt_inflight_size = 0;
 	pool_tls->mpt_refcount = 1;
-	if (arg->svc_list) {
-		rc = daos_rank_list_copy(&pool_tls->mpt_svc_list, arg->svc_list);
+	if (svc_list) {
+		rc = daos_rank_list_copy(&pool_tls->mpt_svc_list, svc_list);
 		if (rc)
 			D_GOTO(out, rc);
 	}
 
 	D_DEBUG(DB_REBUILD, "TLS %p create for "DF_UUID" "DF_UUID"/"DF_UUID
 		" ver %d "DF_RC"\n", pool_tls, DP_UUID(pool_tls->mpt_pool_uuid),
-		DP_UUID(arg->pool_hdl_uuid), DP_UUID(arg->co_hdl_uuid),
-		arg->version, DP_RC(rc));
-	d_list_add(&pool_tls->mpt_list, &tls->ot_pool_list);
+		DP_UUID(pool_hdl_uuid), DP_UUID(co_hdl_uuid), version, DP_RC(rc));
+	d_list_add(&pool_tls->mpt_list, &obj_tls->ot_pool_list);
+	migrate_pool_tls_get(pool_tls);
 out:
 	if (rc && pool_tls)
 		migrate_pool_tls_destroy(pool_tls);
@@ -576,117 +531,13 @@ out:
 	if (pool_child != NULL)
 		ds_pool_child_put(pool_child);
 
-	return rc;
-}
-
-static int
-migrate_pool_tls_lookup_create(struct ds_pool *pool, unsigned int version, unsigned int generation,
-			       uuid_t pool_hdl_uuid, uuid_t co_hdl_uuid, uint64_t max_eph,
-			       uint32_t new_layout_ver, uint32_t opc, struct migrate_pool_tls **p_tls)
-{
-	struct migrate_pool_tls *tls = NULL;
-	struct migrate_pool_tls_create_arg arg = { 0 };
-	daos_prop_t		*prop = NULL;
-	struct daos_prop_entry	*entry;
-	int			rc = 0;
-	uint32_t		max_migrate_ult = MIGRATE_DEFAULT_MAX_ULT;
-
-	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
-	tls = migrate_pool_tls_lookup(pool->sp_uuid, version, generation);
-	if (tls) {
-		if (tls->mpt_init_tls) {
-			ABT_mutex_lock(tls->mpt_init_mutex);
-			ABT_cond_wait(tls->mpt_init_cond, tls->mpt_init_mutex);
-			ABT_mutex_unlock(tls->mpt_init_mutex);
-			if (tls->mpt_init_err) {
-				migrate_pool_tls_put(tls);
-				rc = tls->mpt_init_err;
-			}
-		}
-
-		if (rc == 0)
-			*p_tls = tls;
-
-		return rc;
-	}
-
-	d_getenv_uint(ENV_MIGRATE_ULT_CNT, &max_migrate_ult);
-	D_ASSERT(generation != (unsigned int)(-1));
-	uuid_copy(arg.pool_uuid, pool->sp_uuid);
-	uuid_copy(arg.pool_hdl_uuid, pool_hdl_uuid);
-	uuid_copy(arg.co_hdl_uuid, co_hdl_uuid);
-	arg.version = version;
-	arg.opc = opc;
-	arg.max_eph = max_eph;
-	arg.new_layout_ver = new_layout_ver;
-	arg.generation = generation;
-	arg.max_ult_cnt = max_migrate_ult;
-
-	/*
-	 * dss_task_collective does not do collective on sys xstrem,
-	 * sys xstream need some information to track rebuild status.
-	 */
-	rc = migrate_pool_tls_create_one(&arg);
-	if (rc)
-		D_GOTO(out, rc);
-
-	tls = migrate_pool_tls_lookup(pool->sp_uuid, version, generation);
-	D_ASSERT(tls != NULL);
-	pool->sp_rebuilding++;
-
-	rc = ABT_cond_create(&tls->mpt_init_cond);
-	if (rc != ABT_SUCCESS)
-		D_GOTO(out, rc = dss_abterr2der(rc));
-
-	rc = ABT_mutex_create(&tls->mpt_init_mutex);
-	if (rc != ABT_SUCCESS)
-		D_GOTO(out, rc = dss_abterr2der(rc));
-
-	tls->mpt_init_tls = 1;
-	D_ALLOC_PTR(prop);
-	if (prop == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	rc = ds_pool_iv_prop_fetch(pool, prop);
-	if (rc)
-		D_GOTO(out, rc);
-
-	entry = daos_prop_entry_get(prop, DAOS_PROP_PO_SVC_LIST);
-	D_ASSERT(entry != NULL);
-	arg.svc_list = (d_rank_list_t *)entry->dpe_val_ptr;
-	arg.obj_ult_cnts = tls->mpt_obj_ult_cnts;
-	arg.dkey_ult_cnts = tls->mpt_dkey_ult_cnts;
-	rc = ds_pool_task_collective(pool->sp_uuid,
-				     PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
-				     migrate_pool_tls_create_one, &arg, 0);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to create migrate tls: "DF_RC"\n",
-			DP_UUID(pool->sp_uuid), DP_RC(rc));
-		D_GOTO(out, rc);
-	}
-
-out:
-	if (tls != NULL && tls->mpt_init_tls) {
-		tls->mpt_init_tls = 0;
-		/* Set init failed, so the waiting lookup(above) can be notified */
-		if (rc != 0)
-			tls->mpt_init_err = rc;
-		ABT_mutex_lock(tls->mpt_init_mutex);
-		ABT_cond_broadcast(tls->mpt_init_cond);
-		ABT_mutex_unlock(tls->mpt_init_mutex);
-	}
-	D_DEBUG(DB_TRACE, "create tls "DF_UUID": "DF_RC"\n",
-		DP_UUID(pool->sp_uuid), DP_RC(rc));
-
-	if (rc != 0) {
-		if (tls != NULL)
-			migrate_pool_tls_put(tls);
+	D_DEBUG(DB_TRACE, "create tls " DF_UUID ": " DF_RC "\n", DP_UUID(pool_uuid), DP_RC(rc));
+ 	if (rc != 0) {
+		if (pool_tls != NULL)
+			migrate_pool_tls_put(pool_tls);
 	} else {
-		*p_tls = tls;
+		*p_tls = pool_tls;
 	}
-
-	if (prop != NULL)
-		daos_prop_free(prop);
 
 	return rc;
 }
@@ -1904,82 +1755,56 @@ enum {
 	DKEY_ULT = 2,
 };
 
-/* Check if there are enough resource for the migration to proceed. */
-static int
-migrate_system_enter(struct migrate_pool_tls *tls, int tgt_idx, bool *yielded)
+static inline uint32_t
+migrate_tgt_ult_cnt(struct migrate_pool_tls *tls, int ult_type)
 {
-	uint32_t tgt_cnt = 0;
-	int	 rc = 0;
-
-	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
-	D_ASSERTF(tgt_idx < dss_tgt_nr, "tgt idx %d tgt nr %u\n", tgt_idx, dss_tgt_nr);
-
-	tgt_cnt = atomic_load(&tls->mpt_obj_ult_cnts[tgt_idx]) +
-		  atomic_load(&tls->mpt_dkey_ult_cnts[tgt_idx]);
-
-	while ((tls->mpt_inflight_max_ult / dss_tgt_nr) <= tgt_cnt) {
-		D_DEBUG(DB_REBUILD, "tgt%d:%u max %u\n",
-			tgt_idx, tgt_cnt, tls->mpt_inflight_max_ult / dss_tgt_nr);
-		*yielded = true;
-		dss_sleep(0);
-		if (tls->mpt_fini)
-			D_GOTO(out, rc = -DER_SHUTDOWN);
-
-		tgt_cnt = atomic_load(&tls->mpt_obj_ult_cnts[tgt_idx]) +
-			  atomic_load(&tls->mpt_dkey_ult_cnts[tgt_idx]);
-	}
-
-	atomic_fetch_add(&tls->mpt_obj_ult_cnts[tgt_idx], 1);
-out:
-	return rc;
+	if (ult_type == OBJ_ULT)
+		return tls->mpt_tgt_obj_ult_cnt;
+	else
+		return tls->mpt_tgt_dkey_ult_cnt;
 }
 
 static int
-migrate_tgt_enter(struct migrate_pool_tls *tls)
+migrate_tgt_enter(struct migrate_pool_tls *tls, int ult_type, bool *yielded)
 {
-	uint32_t dkey_cnt = 0;
+	uint32_t ult_cnt = 0;
 	int	 rc = 0;
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
 
-	dkey_cnt = atomic_load(tls->mpt_tgt_dkey_ult_cnt);
-	while (tls->mpt_inflight_max_ult / 2 <= dkey_cnt) {
-		D_DEBUG(DB_REBUILD, "tgt %u max %u\n", dkey_cnt, tls->mpt_inflight_max_ult);
-
+	ult_cnt = migrate_tgt_ult_cnt(tls, ult_type);
+	while (tls->mpt_inflight_max_ult / 2 <= ult_cnt) {
+		D_DEBUG(DB_REBUILD, "tgt %u max %u\n", ult_cnt, tls->mpt_inflight_max_ult);
+ 
+		if (yielded)
+			*yielded = true;
 		ABT_mutex_lock(tls->mpt_inflight_mutex);
 		ABT_cond_wait(tls->mpt_inflight_cond, tls->mpt_inflight_mutex);
 		ABT_mutex_unlock(tls->mpt_inflight_mutex);
 		if (tls->mpt_fini)
 			D_GOTO(out, rc = -DER_SHUTDOWN);
 
-		dkey_cnt = atomic_load(tls->mpt_tgt_dkey_ult_cnt);
+		ult_cnt = migrate_tgt_ult_cnt(tls, ult_type);
 	}
 
-	atomic_fetch_add(tls->mpt_tgt_dkey_ult_cnt, 1);
+	if (ult_type == OBJ_ULT)
+		tls->mpt_tgt_obj_ult_cnt++;
+	else
+		tls->mpt_tgt_dkey_ult_cnt++;
 out:
 	return rc;
 }
 
 static void
-migrate_system_exit(struct migrate_pool_tls *tls, unsigned int tgt_idx)
+migrate_tgt_try_wakeup(struct migrate_pool_tls *tls, int ult_type)
 {
-	/* NB: this will only be called during errr handling. In normal case
-	 * the migrate ULT created by system will be exit on each target XS.
-	 */
-	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
-	atomic_fetch_sub(&tls->mpt_obj_ult_cnts[tgt_idx], 1);
-}
+	uint32_t ult_cnt = 0;
 
-static void
-migrate_tgt_try_wakeup(struct migrate_pool_tls *tls)
-{
-	uint32_t dkey_cnt = 0;
-
+	ult_cnt = migrate_tgt_ult_cnt(tls, ult_type);
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
-	dkey_cnt = atomic_load(tls->mpt_tgt_dkey_ult_cnt);
-	if (tls->mpt_inflight_max_ult / 2 > dkey_cnt) {
+	if (tls->mpt_inflight_max_ult / 2 > ult_cnt) {
 		ABT_mutex_lock(tls->mpt_inflight_mutex);
-		ABT_cond_broadcast(tls->mpt_inflight_cond);
+		ABT_cond_signal(tls->mpt_inflight_cond);
 		ABT_mutex_unlock(tls->mpt_inflight_mutex);
 	}
 }
@@ -1989,12 +1814,13 @@ migrate_tgt_exit(struct migrate_pool_tls *tls, int ult_type)
 {
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
 	if (ult_type == OBJ_ULT) {
-		atomic_fetch_sub(tls->mpt_tgt_obj_ult_cnt, 1);
-		return;
+		D_ASSERT(tls->mpt_tgt_obj_ult_cnt > 0);
+		tls->mpt_tgt_obj_ult_cnt--;
+	} else {
+		D_ASSERT(tls->mpt_tgt_dkey_ult_cnt > 0);
+		tls->mpt_tgt_dkey_ult_cnt--;
 	}
-
-	atomic_fetch_sub(tls->mpt_tgt_dkey_ult_cnt, 1);
-	migrate_tgt_try_wakeup(tls);
+	migrate_tgt_try_wakeup(tls, ult_type);
 }
 
 static void
@@ -2831,7 +2657,7 @@ migrate_start_ult(struct enum_unpack_arg *unpack_arg)
 			continue;
 		}
 
-		rc = migrate_tgt_enter(tls);
+		rc = migrate_tgt_enter(tls, DKEY_ULT, NULL);
 		if (rc)
 			break;
 		d_list_del_init(&mrone->mo_list);
@@ -3129,9 +2955,11 @@ out:
 }
 
 struct migrate_stop_arg {
-	uuid_t	pool_uuid;
+	uuid_t       pool_uuid;
 	unsigned int version;
 	unsigned int generation;
+	unsigned int stop_count;
+	ABT_mutex    stop_lock;
 };
 
 static int
@@ -3147,6 +2975,10 @@ migrate_fini_one_ult(void *data)
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
 	tls->mpt_fini = 1;
+
+	ABT_mutex_lock(arg->stop_lock);
+	arg->stop_count++;
+	ABT_mutex_unlock(arg->stop_lock);
 
 	ABT_mutex_lock(tls->mpt_inflight_mutex);
 	ABT_cond_broadcast(tls->mpt_inflight_cond);
@@ -3172,44 +3004,27 @@ migrate_fini_one_ult(void *data)
 void
 ds_migrate_stop(struct ds_pool *pool, unsigned int version, unsigned int generation)
 {
-	struct migrate_pool_tls *tls;
 	struct migrate_stop_arg arg;
 	int			 rc;
 
-	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
-	tls = migrate_pool_tls_lookup(pool->sp_uuid, version, generation);
-	if (tls == NULL || tls->mpt_fini) {
-		if (tls != NULL)
-		       migrate_pool_tls_put(tls);
-		D_INFO(DF_UUID" migrate stopped\n", DP_UUID(pool->sp_uuid));
-		return;
-	}
-
-	tls->mpt_fini = 1;
 	uuid_copy(arg.pool_uuid, pool->sp_uuid);
 	arg.version = version;
 	arg.generation = generation;
+	arg.stop_count = 0;
+	rc             = ABT_mutex_create(&arg.stop_lock);
+	if (rc != ABT_SUCCESS) {
+		D_ERROR(DF_UUID " migrate stop: %d\n", DP_UUID(pool->sp_uuid), rc);
+		return;
+	}
 
 	rc = ds_pool_thread_collective(pool->sp_uuid, 0, migrate_fini_one_ult, &arg, 0);
 	if (rc)
 		D_ERROR(DF_UUID" migrate stop: %d\n", DP_UUID(pool->sp_uuid), rc);
 
-	migrate_pool_tls_put(tls);
-	/* Wait for xstream 0 migrate ULT(migrate_ult) stop */
-	if (tls->mpt_ult_running) {
-		ABT_mutex_lock(tls->mpt_inflight_mutex);
-		ABT_cond_broadcast(tls->mpt_inflight_cond);
-		ABT_mutex_unlock(tls->mpt_inflight_mutex);
-		rc = ABT_eventual_wait(tls->mpt_done_eventual, NULL);
-		if (rc != ABT_SUCCESS) {
-			rc = dss_abterr2der(rc);
-			D_WARN("failed to migrate wait "DF_UUID": "DF_RC"\n",
-			       DP_UUID(pool->sp_uuid), DP_RC(rc));
-		}
-	}
+	D_ASSERT(pool->sp_rebuilding >= arg.stop_count);
+	pool->sp_rebuilding -= arg.stop_count;
+	ABT_mutex_free(&arg.stop_lock);
 
-	migrate_pool_tls_put(tls);
-	pool->sp_rebuilding--;
 	D_INFO(DF_UUID" migrate stopped\n", DP_UUID(pool->sp_uuid));
 }
 
@@ -3318,15 +3133,15 @@ free:
 	    tls->mpt_obj_count >= daos_fail_value_get())
 		rc = -DER_IO;
 
+	D_DEBUG(DB_REBUILD,
+		DF_RB ":  stop migrate obj " DF_UOID "for shard %u ult %u/%u " DF_U64 " : " DF_RC
+		      "\n",
+		DP_RB_MPT(tls), DP_UOID(arg->oid), arg->shard, tls->mpt_tgt_obj_ult_cnt,
+		tls->mpt_tgt_dkey_ult_cnt, tls->mpt_obj_count, DP_RC(rc));
 out:
 	if (tls->mpt_status == 0 && rc < 0)
 		tls->mpt_status = rc;
 
-	D_DEBUG(DB_REBUILD, ""DF_UUID"/%u stop migrate obj "DF_UOID
-		" for shard %u ult %u/%u "DF_U64" : " DF_RC"\n",
-		DP_UUID(tls->mpt_pool_uuid), tls->mpt_version,
-		DP_UOID(arg->oid), arg->shard, atomic_load(tls->mpt_tgt_obj_ult_cnt),
-		atomic_load(tls->mpt_tgt_dkey_ult_cnt), tls->mpt_obj_count, DP_RC(rc));
 free_notls:
 	if (tls != NULL)
 		migrate_tgt_exit(tls, OBJ_ULT);
@@ -3382,7 +3197,6 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, daos_epoch_t punched_e
 		       sizeof(*obj_arg->snaps) * cont_arg->snap_cnt);
 	}
 
-	/* Let's iterate the object on different xstream */
 	rc = dss_ult_create(migrate_obj_ult, obj_arg, DSS_XS_VOS,
 			    tgt_idx, MIGRATE_STACK_SIZE, NULL);
 	if (rc)
@@ -3397,8 +3211,7 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, daos_epoch_t punched_e
 	D_DEBUG(DB_REBUILD, "Insert "DF_UUID"/"DF_UUID"/"DF_UOID": ver %u "
 		"ult %u/%u "DF_RC"\n", DP_UUID(tls->mpt_pool_uuid),
 		DP_UUID(cont_arg->cont_uuid), DP_UOID(oid), tls->mpt_version,
-		atomic_load(&tls->mpt_obj_ult_cnts[tgt_idx]),
-		atomic_load(&tls->mpt_dkey_ult_cnts[tgt_idx]), DP_RC(rc));
+		tls->mpt_tgt_obj_ult_cnt, tls->mpt_tgt_dkey_ult_cnt, DP_RC(rc));
 
 	return 0;
 free:
@@ -3430,7 +3243,7 @@ migrate_obj_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov, void *
 		" eph "DF_U64" start\n", DP_UUID(arg->cont_uuid), DP_UOID(*oid),
 		ih.cookie, epoch);
 
-	rc = migrate_system_enter(arg->pool_tls, tgt_idx, &yielded);
+	rc = migrate_tgt_enter(arg->pool_tls, OBJ_ULT, &yielded);
 	if (rc != 0) {
 		DL_ERROR(rc, DF_UUID" enter migrate failed.", DP_UUID(arg->cont_uuid));
 		return rc;
@@ -3440,11 +3253,11 @@ migrate_obj_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov, void *
 	if (rc != 0) {
 		D_ERROR("obj "DF_UOID" migration failed: "DF_RC"\n",
 			DP_UOID(*oid), DP_RC(rc));
-		migrate_system_exit(arg->pool_tls, tgt_idx);
+		migrate_tgt_exit(arg->pool_tls, OBJ_ULT);
 		return rc;
 	}
 
-	/* migrate_system_enter possibly yielded the ULT, let's re-probe before delete  */
+	/* migrate_tgt_enter possibly yielded the ULT, let's re-probe before delete  */
 	if (yielded) {
 		d_iov_set(&tmp_iov, oid, sizeof(*oid));
 		rc = dbtree_iter_probe(ih, BTR_PROBE_EQ, DAOS_INTENT_MIGRATION, &tmp_iov, NULL);
@@ -3477,6 +3290,59 @@ migrate_obj_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov, void *
 	return rc;
 }
 
+struct cont_fetch_arg {
+	uuid_t          pool_uuid;
+	uuid_t          cont_uuid;
+	uint64_t       *snapshots;
+	int             snap_cnt;
+	struct ds_pool *pool;
+};
+
+static int
+cont_fetch_start_ult(void *arg)
+{
+	int                    rc;
+	struct cont_fetch_arg *fetch_arg = (struct cont_fetch_arg *)arg;
+
+	rc = ds_pool_lookup(fetch_arg->pool_uuid, &fetch_arg->pool);
+	if (rc) {
+		D_ERROR(DF_UUID " ds_pool_lookup failed: " DF_RC "\n",
+			DP_UUID(fetch_arg->pool_uuid), DP_RC(rc));
+		return rc;
+	}
+
+	rc = ds_cont_fetch_snaps(fetch_arg->pool->sp_iv_ns, fetch_arg->cont_uuid,
+				 &fetch_arg->snapshots, &fetch_arg->snap_cnt);
+	if (rc) {
+		D_ERROR("ds_cont_fetch_snaps failed: " DF_RC "\n", DP_RC(rc));
+		return rc;
+	}
+
+	rc = ds_cont_fetch_ec_agg_boundary(fetch_arg->pool->sp_iv_ns, fetch_arg->cont_uuid);
+	if (rc) {
+		/* Sometime it may too early to fetch the EC boundary,
+		 * since EC boundary does not start yet, which is forbidden
+		 * during rebuild anyway, so let's continue.
+		 */
+		D_DEBUG(DB_REBUILD, DF_UUID " fetch agg_boundary failed: " DF_RC "\n",
+			DP_UUID(fetch_arg->cont_uuid), DP_RC(rc));
+	}
+
+	return rc;
+}
+
+static int
+cont_fetch_end_ult(void *arg)
+{
+	struct cont_fetch_arg *fetch_arg = (struct cont_fetch_arg *)arg;
+
+	if (fetch_arg->pool)
+		ds_pool_put(fetch_arg->pool);
+
+	D_FREE(fetch_arg->snapshots);
+	return 0;
+}
+
 /* This iterates the migration database "container", which is different than the
  * similarly identified by container UUID as the actual container in VOS.
  * However, this container only contains object IDs that were specified to be
@@ -3486,50 +3352,33 @@ static int
 migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 		     d_iov_t *val_iov, void *data)
 {
-	struct ds_pool		*dp;
 	struct iter_cont_arg	 arg = { 0 };
 	struct tree_cache_root	*root = val_iov->iov_buf;
-	struct migrate_pool_tls	*tls = data;
-	uint64_t		*snapshots = NULL;
-	uuid_t			 cont_uuid;
-	int			 snap_cnt;
+	struct migrate_pool_tls *tls  = data;
+	uuid_t                   cont_uuid;
 	d_iov_t			 tmp_iov;
 	int			 rc;
+	struct cont_fetch_arg    fetch_arg = {0};
 
 	uuid_copy(cont_uuid, *(uuid_t *)key_iov->iov_buf);
 	D_DEBUG(DB_REBUILD, "iter cont "DF_UUID"/%"PRIx64" %"PRIx64" start\n",
 		DP_UUID(cont_uuid), ih.cookie, root->root_hdl.cookie);
 
-	rc = ds_pool_lookup(tls->mpt_pool_uuid, &dp);
+	uuid_copy(fetch_arg.cont_uuid, cont_uuid);
+	uuid_copy(fetch_arg.pool_uuid, tls->mpt_pool_uuid);
+	rc = dss_ult_execute(cont_fetch_start_ult, &fetch_arg, NULL, NULL, DSS_XS_SYS, 0, 0);
 	if (rc) {
 		D_ERROR(DF_UUID" ds_pool_lookup failed: "DF_RC"\n",
 			DP_UUID(tls->mpt_pool_uuid), DP_RC(rc));
 		if (rc == -DER_SHUTDOWN)
 			rc = 0;
-		D_GOTO(out_put, rc);
-	}
-
-	rc = ds_cont_fetch_snaps(dp->sp_iv_ns, cont_uuid, &snapshots,
-				 &snap_cnt);
-	if (rc) {
-		D_ERROR("ds_cont_fetch_snaps failed: "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out_put, rc);
-	}
-
-	rc = ds_cont_fetch_ec_agg_boundary(dp->sp_iv_ns, cont_uuid);
-	if (rc) {
-		/* Sometime it may too early to fetch the EC boundary,
-		 * since EC boundary does not start yet, which is forbidden
-		 * during rebuild anyway, so let's continue.
-		 */
-		D_DEBUG(DB_REBUILD, DF_UUID" fetch agg_boundary failed: "DF_RC"\n",
-			DP_UUID(cont_uuid), DP_RC(rc));
+		return rc;
 	}
 
 	arg.yield_freq	= DEFAULT_YIELD_FREQ;
 	arg.cont_root	= root;
-	arg.snaps	= snapshots;
-	arg.snap_cnt	= snap_cnt;
+	arg.snaps       = fetch_arg.snapshots;
+	arg.snap_cnt    = fetch_arg.snap_cnt;
 	arg.pool_tls	= tls;
 	uuid_copy(arg.cont_uuid, cont_uuid);
 	while (!dbtree_is_empty(root->root_hdl)) {
@@ -3577,14 +3426,10 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 		D_GOTO(free, rc);
 	}
 free:
-	if (snapshots)
-		D_FREE(snapshots);
-
-out_put:
+	D_ASSERT(dss_ult_execute(cont_fetch_end_ult, &fetch_arg, NULL, NULL, DSS_XS_SYS, 0, 0) ==
+		 0);
 	if (tls->mpt_status == 0 && rc < 0)
 		tls->mpt_status = rc;
-	if (dp != NULL)
-		ds_pool_put(dp);
 	return rc;
 }
 
@@ -3705,26 +3550,122 @@ migrate_try_obj_insert(struct migrate_pool_tls *tls, uuid_t co_uuid,
 	return rc;
 }
 
-int
-ds_migrate_object(struct ds_pool *pool, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_uuid,
-		  uint32_t version, unsigned int generation, uint64_t max_eph, uint32_t opc,
-		  daos_unit_oid_t *oids, daos_epoch_t *epochs, daos_epoch_t *punched_epochs,
-		  unsigned int *shards, uint32_t count, unsigned int tgt_idx,
-		  uint32_t new_layout_ver)
-{
-	struct migrate_pool_tls	*tls = NULL;
-	int			i;
-	int			rc;
+struct ds_pool_migrate_arg {
+	uuid_t          pool_uuid;
+	struct ds_pool *pool;
+	uint32_t        rebuild_ver;
+	uint32_t        generation;
+	daos_prop_t    *prop;
+	int             tgt_id;
+	int             rebuilding_count;
+	bool            no_iv;
+};
 
-	/* Check if the pool tls exists */
-	rc = migrate_pool_tls_lookup_create(pool, version, generation, po_hdl, co_hdl, max_eph,
-					    new_layout_ver, opc, &tls);
+static int
+ds_migrate_end_ult(void *arg)
+{
+	struct ds_pool_migrate_arg *pool_arg = (struct ds_pool_migrate_arg *)arg;
+
+	if (pool_arg->pool) {
+		pool_arg->pool->sp_rebuilding += pool_arg->rebuilding_count;
+		ds_pool_put(pool_arg->pool);
+	}
+	if (pool_arg->prop)
+		daos_prop_free(pool_arg->prop);
+	return 0;
+}
+
+static int
+ds_migrate_prepare_ult(void *arg)
+{
+	int                         rc;
+	uint32_t                    rebuild_ver;
+	struct ds_pool_migrate_arg *pool_arg = (struct ds_pool_migrate_arg *)arg;
+
+	rc = ds_pool_lookup(pool_arg->pool_uuid, &pool_arg->pool);
+	if (rc != 0) {
+		if (rc == -DER_SHUTDOWN) {
+			D_DEBUG(DB_REBUILD, DF_UUID " pool service is stopping.\n",
+				DP_UUID(pool_arg->pool_uuid));
+			rc = 0;
+		} else {
+			D_DEBUG(DB_REBUILD, DF_UUID " pool service is not started yet. " DF_RC "\n",
+				DP_UUID(pool_arg->pool_uuid), DP_RC(rc));
+			rc = -DER_AGAIN;
+		}
+		return rc;
+	}
+
+	ds_rebuild_running_query(pool_arg->pool_uuid, -1, &rebuild_ver, NULL, NULL);
+	if (rebuild_ver == 0 || rebuild_ver != pool_arg->rebuild_ver) {
+		rc = -DER_SHUTDOWN;
+		D_GOTO(out, rc);
+	}
+
+	if (pool_arg->no_iv)
+		D_GOTO(out, rc = 0);
+
+	D_ALLOC_PTR(pool_arg->prop);
+	if (pool_arg->prop == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	rc = ds_pool_iv_prop_fetch(pool_arg->pool, pool_arg->prop);
+	if (rc)
+		D_GOTO(out, rc);
+
+	pool_arg->pool->sp_rebuilding++;
+out:
+	return rc;
+}
+
+int
+ds_migrate_object(uuid_t pool_uuid, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_uuid, uint32_t version,
+		  unsigned int generation, uint64_t max_eph, uint32_t opc, daos_unit_oid_t *oids,
+		  daos_epoch_t *epochs, daos_epoch_t *punched_epochs, unsigned int *shards,
+		  uint32_t count, unsigned int tgt_idx, uint32_t new_layout_ver)
+{
+	struct migrate_pool_tls   *tls = NULL;
+	int                        i;
+	int                        rc;
+	d_rank_list_t             *svc_list = NULL;
+	struct daos_prop_entry    *entry;
+	struct ds_pool_migrate_arg arg    = {0};
+	uint32_t                   tgt_id = dss_get_module_info()->dmi_tgt_id;
+
+	tls = migrate_pool_tls_lookup(pool_uuid, version, generation);
+	if (tls)
+		arg.no_iv = true;
+
+	uuid_copy(arg.pool_uuid, pool_uuid);
+	arg.rebuild_ver = version;
+	arg.tgt_id      = tgt_id;
+	arg.generation  = generation;
+	rc = dss_ult_execute(ds_migrate_prepare_ult, &arg, NULL, NULL, DSS_XS_SYS, 0, 0);
+	if (rc || arg.pool == NULL)
+		D_GOTO(out, rc);
+
+	if (tls)
+		goto skip_create;
+
+	entry = daos_prop_entry_get(arg.prop, DAOS_PROP_PO_SVC_LIST);
+	D_ASSERT(entry != NULL);
+	svc_list = (d_rank_list_t *)entry->dpe_val_ptr;
+
+	/* prepare might yield */
+	tls = migrate_pool_tls_lookup(pool_uuid, version, generation);
+	if (tls) {
+		arg.rebuilding_count = -1;
+		goto skip_create;
+	}
+
+	rc = migrate_pool_tls_create(pool_uuid, version, generation, po_hdl, co_hdl, max_eph,
+				     new_layout_ver, opc, &tls, svc_list);
 	if (rc != 0)
 		D_GOTO(out, rc);
+skip_create:
 	if (tls->mpt_fini)
 		D_GOTO(out, rc = -DER_SHUTDOWN);
 
-	/* NB: only create this tree on xstream 0 */
 	rc = migrate_try_create_object_tree(tls);
 	if (rc)
 		D_GOTO(out, rc);
@@ -3764,6 +3705,9 @@ ds_migrate_object(struct ds_pool *pool, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_
 out:
 	if (tls)
 		migrate_pool_tls_put(tls);
+	if (arg.pool)
+		D_ASSERT(dss_ult_execute(ds_migrate_end_ult, &arg, NULL, NULL, DSS_XS_SYS, 0, 0) ==
+			 0);
 	return rc;
 }
 
@@ -3785,9 +3729,7 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 	uuid_t			po_uuid;
 	uuid_t			po_hdl_uuid;
 	uuid_t			co_uuid;
-	uuid_t			co_hdl_uuid;
-	struct ds_pool		*pool = NULL;
-	uint32_t		rebuild_ver;
+	uuid_t                   co_hdl_uuid;
 	int			rc;
 
 	migrate_in = crt_req_get(rpc);
@@ -3816,36 +3758,11 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 	uuid_copy(po_uuid, migrate_in->om_pool_uuid);
 	uuid_copy(po_hdl_uuid, migrate_in->om_poh_uuid);
 
-	rc = ds_pool_lookup(po_uuid, &pool);
-	if (rc != 0) {
-		if (rc == -DER_SHUTDOWN) {
-			D_DEBUG(DB_REBUILD, DF_UUID" pool service is stopping.\n",
-				DP_UUID(po_uuid));
-			rc = 0;
-		} else {
-			D_DEBUG(DB_REBUILD, DF_UUID" pool service is not started yet. "DF_RC"\n",
-				DP_UUID(po_uuid), DP_RC(rc));
-			rc = -DER_AGAIN;
-		}
-		D_GOTO(out, rc);
-	}
-
-	ds_rebuild_running_query(migrate_in->om_pool_uuid, -1, &rebuild_ver, NULL, NULL);
-	if (rebuild_ver == 0 || rebuild_ver != migrate_in->om_version) {
-		rc = -DER_SHUTDOWN;
-		DL_ERROR(rc, DF_UUID" rebuild ver %u om version %u",
-			DP_UUID(migrate_in->om_pool_uuid), rebuild_ver, migrate_in->om_version);
-		D_GOTO(out, rc);
-	}
-
-	rc = ds_migrate_object(pool, po_hdl_uuid, co_hdl_uuid, co_uuid, migrate_in->om_version,
+	rc = ds_migrate_object(po_uuid, po_hdl_uuid, co_hdl_uuid, co_uuid, migrate_in->om_version,
 			       migrate_in->om_generation, migrate_in->om_max_eph,
 			       migrate_in->om_opc, oids, ephs, punched_ephs, shards, oids_count,
 			       migrate_in->om_tgt_idx, migrate_in->om_new_layout_ver);
 out:
-	if (pool)
-		ds_pool_put(pool);
-
 	migrate_out = crt_reply_get(rpc);
 	migrate_out->om_status = rc;
 	dss_rpc_reply(rpc, DAOS_REBUILD_DROP_OBJ);
@@ -3856,6 +3773,7 @@ struct migrate_query_arg {
 	ABT_mutex status_lock;
 	struct ds_migrate_status dms;
 	uint32_t version;
+	uint32_t ult_running;
 	uint32_t total_ult_cnt;
 	uint32_t generation;
 };
@@ -3876,14 +3794,13 @@ migrate_check_one(void *data)
 	arg->dms.dm_total_size += tls->mpt_size;
 	if (arg->dms.dm_status == 0)
 		arg->dms.dm_status = tls->mpt_status;
-	arg->total_ult_cnt += atomic_load(tls->mpt_tgt_obj_ult_cnt) +
-			      atomic_load(tls->mpt_tgt_dkey_ult_cnt);
+	arg->total_ult_cnt = tls->mpt_tgt_obj_ult_cnt + tls->mpt_tgt_dkey_ult_cnt;
+	arg->ult_running += tls->mpt_ult_running;
 	ABT_mutex_unlock(arg->status_lock);
 	D_DEBUG(DB_REBUILD, "status %d/%d/ ult %u/%u  rec/obj/size "
 		DF_U64"/"DF_U64"/"DF_U64"\n", tls->mpt_status,
-		arg->dms.dm_status, atomic_load(tls->mpt_tgt_obj_ult_cnt),
-		atomic_load(tls->mpt_tgt_dkey_ult_cnt), tls->mpt_rec_count,
-		tls->mpt_obj_count, tls->mpt_size);
+		arg->dms.dm_status, tls->mpt_tgt_obj_ult_cnt,
+		tls->mpt_tgt_dkey_ult_cnt, tls->mpt_rec_count, tls->mpt_obj_count, tls->mpt_size);
 
 	migrate_pool_tls_put(tls);
 	return 0;
@@ -3894,12 +3811,7 @@ ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, unsigned int generation,
 			struct ds_migrate_status *dms)
 {
 	struct migrate_query_arg	arg = { 0 };
-	struct migrate_pool_tls		*tls;
 	int				rc;
-
-	tls = migrate_pool_tls_lookup(pool_uuid, ver, generation);
-	if (tls == NULL)
-		return 0;
 
 	uuid_copy(arg.pool_uuid, pool_uuid);
 	arg.version = ver;
@@ -3913,7 +3825,7 @@ ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, unsigned int generation,
 	if (rc)
 		D_GOTO(out, rc);
 
-	if (arg.total_ult_cnt > 0 || tls->mpt_ult_running)
+	if (arg.total_ult_cnt > 0 || arg.ult_running)
 		arg.dms.dm_migrating = 1;
 	else
 		arg.dms.dm_migrating = 0;
@@ -3929,7 +3841,6 @@ ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, unsigned int generation,
 		arg.total_ult_cnt, arg.dms.dm_status);
 out:
 	ABT_mutex_free(&arg.status_lock);
-	migrate_pool_tls_put(tls);
 	return rc;
 }
 
@@ -3998,7 +3909,7 @@ ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_h
 	tgt_ep.ep_rank = target->ta_comp.co_rank;
 	index = target->ta_comp.co_index;
 	ABT_rwlock_unlock(pool->sp_lock);
-	tgt_ep.ep_tag = 0;
+	tgt_ep.ep_tag = daos_rpc_tag(DAOS_REQ_TGT, index);
 	opcode = DAOS_RPC_OPCODE(DAOS_OBJ_RPC_MIGRATE, DAOS_OBJ_MODULE,
 				 DAOS_OBJ_VERSION);
 	rc = crt_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep, opcode,

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -586,7 +586,7 @@ rebuild_obj_ult(void *data)
 	struct rebuild_obj_arg		*arg = data;
 	struct rebuild_tgt_pool_tracker	*rpt = arg->rpt;
 
-	ds_migrate_object(rpt->rt_pool, rpt->rt_poh_uuid, rpt->rt_coh_uuid, arg->co_uuid,
+	ds_migrate_object(rpt->rt_pool_uuid, rpt->rt_poh_uuid, rpt->rt_coh_uuid, arg->co_uuid,
 			  rpt->rt_rebuild_ver, rpt->rt_rebuild_gen, rpt->rt_stable_epoch,
 			  rpt->rt_rebuild_op, &arg->oid, &arg->epoch, &arg->punched_epoch,
 			  &arg->shard, 1, arg->tgt_index, rpt->rt_new_layout_ver);
@@ -616,7 +616,7 @@ rebuild_object_local(struct rebuild_tgt_pool_tracker *rpt, uuid_t co_uuid,
 	arg->tgt_index = tgt_index;
 	arg->shard = shard;
 
-	rc = dss_ult_create(rebuild_obj_ult, arg, DSS_XS_SYS, 0, 0, NULL);
+	rc = dss_ult_create(rebuild_obj_ult, arg, DSS_XS_VOS, tgt_index, 0, NULL);
 	if (rc) {
 		D_FREE(arg);
 		rpt_put(rpt);

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -892,11 +892,12 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	while (cont_child->sc_ec_agg_active &&
 	       rpt->rt_rebuild_op != RB_OP_RECLAIM &&
 	       rpt->rt_rebuild_op != RB_OP_FAIL_RECLAIM) {
-		D_ASSERTF(rpt->rt_pool->sp_rebuilding >= 0, DF_UUID" rebuilding %d\n",
-			  DP_UUID(rpt->rt_pool_uuid), rpt->rt_pool->sp_rebuilding);
+		D_ASSERTF(atomic_load(&rpt->rt_pool->sp_rebuilding) >= 0,
+			  DF_UUID " rebuilding %d\n", DP_UUID(rpt->rt_pool_uuid),
+			  atomic_load(&rpt->rt_pool->sp_rebuilding));
 		/* Wait for EC aggregation to abort before discard the object */
 		D_INFO(DF_UUID" wait for ec agg abort, rebuilding %d.\n",
-		       DP_UUID(entry->ie_couuid), rpt->rt_pool->sp_rebuilding);
+		       DP_UUID(entry->ie_couuid), atomic_load(&rpt->rt_pool->sp_rebuilding));
 		dss_sleep(1000);
 		if (rpt->rt_abort || rpt->rt_finishing) {
 			D_DEBUG(DB_REBUILD, DF_CONT" rebuild op %s ver %u abort %u/%u.\n",
@@ -1281,7 +1282,7 @@ tls_lookup:
 		D_GOTO(out, rc);
 	}
 
-	rpt->rt_pool->sp_rebuilding++; /* reset in rebuild_tgt_fini */
+	atomic_fetch_add(&rpt->rt_pool->sp_rebuilding, 1); /* reset in rebuild_tgt_fini */
 
 	rpt_get(rpt);
 	/* step-3: start scan leader */

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -896,7 +896,7 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 			  DF_UUID " rebuilding %d\n", DP_UUID(rpt->rt_pool_uuid),
 			  atomic_load(&rpt->rt_pool->sp_rebuilding));
 		/* Wait for EC aggregation to abort before discard the object */
-		D_INFO(DF_UUID" wait for ec agg abort, rebuilding %d.\n",
+		D_INFO(DF_UUID " wait for ec agg abort, rebuilding %d.\n",
 		       DP_UUID(entry->ie_couuid), atomic_load(&rpt->rt_pool->sp_rebuilding));
 		dss_sleep(1000);
 		if (rpt->rt_abort || rpt->rt_finishing) {

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -2301,8 +2301,8 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 	D_INFO("finishing rebuild for "DF_UUID", map_ver=%u refcount %u\n",
 	       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver, rpt->rt_refcount);
 
-	D_ASSERT(rpt->rt_pool->sp_rebuilding > 0);
-	rpt->rt_pool->sp_rebuilding--;
+	D_ASSERT(atomic_load(&rpt->rt_pool->sp_rebuilding) > 0);
+	atomic_fetch_sub(&rpt->rt_pool->sp_rebuilding, 1);
 	rpt->rt_pool->sp_rebuild_scan = 0;
 
 	ABT_mutex_lock(rpt->rt_lock);


### PR DESCRIPTION
 To enhance object migration efficiency, we recommend processing OIDs directly in main
 xstreams rather than routing them through system xstreams. Currently, the workflow involves
 main xstreams scanning and gathering OIDs before distributing them to corresponding ranks'
 system xstreams for processing. However, this approach introduces significant overhead
 from B+ Tree operations.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
