### PR TITLE
DAOS-17535 chk: misc improvements for CR logic

### DIFF
--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -1073,8 +1073,7 @@ chk_policy_refresh(uint32_t policy_nr, struct chk_policy *policies, struct chk_p
 }
 
 int
-chk_prop_prepare(d_rank_t leader, uint32_t flags, int phase,
-		 uint32_t policy_nr, struct chk_policy *policies,
+chk_prop_prepare(d_rank_t leader, uint32_t flags, uint32_t policy_nr, struct chk_policy *policies,
 		 d_rank_list_t *ranks, struct chk_property *prop)
 {
 	int rc = 0;
@@ -1086,11 +1085,8 @@ chk_prop_prepare(d_rank_t leader, uint32_t flags, int phase,
 		prop->cp_flags &= ~CHK__CHECK_FLAG__CF_FAILOUT;
 	if (flags & CHK__CHECK_FLAG__CF_NO_AUTO)
 		prop->cp_flags &= ~CHK__CHECK_FLAG__CF_AUTO;
-	prop->cp_flags |= flags & ~(CHK__CHECK_FLAG__CF_RESET |
-				    CHK__CHECK_FLAG__CF_ORPHAN_POOL |
-				    CHK__CHECK_FLAG__CF_NO_FAILOUT |
-				    CHK__CHECK_FLAG__CF_NO_AUTO);
-	prop->cp_phase = phase;
+	prop->cp_flags |= flags & ~(CHK__CHECK_FLAG__CF_RESET | CHK__CHECK_FLAG__CF_ORPHAN_POOL |
+				    CHK__CHECK_FLAG__CF_NO_FAILOUT | CHK__CHECK_FLAG__CF_NO_AUTO);
 	if (ranks != NULL)
 		prop->cp_rank_nr = ranks->rl_nr;
 
@@ -1240,12 +1236,7 @@ chk_ins_cleanup(struct chk_instance *ins)
 	chk_stop_sched(ins);
 	ins->ci_inited = 0;
 
-	chk_iv_ns_cleanup(&ins->ci_iv_ns);
-
-	if (ins->ci_iv_group != NULL) {
-		crt_group_secondary_destroy(ins->ci_iv_group);
-		ins->ci_iv_group = NULL;
-	}
+	chk_iv_ns_destroy(ins);
 }
 
 int
@@ -1260,7 +1251,8 @@ chk_ins_init(struct chk_instance **p_ins)
 	if (ins == NULL)
 		D_GOTO(out_init, rc = -DER_NOMEM);
 
-	ins->ci_sched = ABT_THREAD_NULL;
+	ins->ci_sched         = ABT_THREAD_NULL;
+	ins->ci_dead_rank_ult = ABT_THREAD_NULL;
 
 	ins->ci_rank_hdl = DAOS_HDL_INVAL;
 	D_INIT_LIST_HEAD(&ins->ci_rank_list);
@@ -1331,6 +1323,8 @@ chk_ins_fini(struct chk_instance **p_ins)
 
 	D_ASSERT(d_list_empty(&ins->ci_interaction_filter_list));
 	D_ASSERT(d_list_empty(&ins->ci_pool_shutdown_list));
+
+	D_ASSERT(ins->ci_dead_rank_ult == ABT_THREAD_NULL);
 
 	if (ins->ci_sched != ABT_THREAD_NULL)
 		ABT_thread_free(&ins->ci_sched);

--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -76,6 +76,7 @@ struct chk_pool_mbs {
 	uint32_t	*cpm_tgt_status;
 };
 
+/* clang-format off */
 /*
  * CHK_START:
  * From check leader to check engine to start the check instance on specified pool(s) or all pools.
@@ -83,7 +84,7 @@ struct chk_pool_mbs {
 #define DAOS_ISEQ_CHK_START							\
 	((uint64_t)		(csi_gen)		CRT_VAR)		\
 	((uint32_t)		(csi_flags)		CRT_VAR)		\
-	((int32_t)		(csi_phase)		CRT_VAR)		\
+	((int32_t)		(csi_ns_ver)		CRT_VAR)		\
 	((d_rank_t)		(csi_leader_rank)	CRT_VAR)		\
 	((uint32_t)		(csi_api_flags)		CRT_VAR)		\
 	((uuid_t)		(csi_iv_uuid)		CRT_VAR)		\
@@ -272,11 +273,13 @@ CRT_RPC_DECLARE(chk_report, DAOS_ISEQ_CHK_REPORT, DAOS_OSEQ_CHK_REPORT);
 #define DAOS_OSEQ_CHK_REJOIN							\
 	((int32_t)		(cro_status)		CRT_VAR)		\
 	((uint32_t)		(cro_flags)		CRT_VAR)		\
+	((uint32_t)		(cro_ns_ver)		CRT_VAR)		\
+	((uint32_t)		(cro_padding)		CRT_VAR)		\
+	((d_rank_t)		(cro_ranks)		CRT_ARRAY)		\
 	((uuid_t)		(cro_pools)		CRT_ARRAY)
 
 CRT_RPC_DECLARE(chk_rejoin, DAOS_ISEQ_CHK_REJOIN, DAOS_OSEQ_CHK_REJOIN);
 
-/* clang-format off */
 /*
  * CHK_SET_POLICY:
  * From check leader to check engine to set policy during check instance running.
@@ -501,16 +504,12 @@ struct chk_bookmark {
  * 'reset' for all pools.
  */
 struct chk_property {
-	d_rank_t			cp_leader;
-	Chk__CheckFlag			cp_flags;
-	Chk__CheckInconsistAction	cp_policies[CHK_POLICY_MAX];
-	/*
-	 * NOTE: Preserve for supporting to continue the check until the specified phase in the
-	 *	 future. -1 means to check all phases.
-	 */
-	int32_t				cp_phase;
+	d_rank_t                  cp_leader;
+	Chk__CheckFlag            cp_flags;
+	Chk__CheckInconsistAction cp_policies[CHK_POLICY_MAX];
+	uint32_t                  cp_padding;
 	/* How many ranks (ever or should) take part in the check instance. */
-	uint32_t			cp_rank_nr;
+	uint32_t                  cp_rank_nr;
 };
 
 /*
@@ -555,6 +554,7 @@ struct chk_instance {
 	d_list_t		 ci_dead_ranks;
 
 	ABT_thread		 ci_sched;
+	ABT_thread               ci_dead_rank_ult;
 	ABT_rwlock		 ci_abt_lock;
 	ABT_mutex		 ci_abt_mutex;
 	ABT_cond		 ci_abt_cond;
@@ -562,20 +562,12 @@ struct chk_instance {
 	/* Generator for report event, pending repair actions, and so on. */
 	uint64_t		 ci_seq;
 
-	uint32_t		 ci_is_leader:1,
-				 ci_sched_running:1,
-				 ci_sched_exiting:1,
-				 ci_for_orphan:1,
-				 ci_orphan_done:1, /* leader has processed orphan pools. */
-				 ci_pool_stopped:1, /* check on some pools have been stopped. */
-				 ci_starting:1,
-				 ci_stopping:1,
-				 ci_started:1,
-				 ci_inited:1,
-				 ci_pause:1,
-				 ci_rejoining:1,
-				 ci_implicated:1;
-	uint32_t		 ci_start_flags;
+	uint32_t ci_is_leader : 1, ci_sched_running : 1, ci_sched_exiting : 1, ci_for_orphan : 1,
+	    ci_orphan_done : 1, ci_pool_stopped : 1, /* check on some pools have been stopped. */
+	    ci_starting : 1, ci_stopping : 1, ci_started : 1, ci_inited : 1, ci_pause : 1,
+	    ci_skip_oog : 1, ci_rejoining : 1, ci_implicated : 1;
+	uint32_t ci_start_flags;
+	uint32_t ci_ns_ver;
 };
 
 struct chk_iv {
@@ -762,9 +754,8 @@ void chk_pending_destroy(struct chk_pending_rec *cpr);
 
 int chk_policy_refresh(uint32_t policy_nr, struct chk_policy *policies, struct chk_property *prop);
 
-int chk_prop_prepare(d_rank_t leader, uint32_t flags, int phase,
-		     uint32_t policy_nr, struct chk_policy *policies,
-		     d_rank_list_t *ranks, struct chk_property *prop);
+int chk_prop_prepare(d_rank_t leader, uint32_t flags, uint32_t policy_nr,
+		     struct chk_policy *policies, d_rank_list_t *ranks, struct chk_property *prop);
 
 uint32_t chk_pool_merge_status(uint32_t status_a, uint32_t status_b);
 
@@ -781,7 +772,7 @@ void chk_ins_fini(struct chk_instance **p_ins);
 
 int chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
 		     uint32_t policy_nr, struct chk_policy *policies, int pool_nr,
-		     uuid_t pools[], uint32_t api_flags, int phase, d_rank_t leader,
+		     uuid_t pools[], uint32_t api_flags, uint32_t ns_ver, d_rank_t leader,
 		     uint32_t flags, uuid_t iv_uuid, struct ds_pool_clues *clues);
 
 int chk_engine_stop(uint64_t gen, int pool_nr, uuid_t pools[], uint32_t *flags);
@@ -818,7 +809,14 @@ void chk_engine_fini(void);
 
 /* chk_iv.c */
 
-int chk_iv_update(void *ns, struct chk_iv *iv, uint32_t shortcut, uint32_t sync_mode, bool retry);
+void chk_iv_ns_destroy(struct chk_instance *ins);
+
+int chk_iv_ns_create(struct chk_instance *ins, uuid_t uuid, d_rank_t leader, uint32_t ns_ver);
+
+int chk_iv_ns_update(struct chk_instance *ins, uint32_t ns_ver);
+
+int chk_iv_update(struct chk_instance *ins, struct chk_iv *iv, uint32_t shortcut,
+		  uint32_t sync_mode);
 
 int chk_iv_init(void);
 
@@ -834,8 +832,8 @@ int chk_leader_report(struct chk_report_unit *cru, uint64_t *seq, int *decision)
 
 int chk_leader_notify(struct chk_iv *iv);
 
-int chk_leader_rejoin(uint64_t gen, d_rank_t rank, uuid_t iv_uuid, uint32_t *flags, int *pool_nr,
-		      uuid_t **pools);
+int chk_leader_rejoin(uint64_t gen, d_rank_t rank, uuid_t iv_uuid, uint32_t *flags,
+		      uint32_t *ns_ver, int *pool_nr, uuid_t **pools, d_rank_list_t **ranks);
 
 int chk_leader_setup(void);
 
@@ -849,8 +847,8 @@ void chk_leader_fini(void);
 
 int chk_start_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
 		     uint32_t policy_nr, struct chk_policy *policies, int pool_nr,
-		     uuid_t pools[], uint32_t api_flags, int phase, d_rank_t leader, uint32_t flags,
-		     uuid_t iv_uuid, chk_co_rpc_cb_t start_cb, void *args);
+		     uuid_t pools[], uint32_t api_flags, uint32_t ns_ver, d_rank_t leader,
+		     uint32_t flags, uuid_t iv_uuid, chk_co_rpc_cb_t start_cb, void *args);
 
 int chk_stop_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t pools[],
 		    chk_co_rpc_cb_t stop_cb, void *args);
