### PR TITLE
DAOS-18367 vos: properly evict object for failed transaction

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -883,15 +883,10 @@ dtx_handle_reinit(struct dtx_handle *dth)
 
 	dth->dth_modify_shared      = 0;
 	dth->dth_active             = 0;
-	dth->dth_touched_leader_oid = 0;
 	dth->dth_local_tx_started   = 0;
 	dth->dth_cos_done           = 0;
-
-	dth->dth_op_seq = 0;
-	dth->dth_oid_cnt = 0;
-	dth->dth_oid_cap = 0;
-	D_FREE(dth->dth_oid_array);
-	dth->dth_dkey_hash = 0;
+	dth->dth_op_seq             = 0;
+	dth->dth_dkey_hash          = 0;
 	vos_dtx_rsrvd_fini(dth);
 
 	return vos_dtx_rsrvd_init(dth);
@@ -926,32 +921,29 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t xoh, struct dtx_epoch *epoch, 
 		dth->dth_coh        = xoh;
 	}
 
-	dth->dth_ver = pm_ver;
-	dth->dth_refs = 1;
-	dth->dth_mbs = mbs;
-
-	dth->dth_pinned = 0;
-	dth->dth_cos_done = 0;
-	dth->dth_modify_shared = 0;
-	dth->dth_active = 0;
-	dth->dth_touched_leader_oid = 0;
-	dth->dth_local_tx_started = 0;
-	dth->dth_solo = (flags & DTX_SOLO) ? 1 : 0;
-	dth->dth_drop_cmt = (flags & DTX_DROP_CMT) ? 1 : 0;
-	dth->dth_dist = (flags & DTX_DIST) ? 1 : 0;
-	dth->dth_for_migration = (flags & DTX_FOR_MIGRATION) ? 1 : 0;
+	dth->dth_ver                = pm_ver;
+	dth->dth_refs               = 1;
+	dth->dth_mbs                = mbs;
+	dth->dth_pinned             = 0;
+	dth->dth_cos_done           = 0;
+	dth->dth_modify_shared      = 0;
+	dth->dth_active             = 0;
+	dth->dth_local_tx_started   = 0;
+	dth->dth_solo               = (flags & DTX_SOLO) ? 1 : 0;
+	dth->dth_drop_cmt           = (flags & DTX_DROP_CMT) ? 1 : 0;
+	dth->dth_dist               = (flags & DTX_DIST) ? 1 : 0;
+	dth->dth_for_migration      = (flags & DTX_FOR_MIGRATION) ? 1 : 0;
 	dth->dth_ignore_uncommitted = (flags & DTX_IGNORE_UNCOMMITTED) ? 1 : 0;
-	dth->dth_prepared = (flags & DTX_PREPARED) ? 1 : 0;
-	dth->dth_epoch_owner = (flags & DTX_EPOCH_OWNER) ? 1 : 0;
-	dth->dth_aborted = 0;
-	dth->dth_already = 0;
-	dth->dth_need_validation = 0;
+	dth->dth_prepared           = (flags & DTX_PREPARED) ? 1 : 0;
+	dth->dth_epoch_owner        = (flags & DTX_EPOCH_OWNER) ? 1 : 0;
+	dth->dth_aborted            = 0;
+	dth->dth_already            = 0;
+	dth->dth_need_validation    = 0;
 	dth->dth_local              = (flags & DTX_LOCAL) ? 1 : 0;
-
-	dth->dth_dti_cos = dti_cos;
-	dth->dth_dti_cos_count = dti_cos_cnt;
-	dth->dth_ent = NULL;
-	dth->dth_flags = leader ? DTE_LEADER : 0;
+	dth->dth_dti_cos            = dti_cos;
+	dth->dth_dti_cos_count      = dti_cos_cnt;
+	dth->dth_ent                = NULL;
+	dth->dth_flags              = leader ? DTE_LEADER : 0;
 
 	if (flags & DTX_SYNC) {
 		dth->dth_flags |= DTE_BLOCK;
@@ -960,12 +952,11 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t xoh, struct dtx_epoch *epoch, 
 		dth->dth_sync = 0;
 	}
 
