### PR TITLE
DAOS-18458 vos: correctly count the DTX entries in committed tree

### DIFF
--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -439,9 +439,7 @@ struct vos_container {
 	/* GC runtime for container */
 	struct vos_gc_info	vc_gc_info;
 	/* Various flags */
-	unsigned int		vc_in_aggregation:1,
-				vc_in_discard:1,
-				vc_cmt_dtx_indexed:1;
+	uint32_t vc_in_aggregation : 1, vc_in_discard : 1, vc_cmt_dtx_indexed : 1, vc_dtx_reset : 1;
 	unsigned int		vc_obj_discard_count;
 	unsigned int		vc_open_count;
 	/* The latest pool map version that DTX resync has been done. */


### PR DESCRIPTION
Originally, when commit DTX entries, we count the new added entries into DTX committed tree via vos_dtx_post_handle(), and save it in the vos_container::vp_dtx_committed_count. But there may be yield between insert DTX entries into the tree and refrehing vp_dtx_committed_count. Then some others may see some inconsistency between the DTX committed tree and vp_dtx_committed_count.

The patch changes the logic to guarantee that update (insert or delete) DTX entries in the committed tree will be together with refreshing the vp_dtx_committed_count without yield.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
