### PR TITLE
DAOS-18161 object: load container write stamp from VOS

### DIFF
--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2015-2025 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -184,6 +184,8 @@ typedef struct {
 	daos_size_t		ci_used;
 	/** Highest (Last) aggregated epoch */
 	daos_epoch_t		ci_hae;
+	/** latest epoch for writes that require aggregation */
+	daos_epoch_t            ci_agg_write;
 	/** TODO */
 } vos_cont_info_t;
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2756,17 +2756,25 @@ cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 			return rc;
 	}
 
-	if (likely(cont->sc_ec_agg_eph_valid)) {
-		if (cont->sc_ec_agg_eph == 0) {
-			D_INFO(DF_CONT ": update cont->sc_ec_agg_eph to " DF_X64,
-			       DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
-			       cont->sc_ec_agg_eph_boundary);
-			cont->sc_ec_agg_eph = cont->sc_ec_agg_eph_boundary;
-		}
-	} else {
+	if (!cont->sc_ec_agg_eph_valid) {
 		D_DEBUG(DB_EPC, DF_CONT ": pause EC aggregation for sc_ec_agg_eph_boundary.\n",
 			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid));
 		return 0;
+	}
+
+	if (cont->sc_ec_agg_eph == 0) {
+		D_INFO(DF_CONT ": update cont->sc_ec_agg_eph to " DF_X64,
+		       DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
+		       cont->sc_ec_agg_eph_boundary);
+		cont->sc_ec_agg_eph = cont->sc_ec_agg_eph_boundary;
+	}
+
+	if (cont->sc_ec_update_timestamp == 0) {
+		vos_cont_info_t info;
+
+		/* load the timestamp of the last write that can be aggregated from VOS */
+		vos_cont_query(ec_agg_param->ap_cont_handle, &info);
+		cont->sc_ec_update_timestamp = info.ci_agg_write;
 	}
 
 	ec_agg_eph                     = cont->sc_ec_agg_eph;
@@ -2780,10 +2788,7 @@ cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 		ec_agg_param->ap_filter_eph = MAX(epr->epr_lo, cont->sc_ec_agg_eph);
 	}
 
-	/* Currently cont->sc_ec_update_timestamp is in memory so this optimization won't be helpful
-	 * when there is no container update since restart.
-	 */
-	if (ec_agg_param->ap_filter_eph != 0 && cont->sc_ec_update_timestamp != 0 &&
+	if (ec_agg_param->ap_filter_eph != 0 &&
 	    ec_agg_param->ap_filter_eph >= cont->sc_ec_update_timestamp) {
 		D_DEBUG(DB_EPC, DF_CONT " skip EC agg " DF_U64 ">= " DF_U64 "\n",
 			DP_CONT(cont->sc_pool_uuid, cont->sc_uuid), ec_agg_param->ap_filter_eph,

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -545,6 +545,8 @@ int
 vos_cont_query(daos_handle_t coh, vos_cont_info_t *cont_info)
 {
 	struct vos_container	*cont;
+	struct vos_cont_df      *cont_df;
+	uint64_t                 feats;
 
 	cont = vos_hdl2cont(coh);
 	if (cont == NULL) {
@@ -552,9 +554,14 @@ vos_cont_query(daos_handle_t coh, vos_cont_info_t *cont_info)
 		return -DER_INVAL;
 	}
 
-	cont_info->ci_nobjs = cont->vc_cont_df->cd_nobjs;
-	cont_info->ci_used = cont->vc_cont_df->cd_used;
-	cont_info->ci_hae = cont->vc_cont_df->cd_hae;
+	cont_df = cont->vc_cont_df;
+	memset(cont_info, 0, sizeof(*cont_info));
+	cont_info->ci_nobjs = cont_df->cd_nobjs;
+	cont_info->ci_used  = cont_df->cd_used;
+	cont_info->ci_hae   = cont_df->cd_hae;
+
+	feats = dbtree_feats_get(&cont_df->cd_obj_root);
+	vos_feats_agg_time_get(feats, &cont_info->ci_agg_write);
 
 	return 0;
 }


### PR DESCRIPTION
After restart, load the latest epoch of writes that require aggregation from VOS instead of setting it to zero, otherwise EC aggregation has to scan the container again even it's not changed after previous aggregation.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