@@ -879,7 +877,7 @@ int chk_report_remote(d_rank_t leader, uint64_t gen, uint32_t cla, uint32_t act,
 		      uint32_t detail_nr, d_sg_list_t *details, uint64_t seq);
 
 int chk_rejoin_remote(d_rank_t leader, uint64_t gen, d_rank_t rank, uuid_t iv_uuid, uint32_t *flags,
-		      uint32_t *pool_nr, uuid_t **pools);
+		      uint32_t *ns_ver, uint32_t *pool_nr, uuid_t **pools, d_rank_list_t **ranks);
 
 int chk_set_policy_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t policy_nr,
 			  struct chk_policy *policies);
@@ -946,41 +944,24 @@ chk_ins_set_fail(struct chk_instance *ins, uint32_t phase)
 static inline bool
 chk_rank_in_list(d_rank_list_t *rlist, d_rank_t rank)
 {
-	int	i;
-	bool	found = false;
-
-	/* TBD: more efficiently search for the sorted ranks list. */
-
-	for (i = 0; i < rlist->rl_nr; i++) {
-		if (rlist->rl_ranks[i] == rank) {
-			found = true;
-			break;
-		}
-	}
-
-	return found;
+	return d_rank_list_bsearch(rlist, rank, NULL);
 }
 
 static inline bool
 chk_remove_rank_from_list(d_rank_list_t *rlist, d_rank_t rank)
 {
-	int	i;
-	bool	found = false;
+	int  idx   = -1;
+	bool found = false;
 
-	/* TBD: more efficiently search for the sorted ranks list. */
+	if (d_rank_list_bsearch(rlist, rank, &idx)) {
+		D_ASSERT(rlist->rl_nr > 0);
+		D_ASSERT(idx >= 0);
 
-	for (i = 0; i < rlist->rl_nr; i++) {
-		if (rlist->rl_ranks[i] == rank) {
-			found = true;
-			rlist->rl_nr--;
-			/* The leader rank will always be in the rank list. */
-			D_ASSERT(rlist->rl_nr > 0);
-
-			if (i < rlist->rl_nr)
-				memmove(&rlist->rl_ranks[i], &rlist->rl_ranks[i + 1],
-					sizeof(rlist->rl_ranks[i]) * (rlist->rl_nr - i));
-			break;
-		}
+		rlist->rl_nr--;
+		if (idx < rlist->rl_nr)
+			memmove(&rlist->rl_ranks[idx], &rlist->rl_ranks[idx + 1],
+				sizeof(rlist->rl_ranks[idx]) * (rlist->rl_nr - idx));
+		found = true;
 	}
 
 	return found;
@@ -1029,17 +1010,6 @@ chk_query_free(struct chk_query_pool_shard *shards, uint32_t shard_nr)
 			D_FREE(shards[i].cqps_targets);
 
 		D_FREE(shards);
-	}
-}
-
-static inline void
-chk_iv_ns_cleanup(struct ds_iv_ns **ns)
-{
-	if (*ns != NULL) {
-		if ((*ns)->iv_refcount == 1)
-			ds_iv_ns_cleanup(*ns);
-		ds_iv_ns_put(*ns);
-		*ns = NULL;
 	}
 }
 
@@ -1249,7 +1219,7 @@ chk_ins_can_start(struct chk_instance *ins)
 	if (ins->ci_starting)
 		return -DER_INPROGRESS;
 
