### PR TITLE
DAOS-18473 rebuild: check grp_size between obj enumerate

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -550,6 +550,7 @@ daos_unit_oid_compare(daos_unit_oid_t a, daos_unit_oid_t b)
 	return 0;
 }
 
+/* clang-format off */
 int daos_obj_layout_free(struct daos_obj_layout *layout);
 int daos_obj_layout_alloc(struct daos_obj_layout **layout, uint32_t grp_nr,
 			  uint32_t grp_size);
@@ -598,6 +599,8 @@ int dc_obj_hdl2oid(daos_handle_t oh, daos_obj_id_t *oid);
 uint32_t dc_obj_hdl2redun_lvl(daos_handle_t oh);
 uint32_t dc_obj_hdl2pda(daos_handle_t oh);
 uint32_t dc_obj_hdl2pdom(daos_handle_t oh);
+uint32_t dc_obj_hdl2map_ver(daos_handle_t oh);
+uint32_t dc_obj_hdl2grp_size(daos_handle_t oh);
 
 int dc_tx_open(tse_task_t *task);
 int dc_tx_commit(tse_task_t *task);
@@ -609,6 +612,7 @@ int dc_tx_local_open(daos_handle_t coh, daos_epoch_t epoch,
 		     uint32_t flags, daos_handle_t *th);
 int dc_tx_local_close(daos_handle_t th);
 int dc_tx_hdl2epoch(daos_handle_t th, daos_epoch_t *epoch);
+/* clang-format on */
 
 /** Decode shard number from enumeration anchor */
 static inline uint32_t

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1,8 +1,7 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -286,6 +285,34 @@ dc_obj_hdl2pdom(daos_handle_t oh)
 	pdom = dc_obj_get_pdom(obj);
 	obj_decref(obj);
 	return pdom;
+}
+
+uint32_t
+dc_obj_hdl2map_ver(daos_handle_t oh)
+{
+	struct dc_object *obj;
+	uint32_t          ver;
+
+	obj = obj_hdl2ptr(oh);
+	D_ASSERT(obj != NULL);
+	ver = obj->cob_version;
+	obj_decref(obj);
+
+	return ver;
+}
+
+uint32_t
+dc_obj_hdl2grp_size(daos_handle_t oh)
+{
+	struct dc_object *obj;
+	uint32_t          ver;
+
+	obj = obj_hdl2ptr(oh);
+	D_ASSERT(obj != NULL);
+	ver = obj->cob_grp_size;
+	obj_decref(obj);
+
+	return ver;
 }
 
 static int


### PR DESCRIPTION
The anchor was shared between dsc_obj_list_obj() calls, if the pool map version changed the anchor's ssa_shard possible changed due to group extension and cause assertion or shard comparison problem. Just break and fail this rebuild for now.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
