### PR TITLE
DAOS-18161 object: load container write stamp from VOS

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1,7 +1,7 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
  * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2963,10 +2963,4 @@ ds_cont_tgt_prop_update(uuid_t pool_uuid, uuid_t cont_uuid, daos_prop_t	*prop)
 			DP_RC(rc));
 
 	return rc;
-}
-
-void
-ds_cont_ec_timestamp_update(struct ds_cont_child *cont)
-{
-	cont->sc_ec_update_timestamp = d_hlc_get();
 }

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -1,7 +1,7 @@
 /*
  * (C) Copyright 2015-2024 Intel Corporation.
  * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -133,13 +133,7 @@ struct ds_cont_child {
 	 * from all local VOS.
 	 */
 	uint64_t		*sc_query_ec_agg_eph;
-	uint64_t		*sc_query_stable_eph;
-	/**
-	 * Timestamp of last EC update, which is used by aggregation to check
-	 * if it needs to do EC aggregate.
-	 */
-	uint64_t		sc_ec_update_timestamp;
-
+	uint64_t                *sc_query_stable_eph;
 	/* The objects with committable DTXs in DRAM. */
 	daos_handle_t		 sc_dtx_cos_hdl;
 	/* The DTX COS-btree. */
@@ -293,8 +287,6 @@ int dsc_cont_get_props(daos_handle_t coh, struct cont_props *props);
 int
      ds_cont_eph_report(struct ds_pool *pool);
 void ds_cont_track_eph_free(struct ds_pool *pool);
-
-void ds_cont_ec_timestamp_update(struct ds_cont_child *cont);
 
 typedef int(*cont_rdb_iter_cb_t)(uuid_t pool_uuid, uuid_t cont_uuid, struct rdb_tx *tx, void *arg);
 int ds_cont_rdb_iterate(struct cont_svc *svc, cont_rdb_iter_cb_t iter_cb, void *cb_arg);

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2015-2025 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -184,6 +184,8 @@ typedef struct {
 	daos_size_t		ci_used;
 	/** Highest (Last) aggregated epoch */
 	daos_epoch_t		ci_hae;
+	/** latest epoch for writes that require aggregation */
+	daos_epoch_t            ci_agg_write;
 	/** TODO */
 } vos_cont_info_t;
 

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -545,6 +545,8 @@ int
 vos_cont_query(daos_handle_t coh, vos_cont_info_t *cont_info)
 {
 	struct vos_container	*cont;
+	struct vos_cont_df      *cont_df;
+	uint64_t                 feats;
 
 	cont = vos_hdl2cont(coh);
 	if (cont == NULL) {
@@ -552,9 +554,14 @@ vos_cont_query(daos_handle_t coh, vos_cont_info_t *cont_info)
 		return -DER_INVAL;
 	}
 
-	cont_info->ci_nobjs = cont->vc_cont_df->cd_nobjs;
-	cont_info->ci_used = cont->vc_cont_df->cd_used;
-	cont_info->ci_hae = cont->vc_cont_df->cd_hae;
+	cont_df = cont->vc_cont_df;
+	memset(cont_info, 0, sizeof(*cont_info));
+	cont_info->ci_nobjs = cont_df->cd_nobjs;
+	cont_info->ci_used  = cont_df->cd_used;
+	cont_info->ci_hae   = cont_df->cd_hae;
+
+	feats = dbtree_feats_get(&cont_df->cd_obj_root);
+	vos_feats_agg_time_get(feats, &cont_info->ci_agg_write);
 
 	return 0;
 }


### PR DESCRIPTION
After restart, load the latest epoch of writes that require aggregation from VOS instead of resetting it to zero; otherwise, EC aggregation has to rescan the container even if it has not changed since the previous aggregation

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