-	if (ins->ci_stopping || ins->ci_sched_exiting)
+	if (ins->ci_stopping || ins->ci_sched_exiting || ins->ci_rejoining)
 		return -DER_BUSY;
 
 	if (ins->ci_sched_running)

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -226,10 +226,9 @@ static void
 chk_leader_exit(struct chk_instance *ins, uint32_t ins_phase, uint32_t ins_status,
 		uint32_t pool_status, bool bcast)
 {
-	struct chk_dead_rank *cdr;
-	struct chk_bookmark  *cbk = &ins->ci_bk;
-	struct chk_iv         iv  = {0};
-	int                   rc  = 0;
+	struct chk_bookmark *cbk = &ins->ci_bk;
+	struct chk_iv        iv  = {0};
+	int                  rc  = 0;
 
 	ins->ci_sched_exiting = 1;
 
@@ -244,8 +243,7 @@ chk_leader_exit(struct chk_instance *ins, uint32_t ins_phase, uint32_t ins_statu
 		iv.ci_ins_status = ins_status;
 
 		/* Synchronously notify the engines that the check leader exit. */
-		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
-				   CRT_IV_SYNC_EAGER, true);
+		rc = chk_iv_update(ins, &iv, CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_EAGER);
 		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
 			 DF_LEADER" notify the engines its exit, status %u: rc = %d\n",
 			 DP_LEADER(ins), ins_status, rc);
@@ -263,10 +261,6 @@ chk_leader_exit(struct chk_instance *ins, uint32_t ins_phase, uint32_t ins_statu
 			D_ERROR(DF_LEADER" exit with status %u: "DF_RC"\n",
 				DP_LEADER(ins), ins_status, DP_RC(rc));
 	}
-
-	while ((cdr = d_list_pop_entry(&ins->ci_dead_ranks, struct chk_dead_rank, cdr_link)) !=
-	       NULL)
-		D_FREE(cdr);
 
 	ins->ci_sched_exiting = 0;
 }
@@ -316,8 +310,7 @@ chk_leader_post_repair(struct chk_instance *ins, struct chk_pool_rec *cpr,
 		iv.ci_phase       = cbk->cb_phase;
 		iv.ci_pool_status = cbk->cb_pool_status;
 
-		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_EAGER,
-				   true);
+		rc = chk_iv_update(ins, &iv, CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_EAGER);
 		DL_CDEBUG(rc != 0, DLOG_WARN, DLOG_INFO, rc,
 			  DF_LEADER " notify engines that check pool " DF_UUIDF " done, status %u",
 			  DP_LEADER(ins), DP_UUID(cpr->cpr_uuid), iv.ci_pool_status);
@@ -2102,8 +2095,7 @@ out:
 		uuid_copy(iv.ci_uuid, cpr->cpr_uuid);
 		iv.ci_phase = cbk->cb_phase;
 
-		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
-				   CRT_IV_SYNC_EAGER, true);
+		rc = chk_iv_update(ins, &iv, CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_EAGER);
 		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
 			 DF_LEADER" notify engines to exit check for pool "DF_UUIDF" failure: %d\n",
 			 DP_LEADER(ins), DP_UUID(cpr->cpr_uuid), rc);
@@ -2128,7 +2120,7 @@ chk_leader_mark_rank_dead(struct chk_instance *ins, struct chk_dead_rank *cdr)
 	struct chk_pool_shard *tmp;
 	struct chk_property   *prop    = &ins->ci_prop;
 	struct chk_bookmark   *cbk     = &ins->ci_bk;
-	uint32_t               version = cbk->cb_gen - prop->cp_rank_nr - 1;
+	uint32_t               version = ins->ci_ns_ver + 1;
 	int                    rc      = 0;
 
 	if (!chk_remove_rank_from_list(ins->ci_ranks, cdr->cdr_rank))
@@ -2136,11 +2128,12 @@ chk_leader_mark_rank_dead(struct chk_instance *ins, struct chk_dead_rank *cdr)
 
 	prop->cp_rank_nr--;
 	rc = chk_prop_update(prop, ins->ci_ranks);
-	if (rc != 0)
+	if (rc != 0) {
+		ins->ci_skip_oog = 1;
 		goto out;
+	}
 
-	rc = crt_group_secondary_modify(ins->ci_iv_group, ins->ci_ranks, ins->ci_ranks,
-					CRT_GROUP_MOD_OP_REPLACE, version);
+	rc = chk_iv_ns_update(ins, version);
 	if (rc != 0)
 		goto out;
 
@@ -2198,7 +2191,6 @@ chk_leader_sched(void *args)
 {
 	struct chk_instance    *ins = args;
 	struct chk_bookmark    *cbk = &ins->ci_bk;
-	struct chk_dead_rank   *cdr;
 	struct chk_pending_rec *pending;
 	struct chk_iv           iv = {0};
 	uint32_t                ins_phase;
@@ -2208,7 +2200,6 @@ chk_leader_sched(void *args)
 	int                     done  = 0;
 	int                     rc    = 0;
 	bool                    bcast = false;
-	bool                    more_dead;
 
 	D_INFO(DF_LEADER" scheduler enter at phase %u\n", DP_LEADER(ins), cbk->cb_phase);
 
@@ -2239,28 +2230,8 @@ handle:
 	while (1) {
 		dss_sleep(300);
 
-check_dead:
-		ABT_mutex_lock(ins->ci_abt_mutex);
-		if (!d_list_empty(&ins->ci_dead_ranks)) {
-			cdr = d_list_pop_entry(&ins->ci_dead_ranks, struct chk_dead_rank, cdr_link);
-			if (!d_list_empty(&ins->ci_dead_ranks))
-				more_dead = true;
-			else
-				more_dead = false;
-		} else {
-			cdr = NULL;
-			more_dead = false;
-		}
-		ABT_mutex_unlock(ins->ci_abt_mutex);
-
-		if (cdr != NULL)
-			chk_leader_mark_rank_dead(ins, cdr);
-
 		if (chk_leader_need_stop(ins, &rc))
 			D_GOTO(out, bcast = (rc > 0 ? true : false));
-
-		if (more_dead)
-			goto check_dead;
 
 		if (!d_list_empty(&ins->ci_interaction_filter_list)) {
 			pending = d_list_pop_entry(&ins->ci_interaction_filter_list,
@@ -2289,8 +2260,7 @@ check_dead:
 			iv.ci_ins_status = CHK__CHECK_INST_STATUS__CIS_RUNNING;
 
 			/* Synchronously notify engines that orphan pools have been processed. */
-			rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
-					   CRT_IV_SYNC_EAGER, true);
+			rc = chk_iv_update(ins, &iv, CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_EAGER);
 			D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
 				 DF_LEADER" notify engines that orphan pools have been process: %d\n",
 				 DP_LEADER(ins), rc);
@@ -2461,8 +2431,8 @@ out:
 
 static int
 chk_leader_start_prep(struct chk_instance *ins, uint32_t rank_nr, d_rank_t *ranks,
-		      uint32_t policy_nr, struct chk_policy *policies, int pool_nr,
-		      uuid_t pools[], int phase, d_rank_t leader, uint32_t flags)
+		      uint32_t policy_nr, struct chk_policy *policies, int pool_nr, uuid_t pools[],
+		      d_rank_t leader, uint32_t flags)
 {
 	struct chk_property		*prop = &ins->ci_prop;
 	struct chk_bookmark		*cbk = &ins->ci_bk;
@@ -2552,7 +2522,7 @@ reset:
 	cbk->cb_version = chk_ver;
 
 init:
-	rc = chk_prop_prepare(leader, flags, phase, policy_nr, policies, rank_list, prop);
+	rc = chk_prop_prepare(leader, flags, policy_nr, policies, rank_list, prop);
 	if (rc != 0)
 		goto out;
 
@@ -2698,8 +2668,7 @@ chk_leader_start_post(struct chk_instance *ins)
 			 * to notify the engine for the check done, that is not fatal. That
 			 * can be redo in next check instance.
 			 */
-			rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
-					   CRT_IV_SYNC_EAGER, true);
+			rc = chk_iv_update(ins, &iv, CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_EAGER);
 			D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
 				 DF_LEADER" notify engines the pool "DF_UUIDF" is checked: %d\n",
 				 DP_LEADER(ins), DP_UUID(cpr->cpr_uuid), rc);
