### PR TITLE
Revert "DAOS-17444 rebuild: cache obj open handle for rebuild (#16373)"

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -101,7 +101,6 @@ static struct migr_engine_res migr_eng_res;
 
 struct migrate_one {
 	struct migrate_pool_tls  *mo_tls;
-	struct iter_obj_arg      *mo_obj_arg;
 	daos_key_t		 mo_dkey;
 	uint64_t		 mo_dkey_hash;
 	uuid_t			 mo_pool_uuid;
@@ -180,9 +179,6 @@ struct iter_obj_arg {
 	uuid_t			pool_uuid;
 	uuid_t			cont_uuid;
 	daos_unit_oid_t		oid;
-	daos_handle_t            ioa_oh;
-	int                      ioa_obj_ref;
-	struct daos_oclass_attr  ioa_oca;
 	daos_epoch_t		epoch;
 	daos_epoch_t		punched_epoch;
 	unsigned int		shard;
@@ -192,40 +188,6 @@ struct iter_obj_arg {
 	uint32_t		version;
 	uint32_t		generation;
 };
-
-void
-migrate_pool_tls_put(struct migrate_pool_tls *tls);
-
-static void
-migrate_obj_get(struct iter_obj_arg *arg)
-{
-	arg->ioa_obj_ref++;
-}
-
-static void
-obj_iter_arg_free(struct iter_obj_arg *arg)
-{
-	if (arg->pool_tls)
-		migrate_pool_tls_put(arg->pool_tls);
-	if (arg->snaps)
-		D_FREE(arg->snaps);
-	D_FREE(arg);
-}
-
-static void
-migrate_obj_put(struct iter_obj_arg *arg)
-{
-	D_ASSERTF(arg->ioa_obj_ref > 0, DF_CONT " obj " DF_UOID " bad ioa_obj_ref %d\n",
-		  DP_CONT(arg->pool_uuid, arg->cont_uuid), DP_UOID(arg->oid), arg->ioa_obj_ref);
-	arg->ioa_obj_ref--;
-	if (arg->ioa_obj_ref == 0) {
-		if (daos_handle_is_valid(arg->ioa_oh)) {
-			dsc_obj_close(arg->ioa_oh);
-			arg->ioa_oh = DAOS_HDL_INVAL;
-		}
-		obj_iter_arg_free(arg);
-	}
-}
 
 static int
 obj_tree_destory_cb(daos_handle_t ih, d_iov_t *key_iov,
@@ -1750,28 +1712,47 @@ static int
 migrate_dkey(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 	     daos_size_t data_size)
 {
-	struct ds_cont_child    *cont = NULL;
+	struct ds_cont_child	*cont = NULL;
+	struct cont_props	 props;
+	daos_handle_t		 coh = DAOS_HDL_INVAL;
 	daos_handle_t		 oh  = DAOS_HDL_INVAL;
 	int			 rc;
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
 	rc = migrate_get_cont_child(tls, mrone->mo_cont_uuid, &cont, true);
 	if (rc || cont == NULL)
-		D_GOTO(out, rc);
+		D_GOTO(cont_put, rc);
 
-	D_ASSERTF(mrone->mo_obj_arg->ioa_obj_ref > 0,
-		  DF_RB ": oid " DF_UOID ", bad ioa_obj_ref %d\n", DP_RB_MPT(tls),
-		  DP_UOID(mrone->mo_oid), mrone->mo_obj_arg->ioa_obj_ref);
-	D_ASSERT(daos_handle_is_valid(mrone->mo_obj_arg->ioa_oh));
-	oh            = mrone->mo_obj_arg->ioa_oh;
-	mrone->mo_oca = mrone->mo_obj_arg->ioa_oca;
+	rc = dsc_pool_open(tls->mpt_pool_uuid, tls->mpt_poh_uuid, 0,
+			   NULL, tls->mpt_pool->spc_pool->sp_map,
+			   &tls->mpt_svc_list, &tls->mpt_pool_hdl);
+	if (rc)
+		D_GOTO(cont_put, rc);
+
+	/* Open client dc handle used to read the remote object data */
+	rc = migrate_cont_open(tls, mrone->mo_cont_uuid, 0, &coh);
+	if (rc)
+		D_GOTO(cont_put, rc);
+
+	/* Open the remote object */
+	rc = dsc_obj_open(coh, mrone->mo_oid.id_pub, DAOS_OO_RO, &oh);
+	if (rc)
+		D_GOTO(cont_put, rc);
 
 	if (DAOS_FAIL_CHECK(DAOS_REBUILD_TGT_NOSPACE))
-		D_GOTO(out, rc = -DER_NOSPACE);
+		D_GOTO(obj_close, rc = -DER_NOSPACE);
 
 	if (DAOS_FAIL_CHECK(DAOS_REBUILD_NO_REBUILD)) {
 		D_DEBUG(DB_REBUILD, DF_RB ": fault injected, disable rebuild\n", DP_RB_MPT(tls));
-		D_GOTO(out, rc);
+		D_GOTO(obj_close, rc);
+	}
+
+	dsc_cont_get_props(coh, &props);
+	rc = dsc_obj_id2oc_attr(mrone->mo_oid.id_pub, &props, &mrone->mo_oca);
+	if (rc) {
+		D_ERROR(DF_RB ": unknown object class: %u\n", DP_RB_MPT(tls),
+			daos_obj_id2class(mrone->mo_oid.id_pub));
+		D_GOTO(obj_close, rc);
 	}
 
 	/* punch the object */
@@ -1783,21 +1764,21 @@ migrate_dkey(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 		if (rc) {
 			DL_ERROR(rc, DF_RB ": " DF_UOID " punch obj failed", DP_RB_MPT(tls),
 				 DP_UOID(mrone->mo_oid));
-			D_GOTO(out, rc);
+			D_GOTO(obj_close, rc);
 		}
 	}
 
 	rc = migrate_punch(tls, mrone, cont);
 	if (rc)
-		D_GOTO(out, rc);
+		D_GOTO(obj_close, rc);
 
 	if (data_size == 0) {
 		D_DEBUG(DB_REBUILD, DF_RB ": empty mrone %p\n", DP_RB_MPT(tls), mrone);
-		D_GOTO(out, rc);
+		D_GOTO(obj_close, rc);
 	}
 
 	if (DAOS_FAIL_CHECK(DAOS_REBUILD_UPDATE_FAIL))
-		D_GOTO(out, rc = -DER_INVAL);
+		D_GOTO(obj_close, rc = -DER_INVAL);
 
 	if (mrone->mo_iods[0].iod_type == DAOS_IOD_SINGLE)
 		rc = migrate_fetch_update_single(mrone, oh, cont);
@@ -1813,8 +1794,9 @@ migrate_dkey(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 
 	tls->mpt_rec_count += mrone->mo_rec_num;
 	tls->mpt_size += mrone->mo_size;
-
-out:
+obj_close:
+	dsc_obj_close(oh);
+cont_put:
 	if (cont != NULL)
 		ds_cont_child_put(cont);
 	return rc;
@@ -1864,8 +1846,6 @@ migrate_one_destroy(struct migrate_one *mrone)
 
 	if (mrone->mo_iods_csums)
 		D_FREE(mrone->mo_iods_csums);
-	if (mrone->mo_obj_arg)
-		migrate_obj_put(mrone->mo_obj_arg);
 	if (mrone->mo_tls)
 		migrate_pool_tls_put(mrone->mo_tls);
 
@@ -1996,7 +1976,7 @@ migrate_res_release(struct migrate_pool_tls *tls, int res_type, long units)
 static void
 migrate_one_ult(void *arg)
 {
-	struct migrate_one      *mrone = arg;
+	struct migrate_one	*mrone = arg;
 	struct migrate_pool_tls	*tls;
 	daos_size_t		data_size;
 	int			rc = 0;
@@ -2836,8 +2816,6 @@ migrate_start_ult(struct enum_unpack_arg *unpack_arg)
 			break;
 		d_list_del_init(&mrone->mo_list);
 
-		migrate_obj_get(arg);
-		mrone->mo_obj_arg = arg;
 		migrate_pool_tls_get(tls);
 		mrone->mo_tls = tls;
 
@@ -2873,10 +2851,13 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 	daos_key_desc_t		 kds[KDS_NUM] = {0};
 	d_iov_t			 csum = {0};
 	d_iov_t			 *p_csum;
-	uint8_t                   stack_csum_buf[CSUM_BUF_SIZE] = {0};
+	uint8_t			 stack_csum_buf[CSUM_BUF_SIZE] = {0};
+	struct cont_props	 props;
 	struct enum_unpack_arg	 unpack_arg = { 0 };
 	d_iov_t			 iov = { 0 };
-	d_sg_list_t               sgl                           = {0};
+	d_sg_list_t		 sgl = { 0 };
+	daos_handle_t		 coh = DAOS_HDL_INVAL;
+	daos_handle_t		 oh  = DAOS_HDL_INVAL;
 	uint32_t		 minimum_nr;
 	uint32_t		 enum_flags;
 	uint32_t		 num;
@@ -2893,15 +2874,44 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
 
-	D_ASSERT(daos_handle_is_valid(arg->ioa_oh));
+	rc = dsc_pool_open(tls->mpt_pool_uuid, tls->mpt_poh_uuid, 0,
+			   NULL, tls->mpt_pool->spc_pool->sp_map,
+			   &tls->mpt_svc_list, &tls->mpt_pool_hdl);
+	if (rc) {
+		DL_ERROR(rc, DF_RB ": dsc_pool_open failed", DP_RB_MPT(tls));
+		D_GOTO(out, rc);
+	}
+
+	rc = migrate_cont_open(tls, arg->cont_uuid, 0, &coh);
+	if (rc) {
+		DL_ERROR(rc, DF_RB ": migrate_cont_open failed", DP_RB_MPT(tls));
+		D_GOTO(out, rc);
+	}
+
+	/* Only open with RW flag, reintegrating flag will be set, which is needed
+	 * during unpack_cb to check if parity shard alive.
+	 */
+	rc = dsc_obj_open(coh, arg->oid.id_pub, DAOS_OO_RO, &oh);
+	if (rc) {
+		DL_ERROR(rc, DF_RB ": dsc_obj_open failed", DP_RB_MPT(tls));
+		D_GOTO(out, rc);
+	}
+
 	unpack_arg.arg = arg;
 	unpack_arg.epr = *epr;
-	unpack_arg.oh      = arg->ioa_oh;
+	unpack_arg.oh = oh;
 	unpack_arg.version = tls->mpt_version;
 	D_INIT_LIST_HEAD(&unpack_arg.merge_list);
 	buf = stack_buf;
 	buf_len = ITER_BUF_SIZE;
-	unpack_arg.oc_attr = arg->ioa_oca;
+
+	dsc_cont_get_props(coh, &props);
+	rc = dsc_obj_id2oc_attr(arg->oid.id_pub, &props, &unpack_arg.oc_attr);
+	if (rc) {
+		DL_ERROR(rc, DF_RB ": unknown object class: %u", DP_RB_MPT(tls),
+			 daos_obj_id2class(arg->oid.id_pub));
+		D_GOTO(out_obj, rc);
+	}
 
 	memset(&anchor, 0, sizeof(anchor));
 	memset(&akey_anchor, 0, sizeof(akey_anchor));
@@ -2953,8 +2963,9 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 
 		daos_anchor_set_flags(&dkey_anchor, enum_flags);
 		num = KDS_NUM;
-		rc  = dsc_obj_list_obj(arg->ioa_oh, epr, NULL, NULL, NULL, &num, kds, &sgl, &anchor,
-				       &dkey_anchor, &akey_anchor, p_csum);
+		rc = dsc_obj_list_obj(oh, epr, NULL, NULL, NULL,
+				     &num, kds, &sgl, &anchor,
+				     &dkey_anchor, &akey_anchor, p_csum);
 
 		if (rc == -DER_KEY2BIG) {
 			D_DEBUG(DB_REBUILD,
@@ -3093,7 +3104,9 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 
 	if (csum.iov_buf != NULL && csum.iov_buf != stack_csum_buf)
 		D_FREE(csum.iov_buf);
-
+out_obj:
+	dsc_obj_close(oh);
+out:
 	D_DEBUG(DB_REBUILD,
 		DF_RB ": obj " DF_UOID " shard %u eph " DF_U64 "-" DF_U64 ": " DF_RC "\n",
 		DP_RB_MPT(tls), DP_UOID(arg->oid), arg->shard, epr->epr_lo, epr->epr_hi, DP_RC(rc));
@@ -3189,6 +3202,16 @@ migrate_obj_punch(struct iter_obj_arg *arg)
 			       arg->tgt_idx, MIGRATE_STACK_SIZE);
 }
 
+static void
+obj_iter_arg_free(struct iter_obj_arg *arg)
+{
+	if (arg->pool_tls)
+		migrate_pool_tls_put(arg->pool_tls);
+	if (arg->snaps)
+		D_FREE(arg->snaps);
+	D_FREE(arg);
+}
+
 /**
  * This ULT manages migration one object ID for one container. It does not do
  * the data migration itself - instead it iterates akeys/dkeys as a client and
@@ -3209,12 +3232,9 @@ migrate_obj_ult(void *data)
 	struct migrate_pool_tls	*tls = NULL;
 	daos_epoch_range_t	epr;
 	daos_epoch_t		stable_epoch = 0;
-	daos_handle_t            coh          = DAOS_HDL_INVAL;
-	struct cont_props        props;
 	int			i;
 	int			rc = 0;
 
-	migrate_obj_get(arg);
 	tls = arg->pool_tls;
 	if (tls->mpt_fini) {
 		D_WARN("someone aborted the rebuild " DF_UUID "\n", DP_UUID(arg->pool_uuid));
@@ -3264,33 +3284,6 @@ migrate_obj_ult(void *data)
 
 		if (cont_child)
 			ds_cont_child_put(cont_child);
-	}
-
-	rc = dsc_pool_open(tls->mpt_pool_uuid, tls->mpt_poh_uuid, 0, NULL,
-			   tls->mpt_pool->spc_pool->sp_map, &tls->mpt_svc_list, &tls->mpt_pool_hdl);
-	if (rc) {
-		DL_ERROR(rc, DF_RB ": dsc_pool_open failed", DP_RB_MPT(tls));
-		D_GOTO(out, rc);
-	}
-
-	rc = migrate_cont_open(tls, arg->cont_uuid, 0, &coh);
-	if (rc) {
-		DL_ERROR(rc, DF_RB ": migrate_cont_open failed", DP_RB_MPT(tls));
-		D_GOTO(out, rc);
-	}
-
-	rc = dsc_obj_open(coh, arg->oid.id_pub, DAOS_OO_RO, &arg->ioa_oh);
-	if (rc) {
-		DL_ERROR(rc, DF_RB ": dsc_obj_open failed", DP_RB_MPT(tls));
-		D_GOTO(out, rc);
-	}
-
-	dsc_cont_get_props(coh, &props);
-	rc = dsc_obj_id2oc_attr(arg->oid.id_pub, &props, &arg->ioa_oca);
-	if (rc) {
-		DL_ERROR(rc, DF_RB ": unknown object class: %u", DP_RB_MPT(tls),
-			 daos_obj_id2class(arg->oid.id_pub));
-		D_GOTO(out, rc);
 	}
 
 	for (i = 0; i < arg->snap_cnt; i++) {
@@ -3368,7 +3361,7 @@ out:
 		tls->mpt_tgt_dkey_ult_cnt, tls->mpt_obj_count, DP_RC(rc));
 free_notls:
 	migrate_res_release(tls, MIGR_OBJ, 1);
-	migrate_obj_put(arg);
+	obj_iter_arg_free(arg);
 }
 
 struct migrate_obj_val {
@@ -3400,8 +3393,6 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, daos_epoch_t punched_e
 	migrate_pool_tls_get(tls);
 	obj_arg->pool_tls      = tls;
 	obj_arg->oid = oid;
-	obj_arg->ioa_oh        = DAOS_HDL_INVAL;
-	obj_arg->ioa_obj_ref   = 0;
 	obj_arg->epoch = eph;
 	obj_arg->shard = shard;
 	obj_arg->punched_epoch = punched_eph;


### PR DESCRIPTION
This reverts commit d9f7d8386af5d83bd4cbeb66706da74a3a14a852.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
