### PR TITLE
DAOS-18368 rebuild: fix bug of ec_agg_boundary and agg peer update

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -80,6 +80,7 @@ struct ds_pool {
 	struct sched_request	*sp_ec_ephs_req;
 
 	uint32_t		sp_dtx_resync_version;
+	uint32_t                 sp_gl_dtx_resync_version; /* global DTX resync version */
 	/* Special pool/container handle uuid, which are
 	 * created on the pool leader step up, and propagated
 	 * to all servers by IV. Then they will be used by server

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -1181,6 +1181,8 @@ iov_alloc_for_csum_info(d_iov_t *iov, struct dcs_csum_info *csum_info);
 /* obj_layout.c */
 int
 obj_pl_grp_idx(uint32_t layout_gl_ver, uint64_t hash, uint32_t grp_nr);
+void
+obj_dump_grp_layout(daos_handle_t oh, uint32_t shard);
 
 int
 obj_pl_place(struct pl_map *map, uint16_t layout_ver, struct daos_obj_md *md,

--- a/src/object/obj_layout.c
+++ b/src/object/obj_layout.c
@@ -1,6 +1,6 @@
 /*
  *  (C) Copyright 2016-2023 Intel Corporation.
- *  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/object/obj_layout.c
+++ b/src/object/obj_layout.c
@@ -1,5 +1,6 @@
 /*
  *  (C) Copyright 2016-2023 Intel Corporation.
+ *  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -94,4 +95,37 @@ out:
 		pl_obj_layout_free(old_layout);
 
 	return rc;
+}
+
+void
+obj_dump_grp_layout(daos_handle_t oh, uint32_t shard)
+{
+	struct dc_object    *obj;
+	struct dc_obj_shard *obj_shard;
+	uint32_t             grp_idx, i, nr;
+
+	obj = obj_hdl2ptr(oh);
+	if (obj == NULL) {
+		D_INFO("invalid oh");
+		return;
+	}
+	if (shard >= obj->cob_shards_nr) {
+		D_ERROR("bad shard %d, cob_shards_nr %d", shard, obj->cob_shards_nr);
+		goto out;
+	}
+
+	grp_idx = shard / obj->cob_grp_size;
+	D_INFO(DF_OID " shard %d, grp_idx %d, grp_size %d", DP_OID(obj->cob_md.omd_id), shard,
+	       grp_idx, obj->cob_grp_size);
+	for (i = grp_idx * obj->cob_grp_size, nr = 0; nr < obj->cob_grp_size; i++, nr++) {
+		obj_shard = &obj->cob_shards->do_shards[i];
+		D_INFO("shard %d/%d/%d, tgt_id %d, rank %d, tgt_idx %d, "
+		       "rebuilding %d, reintegrating %d, fseq %d",
+		       i, obj_shard->do_shard_idx, obj_shard->do_shard, obj_shard->do_target_id,
+		       obj_shard->do_target_rank, obj_shard->do_target_idx,
+		       obj_shard->do_rebuilding, obj_shard->do_reintegrating, obj_shard->do_fseq);
+	}
+
+out:
+	obj_decref(obj);
 }

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1,7 +1,7 @@
 /**
  * (C) Copyright 2020-2024 Intel Corporation.
  * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1278,6 +1278,42 @@ out:
 	return rc;
 }
 
+static bool
+agg_peer_failed(struct ec_agg_param *agg_param, struct daos_shard_loc *peer_loc)
+{
+	struct pool_target *targets         = NULL;
+	uint32_t            failed_tgts_cnt = 0;
+	int                 i;
+	int                 rc;
+
+	rc = pool_map_find_failed_tgts(agg_param->ap_pool_info.api_pool->sp_map, &targets,
+				       &failed_tgts_cnt);
+	if (rc) {
+		DL_ERROR(rc, DF_CONT " pool_map_find_failed_tgts failed.",
+			 DP_CONT(agg_param->ap_pool_info.api_pool_uuid,
+				 agg_param->ap_pool_info.api_cont_uuid));
+		return false;
+	}
+
+	if (targets == NULL || failed_tgts_cnt == 0)
+		return false;
+
+	for (i = 0; i < failed_tgts_cnt; i++) {
+		if (targets[i].ta_comp.co_rank == peer_loc->sd_rank &&
+		    targets[i].ta_comp.co_index == peer_loc->sd_tgt_idx) {
+			D_DEBUG(DB_EPC, DF_CONT " peer parity tgt failed rank %d, tgt_idx %d.\n",
+				DP_CONT(agg_param->ap_pool_info.api_pool_uuid,
+					agg_param->ap_pool_info.api_cont_uuid),
+				peer_loc->sd_rank, peer_loc->sd_tgt_idx);
+			D_FREE(targets);
+			return true;
+		}
+	}
+
+	D_FREE(targets);
+	return false;
+}
+
 int
 agg_peer_check_avail(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 {
@@ -1334,6 +1370,12 @@ out:
 	return rc;
 }
 
+static bool
+agg_peer_retryable_err(int err)
+{
+	return err == -DER_STALE || err == -DER_TIMEDOUT || daos_crt_network_error(err);
+}
+
 /* Sends the generated parity and the stripe number to the peer
  * parity target. Handler writes the parity and deletes the replicas
  * for the stripe.
@@ -1382,7 +1424,7 @@ agg_peer_update_ult(void *arg)
 	obj = obj_hdl2ptr(entry->ae_obj_hdl);
 	for (peer = 0; peer < p; peer++) {
 		uint64_t enqueue_id = 0;
-		bool     overloaded;
+		bool     peer_retry;
 
 		if (peer == pidx)
 			continue;
@@ -1390,7 +1432,7 @@ agg_peer_update_ult(void *arg)
 		tgt_ep.ep_rank = entry->ae_peer_pshards[peer].sd_rank;
 		tgt_ep.ep_tag  = entry->ae_peer_pshards[peer].sd_tgt_idx;
 retry:
-		overloaded = false;
+		peer_retry = false;
 		rc = ds_obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
 				       DAOS_OBJ_RPC_EC_AGGREGATE, &rpc);
 		if (rc) {
@@ -1470,13 +1512,20 @@ retry:
 			rc         = ec_agg_out->ea_status;
 			if (rc == -DER_OVERLOAD_RETRY) {
 				enqueue_id = ec_agg_out->ea_comm_out.req_out_enqueue_id;
-				overloaded = true;
+				peer_retry = true;
 			}
 			D_CDEBUG(rc == 0, DB_TRACE, DLOG_ERR,
 				 "update parity[%d] to %d:%d, status = " DF_RC "\n", peer,
 				 tgt_ep.ep_rank, tgt_ep.ep_tag, DP_RC(rc));
 			peer_updated += rc == 0;
 		}
+		if (rc != 0 && peer_updated && agg_peer_retryable_err(rc) &&
+		    !agg_peer_failed(agg_param, &entry->ae_peer_pshards[peer])) {
+			DL_INFO(rc, DF_UOID " pidx %d to parity[%d] will retry.",
+				DP_UOID(entry->ae_oid), pidx, peer);
+			peer_retry = true;
+		}
+
 next:
 		if (bulk_hdl)
 			crt_bulk_free(bulk_hdl);
@@ -1487,7 +1536,7 @@ next:
 		rpc = NULL;
 		bulk_hdl  = NULL;
 		iod_csums = NULL;
-		if (overloaded) {
+		if (peer_retry) {
 			dss_sleep(daos_rpc_rand_delay(max_delay) << 10);
 			goto retry;
 		}
@@ -1665,13 +1714,13 @@ agg_process_holes_ult(void *arg)
 	for (peer = 0; peer < p; peer++) {
 		uint64_t enqueue_id = 0;
 		uint32_t peer_shard;
-		bool     overloaded;
+		bool     peer_retry;
 
 		if (pidx == peer)
 			continue;
 
 retry:
-		overloaded = false;
+		peer_retry = false;
 		D_ASSERT(entry->ae_peer_pshards[peer].sd_rank != DAOS_TGT_IGNORE);
 		tgt_ep.ep_rank = entry->ae_peer_pshards[peer].sd_rank;
 		tgt_ep.ep_tag = entry->ae_peer_pshards[peer].sd_tgt_idx;
@@ -1719,7 +1768,7 @@ retry:
 			rc         = ec_rep_out->er_status;
 			if (rc == -DER_OVERLOAD_RETRY) {
 				enqueue_id = ec_rep_out->er_comm_out.req_out_enqueue_id;
-				overloaded = true;
+				peer_retry = true;
 			}
 			D_CDEBUG(rc == 0, DB_TRACE, DLOG_ERR,
 				 DF_UOID " parity[%d] er_status = " DF_RC "\n",
@@ -1728,7 +1777,13 @@ retry:
 		}
 		crt_req_decref(rpc);
 		rpc = NULL;
-		if (overloaded) {
+		if (rc != 0 && peer_updated && agg_peer_retryable_err(rc) &&
+		    !agg_peer_failed(agg_param, &entry->ae_peer_pshards[peer])) {
+			DL_INFO(rc, DF_UOID " pidx %d to parity[%d] will retry.",
+				DP_UOID(entry->ae_oid), pidx, peer);
+			peer_retry = true;
+		}
+		if (peer_retry) {
 			dss_sleep(daos_rpc_rand_delay(max_delay) << 10);
 			goto retry;
 		}

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1,7 +1,7 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
  * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -702,17 +702,19 @@ obj_set_reply_sizes(crt_rpc_t *rpc, daos_iod_t *iods, int iod_nr, uint8_t *skips
 		D_DEBUG(DB_IO, DF_UOID" %d:"DF_U64"\n", DP_UOID(orw->orw_oid),
 			i, iods[idx].iod_size);
 		if ((orw->orw_flags & ORF_FOR_MIGRATION) && sizes[i] == 0) {
-			D_INFO(DF_CONT " obj " DF_UOID "rebuild fetch zero iod_size, i:%d/idx:%d, "
-				       "iod_nr %d, orw_epoch " DF_X64 ", orw_epoch_first " DF_X64
-				       " may cause DER_DATA_LOSS",
-			       DP_CONT(orw->orw_pool_uuid, orw->orw_co_uuid), DP_UOID(orw->orw_oid),
-			       i, idx, iods[idx].iod_nr, orw->orw_epoch, orw->orw_epoch_first);
+			D_DEBUG(DB_REBUILD,
+				DF_CONT " obj " DF_UOID "rebuild fetch zero iod_size, "
+					"i:%d/idx:%d, iod_nr %d, orw_epoch " DF_X64
+					", orw_epoch_first " DF_X64 " may cause DER_DATA_LOSS",
+				DP_CONT(orw->orw_pool_uuid, orw->orw_co_uuid),
+				DP_UOID(orw->orw_oid), i, idx, iods[idx].iod_nr, orw->orw_epoch,
+				orw->orw_epoch_first);
 			if (iods[idx].iod_type == DAOS_IOD_ARRAY) {
 				int j;
 
 				for (j = 0; j < min(8, iods[idx].iod_nr); j++)
-					D_INFO("recx[%d] - " DF_RECX, j,
-					       DP_RECX(iods[idx].iod_recxs[j]));
+					D_DEBUG(DB_REBUILD, "recx[%d] - " DF_RECX, j,
+						DP_RECX(iods[idx].iod_recxs[j]));
 			}
 		}
 		idx++;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -790,7 +790,7 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 	struct dcs_iod_csums	*iod_csums = NULL;
 	int			 iod_cnt = 0;
 	int			 start;
-	char		 iov_buf[OBJ_ENUM_UNPACK_MAX_IODS][MAX_BUF_SIZE];
+	char                     iov_buf[OBJ_ENUM_UNPACK_MAX_IODS][MAX_BUF_SIZE];
 	bool			 fetch = false;
 	int			 i;
 	int			 rc = 0;
@@ -1259,13 +1259,13 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 			 * the rebuild and retry.
 			 */
 			rc = -DER_DATA_LOSS;
-			D_DEBUG(DB_REBUILD,
+			DL_INFO(rc,
 				DF_RB ": cont " DF_UUID " obj " DF_UOID " dkey " DF_KEY " " DF_KEY
-				      " nr %d/%d eph " DF_X64 " " DF_RC "\n",
+				      " nr %d/%d eph " DF_X64,
 				DP_RB_MRO(mrone), DP_UUID(mrone->mo_cont_uuid),
 				DP_UOID(mrone->mo_oid), DP_KEY(&mrone->mo_dkey),
 				DP_KEY(&mrone->mo_iods[i].iod_name), mrone->mo_iod_num, i,
-				mrone->mo_epoch, DP_RC(rc));
+				mrone->mo_epoch);
 			if (log_nr <= 128) {
 				mrone_dump_info(mrone, oh, &mrone->mo_iods[i]);
 				log_nr++;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -3070,8 +3070,8 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 
 		/* Each object enumeration RPC will at least one OID */
 		if (num < minimum_nr && (enum_flags & DIOF_TO_SPEC_GROUP)) {
-			D_DEBUG(DB_REBUILD, DF_RB ": enumeration buffer %u empty" DF_UOID "\n",
-				DP_RB_MPT(tls), num, DP_UOID(arg->oid));
+			D_INFO(DF_RB ": enumeration buffer %u empty" DF_UOID, DP_RB_MPT(tls), num,
+			       DP_UOID(arg->oid));
 			break;
 		}
 

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -1078,13 +1078,21 @@ static void
 rebuild_scan_leader(void *data)
 {
 	struct rebuild_tgt_pool_tracker *rpt = data;
-	struct rebuild_pool_tls	  *tls;
-	int			   rc;
-	bool			   wait = false;
+	struct rebuild_pool_tls         *tls;
+	int                              rc;
 
-	D_DEBUG(DB_REBUILD, DF_RB " check resync %u/%u < %u\n", DP_RB_RPT(rpt),
-		rpt->rt_pool->sp_dtx_resync_version, rpt->rt_global_dtx_resync_version,
-		rpt->rt_rebuild_ver);
+	if (rpt->rt_pool->sp_gl_dtx_resync_version >= rpt->rt_rebuild_ver) {
+		D_DEBUG(DB_REBUILD, DF_RB " sp_gl_dtx_resync_version %d exceed rt_rebuild_ver %d.",
+			DP_RB_RPT(rpt), rpt->rt_pool->sp_gl_dtx_resync_version,
+			rpt->rt_rebuild_ver);
+		if (rpt->rt_global_dtx_resync_version < rpt->rt_pool->sp_gl_dtx_resync_version)
+			rpt->rt_global_dtx_resync_version = rpt->rt_pool->sp_gl_dtx_resync_version;
+		goto do_scan;
+	} else {
+		D_DEBUG(DB_REBUILD, DF_RB " check resync %u/%u < %u\n", DP_RB_RPT(rpt),
+			rpt->rt_pool->sp_dtx_resync_version, rpt->rt_global_dtx_resync_version,
+			rpt->rt_rebuild_ver);
+	}
 
 	/* Wait for dtx resync to finish */
 	while (rpt->rt_global_dtx_resync_version < rpt->rt_rebuild_ver) {
@@ -1093,7 +1101,6 @@ rebuild_scan_leader(void *data)
 			if (rpt->rt_global_dtx_resync_version < rpt->rt_rebuild_ver) {
 				D_INFO(DF_RB " wait for global dtx %u\n", DP_RB_RPT(rpt),
 				       rpt->rt_global_dtx_resync_version);
-				       wait = true;
 				ABT_cond_wait(rpt->rt_global_dtx_wait_cond, rpt->rt_lock);
 			}
 			ABT_mutex_unlock(rpt->rt_lock);
@@ -1103,23 +1110,21 @@ rebuild_scan_leader(void *data)
 			D_GOTO(out, rc = -DER_SHUTDOWN);
 		}
 	}
+	if (rpt->rt_pool->sp_gl_dtx_resync_version < rpt->rt_global_dtx_resync_version) {
+		rpt->rt_pool->sp_gl_dtx_resync_version = rpt->rt_global_dtx_resync_version;
+		D_INFO(DF_RB " update sp_gl_dtx_resync_version to %d", DP_RB_RPT(rpt),
+		       rpt->rt_pool->sp_gl_dtx_resync_version);
+	}
 
-	if (wait)
-		D_INFO(DF_RB " scan collective begin\n", DP_RB_RPT(rpt));
-	else
-		D_DEBUG(DB_REBUILD, DF_RB " scan collective begin\n", DP_RB_RPT(rpt));
-
+do_scan:
+	D_INFO(DF_RB " scan collective begin\n", DP_RB_RPT(rpt));
 	rc = ds_pool_thread_collective(rpt->rt_pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN |
 				       PO_COMP_ST_DOWNOUT, rebuild_scanner, rpt,
 				       DSS_ULT_DEEP_STACK);
 	if (rc)
 		D_GOTO(out, rc);
 
-	if (wait)
-		D_INFO(DF_RB " rebuild scan collective done\n", DP_RB_RPT(rpt));
-	else
-		D_DEBUG(DB_REBUILD, DF_RB "rebuild scan collective done\n", DP_RB_RPT(rpt));
-
+	D_INFO(DF_RB " rebuild scan collective done\n", DP_RB_RPT(rpt));
 	ABT_mutex_lock(rpt->rt_lock);
 	rc = ds_pool_task_collective(rpt->rt_pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN |
 				     PO_COMP_ST_DOWNOUT, rebuild_scan_done, rpt, 0);

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -68,9 +68,9 @@ rebuild_obj_fill_buf(daos_handle_t ih, d_iov_t *key_iov,
 	shards[count] = obj_val->shard;
 	arg->count++;
 
-	D_DEBUG(DB_REBUILD, "send oid/con "DF_UOID"/"DF_UUID" ephs "DF_U64
-		"shard %d cnt %d tgt_id %d\n", DP_UOID(oids[count]),
-		DP_UUID(arg->cont_uuid), obj_val->eph, shards[count],
+	D_DEBUG(DB_REBUILD,
+		"send oid/con " DF_UOID "/" DF_UUID " ephs " DF_X64 " shard %d cnt %d tgt_id %d\n",
+		DP_UOID(oids[count]), DP_UUID(arg->cont_uuid), obj_val->eph, shards[count],
 		arg->count, arg->tgt_id);
 
 	rc = dbtree_iter_delete(ih, NULL);


### PR DESCRIPTION
    1. fix a bug of using ec_agg_boundary before checking its valid
    2. add some more logs for rebuild fetch getting zero iod_size,
       to provide some hints for layout information.
    3. fix a bug of EC agg peer update, some failed update need to be retried
        to avoid data corruption.
    4. refine some detailed process of dtx_resync wating for rebuild scan.
    
     Signed-off-by: Xuezhao Liu <xuezhao.liu@hpe.com>



### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