@@ -2879,20 +2848,20 @@ out:
 
 int
 chk_leader_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr, struct chk_policy *policies,
-		 int pool_nr, uuid_t pools[], uint32_t api_flags, int phase)
+		 int pool_nr, uuid_t pools[], uint32_t api_flags)
 {
-	struct chk_instance	*ins = chk_leader;
-	struct chk_bookmark	*cbk = &ins->ci_bk;
-	uuid_t			*c_pools = NULL;
-	struct umem_attr	 uma = { 0 };
-	uuid_t			 dummy_pool = { 0 };
-	char			 uuid_str[DAOS_UUID_STR_SIZE];
-	uint64_t		 old_gen = cbk->cb_gen;
-	d_rank_t		 myrank = dss_self_rank();
-	uint32_t		 flags = api_flags;
-	int			 c_pool_nr = 0;
-	int			 rc;
-	int			 rc1;
+	struct chk_instance *ins        = chk_leader;
+	struct chk_bookmark *cbk        = &ins->ci_bk;
+	uuid_t              *c_pools    = NULL;
+	struct umem_attr     uma        = {0};
+	uuid_t               dummy_pool = {0};
+	uint64_t             old_gen    = cbk->cb_gen;
+	d_rank_t             myrank     = dss_self_rank();
+	uint32_t             flags      = api_flags;
+	uint32_t             ns_ver     = (uint32_t)daos_wallclock_secs();
+	int                  c_pool_nr  = 0;
+	int                  rc;
+	int                  rc1;
 
 	rc = chk_ins_can_start(ins);
 	if (rc != 0)
@@ -2917,13 +2886,7 @@ chk_leader_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr, struct c
 	if (ins->ci_sched != ABT_THREAD_NULL)
 		ABT_thread_free(&ins->ci_sched);
 
-	chk_iv_ns_cleanup(&ins->ci_iv_ns);
-
-	if (ins->ci_iv_group != NULL) {
-		crt_group_secondary_destroy(ins->ci_iv_group);
-		ins->ci_iv_group = NULL;
-	}
-
+	chk_iv_ns_destroy(ins);
 	uma.uma_id = UMEM_CLASS_VMEM;
 
 	rc = dbtree_create_inplace(DBTREE_CLASS_CHK_RANK, 0, CHK_BTREE_ORDER, &uma,
@@ -2942,8 +2905,8 @@ chk_leader_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr, struct c
 		goto out_tree;
 
 reset:
-	rc = chk_leader_start_prep(ins, rank_nr, ranks, policy_nr, policies, pool_nr, pools,
-				   phase, myrank, flags);
+	rc = chk_leader_start_prep(ins, rank_nr, ranks, policy_nr, policies, pool_nr, pools, myrank,
+				   flags);
 	if (rc == 1 && !(flags & CHK__CHECK_FLAG__CF_RESET)) {
 		/* Former check instance has done, let's re-start from the beginning. */
 		flags |= CHK__CHECK_FLAG__CF_RESET;
@@ -2957,17 +2920,9 @@ reset:
 		goto remote;
 
 	uuid_generate(dummy_pool);
-	uuid_unparse_lower(dummy_pool, uuid_str);
-	rc = crt_group_secondary_create(uuid_str, NULL, ins->ci_ranks, &ins->ci_iv_group);
+	rc = chk_iv_ns_create(ins, dummy_pool, myrank, ns_ver);
 	if (rc != 0)
 		goto out_tree;
-
-	rc = ds_iv_ns_create(dss_get_module_info()->dmi_ctx, dummy_pool, ins->ci_iv_group,
-			     &ins->ci_iv_id, &ins->ci_iv_ns);
-	if (rc != 0)
-		goto out_group;
-
-	ds_iv_ns_update(ins->ci_iv_ns, myrank, ins->ci_iv_ns->iv_master_term + 1);
 
 	if (d_list_empty(&ins->ci_pool_list)) {
 		c_pool_nr = pool_nr;
@@ -2980,7 +2935,7 @@ reset:
 
 remote:
 	rc = chk_start_remote(ins->ci_ranks, cbk->cb_gen, rank_nr, ranks, policy_nr, policies,
-			      c_pool_nr, c_pools, flags, phase, myrank, ins->ci_start_flags,
+			      c_pool_nr, c_pools, flags, ns_ver, myrank, ins->ci_start_flags,
 			      dummy_pool, chk_leader_start_cb, ins);
 	if (rc != 0) {
 		if (rc == -DER_OOG || rc == -DER_GRPVER || rc == -DER_AGAIN) {
@@ -3023,10 +2978,9 @@ remote:
 		goto out_stop_pools;
 	}
 
-	D_INFO("Leader %s check with api_flags %x, phase %d, leader %u, flags %x, gen " DF_X64
-	       " iv "DF_UUIDF": rc %d\n",
-	       chk_is_ins_reset(ins, flags) ? "start" : "resume", api_flags, phase, myrank,
-	       ins->ci_start_flags, cbk->cb_gen, DP_UUID(dummy_pool), rc);
+	D_INFO("Leader %s with api_flags %x, leader %u, flags %x, gen " DF_X64 " iv " DF_UUIDF "\n",
+	       chk_is_ins_reset(ins, flags) ? "start" : "resume", api_flags, myrank,
+	       ins->ci_start_flags, cbk->cb_gen, DP_UUID(dummy_pool));
 
 	chk_ranks_dump(ins->ci_ranks->rl_nr, ins->ci_ranks->rl_ranks);
 	chk_pools_dump(&ins->ci_pool_list, c_pool_nr > 0 ? c_pool_nr : pool_nr,
@@ -3049,8 +3003,6 @@ out_stop_remote:
 		D_WARN(DF_LEADER" failed to rollback failed check start: "DF_RC"\n",
 		       DP_LEADER(ins), DP_RC(rc1));
 out_iv:
-	chk_iv_ns_cleanup(&ins->ci_iv_ns);
-out_group:
 	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING || cbk->cb_gen != old_gen) {
 		cbk->cb_gen = old_gen;
 		if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING) {
@@ -3062,17 +3014,16 @@ out_group:
 			D_WARN(DF_LEADER" failed to update leader bookmark: "DF_RC"\n",
 			       DP_LEADER(ins), DP_RC(rc1));
 	}
-	crt_group_secondary_destroy(ins->ci_iv_group);
-	ins->ci_iv_group = NULL;
+	chk_iv_ns_destroy(ins);
 out_tree:
 	chk_leader_destroy_trees(ins);
 	ins->ci_starting = 0;
 out_log:
-	D_CDEBUG(likely(rc < 0), DLOG_ERR, DLOG_INFO,
-		 "Leader %s to start check on %u ranks for %d pools with "
-		 "api_flags %x, phase %d, leader %u, gen "DF_X64": rc = %d\n",
-		 rc < 0 ? "failed" : "try", rank_nr, pool_nr, api_flags, phase,
-		 myrank, cbk->cb_gen, rc);
+	DL_CDEBUG(likely(rc < 0), DLOG_ERR, DLOG_INFO, rc,
+		  "Leader %s to start check on %u ranks for %d pools with api_flags %x, ns_ver %d, "
+		  "leader %u, gen " DF_X64,
+		  rc < 0 ? "failed" : "try", rank_nr, pool_nr, api_flags, ns_ver, myrank,
+		  cbk->cb_gen);
 
 	if (unlikely(rc > 0))
 		rc = 0;
@@ -3328,6 +3279,9 @@ chk_leader_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 	uint32_t                     idx = 0;
 	uint32_t                     status;
 	uint32_t                     phase;
+	uint32_t                     ver;
+	int                          try_cnt  = 0;
+	int                          wait_cnt = 0;
 	int                          rc;
 	int                          i;
 	bool                         skip;
@@ -3359,22 +3313,38 @@ chk_leader_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 		D_GOTO(out, rc = -DER_NOMEM);
 
 again:
-	rc = chk_query_remote(ins->ci_ranks, gen, pool_nr, pools, chk_leader_query_cb, cqa);
+	try_cnt++;
+	ver = ins->ci_ns_ver;
+	rc  = chk_query_remote(ins->ci_ranks, gen, pool_nr, pools, chk_leader_query_cb, cqa);
 	if (rc != 0) {
-		if (rc == -DER_OOG || rc == -DER_GRPVER || rc == -DER_AGAIN) {
-			D_INFO(DF_LEADER" Someone is not ready %d, let's retry query after 1 sec\n",
-			       DP_LEADER(ins), rc);
-			if (!d_list_empty(&cqa->cqa_list)) {
-				chk_cqa_free(cqa);
-				cqa = chk_cqa_alloc(ins);
-				if (cqa == NULL)
-					D_GOTO(out, rc = -DER_NOMEM);
-			}
-			dss_sleep(1000);
-			goto again;
+		if (rc != -DER_OOG && rc != -DER_GRPVER && rc != -DER_AGAIN)
+			goto out;
+
+		if (try_cnt % 10 == 0)
+			D_WARN("Leader (" DF_X64 ") query retried because of %d for %d times.\n",
+			       gen, rc, try_cnt);
+
+		while (ver == ins->ci_ns_ver && ins->ci_skip_oog == 0 && ins->ci_pause == 0) {
+			dss_sleep(500);
+			if (++wait_cnt % 40 == 0)
+				D_WARN("Leader (" DF_X64 ") query is blocked because of %d for "
+				       "about %d seconds.\n",
+				       gen, rc, wait_cnt / 2);
+			if (rc != -DER_OOG)
+				break;
 		}
 
-		goto out;
+		if (ins->ci_pause || ins->ci_skip_oog)
+			goto out;
+
+		if (!d_list_empty(&cqa->cqa_list)) {
+			chk_cqa_free(cqa);
+			cqa = chk_cqa_alloc(ins);
+			if (cqa == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
+
+		goto again;
 	}
 
 	d_list_for_each_entry(cpr, &ins->ci_pool_list, cpr_link) {
@@ -3826,8 +3796,8 @@ out:
 }
 
 int
-chk_leader_rejoin(uint64_t gen, d_rank_t rank, uuid_t iv_uuid, uint32_t *flags, int *pool_nr,
-		  uuid_t **pools)
+chk_leader_rejoin(uint64_t gen, d_rank_t rank, uuid_t iv_uuid, uint32_t *flags, uint32_t *ns_ver,
+		  int *pool_nr, uuid_t **pools, d_rank_list_t **ranks)
 {
 	struct chk_instance	*ins = chk_leader;
 	struct chk_bookmark	*cbk = &ins->ci_bk;
@@ -3854,7 +3824,9 @@ chk_leader_rejoin(uint64_t gen, d_rank_t rank, uuid_t iv_uuid, uint32_t *flags, 
 	if (ins->ci_orphan_done)
 		*flags = CRF_ORPHAN_DONE;
 
-	rc = chk_leader_pools2list(ins, pool_nr, pools);
+	*ns_ver = ins->ci_ns_ver;
+	*ranks  = ins->ci_ranks;
+	rc      = chk_leader_pools2list(ins, pool_nr, pools);
 
 out:
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
@@ -3872,15 +3844,15 @@ chk_rank_event_cb(d_rank_t rank, uint64_t incarnation, enum crt_event_source src
 	struct chk_dead_rank	*cdr = NULL;
 	int			 rc = 0;
 
+	if (ins->ci_ranks == NULL)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
 	/* Ignore the event that is not applicable to current rank. */
 
 	if (src != CRT_EVS_SWIM)
 		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
 
 	if (type != CRT_EVT_DEAD && type != CRT_EVT_ALIVE)
-		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
-
-	if (!ins->ci_sched_running)
 		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
 
 	if (type == CRT_EVT_DEAD) {
@@ -3917,6 +3889,34 @@ out:
 			 DP_LEADER(ins), rank, type == CRT_EVT_DEAD ? "dead" : "alive", DP_RC(rc));
 }
 
+static void
+chk_dead_rank_ult(void *args)
+{
+	struct chk_instance  *ins = args;
+	struct chk_dead_rank *cdr;
+
+	while (ins->ci_inited) {
+		cdr = NULL;
+		if (!d_list_empty(&ins->ci_dead_ranks)) {
+			ABT_mutex_lock(ins->ci_abt_mutex);
+			if (likely(!d_list_empty(&ins->ci_dead_ranks)))
+				cdr = d_list_pop_entry(&ins->ci_dead_ranks, struct chk_dead_rank,
+						       cdr_link);
+			ABT_mutex_unlock(ins->ci_abt_mutex);
+		}
+
+		if (cdr != NULL)
+			chk_leader_mark_rank_dead(ins, cdr);
+
+		if (d_list_empty(&ins->ci_dead_ranks))
+			dss_sleep(500);
+	}
+
+	while ((cdr = d_list_pop_entry(&ins->ci_dead_ranks, struct chk_dead_rank, cdr_link)) !=
+	       NULL)
+		D_FREE(cdr);
+}
+
 int
 chk_leader_setup(void)
 {
@@ -3931,6 +3931,8 @@ chk_leader_setup(void)
 	 * that local consistency is not guaranteed. Need to break and resolve
 	 * related local inconsistency firstly.
 	 */
+
+	chk_report_seq_init(ins);
 
 	rc = chk_bk_fetch_leader(cbk);
 	if (rc == -DER_NONEXIST)
@@ -3985,17 +3987,19 @@ chk_leader_setup(void)
 
 prop:
 	rc = chk_prop_fetch(&ins->ci_prop, &ins->ci_ranks);
-	if (rc == 0 || rc == -DER_NONEXIST)
-		rc = crt_register_event_cb(chk_rank_event_cb, NULL);
-fini:
-	if (rc != 0) {
-		chk_ins_fini(&ins);
-	} else {
-		chk_report_seq_init(ins);
-		ins->ci_inited = 1;
-		ins->ci_pause  = 0;
-	}
+	if (rc != 0 && rc != -DER_NONEXIST)
+		goto fini;
 
+	ins->ci_inited = 1;
+	ins->ci_pause  = 0;
+
+	rc = dss_ult_create(chk_dead_rank_ult, ins, DSS_XS_SYS, 0, 0, &ins->ci_dead_rank_ult);
+	if (rc == 0)
+		rc = crt_register_event_cb(chk_rank_event_cb, NULL);
+
+fini:
+	if (rc != 0)
+		chk_leader_cleanup();
 	return rc;
 }
 
@@ -4004,8 +4008,13 @@ chk_leader_cleanup(void)
 {
 	struct chk_instance *ins = chk_leader;
 
+	crt_unregister_event_cb(chk_rank_event_cb, NULL);
+
 	chk_ins_cleanup(ins);
 	D_ASSERT(d_list_empty(&ins->ci_rank_list));
+
+	if (ins->ci_dead_rank_ult != ABT_THREAD_NULL)
+		ABT_thread_free(&ins->ci_dead_rank_ult);
 }
 
 int
@@ -4023,6 +4032,5 @@ chk_leader_init(void)
 void
 chk_leader_fini(void)
 {
-	crt_unregister_event_cb(chk_rank_event_cb, NULL);
 	chk_ins_fini(&chk_leader);
 }

--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2022-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -527,8 +527,8 @@ chk_sg_rpc_prepare(d_rank_t rank, crt_opcode_t opc, crt_rpc_t **req)
 
 int
 chk_start_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
-		 uint32_t policy_nr, struct chk_policy *policies, int pool_nr,
-		 uuid_t pools[], uint32_t api_flags, int phase, d_rank_t leader, uint32_t flags,
+		 uint32_t policy_nr, struct chk_policy *policies, int pool_nr, uuid_t pools[],
+		 uint32_t api_flags, uint32_t ns_ver, d_rank_t leader, uint32_t flags,
 		 uuid_t iv_uuid, chk_co_rpc_cb_t start_cb, void *args)
 {
 	struct chk_co_rpc_cb_args	cb_args = { 0 };
@@ -544,12 +544,12 @@ chk_start_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t rank_nr, d_ran
 	if (rc != 0)
 		goto out;
 
-	csi = crt_req_get(req);
-	csi->csi_gen = gen;
-	csi->csi_flags = flags;
-	csi->csi_phase = phase;
+	csi                  = crt_req_get(req);
+	csi->csi_gen         = gen;
+	csi->csi_flags       = flags;
+	csi->csi_ns_ver      = ns_ver;
 	csi->csi_leader_rank = leader;
-	csi->csi_api_flags = api_flags;
+	csi->csi_api_flags   = api_flags;
 	uuid_copy(csi->csi_iv_uuid, iv_uuid);
 	csi->csi_ranks.ca_count = rank_nr;
 	csi->csi_ranks.ca_arrays = ranks;
@@ -605,9 +605,9 @@ out:
 		crt_req_decref(req);
 	}
 
-	D_CDEBUG(rc < 0, DLOG_ERR, DLOG_INFO,
-		 "Rank %u start checker, gen "DF_X64", flags %x, phase %d, iv "DF_UUIDF":"DF_RC"\n",
-		 leader, gen, flags, phase, DP_UUID(iv_uuid), DP_RC(rc));
+	DL_CDEBUG(rc < 0, DLOG_ERR, DLOG_INFO, rc,
+		  "Rank %u start checker, gen " DF_X64 ", flags %x, ns_ver %d, iv " DF_UUIDF,
+		  leader, gen, flags, ns_ver, DP_UUID(iv_uuid));
 
 	return rc;
 }
@@ -1019,7 +1019,7 @@ out:
 
 int
 chk_rejoin_remote(d_rank_t leader, uint64_t gen, d_rank_t rank, uuid_t iv_uuid, uint32_t *flags,
-		  uint32_t *pool_nr, uuid_t **pools)
+		  uint32_t *ns_ver, uint32_t *pool_nr, uuid_t **pools, d_rank_list_t **ranks)
 {
 	crt_rpc_t		*req = NULL;
 	struct chk_rejoin_in	*cri;
@@ -1042,8 +1042,22 @@ chk_rejoin_remote(d_rank_t leader, uint64_t gen, d_rank_t rank, uuid_t iv_uuid, 
 
 	cro = crt_reply_get(req);
 	rc = cro->cro_status;
-	if (rc == 0 && cro->cro_pools.ca_count > 0) {
-		*flags = cro->cro_flags;
+	if (rc != 0)
+		goto out;
+
+	*flags  = cro->cro_flags;
+	*ns_ver = cro->cro_ns_ver;
+
+	if (cro->cro_ranks.ca_count > 0) {
+		*ranks = d_rank_list_alloc(cro->cro_ranks.ca_count);
+		if (*ranks == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		memcpy((*ranks)->rl_ranks, cro->cro_ranks.ca_arrays,
+		       sizeof(d_rank_t) * cro->cro_ranks.ca_count);
+	}
+
+	if (cro->cro_pools.ca_count > 0) {
 		D_ALLOC(tmp, cro->cro_pools.ca_count);
 		if (tmp == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -27,7 +27,7 @@ ds_chk_start_hdlr(crt_rpc_t *rpc)
 	rc = chk_engine_start(csi->csi_gen, csi->csi_ranks.ca_count, csi->csi_ranks.ca_arrays,
 			      csi->csi_policies.ca_count, csi->csi_policies.ca_arrays,
 			      csi->csi_uuids.ca_count, csi->csi_uuids.ca_arrays, csi->csi_api_flags,
-			      csi->csi_phase, csi->csi_leader_rank, csi->csi_flags,
+			      csi->csi_ns_ver, csi->csi_leader_rank, csi->csi_flags,
 			      csi->csi_iv_uuid, &clues);
 	if (rc > 0) {
 		D_ALLOC_PTR(rank);
@@ -249,18 +249,21 @@ ds_chk_report_hdlr(crt_rpc_t *rpc)
 static void
 ds_chk_rejoin_hdlr(crt_rpc_t *rpc)
 {
-	struct chk_rejoin_in	*cri = crt_req_get(rpc);
-	struct chk_rejoin_out	*cro = crt_reply_get(rpc);
-	uuid_t			*pools = NULL;
-	int			 pool_nr = 0;
-	int			 rc;
+	struct chk_rejoin_in  *cri     = crt_req_get(rpc);
+	struct chk_rejoin_out *cro     = crt_reply_get(rpc);
+	uuid_t                *pools   = NULL;
+	d_rank_list_t         *ranks   = NULL;
+	int                    pool_nr = 0;
+	int                    rc;
 
 	rc = chk_leader_rejoin(cri->cri_gen, cri->cri_rank, cri->cri_iv_uuid, &cro->cro_flags,
-			       &pool_nr, &pools);
+			       &cro->cro_ns_ver, &pool_nr, &pools, &ranks);
 
 	cro->cro_status = rc;
 	if (rc == 0) {
-		cro->cro_pools.ca_count = pool_nr;
+		cro->cro_ranks.ca_count  = ranks->rl_nr;
+		cro->cro_ranks.ca_arrays = ranks->rl_ranks;
+		cro->cro_pools.ca_count  = pool_nr;
 		cro->cro_pools.ca_arrays = pools;
 	}
 

--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1129,7 +1129,7 @@ retry:
 	rc = iv_op_internal(ns, key, value, sync, shortcut, opc);
 	if (retry && !ns->iv_stop &&
 	    (daos_rpc_retryable_rc(rc) || rc == -DER_NOTLEADER || rc == -DER_BUSY)) {
-		if (rc == -DER_GRPVER && engine_in_check()) {
+		if ((rc == -DER_GRPVER || rc == -DER_OOG) && engine_in_check()) {
 			/*
 			 * Under check mode, the pool shard on peer rank/target does
 			 * not exist, then it will reply "-DER_GRPVER" that is normal

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -550,9 +550,24 @@ d_rank_list_shuffle(d_rank_list_t *rank_list)
 }
 
 /**
- * Must be previously sorted or not modified at all in order to guarantee
- * consistent indexes.
- **/
+ * Binary search \a rank in the sorted \a rank_list.
+ */
+
+bool
+d_rank_list_bsearch(d_rank_list_t *rank_list, d_rank_t rank, int *idx)
+{
+	d_rank_t *pos = NULL;
+
+	if (rank_list != NULL) {
+		pos = bsearch(&rank, rank_list->rl_ranks, rank_list->rl_nr, sizeof(rank),
+			      rank_compare);
+		if (pos != NULL && idx != NULL)
+			*idx = ((void *)pos - (void *)rank_list->rl_ranks) / sizeof(rank);
+	}
+
+	return pos != NULL;
+}
+
 bool
 d_rank_list_find(d_rank_list_t *rank_list, d_rank_t rank, int *idx)
 {

--- a/src/include/daos_srv/daos_chk.h
+++ b/src/include/daos_srv/daos_chk.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2022-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -74,9 +74,9 @@ typedef int (*chk_query_pool_cb_t)(struct chk_query_pool_shard *shard, uint32_t 
 
 typedef int (*chk_prop_cb_t)(void *buf, uint32_t policies[], int cnt, uint32_t flags);
 
-int chk_leader_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		     struct chk_policy *policies, int pool_nr, uuid_t pools[],
-		     uint32_t api_flags, int phase);
+int
+chk_leader_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr, struct chk_policy *policies,
+		 int pool_nr, uuid_t pools[], uint32_t api_flags);
 
 int chk_leader_stop(int pool_nr, uuid_t pools[]);
 

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -457,6 +457,7 @@ d_power2_nbits(unsigned int val)
 	return val == LOWEST_BIT_SET(val) ? shift - 1 : shift;
 }
 
+/* clang-format off */
 int d_rank_list_dup(d_rank_list_t **dst, const d_rank_list_t *src);
 int d_rank_list_dup_sort_uniq(d_rank_list_t **dst, const d_rank_list_t *src);
 void d_rank_list_filter(d_rank_list_t *src_set, d_rank_list_t *dst_set,
@@ -468,6 +469,7 @@ void d_rank_list_free(d_rank_list_t *rank_list);
 int d_rank_list_copy(d_rank_list_t *dst, d_rank_list_t *src);
 void d_rank_list_shuffle(d_rank_list_t *rank_list);
 void d_rank_list_sort(d_rank_list_t *rank_list);
+bool d_rank_list_bsearch(d_rank_list_t *rank_list, d_rank_t rank, int *idx);
 bool d_rank_list_find(d_rank_list_t *rank_list, d_rank_t rank, int *idx);
 void d_rank_list_del_at(d_rank_list_t *list, int idx);
 int d_rank_list_del(d_rank_list_t *rank_list, d_rank_t rank);
@@ -479,15 +481,13 @@ int d_rank_list_append(d_rank_list_t *rank_list, d_rank_t rank);
 int d_rank_list_dump(d_rank_list_t *rank_list, d_string_t name, int name_len);
 d_rank_list_t *uint32_array_to_rank_list(uint32_t *ints, size_t len);
 int rank_list_to_uint32_array(d_rank_list_t *rl, uint32_t **ints, size_t *len);
-int
-		     d_rank_list_to_str(d_rank_list_t *rank_list, char **rank_str);
-
+int d_rank_list_to_str(d_rank_list_t *rank_list, char **rank_str);
 d_rank_range_list_t *d_rank_range_list_alloc(uint32_t size);
 d_rank_range_list_t *d_rank_range_list_realloc(d_rank_range_list_t *range_list, uint32_t size);
 d_rank_range_list_t *d_rank_range_list_create_from_ranks(d_rank_list_t *rank_list);
-int
-     d_rank_range_list_str(d_rank_range_list_t *list, char **ranks_str);
+int d_rank_range_list_str(d_rank_range_list_t *list, char **ranks_str);
 void d_rank_range_list_free(d_rank_range_list_t *range_list);
+/* clang-format on */
 
 #ifdef FAULT_INJECTION
 

--- a/src/mgmt/srv_chk.c
+++ b/src/mgmt/srv_chk.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2022 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -48,7 +48,7 @@ out:
 int
 ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
 		    Mgmt__CheckInconsistPolicy **policies, int32_t pool_nr, char **pools,
-		    uint32_t flags, int32_t phase)
+		    uint32_t flags)
 {
 	uuid_t			*uuids = NULL;
 	struct chk_policy	*ply = NULL;
@@ -70,7 +70,7 @@ ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
 		}
 	}
 
-	rc = chk_leader_start(rank_nr, ranks, policy_nr, ply, pool_nr, uuids, flags, phase);
+	rc = chk_leader_start(rank_nr, ranks, policy_nr, ply, pool_nr, uuids, flags);
 
 out:
 	D_FREE(uuids);

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2019-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2789,7 +2789,7 @@ ds_mgmt_drpc_check_start(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	D_INFO("Received request to start check\n");
 
 	rc = ds_mgmt_check_start(req->n_ranks, req->ranks, req->n_policies, req->policies,
-				 req->n_uuids, req->uuids, req->flags, -1 /* phase */);
+				 req->n_uuids, req->uuids, req->flags);
 	if (rc < 0)
 		D_ERROR("Failed to start check: "DF_RC"\n", DP_RC(rc));
 

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -139,9 +139,10 @@ int
 			    const char *user, const char *group);
 
 /** srv_chk.c */
-int ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
+int
+    ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
 			Mgmt__CheckInconsistPolicy **policies, int pool_nr, char **pools,
-			uint32_t flags, int phase);
+			uint32_t flags);
 int ds_mgmt_check_stop(int pool_nr, char **pools);
 int ds_mgmt_check_query(int pool_nr, char **pools, chk_query_head_cb_t head_cb,
 			chk_query_pool_cb_t pool_cb, void *buf);

--- a/src/mgmt/tests/mocks.c
+++ b/src/mgmt/tests/mocks.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2019-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -694,7 +694,7 @@ mock_ds_mgmt_dev_set_faulty_setup(void)
 int
 ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
 		    Mgmt__CheckInconsistPolicy **policies, int pool_nr, char **pools,
-		    uint32_t flags, int phase)
+		    uint32_t flags)
 {
 	return 0;
 }

--- a/src/object/cli_coll.c
+++ b/src/object/cli_coll.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -724,8 +725,8 @@ dc_obj_coll_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epo
 		if (rc == 0) {
 			if (!shard->do_rebuilding && !shard->do_reintegrating) {
 				tmp_tgt.dct_rank = shard->do_target_rank;
-				dct = bsearch(&tmp_tgt, coa->coa_dcts, coa->coa_dct_nr,
-					      sizeof(tmp_tgt), &dc_coll_sort_cmp);
+				dct              = bsearch(&tmp_tgt, coa->coa_dcts, coa->coa_dct_nr,
+							   sizeof(tmp_tgt), dc_coll_sort_cmp);
 				D_ASSERT(dct != NULL);
 
 				goto gen_mbs;

--- a/src/tests/ftest/recovery/cat_recov_core.yaml
+++ b/src/tests/ftest/recovery/cat_recov_core.yaml
@@ -8,6 +8,7 @@ server_config:
   engines_per_host: 2
   engines:
     0:
+      targets: 4
       pinned_numa_node: 0
       nr_xs_helpers: 0
       log_file: daos_server0.log
@@ -22,6 +23,7 @@ server_config:
       storage: auto
 
     1:
+      targets: 4
       pinned_numa_node: 1
       nr_xs_helpers: 0
       log_file: daos_server1.log
@@ -37,7 +39,10 @@ server_config:
 
   transport_config:
     allow_insecure: true
-  system_ram_reserved: 64
+
+pool:
+  scm_size: 6G
+  nvme_size: 80G
 
 agent_config:
   transport_config:

--- a/src/tests/ftest/recovery/check_start_corner_case.py
+++ b/src/tests/ftest/recovery/check_start_corner_case.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -233,7 +233,7 @@ class DMGCheckStartCornerCaseTest(TestWithServers):
         # Wait for the checker to detect the inconsistent container label.
         query_reports = None
         for _ in range(8):
-            check_query_out = dmg_command.check_query()
+            check_query_out = dmg_command.check_query(pool=pool_3.uuid)
             # Status becomes RUNNING immediately, but it may take a while to detect the
             # inconsistency. If detected, "reports" field is filled.
             if check_query_out["response"]["status"] == "RUNNING":

--- a/src/tests/ftest/recovery/container_cleanup.yaml
+++ b/src/tests/ftest/recovery/container_cleanup.yaml
@@ -14,7 +14,7 @@ server_config:
       storage: auto
 
 pool:
-  size: 5G
+  size: 15G
 
 container:
   type: POSIX

--- a/src/tests/ftest/recovery/container_list_consolidation.yaml
+++ b/src/tests/ftest/recovery/container_list_consolidation.yaml
@@ -14,7 +14,7 @@ server_config:
       storage: auto
 
 pool:
-  size: 5G
+  size: 15G
 
 container:
   type: POSIX

--- a/src/tests/ftest/recovery/ms_membership.yaml
+++ b/src/tests/ftest/recovery/ms_membership.yaml
@@ -7,12 +7,17 @@ server_config:
   engines_per_host: 2
   engines:
     0:
+      targets: 4
       pinned_numa_node: 0
       nr_xs_helpers: 1
       log_file: daos_server0.log
       storage: auto
     1:
+      targets: 4
       pinned_numa_node: 1
       nr_xs_helpers: 1
       log_file: daos_server1.log
       storage: auto
+
+pool:
+  size: 80G

--- a/src/tests/ftest/recovery/pool_cleanup.yaml
+++ b/src/tests/ftest/recovery/pool_cleanup.yaml
@@ -13,4 +13,4 @@ server_config:
       storage: auto
 
 pool:
-  size: 5G
+  size: 15G

--- a/src/tests/ftest/recovery/pool_list_consolidation.yaml
+++ b/src/tests/ftest/recovery/pool_list_consolidation.yaml
@@ -23,7 +23,7 @@ setup:
   start_servers_once: False
 
 pool:
-  size: 60G
+  size: 100G
 
 container:
   control_method: daos

--- a/src/tests/suite/daos_cr.c
+++ b/src/tests/suite/daos_cr.c
@@ -1350,7 +1350,7 @@ cr_engine_interaction(void **state)
 	rc = cr_system_start();
 	assert_rc_equal(rc, 0);
 
-	/* Former connection for the pool has been evicted by checkre. Let's re-connect the pool. */
+	/* Former connection for the pool has been evicted by checker. Let's re-connect the pool. */
 	rc = cr_cont_get_label(state, &pool, &cont, true, &label);
 	assert_rc_equal(rc, 0);
 
@@ -1732,7 +1732,7 @@ cr_stop_engine_interaction(void **state)
 	rc = cr_system_start();
 	assert_rc_equal(rc, 0);
 
-	/* Former connection for the pool has been evicted by checkre. Let's re-connect the pool. */
+	/* Former connection for the pool has been evicted by checker. Let's re-connect the pool. */
 	rc = cr_cont_get_label(state, &pool, &cont, true, &label);
 	assert_rc_equal(rc, 0);
 
@@ -3848,6 +3848,61 @@ cr_maintenance_mode(void **state)
 	cr_cleanup(arg, &pool, 1);
 }
 
+/*
+ * 1. Exclude rank 0.
+ * 2. Create pool without inconsistency.
+ * 3. Start checker without options.
+ * 4. Query checker, it should be completed instead of being blocked.
+ * 5. Switch to normal mode and cleanup.
+ */
+static void
+cr_lost_rank0(void **state)
+{
+	test_arg_t            *arg  = *state;
+	struct test_pool       pool = {0};
+	struct daos_check_info dci  = {0};
+	int                    rc;
+
+	print_message("CR29: CR with rank 0 excluded at the beginning\n");
+
+	print_message("CR: excluding the rank 0 ...\n");
+	rc = dmg_system_exclude_rank(dmg_config_file, 0);
+	assert_rc_equal(rc, 0);
+
+	rc = cr_pool_create(state, &pool, false, TCC_NONE);
+	assert_rc_equal(rc, 0);
+
+	rc = cr_system_stop(false);
+	assert_rc_equal(rc, 0);
+
+	rc = cr_mode_switch(true);
+	assert_rc_equal(rc, 0);
+
+	rc = cr_check_start(TCSF_RESET, 0, NULL, NULL);
+	assert_rc_equal(rc, 0);
+
+	cr_ins_wait(1, &pool.pool_uuid, &dci);
+
+	rc = cr_ins_verify(&dci, TCIS_COMPLETED);
+	assert_rc_equal(rc, 0);
+
+	rc = cr_pool_verify(&dci, pool.pool_uuid, TCPS_CHECKED, 0, NULL, NULL, NULL);
+	assert_rc_equal(rc, 0);
+
+	/* Reint the rank for subsequent test. */
+	rc = cr_rank_reint(0, true);
+	assert_rc_equal(rc, 0);
+
+	rc = cr_mode_switch(false);
+	assert_rc_equal(rc, 0);
+
+	rc = cr_system_start();
+	assert_rc_equal(rc, 0);
+
+	cr_dci_fini(&dci);
+	cr_cleanup(arg, &pool, 1);
+}
+
 /* clang-format off */
 static const struct CMUnitTest cr_tests[] = {
 	{ "CR1: start checker for specified pools",
@@ -3906,6 +3961,8 @@ static const struct CMUnitTest cr_tests[] = {
 	  cr_handle_fail_pool2, async_disable, test_case_teardown},
 	{ "CR28: maintenance mode after dry-run check",
 	  cr_maintenance_mode, async_disable, test_case_teardown},
+	{ "CR29: CR with rank 0 excluded at the beginning",
+	  cr_lost_rank0, async_disable, test_case_teardown},
 };
 /* clang-format on */
 


### PR DESCRIPTION
Include the followings:

1. When create CHK IV namespace, make the secondary group to be same as
   the primary group. Otherwise, CHK logic may hit DER_NONEXIST trouble
   when communicate via IV.

2. Integrate CHK IV namespace create and destroy API, cleanup related
   logic, redefine the version.

3. Get ranks list and IV namespace version from CHK leader when rejoin.
   Adjust CHK_REJOIN RPC for related changes.

4. Remove unsupported functionality for checking the specified 'phase'.

5. Add new test for case of lost some engine(s) before start checker.

6. Dedicated ULT to handle dead rank event, that will not be affected
   by checker start or stop. Then even if check scheduler exited, the
   subsequent check query still can work against the latest rank list.

Test-tag: recovery

Signed-off-by: Fan Yong <fan.yong@hpe.com>
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
