### PR TITLE
DAOS-18192 rebuild: global resource control for rebuild

### DIFF
--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -25,6 +25,8 @@
 #include "obj_ec.h"
 
 extern struct dss_module_key obj_module_key;
+
+struct migr_res_manager;
 
 /* Per pool attached to the migrate tls(per xstream) */
 struct migrate_pool_tls {
@@ -75,18 +77,13 @@ struct migrate_pool_tls {
 	 */
 	uint32_t                 mpt_tgt_obj_ult_cnt;
 	uint32_t                 mpt_tgt_dkey_ult_cnt;
+	/* The current in-flight data size */
+	uint64_t                 mpt_inflight_size;
+
+	struct migr_res_manager *mpt_rmg;
 
 	/* reference count for the structure */
-	uint64_t		mpt_refcount;
-
-	/* The current in-flight iod, mainly used for controlling
-	 * rebuild in-flight rate to avoid the DMA buffer overflow.
-	 */
-	uint64_t		mpt_inflight_size;
-	uint64_t		mpt_inflight_max_size;
-	ABT_cond		mpt_inflight_cond;
-	ABT_mutex		mpt_inflight_mutex;
-	uint32_t		mpt_inflight_max_ult;
+	uint64_t                 mpt_refcount;
 	uint32_t		mpt_opc;
 
 	/* The new layout version for upgrade job */
@@ -145,6 +142,10 @@ struct obj_tgt_punch_args {
 
 void
 migrate_pool_tls_destroy(struct migrate_pool_tls *tls);
+int
+obj_migrate_init(void);
+void
+obj_migrate_fini(void);
 
 struct obj_tls {
 	d_sg_list_t		ot_echo_sgl;

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -40,9 +40,16 @@ obj_mod_init(void)
 		D_ERROR("failed to obj_ec_codec_init\n");
 		goto out_class;
 	}
+	rc = obj_migrate_init();
+	if (rc) {
+		D_ERROR("failed to init migration resource managers\n");
+		goto out_ec;
+	}
 
 	return 0;
 
+out_ec:
+	obj_ec_codec_fini();
 out_class:
 	obj_class_fini();
 out_utils:
@@ -55,6 +62,7 @@ out:
 static int
 obj_mod_fini(void)
 {
+	obj_migrate_fini();
 	obj_ec_codec_fini();
 	obj_class_fini();
 	obj_utils_fini();

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -31,15 +31,76 @@
 	#pragma GCC diagnostic ignored "-Wframe-larger-than="
 #endif
 
-/* Max in-flight data size per xstream */
-/* Set the total in-flight size to be 25% of MAX DMA size for
+/* Max in-flight transfer size per xstream */
+/* Set the total in-flight size to be 50% of MAX DMA size for
  * the moment, will adjust it later if needed.
  */
-#define MIGRATE_MAX_SIZE	(1 << 28)
-/* Max migrate ULT number on the server */
-#define MIGRATE_DEFAULT_MAX_ULT	4096
+#define MIGR_TGT_INF_DATA       (1 << 29)
+
+/* Threshold for very large transfers.
+ * This may exceed the MIGR_TGT_INF_DATA limit to prevent starvation.
+ * Only one such transfer is allowed at a time.
+ */
+#define MIGR_INF_DATA_HULK      (1 << 28)
+
+/* Low water mark for DMA buffer usage, hulk transfer is allowed in this case.
+ */
+#define MIGR_INF_DATA_LWM       (1 << 28)
+
 #define ENV_MIGRATE_ULT_CNT	"D_MIGRATE_ULT_CNT"
+
+/* Number of migration ULTs per target */
+#define MIGR_TGT_ULTS_MIN       100
+#define MIGR_TGT_ULTS_DEF       500
+#define MIGR_TGT_ULTS_MAX       2000
+
+/* 1/3 object ults, 2/3 key ULTs */
+#define MIGR_OBJ_ULT_PERCENT    33
+
+#define MIGR_TGT_OBJ_ULTS(ults) ((ults * MIGR_OBJ_ULT_PERCENT) / 100)
+#define MIGR_TGT_KEY_ULTS(ults) (ults - MIGR_TGT_OBJ_ULTS(ults))
+
+enum {
+	MIGR_OBJ = 0,
+	MIGR_KEY,
+	MIGR_DATA,
+	MIGR_MAX,
+};
+
+/* resource consumed by migration */
+struct migr_resource {
+	const char *res_name;
+	/* upper limit of the resource */
+	long        res_limit;
+	/* resource amount in "unit" */
+	long        res_units;
+	/* number of waiters on this resource */
+	int         res_waiters;
+	/* Only used by MIGR_DATA, it always allows exactly one ULT to use unbounded
+	 * buffer for super large value (rare).
+	 */
+	int         res_hulk;
+	/* ABT_cond for waiters */
+	ABT_cond    res_cond;
+};
+
+/* migration resources manager */
+struct migr_res_manager {
+	ABT_mutex            rmg_mutex;
+	struct migr_resource rmg_resources[MIGR_MAX];
+};
+
+struct migr_engine_res {
+	/* total ULTs per target, it a tunable which can be set by admin */
+	unsigned int             er_max_ults;
+	/* dss_tgt_nr resource managers */
+	struct migr_res_manager *er_rmgs;
+};
+
+static struct migr_engine_res migr_eng_res;
+
 struct migrate_one {
+	struct migrate_pool_tls  *mo_tls;
 	daos_key_t		 mo_dkey;
 	uint64_t		 mo_dkey_hash;
 	uuid_t			 mo_pool_uuid;
@@ -113,6 +174,7 @@ struct iter_cont_arg {
 
 /* Argument for object iteration and migrate */
 struct iter_obj_arg {
+	struct migrate_pool_tls *pool_tls;
 	uuid_t			pool_uuid;
 	uuid_t			cont_uuid;
 	daos_unit_oid_t		oid;
@@ -391,10 +453,6 @@ migrate_pool_tls_destroy(struct migrate_pool_tls *tls)
 		D_FREE(tls->mpt_svc_list.rl_ranks);
 	if (tls->mpt_done_eventual)
 		ABT_eventual_free(&tls->mpt_done_eventual);
-	if (tls->mpt_inflight_cond)
-		ABT_cond_free(&tls->mpt_inflight_cond);
-	if (tls->mpt_inflight_mutex)
-		ABT_mutex_free(&tls->mpt_inflight_mutex);
 	if (daos_handle_is_valid(tls->mpt_root_hdl))
 		obj_tree_destroy(tls->mpt_root_hdl);
 	if (daos_handle_is_valid(tls->mpt_migrated_root_hdl))
@@ -450,13 +508,11 @@ migrate_pool_tls_create(uuid_t pool_uuid, unsigned int version, unsigned int gen
 			uint32_t new_layout_ver, uint32_t opc, struct migrate_pool_tls **p_tls,
 			d_rank_list_t *svc_list)
 {
-	uint32_t                            max_migrate_ult = MIGRATE_DEFAULT_MAX_ULT;
 	struct obj_tls                     *obj_tls         = obj_tls_get();
 	struct migrate_pool_tls            *pool_tls        = NULL;
 	struct ds_pool_child		   *pool_child = NULL;
 	int				    rc = 0;
 
-	d_getenv_uint(ENV_MIGRATE_ULT_CNT, &max_migrate_ult);
 	D_ASSERT(generation != (unsigned int)(-1));
 
 	pool_child = ds_pool_child_lookup(pool_uuid);
@@ -484,14 +540,6 @@ migrate_pool_tls_create(uuid_t pool_uuid, unsigned int version, unsigned int gen
 	if (rc != ABT_SUCCESS)
 		D_GOTO(out, rc = dss_abterr2der(rc));
 
-	rc = ABT_cond_create(&pool_tls->mpt_inflight_cond);
-	if (rc != ABT_SUCCESS)
-		D_GOTO(out, rc = dss_abterr2der(rc));
-
-	rc = ABT_mutex_create(&pool_tls->mpt_inflight_mutex);
-	if (rc != ABT_SUCCESS)
-		D_GOTO(out, rc = dss_abterr2der(rc));
-
 	uuid_copy(pool_tls->mpt_pool_uuid, pool_uuid);
 	uuid_copy(pool_tls->mpt_poh_uuid, pool_hdl_uuid);
 	uuid_copy(pool_tls->mpt_coh_uuid, co_hdl_uuid);
@@ -507,8 +555,6 @@ migrate_pool_tls_create(uuid_t pool_uuid, unsigned int version, unsigned int gen
 	pool_tls->mpt_pool           = ds_pool_child_lookup(pool_uuid);
 	if (pool_tls->mpt_pool == NULL)
 		D_GOTO(out, rc = -DER_NO_HDL);
-	pool_tls->mpt_inflight_max_size = MIGRATE_MAX_SIZE / dss_tgt_nr;
-	pool_tls->mpt_inflight_max_ult  = max_migrate_ult / dss_tgt_nr;
 	pool_tls->mpt_tgt_obj_ult_cnt   = 0;
 	pool_tls->mpt_tgt_dkey_ult_cnt  = 0;
 	pool_tls->mpt_inflight_size = 0;
@@ -646,12 +692,10 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 		daos_iod_t *iods, int iod_num, daos_epoch_t eph, uint32_t flags,
 		d_iov_t *csum_iov_fetch)
 {
-	struct migrate_pool_tls	*tls;
+	struct migrate_pool_tls *tls = mrone->mo_tls;
 	int			rc = 0;
 
-	tls = migrate_pool_tls_lookup(mrone->mo_pool_uuid,
-				      mrone->mo_pool_tls_version, mrone->mo_generation);
-	if (tls == NULL || tls->mpt_fini) {
+	if (tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(mrone->mo_pool_uuid));
 		D_GOTO(out, rc = migrate_pool_tls_get_status(tls));
@@ -685,7 +729,6 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 	}
 
 out:
-	migrate_pool_tls_put(tls);
 	return rc;
 }
 
@@ -1754,81 +1797,131 @@ migrate_one_destroy(struct migrate_one *mrone)
 
 	if (mrone->mo_iods_csums)
 		D_FREE(mrone->mo_iods_csums);
+	if (mrone->mo_tls)
+		migrate_pool_tls_put(mrone->mo_tls);
 
 	D_FREE(mrone);
 }
 
-enum {
-	OBJ_ULT = 1,
-	DKEY_ULT = 2,
-};
-
-static inline uint32_t
-migrate_tgt_ult_cnt(struct migrate_pool_tls *tls, int ult_type)
+static bool
+migr_res_is_hulk(int res_type, long units)
 {
-	if (ult_type == OBJ_ULT)
-		return tls->mpt_tgt_obj_ult_cnt;
-	else
-		return tls->mpt_tgt_dkey_ult_cnt;
+	return res_type == MIGR_DATA && units >= MIGR_INF_DATA_HULK;
 }
 
 static int
-migrate_tgt_enter(struct migrate_pool_tls *tls, int ult_type, bool *yielded)
+migrate_res_hold(struct migrate_pool_tls *tls, int res_type, long units, bool *yielded)
 {
-	uint32_t ult_cnt = 0;
-	int	 rc = 0;
+	struct dss_module_info  *dmi = dss_get_module_info();
+	struct migr_res_manager *rmg;
+	struct migr_resource    *res;
+	bool                     is_hulk;
+	bool                     waited = false;
+	int                      rc     = 0;
 
-	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
+	D_ASSERT(dmi->dmi_xs_id != 0);
 
-	ult_cnt = migrate_tgt_ult_cnt(tls, ult_type);
-	while (tls->mpt_inflight_max_ult / 2 <= ult_cnt) {
-		D_DEBUG(DB_REBUILD, "tgt %u max %u\n", ult_cnt, tls->mpt_inflight_max_ult);
-
-		if (yielded)
-			*yielded = true;
-		ABT_mutex_lock(tls->mpt_inflight_mutex);
-		ABT_cond_wait(tls->mpt_inflight_cond, tls->mpt_inflight_mutex);
-		ABT_mutex_unlock(tls->mpt_inflight_mutex);
-		if (tls->mpt_fini)
-			D_GOTO(out, rc = migrate_pool_tls_get_status(tls));
-
-		ult_cnt = migrate_tgt_ult_cnt(tls, ult_type);
+	rmg = &migr_eng_res.er_rmgs[dmi->dmi_tgt_id];
+	if (tls->mpt_rmg == NULL) {
+		tls->mpt_rmg = rmg;
+	} else {
+		D_ASSERTF(tls->mpt_rmg == rmg, "target=%d, rmg_off=%d\n", dmi->dmi_tgt_id,
+			  (int)(tls->mpt_rmg - &migr_eng_res.er_rmgs[0]));
 	}
 
-	if (ult_type == OBJ_ULT)
+	res     = &rmg->rmg_resources[res_type];
+	is_hulk = migr_res_is_hulk(res_type, units);
+	while (1) {
+		if (tls->mpt_fini) {
+			rc = migrate_pool_tls_get_status(tls);
+			D_GOTO(out, rc);
+		}
+
+		if (is_hulk && res->res_hulk == 0 && res->res_units < MIGR_INF_DATA_LWM) {
+			/* skip the limit check and allow (only) one hulk transfer at a time */
+			res->res_units += units;
+			res->res_hulk = 1;
+			break;
+
+		} else if (!is_hulk && res->res_units + units <= res->res_limit) {
+			res->res_units += units;
+			break;
+		}
+
+		ABT_mutex_lock(rmg->rmg_mutex);
+		res->res_waiters++;
+		if (res->res_waiters >= 100 && res->res_waiters % 100 == 0) {
+			D_DEBUG(DB_REBUILD,
+				"%d waiters are waiting on res=%s (target=%d, unit=%lu)\n",
+				res->res_waiters, res->res_name, dmi->dmi_tgt_id, units);
+		}
+
+		ABT_cond_wait(res->res_cond, rmg->rmg_mutex);
+		res->res_waiters--;
+		ABT_mutex_unlock(rmg->rmg_mutex);
+		waited = true;
+	}
+	if (yielded)
+		*yielded = waited;
+
+	/* per-pool counters for rebuild status tracking */
+	if (res_type == MIGR_OBJ)
 		tls->mpt_tgt_obj_ult_cnt++;
-	else
+	else if (res_type == MIGR_KEY)
 		tls->mpt_tgt_dkey_ult_cnt++;
+	else
+		tls->mpt_inflight_size += units;
+
+	D_DEBUG(DB_REBUILD,
+		"res=%s, hold=%lu, used=%lu, limit=%lu, waited=%d)\n" DF_RB
+		" obj_ults=%u, key_ults=%u, inf_data=" DF_U64 ")\n",
+		res->res_name, units, res->res_units, res->res_limit, waited, DP_RB_MPT(tls),
+		tls->mpt_tgt_obj_ult_cnt, tls->mpt_tgt_dkey_ult_cnt, tls->mpt_inflight_size);
 out:
 	return rc;
 }
 
 static void
-migrate_tgt_try_wakeup(struct migrate_pool_tls *tls, int ult_type)
+migrate_res_release(struct migrate_pool_tls *tls, int res_type, long units)
 {
-	uint32_t ult_cnt = 0;
+	struct migr_res_manager *rmg;
+	struct migr_resource    *res;
 
-	ult_cnt = migrate_tgt_ult_cnt(tls, ult_type);
-	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
-	if (tls->mpt_inflight_max_ult / 2 > ult_cnt) {
-		ABT_mutex_lock(tls->mpt_inflight_mutex);
-		ABT_cond_signal(tls->mpt_inflight_cond);
-		ABT_mutex_unlock(tls->mpt_inflight_mutex);
-	}
-}
+	rmg = tls->mpt_rmg;
+	D_ASSERT(rmg != NULL);
 
-static void
-migrate_tgt_exit(struct migrate_pool_tls *tls, int ult_type)
-{
-	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
-	if (ult_type == OBJ_ULT) {
+	res = &rmg->rmg_resources[res_type];
+
+	D_DEBUG(DB_REBUILD,
+		"%s: release=%lu, used=%lu, limit=%lu\n" DF_RB
+		" obj_ults=%u, key_ults=%u, inf_data=" DF_U64 ")\n",
+		res->res_name, units, res->res_units, res->res_limit, DP_RB_MPT(tls),
+		tls->mpt_tgt_obj_ult_cnt, tls->mpt_tgt_dkey_ult_cnt, tls->mpt_inflight_size);
+
+	if (res_type == MIGR_OBJ) {
 		D_ASSERT(tls->mpt_tgt_obj_ult_cnt > 0);
 		tls->mpt_tgt_obj_ult_cnt--;
-	} else {
+	} else if (res_type == MIGR_KEY) {
 		D_ASSERT(tls->mpt_tgt_dkey_ult_cnt > 0);
 		tls->mpt_tgt_dkey_ult_cnt--;
+	} else {
+		D_ASSERT(tls->mpt_inflight_size >= units);
+		tls->mpt_inflight_size -= units;
 	}
-	migrate_tgt_try_wakeup(tls, ult_type);
+
+	D_ASSERT(res->res_units >= units);
+	res->res_units -= units;
+
+	if (migr_res_is_hulk(res_type, units)) {
+		D_ASSERT(res->res_hulk == 1);
+		res->res_hulk = 0;
+	}
+
+	if (res->res_waiters > 0) {
+		ABT_mutex_lock(rmg->rmg_mutex);
+		ABT_cond_signal(res->res_cond);
+		ABT_mutex_unlock(rmg->rmg_mutex);
+	}
 }
 
 static void
@@ -1842,11 +1935,9 @@ migrate_one_ult(void *arg)
 	while (daos_fail_check(DAOS_REBUILD_TGT_REBUILD_HANG))
 		dss_sleep(0);
 
-	tls = migrate_pool_tls_lookup(mrone->mo_pool_uuid,
-				      mrone->mo_pool_tls_version, mrone->mo_generation);
-	if (tls == NULL || tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(mrone->mo_pool_uuid));
+	tls = mrone->mo_tls;
+	if (tls->mpt_fini) {
+		D_WARN("some one abort the rebuild " DF_UUID "\n", DP_UUID(mrone->mo_pool_uuid));
 		goto out;
 	}
 
@@ -1858,25 +1949,14 @@ migrate_one_ult(void *arg)
 		mrone, data_size, mrone->mo_iod_num, mrone->mo_iods_num_from_parity);
 
 	D_ASSERT(data_size != (daos_size_t)-1);
-	D_DEBUG(DB_REBUILD, "mrone %p inflight_size "DF_U64" max "DF_U64"\n",
-		mrone, tls->mpt_inflight_size, tls->mpt_inflight_max_size);
 
-	while (tls->mpt_inflight_size + data_size >= tls->mpt_inflight_max_size &&
-	       tls->mpt_inflight_max_size != 0 && tls->mpt_inflight_size != 0 &&
-	       !tls->mpt_fini) {
-		D_DEBUG(DB_REBUILD, "mrone %p wait "DF_U64"/"DF_U64"/"DF_U64"\n", mrone,
-			tls->mpt_inflight_size, tls->mpt_inflight_max_size, data_size);
-		ABT_mutex_lock(tls->mpt_inflight_mutex);
-		ABT_cond_wait(tls->mpt_inflight_cond, tls->mpt_inflight_mutex);
-		ABT_mutex_unlock(tls->mpt_inflight_mutex);
-	}
-
-	if (tls->mpt_fini)
+	rc = migrate_res_hold(tls, MIGR_DATA, data_size, NULL);
+	if (rc)
 		D_GOTO(out, rc);
 
-	tls->mpt_inflight_size += data_size;
 	rc = migrate_dkey(tls, mrone, data_size);
-	tls->mpt_inflight_size -= data_size;
+
+	migrate_res_release(tls, MIGR_DATA, data_size);
 
 	D_DEBUG(DB_REBUILD, DF_UOID" layout %u migrate dkey "DF_KEY" inflight_size "DF_U64": "
 		DF_RC"\n", DP_UOID(mrone->mo_oid), mrone->mo_oid.id_layout_ver,
@@ -1898,11 +1978,8 @@ migrate_one_ult(void *arg)
 		tls->mpt_fini = 1;
 	}
 out:
+	migrate_res_release(tls, MIGR_KEY, 1);
 	migrate_one_destroy(mrone);
-	if (tls != NULL) {
-		migrate_tgt_exit(tls, DKEY_ULT);
-		migrate_pool_tls_put(tls);
-	}
 }
 
 /* If src_iod is NULL, it will try to merge the recxs inside dst_iod */
@@ -2303,7 +2380,7 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dc_obj_enum_unpack_io *io
 	d_sg_list_t		*sgls = io->ui_sgls;
 	uint32_t		version = io->ui_version;
 	struct dc_object	*obj = NULL;
-	struct migrate_pool_tls *tls;
+	struct migrate_pool_tls *tls             = iter_arg->pool_tls;
 	struct migrate_one	*mrone = NULL;
 	bool			inline_copy = true;
 	int			i;
@@ -2312,22 +2389,21 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dc_obj_enum_unpack_io *io
 	D_DEBUG(DB_REBUILD, "migrate dkey "DF_KEY" iod nr %d\n", DP_KEY(dkey),
 		iod_eph_total);
 
-	tls = migrate_pool_tls_lookup(iter_arg->pool_uuid, iter_arg->version, iter_arg->generation);
-	if (tls == NULL || tls->mpt_fini) {
+	if (tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(iter_arg->pool_uuid));
-		D_GOTO(put, rc = 0);
+		D_GOTO(out, rc = 0);
 	}
 	if (iod_eph_total == 0 || tls->mpt_fini) {
 		D_DEBUG(DB_REBUILD, "No need eph_total %d version %u"
 			" migrate ver %u fini %d\n", iod_eph_total, version,
 			tls->mpt_version, tls->mpt_fini);
-		D_GOTO(put, rc = 0);
+		D_GOTO(out, rc = 0);
 	}
 
 	D_ALLOC_PTR(mrone);
 	if (mrone == NULL)
-		D_GOTO(put, rc = -DER_NOMEM);
+		D_GOTO(out, rc = -DER_NOMEM);
 
 	D_INIT_LIST_HEAD(&mrone->mo_list);
 	D_ALLOC_ARRAY(mrone->mo_iods, iod_eph_total);
@@ -2434,8 +2510,7 @@ free:
 		d_list_del_init(&mrone->mo_list);
 		migrate_one_destroy(mrone);
 	}
-put:
-	migrate_pool_tls_put(tls);
+out:
 	return rc;
 }
 
@@ -2443,14 +2518,14 @@ static int
 migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 {
 	struct enum_unpack_arg	*arg = data;
+	struct migrate_pool_tls *tls   = arg->arg->pool_tls;
 	uint32_t		shard = arg->arg->shard;
 	struct migrate_one	*mo;
 	uint32_t		unpack_tgt_off;
 	uint32_t		migrate_tgt_off;
 	bool			merged = false;
 	bool			create_migrate_one = false;
-	int			rc = 0;
-	struct migrate_pool_tls *tls;
+	int                      rc                 = 0;
 	struct dc_object	*obj = NULL;
 	uint32_t		parity_shard = -1;
 	uint32_t		layout_ver;
@@ -2472,9 +2547,7 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	if (rc < 0)
 		return rc;
 
-	tls = migrate_pool_tls_lookup(arg->arg->pool_uuid, arg->arg->version,
-				      arg->arg->generation);
-	if (tls == NULL || tls->mpt_fini) {
+	if (tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(arg->arg->pool_uuid));
 		D_GOTO(put, rc = 0);
@@ -2588,7 +2661,6 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 put:
 	if (obj)
 		obj_decref(obj);
-	migrate_pool_tls_put(tls);
 	return rc;
 }
 
@@ -2600,11 +2672,11 @@ migrate_obj_punch_one(void *data)
 	struct ds_cont_child	*cont;
 	int			rc;
 
-	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
-	if (tls == NULL || tls->mpt_fini) {
+	tls = arg->pool_tls;
+	if (tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(arg->pool_uuid));
-		D_GOTO(put, rc = 0);
+		D_GOTO(out, rc = 0);
 	}
 
 	D_DEBUG(DB_REBUILD, "tls %p "DF_UUID" version %d punch "DF_U64" "DF_UOID"\n",
@@ -2613,22 +2685,20 @@ migrate_obj_punch_one(void *data)
 
 	rc = migrate_get_cont_child(tls, arg->cont_uuid, &cont, true);
 	if (rc != 0 || cont == NULL)
-		D_GOTO(put, rc);
+		D_GOTO(out, rc);
 
 	D_ASSERT(arg->punched_epoch != 0);
 	rc = vos_obj_punch(cont->sc_hdl, arg->oid, arg->punched_epoch,
 			   tls->mpt_version, VOS_OF_REPLAY_PC,
 			   NULL, 0, NULL, NULL);
 	ds_cont_child_put(cont);
-put:
+out:
 	if (rc)
 		D_ERROR(DF_UOID" migrate punch failed: "DF_RC"\n",
 			DP_UOID(arg->oid), DP_RC(rc));
-	if (tls) {
-		if (tls->mpt_status == 0 && rc != 0)
-			tls->mpt_status = rc;
-		migrate_pool_tls_put(tls);
-	}
+
+	if (tls->mpt_status == 0 && rc != 0)
+		tls->mpt_status = rc;
 
 	return rc;
 }
@@ -2636,17 +2706,16 @@ put:
 static int
 migrate_start_ult(struct enum_unpack_arg *unpack_arg)
 {
-	struct migrate_pool_tls *tls;
 	struct iter_obj_arg	*arg = unpack_arg->arg;
+	struct migrate_pool_tls *tls = arg->pool_tls;
 	struct migrate_one	*mrone;
 	struct migrate_one	*tmp;
 	int			rc = 0;
 
-	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
-	if (tls == NULL || tls->mpt_fini) {
+	if (tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(arg->pool_uuid));
-		D_GOTO(put, rc = 0);
+		D_GOTO(out, rc = 0);
 	}
 	d_list_for_each_entry_safe(mrone, tmp, &unpack_arg->merge_list,
 				   mo_list) {
@@ -2663,21 +2732,24 @@ migrate_start_ult(struct enum_unpack_arg *unpack_arg)
 			continue;
 		}
 
-		rc = migrate_tgt_enter(tls, DKEY_ULT, NULL);
+		rc = migrate_res_hold(tls, MIGR_KEY, 1, NULL);
 		if (rc)
 			break;
 		d_list_del_init(&mrone->mo_list);
-		rc = dss_ult_create(migrate_one_ult, mrone, DSS_XS_VOS,
-				    arg->tgt_idx, MIGRATE_STACK_SIZE, NULL);
+
+		migrate_pool_tls_get(tls);
+		mrone->mo_tls = tls;
+
+		D_ASSERT(arg->tgt_idx == dss_get_module_info()->dmi_tgt_id);
+		rc = dss_ult_create(migrate_one_ult, mrone, DSS_XS_SELF, 0, MIGRATE_STACK_SIZE,
+				    NULL);
 		if (rc) {
-			migrate_tgt_exit(tls, DKEY_ULT);
+			migrate_res_release(tls, MIGR_KEY, 1);
 			migrate_one_destroy(mrone);
 			break;
 		}
 	}
-
-put:
-	migrate_pool_tls_put(tls);
+out:
 	return rc;
 }
 
@@ -2987,9 +3059,16 @@ migrate_fini_one_ult(void *data)
 	arg->stop_count++;
 	ABT_mutex_unlock(arg->stop_lock);
 
-	ABT_mutex_lock(tls->mpt_inflight_mutex);
-	ABT_cond_broadcast(tls->mpt_inflight_cond);
-	ABT_mutex_unlock(tls->mpt_inflight_mutex);
+	if (tls->mpt_rmg) {
+		struct migr_res_manager *rmg = tls->mpt_rmg;
+		int                      i;
+
+		/* NB: no big deal but ULTs of all pools will be waken up */
+		ABT_mutex_lock(rmg->rmg_mutex);
+		for (i = 0; i < MIGR_MAX; i++)
+			ABT_cond_broadcast(rmg->rmg_resources[i].res_cond);
+		ABT_mutex_unlock(rmg->rmg_mutex);
+	}
 
 	migrate_pool_tls_put(tls); /* lookup */
 	rc = ABT_eventual_wait(tls->mpt_done_eventual, NULL);
@@ -3042,6 +3121,16 @@ migrate_obj_punch(struct iter_obj_arg *arg)
 			       arg->tgt_idx, MIGRATE_STACK_SIZE);
 }
 
+static void
+obj_iter_arg_free(struct iter_obj_arg *arg)
+{
+	if (arg->pool_tls)
+		migrate_pool_tls_put(arg->pool_tls);
+	if (arg->snaps)
+		D_FREE(arg->snaps);
+	D_FREE(arg);
+}
+
 /**
  * This ULT manages migration one object ID for one container. It does not do
  * the data migration itself - instead it iterates akeys/dkeys as a client and
@@ -3064,8 +3153,8 @@ migrate_obj_ult(void *data)
 	int			i;
 	int			rc = 0;
 
-	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
-	if (tls == NULL || tls->mpt_fini) {
+	tls = arg->pool_tls;
+	if (tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(arg->pool_uuid));
 		D_GOTO(free_notls, rc);
@@ -3141,8 +3230,7 @@ free:
 		rc = -DER_IO;
 
 	D_DEBUG(DB_REBUILD,
-		DF_RB ":  stop migrate obj " DF_UOID "for shard %u ult %u/%u " DF_U64 " : " DF_RC
-		      "\n",
+		DF_RB ": stop migrate obj " DF_UOID "for shard %u ult %u/%u " DF_U64 " : " DF_RC,
 		DP_RB_MPT(tls), DP_UOID(arg->oid), arg->shard, tls->mpt_tgt_obj_ult_cnt,
 		tls->mpt_tgt_dkey_ult_cnt, tls->mpt_obj_count, DP_RC(rc));
 out:
@@ -3150,12 +3238,8 @@ out:
 		tls->mpt_status = rc;
 
 free_notls:
-	if (tls != NULL)
-		migrate_tgt_exit(tls, OBJ_ULT);
-
-	D_FREE(arg->snaps);
-	D_FREE(arg);
-	migrate_pool_tls_put(tls);
+	migrate_res_release(tls, MIGR_OBJ, 1);
+	obj_iter_arg_free(arg);
 }
 
 struct migrate_obj_val {
@@ -3184,6 +3268,8 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, daos_epoch_t punched_e
 	if (obj_arg == NULL)
 		return -DER_NOMEM;
 
+	migrate_pool_tls_get(tls);
+	obj_arg->pool_tls      = tls;
 	obj_arg->oid = oid;
 	obj_arg->epoch = eph;
 	obj_arg->shard = shard;
@@ -3204,8 +3290,8 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, daos_epoch_t punched_e
 		       sizeof(*obj_arg->snaps) * cont_arg->snap_cnt);
 	}
 
-	rc = dss_ult_create(migrate_obj_ult, obj_arg, DSS_XS_VOS,
-			    tgt_idx, MIGRATE_STACK_SIZE, NULL);
+	D_ASSERT(tgt_idx == dss_get_module_info()->dmi_tgt_id);
+	rc = dss_ult_create(migrate_obj_ult, obj_arg, DSS_XS_SELF, 0, MIGRATE_STACK_SIZE, NULL);
 	if (rc)
 		goto free;
 
@@ -3223,8 +3309,7 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, daos_epoch_t punched_e
 
 	return 0;
 free:
-	D_FREE(obj_arg->snaps);
-	D_FREE(obj_arg);
+	obj_iter_arg_free(obj_arg);
 	return rc;
 }
 
@@ -3251,7 +3336,7 @@ migrate_obj_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov, void *
 		" eph "DF_U64" start\n", DP_UUID(arg->cont_uuid), DP_UOID(*oid),
 		ih.cookie, epoch);
 
-	rc = migrate_tgt_enter(arg->pool_tls, OBJ_ULT, &yielded);
+	rc = migrate_res_hold(arg->pool_tls, MIGR_OBJ, 1, &yielded);
 	if (rc != 0) {
 		DL_ERROR(rc, DF_UUID" enter migrate failed.", DP_UUID(arg->cont_uuid));
 		return rc;
@@ -3261,11 +3346,11 @@ migrate_obj_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov, void *
 	if (rc != 0) {
 		D_ERROR("obj "DF_UOID" migration failed: "DF_RC"\n",
 			DP_UOID(*oid), DP_RC(rc));
-		migrate_tgt_exit(arg->pool_tls, OBJ_ULT);
+		migrate_res_release(arg->pool_tls, MIGR_OBJ, 1);
 		return rc;
 	}
 
-	/* migrate_tgt_enter possibly yielded the ULT, let's re-probe before delete  */
+	/* migrate_res_hold possibly yielded the ULT, let's re-probe before delete  */
 	if (yielded) {
 		d_iov_set(&tmp_iov, oid, sizeof(*oid));
 		rc = dbtree_iter_probe(ih, BTR_PROBE_EQ, DAOS_INTENT_MIGRATION, &tmp_iov, NULL);
@@ -3969,4 +4054,93 @@ out:
 		crt_req_decref(rpc);
 
 	return rc;
+}
+
+static int
+migr_res_init(struct migr_resource *res, const char *name, long limit)
+{
+	int rc;
+
+	memset(res, 0, sizeof(*res));
+	res->res_name  = name;
+	res->res_limit = limit;
+	rc             = ABT_cond_create(&res->res_cond);
+
+	return (rc != ABT_SUCCESS) ? dss_abterr2der(rc) : 0;
+}
+
+static void
+migr_res_fini(struct migr_resource *res)
+{
+	if (res->res_cond)
+		ABT_cond_free(&res->res_cond);
+}
+
+int
+obj_migrate_init(void)
+{
+	unsigned int ults = MIGR_TGT_ULTS_DEF;
+	int          i;
+	int          rc = 0;
+
+	D_CASSERT(MIGR_TGT_INF_DATA > MIGR_INF_DATA_LWM);
+	D_CASSERT(MIGR_TGT_INF_DATA > MIGR_INF_DATA_HULK);
+
+	d_getenv_uint(ENV_MIGRATE_ULT_CNT, &ults);
+	if (ults < MIGR_TGT_ULTS_MIN)
+		ults = MIGR_TGT_ULTS_MIN;
+	if (ults > MIGR_TGT_ULTS_MAX)
+		ults = MIGR_TGT_ULTS_MAX;
+
+	memset(&migr_eng_res, 0, sizeof(migr_eng_res));
+	migr_eng_res.er_max_ults = ults;
+
+	D_ASSERT(dss_tgt_nr > 0);
+	D_ALLOC(migr_eng_res.er_rmgs, sizeof(struct migr_res_manager) * dss_tgt_nr);
+	if (!migr_eng_res.er_rmgs)
+		return -DER_NOMEM;
+
+	for (i = 0; i < dss_tgt_nr; i++) {
+		struct migr_res_manager *rmg = &migr_eng_res.er_rmgs[i];
+
+		rc = ABT_mutex_create(&rmg->rmg_mutex);
+		if (rc != ABT_SUCCESS)
+			D_GOTO(out, rc = dss_abterr2der(rc));
+
+		rc = migr_res_init(&rmg->rmg_resources[MIGR_OBJ], "OBJ", MIGR_TGT_OBJ_ULTS(ults));
+		if (rc)
+			D_GOTO(out, rc);
+
+		rc = migr_res_init(&rmg->rmg_resources[MIGR_KEY], "KEY", MIGR_TGT_KEY_ULTS(ults));
+		if (rc)
+			D_GOTO(out, rc);
+
+		rc = migr_res_init(&rmg->rmg_resources[MIGR_DATA], "DATA", MIGR_TGT_INF_DATA);
+		if (rc)
+			D_GOTO(out, rc);
+	}
+	return 0;
+out:
+	obj_migrate_fini();
+	return rc;
+}
+
+void
+obj_migrate_fini(void)
+{
+	int i;
+	int j;
+
+	if (migr_eng_res.er_rmgs) {
+		for (i = 0; i < dss_tgt_nr; i++) {
+			struct migr_res_manager *rmg = &migr_eng_res.er_rmgs[i];
+
+			for (j = 0; j < MIGR_MAX; j++)
+				migr_res_fini(&rmg->rmg_resources[j]);
+			if (rmg->rmg_mutex)
+				ABT_mutex_free(&rmg->rmg_mutex);
+		}
+		D_FREE(migr_eng_res.er_rmgs);
+	}
+	memset(&migr_eng_res, 0, sizeof(migr_eng_res));
 }


### PR DESCRIPTION
Previously, the resource controls within the rebuild system—such as the limits on ULT (user-level thread) counts and DMA buffer usage—were scoped per pool.

This meant that when rebuild or migration operations occurred across multiple pools, each pool operated within its own local resource boundaries. As a result, simultaneous rebuilds in several pools could lead to excessive system-wide consumption of threads and memory, potentially impacting performance and system stability.

This patch reworks the rebuild migration resource management to introduce global limits on the number of ULTs and DMA buffers the rebuild system can use across all pools. A centralized migration resource manager is established per target to coordinate these resources across all active pools, preventing overallocation and minimizing resource contention.

This patch also bumps the inflight size limit to 50% of DMA buffer

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
