### PR TITLE
SRE-3522 ci: clamav and libryypto mismatch

### DIFF
--- a/ci/provisioning/post_provision_config_nodes_EL.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #  Copyright 2021-2024 Intel Corporation.
-#  Copyright 2025 Hewlett Packard Enterprise Development LP
+#  Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -18,6 +18,8 @@ set +e
 set -e
     # Seems to be needed to fix some issues.
     dnf -y reinstall sssd-common
+    # Remove ClamAV to avoid libcrypto version mismatch on older el9 systems (< el9.7)
+    dnf -y remove clamav-lib
 }
 
 group_repo_post() {


### PR DESCRIPTION
Avoid clamav and libcrypto mismatch on older (unsupported) versions of EL9 ( < 9.7)


### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
