### PR TITLE
DAOS-18356 object: skip key checksum for value enumeration

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2019-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2019-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -355,6 +356,21 @@ daos_csummer_verify_iod(struct daos_csummer *obj, daos_iod_t *iod,
 int
 daos_csummer_verify_key(struct daos_csummer *obj, daos_key_t *key,
 			struct dcs_csum_info *csum);
+
+/**
+ * Verify a value to a checksum
+ *
+ * @param obj		The daos_csummer obj
+ * @param recx		extent for array value (NULL for single value)
+ * @param rsize		element/value size
+ * @param val		The key to verify
+ * @param csum_info	The dcs_csum_info that describes the checksum
+ *
+ * @return		0 for success, -DER_CSUM if corruption is detected
+ */
+int
+daos_csummer_verify_value(struct daos_csummer *obj, daos_recx_t *recx, daos_size_t rsize,
+			  d_iov_t *val, struct dcs_csum_info *csum_info);
 
 /**
  * Calculate the needed memory for all the structures that will

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1599,62 +1599,6 @@ struct obj_enum_args {
 	uint32_t		*max_delay;
 };
 
-/**
- * use iod/iod_csum as vehicle to verify data
- */
-static int
-csum_enum_verify_recx(struct daos_csummer *csummer, struct obj_enum_rec *rec,
-		      d_iov_t *enum_type_val, struct dcs_csum_info *csum_info)
-{
-	daos_iod_t		 tmp_iod = {0};
-	d_sg_list_t		 tmp_sgl = {0};
-	struct dcs_iod_csums	 tmp_iod_csum = {0};
-	int			 rc;
-
-	tmp_iod.iod_size = rec->rec_size;
-	tmp_iod.iod_type = DAOS_IOD_ARRAY;
-	tmp_iod.iod_recxs = &rec->rec_recx;
-	tmp_iod.iod_nr = 1;
-
-	tmp_sgl.sg_nr = tmp_sgl.sg_nr_out = 1;
-	tmp_sgl.sg_iovs = enum_type_val;
-
-	tmp_iod_csum.ic_nr = 1;
-	tmp_iod_csum.ic_data = csum_info;
-
-	rc = daos_csummer_verify_iod(csummer, &tmp_iod, &tmp_sgl,
-				     &tmp_iod_csum, NULL, 0, NULL);
-
-	return rc;
-}
-
-/**
- * use iod/iod_csum as vehicle to verify data
- */
-static int
-csum_enum_verify_sv(struct daos_csummer *csummer, struct obj_enum_rec *rec,
-		    d_iov_t *enum_type_val, struct dcs_csum_info *csum_info)
-{
-	daos_iod_t		 tmp_iod = {0};
-	d_sg_list_t		 tmp_sgl = {0};
-	struct dcs_iod_csums	 tmp_iod_csum = {0};
-	int			 rc;
-
-	tmp_iod.iod_size = rec->rec_size;
-	tmp_iod.iod_type = DAOS_IOD_SINGLE;
-	tmp_iod.iod_nr = 1;
-
-	tmp_sgl.sg_nr = tmp_sgl.sg_nr_out = 1;
-	tmp_sgl.sg_iovs = enum_type_val;
-
-	tmp_iod_csum.ic_nr = 1;
-	tmp_iod_csum.ic_data = csum_info;
-	rc = daos_csummer_verify_iod(csummer, &tmp_iod, &tmp_sgl,
-				     &tmp_iod_csum, NULL, 0, NULL);
-
-	return rc;
-}
-
 struct csum_enum_args {
 	d_iov_t			*csum_iov;
 	struct daos_csummer	*csummer;
@@ -1664,10 +1608,7 @@ static int
 verify_csum_cb(daos_key_desc_t *kd, void *buf, unsigned int size, void *arg)
 {
 	struct dcs_csum_info	 *ci_to_compare = NULL;
-	struct csum_enum_args	*args = arg;
-	struct daos_csummer      *csummer         = args->csummer;
-	bool                      skip_key_calc   = csummer->dcs_skip_key_calc;
-	bool                      skip_key_verify = csummer->dcs_skip_key_verify;
+	struct csum_enum_args    *args          = arg;
 	d_iov_t			 enum_type_val;
 	int rc;
 
@@ -1675,6 +1616,7 @@ verify_csum_cb(daos_key_desc_t *kd, void *buf, unsigned int size, void *arg)
 	case OBJ_ITER_SINGLE:
 	case OBJ_ITER_RECX: {
 		struct obj_enum_rec	*rec;
+		daos_recx_t             *recx;
 		uint64_t		 rec_data_len;
 
 		rec = buf;
@@ -1694,17 +1636,9 @@ verify_csum_cb(daos_key_desc_t *kd, void *buf, unsigned int size, void *arg)
 
 		d_iov_set(&enum_type_val, buf, rec_data_len);
 
-		/* NB: csum_enum_verify_recx/sv() calls daos_csummer_verify_iod() with dummy
-		 * iod which has no akey.
-		 */
-		csummer->dcs_skip_key_calc   = true;
-		csummer->dcs_skip_key_verify = true;
-		if (kd->kd_val_type == OBJ_ITER_RECX)
-			rc = csum_enum_verify_recx(csummer, rec, &enum_type_val, ci_to_compare);
-		else
-			rc = csum_enum_verify_sv(csummer, rec, &enum_type_val, ci_to_compare);
-		csummer->dcs_skip_key_calc   = skip_key_calc;
-		csummer->dcs_skip_key_verify = skip_key_verify;
+		recx = (kd->kd_val_type == OBJ_ITER_RECX) ? &rec->rec_recx : NULL;
+		rc   = daos_csummer_verify_value(args->csummer, recx, rec->rec_size, &enum_type_val,
+						 ci_to_compare);
 		if (rc != 0)
 			return rc;
 		break;
@@ -1723,7 +1657,7 @@ verify_csum_cb(daos_key_desc_t *kd, void *buf, unsigned int size, void *arg)
 		ci_cast(&ci_to_compare, args->csum_iov);
 		ci_move_next_iov(ci_to_compare, args->csum_iov);
 
-		rc = daos_csummer_verify_key(csummer, &enum_type_val, ci_to_compare);
+		rc = daos_csummer_verify_key(args->csummer, &enum_type_val, ci_to_compare);
 		if (rc != 0) {
 			D_ERROR("daos_csummer_verify_key error for %s: %d\n",
 				kd->kd_val_type == OBJ_ITER_AKEY ? "AKEY" : "DKEY", rc);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1,6 +1,6 @@
 /*
  *  (C) Copyright 2016-2024 Intel Corporation.
- *  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/object/srv_enum.c
+++ b/src/object/srv_enum.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2018-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/object/srv_enum.c
+++ b/src/object/srv_enum.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -321,37 +322,6 @@ entry_is_partial_extent(const vos_iter_entry_t *key_ent)
 }
 
 static int
-csummer_verify_recx(struct daos_csummer *csummer, d_iov_t *data_to_verify,
-		    daos_recx_t *recx, daos_size_t rsize,
-		    struct dcs_csum_info *csum_info)
-{
-	int			rc;
-	struct dcs_iod_csums	iod_csum = {0};
-	daos_iod_t		iod = {0};
-	d_sg_list_t		sgl = {0};
-
-	iod.iod_type = DAOS_IOD_ARRAY;
-	iod.iod_recxs = recx;
-	iod.iod_nr = 1;
-	iod.iod_size = rsize;
-
-	sgl.sg_iovs = data_to_verify;
-	sgl.sg_nr = 1;
-	sgl.sg_nr_out = 1;
-
-	iod_csum.ic_nr = 1;
-	iod_csum.ic_data = csum_info;
-
-	rc = daos_csummer_verify_iod(csummer, &iod, &sgl,
-				     &iod_csum, NULL, 0, NULL);
-	if (rc != 0)
-		D_ERROR("Corruption found for recx "DF_RECX"\n",
-			DP_RECX(*recx));
-
-	return rc;
-}
-
-static int
 csummer_alloc_csum_info(struct daos_csummer *csummer,
 			daos_recx_t *recx, daos_size_t rsize,
 			struct dcs_csum_info **csum_info)
@@ -467,15 +437,13 @@ csum_copy_inline(int type, vos_iter_entry_t *ent, struct ds_obj_enum_arg *arg,
 			return rc;
 		}
 
-		rc = csummer_verify_recx(csummer,
-					 &data_to_verify,
-					 &ent_to_verify.ie_orig_recx,
-					 ent_to_verify.ie_rsize,
-					 &ent_to_verify.ie_csum);
-
+		rc = daos_csummer_verify_value(csummer, &ent_to_verify.ie_orig_recx,
+					       ent_to_verify.ie_rsize, &data_to_verify,
+					       &ent_to_verify.ie_csum);
 		D_FREE(data_to_verify.iov_buf);
 		if (rc != 0) {
-			D_ERROR("Found corruption!\n");
+			D_ERROR("Found corrupted recx " DF_RECX "\n",
+				DP_RECX(ent_to_verify.ie_orig_recx));
 			return rc;
 		}
 


### PR DESCRIPTION
During enumeration, key and value checksum verification are performed separately. In the value path (csum_enum_verify_recx/sv), a dummy IOD is passed to daos_csummer_verify_iod(), which causes the ISA-L SHA-256 update (isal_mh_sha256_update()) to fail.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