-	dth->dth_op_seq = 0;
-	dth->dth_oid_cnt = 0;
-	dth->dth_oid_cap = 0;
-	dth->dth_oid_array = NULL;
-
-	dth->dth_dkey_hash = 0;
+	dth->dth_op_seq          = 0;
+	dth->dth_local_oid_cnt   = 0;
+	dth->dth_local_oid_cap   = 0;
+	dth->dth_local_oid_array = NULL;
+	dth->dth_dkey_hash       = 0;
 
 	if (!(flags & DTX_LOCAL)) {
 		if (daos_is_zero_dti(dti))
@@ -1001,83 +992,6 @@ error:
 	return rc;
 }
 
-static int
-dtx_insert_oid(struct dtx_handle *dth, daos_unit_oid_t *oid, bool touch_leader)
-{
-	int	start = 0;
-	int	end = dth->dth_oid_cnt - 1;
-	int	at;
-	int	rc = 0;
-
-	do {
-		at = (start + end) / 2;
-		rc = daos_unit_oid_compare(dth->dth_oid_array[at], *oid);
-		if (rc == 0)
-			return 0;
-
-		if (rc > 0)
-			end = at - 1;
-		else
-			start = at + 1;
-	} while (start <= end);
-
-	if (dth->dth_oid_cnt == dth->dth_oid_cap) {
-		daos_unit_oid_t		*oid_array;
-
-		D_ALLOC_ARRAY(oid_array, dth->dth_oid_cap << 1);
-		if (oid_array == NULL)
-			return -DER_NOMEM;
-
-		if (rc > 0) {
-			/* Insert before dth->dth_oid_array[at]. */
-			if (at > 0)
-				memcpy(&oid_array[0], &dth->dth_oid_array[0],
-				       sizeof(*oid) * at);
-			oid_array[at] = *oid;
-			memcpy(&oid_array[at + 1], &dth->dth_oid_array[at],
-			       sizeof(*oid) * (dth->dth_oid_cnt - at));
-		} else {
-			/* Insert after dth->dth_oid_array[at]. */
-			memcpy(&oid_array[0], &dth->dth_oid_array[0],
-			       sizeof(*oid) * (at + 1));
-			oid_array[at + 1] = *oid;
-			if (at < dth->dth_oid_cnt - 1)
-				memcpy(&oid_array[at + 2],
-				&dth->dth_oid_array[at + 1],
-				sizeof(*oid) * (dth->dth_oid_cnt - 1 - at));
-		}
-
-		D_FREE(dth->dth_oid_array);
-		dth->dth_oid_array = oid_array;
-		dth->dth_oid_cap <<= 1;
-
-		goto out;
-	}
-
-	if (rc > 0) {
-		/* Insert before dth->dth_oid_array[at]. */
-		memmove(&dth->dth_oid_array[at + 1],
-			&dth->dth_oid_array[at],
-			sizeof(*oid) * (dth->dth_oid_cnt - at));
-		dth->dth_oid_array[at] = *oid;
-	} else {
-		/* Insert after dth->dth_oid_array[at]. */
-		if (at < dth->dth_oid_cnt - 1)
-			memmove(&dth->dth_oid_array[at + 2],
-				&dth->dth_oid_array[at + 1],
-				sizeof(*oid) * (dth->dth_oid_cnt - 1 - at));
-		dth->dth_oid_array[at + 1] = *oid;
-	}
-
-out:
-	if (touch_leader)
-		dth->dth_touched_leader_oid = 1;
-
-	dth->dth_oid_cnt++;
-
-	return 0;
-}
-
 void
 dtx_renew_epoch(struct dtx_epoch *epoch, struct dtx_handle *dth)
 {
@@ -1110,51 +1024,6 @@ dtx_sub_init(struct dtx_handle *dth, daos_unit_oid_t *oid, uint64_t dkey_hash)
 	dth->dth_dkey_hash = dkey_hash;
 	dth->dth_op_seq++;
 
-	rc = daos_unit_oid_compare(dth->dth_leader_oid, *oid);
-	if (rc == 0) {
-		if (dth->dth_oid_array == NULL)
-			dth->dth_touched_leader_oid = 1;
-
-		if (dth->dth_touched_leader_oid)
-			goto out;
-
-		rc = dtx_insert_oid(dth, oid, true);
-
-		D_GOTO(out, rc);
-	}
-
-	if (dth->dth_oid_array == NULL) {
-		D_ASSERT(dth->dth_oid_cnt == 0);
-
-		/* 4 slots by default to hold rename case. */
-		dth->dth_oid_cap = 4;
-		D_ALLOC_ARRAY(dth->dth_oid_array, dth->dth_oid_cap);
-		if (dth->dth_oid_array == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-
-		if (!dth->dth_touched_leader_oid) {
-			dth->dth_oid_array[0] = *oid;
-			dth->dth_oid_cnt = 1;
-
-			D_GOTO(out, rc = 0);
-		}
-
-		dth->dth_oid_cnt = 2;
-
-		if (rc > 0) {
-			dth->dth_oid_array[0] = *oid;
-			dth->dth_oid_array[1] = dth->dth_leader_oid;
-		} else {
-			dth->dth_oid_array[0] = dth->dth_leader_oid;
-			dth->dth_oid_array[1] = *oid;
-		}
-
-		D_GOTO(out, rc = 0);
-	}
-
-	rc = dtx_insert_oid(dth, oid, false);
-
-out:
 	D_DEBUG(DB_IO, "Sub init DTX "DF_DTI" for object "DF_UOID
 		" dkey %lu, opc seq %d: "DF_RC"\n",
 		DP_DTI(&dth->dth_xid), DP_UOID(*oid),
@@ -1493,7 +1362,6 @@ out:
 		dth->dth_sync ? "sync" : "async", dth->dth_dti_cos_count,
 		dth->dth_cos_done ? dth->dth_dti_cos_count : 0, DP_RC(result));
 
-	D_FREE(dth->dth_oid_array);
 	D_FREE(dlh);
 	d_tm_dec_gauge(dtx_tls_get()->dt_dtx_leader_total, 1);
 
@@ -1617,7 +1485,6 @@ fini:
 	vos_dtx_detach(dth);
 
 out:
-	D_FREE(dth->dth_oid_array);
 	D_FREE(dth);
 
 	return result;

--- a/src/dtx/tests/dts_structs.c
+++ b/src/dtx/tests/dts_structs.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -62,7 +62,6 @@ struct_dtx_handle(void **state)
 	SET_BITFIELD_1(dummy, dth_drop_cmt);
 	SET_BITFIELD_1(dummy, dth_modify_shared);
 	SET_BITFIELD_1(dummy, dth_active);
-	SET_BITFIELD_1(dummy, dth_touched_leader_oid);
 	SET_BITFIELD_1(dummy, dth_local_tx_started);
 	SET_BITFIELD_1(dummy, dth_shares_inited);
 	SET_BITFIELD_1(dummy, dth_dist);
@@ -75,7 +74,7 @@ struct_dtx_handle(void **state)
 	SET_BITFIELD_1(dummy, dth_local);
 	SET_BITFIELD_1(dummy, dth_epoch_owner);
 	SET_BITFIELD_1(dummy, dth_local_complete);
-	SET_BITFIELD(dummy, padding1, 12);
+	SET_BITFIELD(dummy, padding1, 13);
 
 	SET_FIELD(dummy, dth_dti_cos_count);
 	SET_FIELD(dummy, dth_dti_cos);
@@ -87,10 +86,6 @@ struct_dtx_handle(void **state)
 	SET_FIELD(dummy, dth_op_seq);
 	SET_FIELD(dummy, dth_deferred_used_cnt);
 	SET_FIELD(dummy, padding2);
-	SET_FIELD(dummy, dth_oid_cnt);
-	SET_FIELD(dummy, dth_oid_cap);
-	SET_FIELD(dummy, padding3);
-	SET_FIELD(dummy, dth_oid_array);
 	SET_FIELD(dummy, dth_local_oid_cnt);
 	SET_FIELD(dummy, dth_local_oid_cap);
 	SET_FIELD(dummy, padding4);

--- a/src/include/daos/lru.h
+++ b/src/include/daos/lru.h
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -135,6 +135,15 @@ daos_lru_ref_evict(struct daos_lru_cache *lcache, struct daos_llink *llink)
 
 	llink->ll_evicted = 1;
 	d_hash_rec_evict_at(&lcache->dlc_htable, &llink->ll_link);
+}
+
+/**
+ * Whether the item is evicted or not.
+ */
+static inline bool
+daos_lru_is_evicted(struct daos_llink *llink)
+{
+	return llink->ll_evicted != 0;
 }
 
 /**

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -47,6 +47,7 @@ struct dtx_local_oid_record {
  * the most optimal way (packed). Please make sure that all necessary padding
  * is explicit so it could be used in the future.
  */
+/* clang-format off */
 struct dtx_handle {
 	union {
 		struct dtx_entry		 dth_dte;
@@ -92,8 +93,6 @@ struct dtx_handle {
 	    dth_modify_shared                     : 1,
 	    /* The DTX entry is in active table. */
 	    dth_active                            : 1,
-	    /* Leader oid is touched. */
-	    dth_touched_leader_oid                : 1,
 	    /* Local TX is started. */
 	    dth_local_tx_started                  : 1,
 	    /* The DTX share lists are inited. */
@@ -117,7 +116,7 @@ struct dtx_handle {
 	    /* Locally generate the epoch. */
 	    dth_epoch_owner			  : 1,
 	    /* Flag to commit the local transaction */
-	    dth_local_complete : 1, padding1 : 12;
+	    dth_local_complete : 1, padding1 : 13;
 
 	/* The count the DTXs in the dth_dti_cos array. */
 	uint32_t			 dth_dti_cos_count;
@@ -138,25 +137,14 @@ struct dtx_handle {
 	uint16_t			 dth_deferred_used_cnt;
 	uint16_t                         padding2;
 
-	union {
-		struct {
-			/** The count of objects that are modified by this DTX. */
-			uint16_t         dth_oid_cnt;
-			/** The total slots in the dth_oid_array. */
-			uint16_t         dth_oid_cap;
-			uint32_t         padding3;
-			/** If more than one objects are modified, the IDs are reocrded here. */
-			daos_unit_oid_t *dth_oid_array;
-		};
-		struct {
-			/** The count of objects stored in dth_local_oid_array. */
-			uint16_t                     dth_local_oid_cnt;
-			/** The total slots in the dth_local_oid_array. */
-			uint16_t                     dth_local_oid_cap;
-			uint32_t                     padding4;
-			/** The record of all objects touched by the local transaction. */
-			struct dtx_local_oid_record *dth_local_oid_array;
-		};
+	struct {
+		/** The count of objects stored in dth_local_oid_array. */
+		uint16_t                     dth_local_oid_cnt;
+		/** The total slots in the dth_local_oid_array. */
+		uint16_t                     dth_local_oid_cap;
+		uint32_t                     padding4;
+		/** The record of all objects touched by the local transaction. */
+		struct dtx_local_oid_record *dth_local_oid_array;
 	};
 
 	/* Hash of the dkey to be modified if applicable. Per modification. */
@@ -179,6 +167,7 @@ struct dtx_handle {
 	int                               dth_share_tbd_count;
 	uint32_t                          padding5;
 };
+/* clang-format on */
 
 /* Each sub transaction handle to manage each sub thandle */
 struct dtx_sub_status {

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -51,40 +51,13 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 
 	vts_init_dte(&dth->dth_dte);
 
-	dth->dth_coh = coh;
-	dth->dth_epoch = epoch;
-	dth->dth_leader_oid = *oid;
-
-	dth->dth_pinned = 0;
-	dth->dth_sync = 0;
-	dth->dth_cos_done = 0;
-	dth->dth_touched_leader_oid = 0;
-	dth->dth_local_tx_started = 0;
-	dth->dth_solo = 0;
-	dth->dth_drop_cmt = 0;
-	dth->dth_modify_shared = 0;
-	dth->dth_active = 0;
-	dth->dth_dist = 0;
-	dth->dth_for_migration = 0;
-	dth->dth_ignore_uncommitted = 0;
-	dth->dth_prepared = 0;
-	dth->dth_epoch_owner = 0;
-	dth->dth_aborted = 0;
-	dth->dth_already = 0;
-	dth->dth_need_validation = 0;
-
-	dth->dth_dti_cos_count = 0;
-	dth->dth_dti_cos = NULL;
-	dth->dth_ent = NULL;
-	dth->dth_flags = DTE_LEADER;
+	dth->dth_coh              = coh;
+	dth->dth_epoch            = epoch;
+	dth->dth_leader_oid       = *oid;
+	dth->dth_flags            = DTE_LEADER;
 	dth->dth_modification_cnt = 1;
-
-	dth->dth_op_seq = 1;
-	dth->dth_oid_cnt = 0;
-	dth->dth_oid_cap = 0;
-	dth->dth_oid_array = NULL;
-
-	dth->dth_dkey_hash = dkey_hash;
+	dth->dth_op_seq           = 1;
+	dth->dth_dkey_hash        = dkey_hash;
 
 	D_INIT_LIST_HEAD(&dth->dth_share_cmt_list);
 	D_INIT_LIST_HEAD(&dth->dth_share_abt_list);

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -223,7 +223,7 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm, bool is_sysdb,
 	if (dth == NULL) {
 		/* CPU may yield when umem_tx_begin, related object maybe evicted during that. */
 		rc = umem_tx_begin(umm, vos_txd_get(is_sysdb));
-		if (rc == 0 && unlikely(vos_obj_is_evicted(obj))) {
+		if (rc == 0 && obj != NULL && unlikely(vos_obj_is_evicted(obj))) {
 			D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted(1), need to restart TX.\n",
 				DP_UOID(obj->obj_id));
 			rc = umem_tx_end(umm, -DER_TX_RESTART);
@@ -246,7 +246,7 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm, bool is_sysdb,
 	rc = umem_tx_begin(umm, vos_txd_get(is_sysdb));
 	if (rc == 0) {
 		/* CPU may yield when umem_tx_begin, related object maybe evicted during that. */
-		if (unlikely(vos_obj_is_evicted(obj))) {
+		if (obj != NULL && unlikely(vos_obj_is_evicted(obj))) {
 			D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted(2), need to restart TX.\n",
 				DP_UOID(obj->obj_id));
 

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -215,12 +215,22 @@ vos_tx_publish(struct dtx_handle *dth, bool publish)
 }
 
 int
-vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm, bool is_sysdb)
+vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm, bool is_sysdb,
+	     struct vos_object *obj)
 {
 	int	rc;
 
-	if (dth == NULL)
-		return umem_tx_begin(umm, vos_txd_get(is_sysdb));
+	if (dth == NULL) {
+		/* CPU may yield when umem_tx_begin, related object maybe evicted during that. */
+		rc = umem_tx_begin(umm, vos_txd_get(is_sysdb));
+		if (rc == 0 && unlikely(vos_obj_is_evicted(obj))) {
+			D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted(1), need to restart TX.\n",
+				DP_UOID(obj->obj_id));
+			rc = umem_tx_end(umm, -DER_TX_RESTART);
+		}
+
+		return rc;
+	}
 
 	D_ASSERT(!is_sysdb);
 	/** Note: On successful return, dth tls gets set and will be cleared by the corresponding
@@ -235,6 +245,14 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm, bool is_sysdb)
 
 	rc = umem_tx_begin(umm, vos_txd_get(is_sysdb));
 	if (rc == 0) {
+		/* CPU may yield when umem_tx_begin, related object maybe evicted during that. */
+		if (unlikely(vos_obj_is_evicted(obj))) {
+			D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted(2), need to restart TX.\n",
+				DP_UOID(obj->obj_id));
+
+			return umem_tx_end(umm, -DER_TX_RESTART);
+		}
+
 		dth->dth_local_tx_started = 1;
 		vos_dth_set(dth, false);
 	}
@@ -249,12 +267,6 @@ vos_local_tx_abort(struct dtx_handle *dth)
 
 	if (dth->dth_local_oid_cnt == 0)
 		return;
-
-	/**
-	 * Since a local transaction spawns always a single pool an eaither one of the containers
-	 * can be used to access the pool.
-	 */
-	record = &dth->dth_local_oid_array[0];
 
 	/**
 	 * Evict all objects touched by the aborted transaction from the object cache to make sure

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -151,37 +151,21 @@ out:
 }
 
 static void
-dtx_act_ent_cleanup(struct vos_container *cont, struct vos_dtx_act_ent *dae,
-		    struct dtx_handle *dth, bool evict, bool keep_df)
+dtx_act_ent_cleanup(struct vos_container *cont, struct vos_dtx_act_ent *dae, bool evict,
+		    bool keep_df)
 {
-	if (evict) {
-		daos_unit_oid_t	*oids;
-		int		 count;
-		int		 i;
+	if (evict && dae->dae_oids != NULL) {
+		int i;
 
-		if (dth != NULL) {
-			if (dth->dth_oid_array != NULL) {
-				D_ASSERT(dth->dth_oid_cnt > 0);
-
-				count = dth->dth_oid_cnt;
-				oids = dth->dth_oid_array;
-			} else {
-				count = 1;
-				oids = &dth->dth_leader_oid;
-			}
-		} else {
-			count = dae->dae_oid_cnt;
-			oids = dae->dae_oids;
-		}
-
-		for (i = 0; i < count; i++)
-			vos_obj_evict_by_oid(cont, oids[i]);
+		for (i = 0; i < dae->dae_oid_cnt; i++)
+			vos_obj_evict_by_oid(cont, dae->dae_oids[i]);
 	}
 
 	if (dae->dae_oids != NULL && dae->dae_oids != &dae->dae_oid_inline &&
 	    dae->dae_oids != &DAE_OID(dae)) {
 		D_FREE(dae->dae_oids);
 		dae->dae_oid_cnt = 0;
+		dae->dae_oid_cap = 0;
 	}
 
 	DAE_REC_OFF(dae) = UMOFF_NULL;
@@ -254,7 +238,7 @@ dtx_act_ent_free(struct btr_instance *tins, struct btr_record *rec,
 		D_ASSERT(dae != NULL);
 		*(struct vos_dtx_act_ent **)args = dae;
 	} else if (dae != NULL) {
-		dtx_act_ent_cleanup(tins->ti_priv, dae, NULL, true, false);
+		dtx_act_ent_cleanup(tins->ti_priv, dae, true, false);
 	}
 
 	return 0;
@@ -879,7 +863,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 			rc = dbtree_delete(cont->vc_dtx_active_hdl,
 					   BTR_PROBE_BYPASS, &kiov, &dae);
 			if (rc == 0) {
-				dtx_act_ent_cleanup(cont, dae, NULL, false, false);
+				dtx_act_ent_cleanup(cont, dae, false, false);
 				dtx_evict_lid(cont, dae);
 			}
 
@@ -1845,30 +1829,6 @@ vos_dtx_prepared(struct dtx_handle *dth, struct vos_dtx_cmt_ent **dce_p)
 	    (dth->dth_modification_cnt > 0))
 		dth->dth_sync = 1;
 
-	if (dth->dth_oid_array != NULL) {
-		D_ASSERT(dth->dth_oid_cnt > 0);
-
-		dae->dae_oid_cnt = dth->dth_oid_cnt;
-		if (dth->dth_oid_cnt == 1) {
-			dae->dae_oid_inline = dth->dth_oid_array[0];
-			dae->dae_oids = &dae->dae_oid_inline;
-		} else {
-			size = sizeof(daos_unit_oid_t) * dth->dth_oid_cnt;
-			D_ALLOC_NZ(dae->dae_oids, size);
-			if (dae->dae_oids == NULL) {
-				/* Not fatal. */
-				D_WARN("No DRAM to store ACT DTX OIDs "
-				       DF_DTI"\n", DP_DTI(&DAE_XID(dae)));
-				dae->dae_oid_cnt = 0;
-			} else {
-				memcpy(dae->dae_oids, dth->dth_oid_array, size);
-			}
-		}
-	} else {
-		dae->dae_oids = &DAE_OID(dae);
-		dae->dae_oid_cnt = 1;
-	}
-
 	if (DAE_MBS_DSIZE(dae) <= sizeof(DAE_MBS_INLINE(dae))) {
 		memcpy(DAE_MBS_INLINE(dae), dth->dth_mbs->dm_data,
 		       DAE_MBS_DSIZE(dae));
@@ -2441,7 +2401,7 @@ vos_dtx_post_handle(struct vos_container *cont,
 			DAE_FLAGS(daes[i]) |= DTE_PARTIAL_COMMITTED;
 
 			daes[i]->dae_committing = 0;
-			dtx_act_ent_cleanup(cont, daes[i], NULL, false, true);
+			dtx_act_ent_cleanup(cont, daes[i], false, true);
 			continue;
 		}
 
@@ -2467,13 +2427,13 @@ vos_dtx_post_handle(struct vos_container *cont,
 
 				daes[i]->dae_aborted = 1;
 				daes[i]->dae_aborting = 0;
-				dtx_act_ent_cleanup(cont, daes[i], NULL, true, false);
+				dtx_act_ent_cleanup(cont, daes[i], true, false);
 			} else {
 				D_ASSERT(daes[i]->dae_aborting == 0);
 
 				daes[i]->dae_committed = 1;
 				daes[i]->dae_committing = 0;
-				dtx_act_ent_cleanup(cont, daes[i], NULL, false, false);
+				dtx_act_ent_cleanup(cont, daes[i], false, false);
 			}
 			DAE_FLAGS(daes[i]) &= ~(DTE_CORRUPTED | DTE_ORPHAN | DTE_PARTIAL_COMMITTED);
 		}
@@ -3659,7 +3619,7 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 		 */
 		if (dae != NULL) {
 			D_ASSERT(!vos_dae_is_prepare(dae));
-			dtx_act_ent_cleanup(cont, dae, dth, true, false);
+			dtx_act_ent_cleanup(cont, dae, true, false);
 		}
 	} else {
 		d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
@@ -3682,7 +3642,7 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 		if (DAE_EPOCH(dae) != dth->dth_epoch)
 			goto out;
 
-		dtx_act_ent_cleanup(cont, dae, dth, true, false);
+		dtx_act_ent_cleanup(cont, dae, true, false);
 
 		rc = dbtree_delete(cont->vc_dtx_active_hdl,
 				   riov.iov_buf != NULL ? BTR_PROBE_BYPASS : BTR_PROBE_EQ,
@@ -4040,7 +4000,7 @@ vos_dtx_local_begin(struct dtx_handle *dth, daos_handle_t poh)
 		goto error;
 	}
 
-	rc = vos_tx_begin(dth, umm, pool->vp_sysdb);
+	rc = vos_tx_begin(dth, umm, pool->vp_sysdb, NULL);
 	if (rc != 0) {
 		D_ERROR("Failed to start transaction: rc=" DF_RC "\n", DP_RC(rc));
 		goto error;
@@ -4165,5 +4125,70 @@ vos_dtx_get_cmt_stat(daos_handle_t coh, uint64_t *cmt_cnt, struct dtx_time_stat 
 	rc   = 0;
 
 out:
+	return rc;
+}
+
+int
+vos_dtx_record_oid(struct dtx_handle *dth, struct vos_container *cont, daos_unit_oid_t oid)
+{
+	struct dtx_local_oid_record *oid_array;
+	struct dtx_local_oid_record *record;
+	struct vos_dtx_act_ent      *dae;
+	daos_unit_oid_t             *oids;
+	int                          rc = 0;
+
+	if (dth == NULL)
+		D_GOTO(out, rc = 0);
+
+	if (dth->dth_local) {
+		if (dth->dth_local_oid_cnt == dth->dth_local_oid_cap) {
+			D_REALLOC_ARRAY(oid_array, dth->dth_local_oid_array, dth->dth_local_oid_cap,
+					dth->dth_local_oid_cap << 1);
+			if (oid_array == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			dth->dth_local_oid_array = oid_array;
+			dth->dth_local_oid_cap <<= 1;
+		}
+
+		record           = &dth->dth_local_oid_array[dth->dth_local_oid_cnt];
+		record->dor_cont = cont;
+		vos_cont_addref(cont);
+		record->dor_oid = oid;
+		dth->dth_local_oid_cnt++;
+
+		D_GOTO(out, rc = 0);
+	}
+
+	if (daos_is_zero_dti(&dth->dth_xid))
+		D_GOTO(out, rc = 0);
+
+	dae = dth->dth_ent;
+	D_ASSERT(dae != NULL);
+
+	if (dae->dae_oid_cnt == 0) {
+		if (daos_unit_oid_compare(oid, DAE_OID(dae)) == 0)
+			dae->dae_oids = &DAE_OID(dae);
+		else
+			dae->dae_oids = &dae->dae_oid_inline;
+	} else if (dae->dae_oid_cnt >= dae->dae_oid_cap) {
+		D_ALLOC_ARRAY(oids, dae->dae_oid_cnt << 1);
+		if (oids == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		memcpy(oids, dae->dae_oids, sizeof(*oids) * dae->dae_oid_cnt);
+		if (dae->dae_oids != &DAE_OID(dae) && dae->dae_oids != &dae->dae_oid_inline)
+			D_FREE(dae->dae_oids);
+
+		dae->dae_oids    = oids;
+		dae->dae_oid_cap = dae->dae_oid_cnt << 1;
+	}
+
+	dae->dae_oids[dae->dae_oid_cnt++] = oid;
+
+out:
+	if (rc != 0)
+		D_ERROR("Failed to record oid " DF_UOID ": " DF_RC "\n", DP_UOID(oid), DP_RC(rc));
+
 	return rc;
 }

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -470,10 +470,6 @@ struct vos_dtx_act_ent {
 	 * then 'dae_oids' points to the 'dae_oid_inline'.
 	 *
 	 * Otherwise, 'dae_oids' points to new buffer to hold more.
-	 *
-	 * These information is used for EC aggregation optimization.
-	 * If server restarts, then we will lose the optimization but
-	 * it is not fatal.
 	 */
 	daos_unit_oid_t			*dae_oids;
 	/* The time (hlc) when the DTX entry is created. */
@@ -484,6 +480,9 @@ struct vos_dtx_act_ent {
 	d_list_t			 dae_link;
 	/* Back pointer to the DTX handle. */
 	struct dtx_handle		*dae_dth;
+
+	/* The capacity of dae_oids if it points to new allocated area. */
+	uint32_t                         dae_oid_cap;
 
 	unsigned int			 dae_committable:1,
 					 dae_committing:1,
@@ -854,6 +853,9 @@ vos_dtx_post_handle(struct vos_container *cont,
  */
 int
 vos_dtx_act_reindex(struct vos_container *cont);
+
+int
+vos_dtx_record_oid(struct dtx_handle *dth, struct vos_container *cont, daos_unit_oid_t oid);
 
 enum vos_tree_class {
 	/** the first reserved tree class */
@@ -1336,7 +1338,8 @@ vos_evt_desc_cbs_init(struct evt_desc_cbs *cbs, struct vos_pool *pool,
 		      daos_handle_t coh, struct vos_object *obj);
 
 int
-vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm, bool is_sysdb);
+vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm, bool is_sysdb,
+	     struct vos_object *obj);
 
 /** Finish the transaction and publish or cancel the reservations or
  *  return if err == 0 and it's a multi-modification transaction that
@@ -1927,20 +1930,6 @@ vos_io_scm(struct vos_pool *pool, daos_iod_type_t type, daos_size_t size, enum v
 
 	return false;
 }
-
-/**
- * Insert object ID and its parent container into the array of objects touched by the ongoing
- * local transaction.
- *
- * \param[in] dth	DTX handle for ongoing local transaction
- * \param[in] cont	VOS container
- * \param[in] oid	Object ID
- *
- * \return		0		: Success.
- *			-DER_NOMEM	: Run out of the volatile memory.
- */
-int
-vos_insert_oid(struct dtx_handle *dth, struct vos_container *cont, daos_unit_oid_t *oid);
 
 static inline bool
 vos_pool_is_p2(struct vos_pool *pool)

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2572,7 +2572,7 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	if (err != 0)
 		goto abort;
 
-	if (unlikely(vos_obj_is_evicted(ioc->ic_pinned_obj))) {
+	if (ioc->ic_pinned_obj != NULL && unlikely(vos_obj_is_evicted(ioc->ic_pinned_obj))) {
 		D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted during update, need to restart TX.\n",
 			DP_UOID(ioc->ic_oid));
 

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -127,7 +127,7 @@ int vos_obj_evict_by_oid(struct vos_container *cont, daos_unit_oid_t oid);
 static inline bool
 vos_obj_is_evicted(struct vos_object *obj)
 {
-	return obj != NULL && daos_lru_is_evicted(&obj->obj_llink);
+	return daos_lru_is_evicted(&obj->obj_llink);
 }
 
 /**

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -122,6 +123,12 @@ vos_obj_release(struct vos_object *obj, uint64_t flags, bool evict);
 void vos_obj_evict(struct vos_object *obj);
 
 int vos_obj_evict_by_oid(struct vos_container *cont, daos_unit_oid_t oid);
+
+static inline bool
+vos_obj_is_evicted(struct vos_object *obj)
+{
+	return obj != NULL && daos_lru_is_evicted(&obj->obj_llink);
+}
 
 /**
  * Create an object cache.


### PR DESCRIPTION
Currently, if a transaction failed for some reason, the cleanup logic
will try to evict related vos object from cache to avoid leaving stable
information in cache. Such logic works well for the system with PMEM.
But under md-on-ssd mode, the eviction may cause trouble. Because one
vos modification may hold the same object multiple times, and there is
CPU yield during these object hold actions. That creates race windows
for other concurrent operations against the same object.

This patch changes the logic: when the transaction changes some vos
object(s), it will record related oid(s), if such transaction failed
in subsequent process, it will only evict these modified objects. The
others in cache will not be affected during transaction cleanup.

On the other hand, under md-on-ssd mode, CPU may yield during backend
TX start, the object that is held by current modification maybe marked
as evicted in such race windows. So add logic to check whether related
object is evicted or not after backend TX started, if yes, then restart
current transaction.

Allow-unstable-test: true

Signed-off-by: Fan Yong <fan.yong@hpe.com>
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
