### PR TITLE
DAOS-18368 object: refine EC rotate enumeration minimum_nr and break …

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2953,9 +2953,11 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 
 	if (daos_oclass_is_ec(&unpack_arg.oc_attr)) {
 		p_csum = NULL;
-		/* EC rotate needs to fetch from all shards */
+		/* EC rotate needs to fetch from all shards, at least with data_tgt_nr alive,
+		 * at least one shard should get 2 KDs.
+		 */
 		if (obj_ec_parity_rotate_enabled_by_version(arg->oid.id_layout_ver))
-			minimum_nr = obj_ec_tgt_nr(&unpack_arg.oc_attr);
+			minimum_nr = obj_ec_data_tgt_nr(&unpack_arg.oc_attr) + 1;
 		else
 			minimum_nr = 2;
 		enum_flags |= DIOF_RECX_REVERSE;
@@ -3083,7 +3085,7 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 		}
 
 		/* Each object enumeration RPC will at least one OID */
-		if (num <= minimum_nr && (enum_flags & DIOF_TO_SPEC_GROUP)) {
+		if (num < minimum_nr && (enum_flags & DIOF_TO_SPEC_GROUP)) {
 			D_DEBUG(DB_REBUILD, "enumeration buffer %u empty"
 				DF_UOID"\n", num, DP_UOID(arg->oid));
 			break;


### PR DESCRIPTION
…condition (#17336)

- For EC parity rotate, set minimum_nr to data_tgt_nr + 1 instead of all EC targets. This ensures that, even with some shard failures, at least one shard can return 2 keys (KDs).
- Make the enumeration break condition stricter: only break if num < minimum_nr, not <=, to avoid premature termination when the buffer is exactly full.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
