### PR TITLE
DAOS-18400 vos: increase VOS_AGG_GAP_DEF to 30 seconds

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -727,8 +727,10 @@ dtx_batched_commit(void *arg)
 		}
 
 		if (DAOS_FAIL_CHECK(DAOS_DTX_NO_BATCHED_CMT) ||
-		    DAOS_FAIL_CHECK(DAOS_DTX_NO_COMMITTABLE))
+		    DAOS_FAIL_CHECK(DAOS_DTX_NO_COMMITTABLE)) {
+			sleep_time = 500;
 			goto check;
+		}
 
 		dbca = d_list_entry(dmi->dmi_dtx_batched_cont_open_list.next,
 				    struct dtx_batched_cont_args, dbca_sys_link);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -145,7 +145,7 @@ enum {
 extern uint32_t vos_agg_gap;
 
 #define VOS_AGG_GAP_MIN		20 /* seconds */
-#define VOS_AGG_GAP_DEF         20
+#define VOS_AGG_GAP_DEF         30
 #define VOS_AGG_GAP_MAX		180
 
 extern unsigned int vos_agg_nvme_thresh;


### PR DESCRIPTION
Increase VOS_AGG_GAP_DEF from 20 seconds to 30 seconds to reduce the possibility of unexpected rejection for some slow transaction.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
