### PR TITLE
DAOS-18486 dfs: Fix snapshot stat returning live timestamps.

### DIFF
--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -423,9 +423,11 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name, siz
 	   struct dfs_obj *obj, bool get_size, struct stat *stbuf, uint64_t *obj_hlc);
 int
 get_num_entries(daos_handle_t oh, daos_handle_t th, uint32_t *nr, bool check_empty);
+void
+update_stbuf_times_snapshot(struct dfs_entry entry, struct stat *stbuf);
 int
 update_stbuf_times(struct dfs_entry entry, daos_epoch_t max_epoch, struct stat *stbuf,
-		   uint64_t *obj_hlc);
+		   uint64_t *obj_hlc, daos_epoch_t th_epoch);
 int
 lookup_rel_path(dfs_t *dfs, dfs_obj_t *root, const char *path, int flags, dfs_obj_t **_obj,
 		mode_t *mode, struct stat *stbuf, size_t depth);

--- a/src/client/dfs/obj.c
+++ b/src/client/dfs/obj.c
@@ -856,7 +856,7 @@ ostatx_cb(tse_task_t *task, void *data)
 		D_GOTO(out, rc = -DER_ENOENT);
 
 	rc = update_stbuf_times(op_args->entry, op_args->array_stbuf.st_max_epoch, args->stbuf,
-				NULL);
+				NULL, args->dfs->th_epoch);
 	if (rc)
 		D_GOTO(out, rc = daos_errno2der(rc));
 


### PR DESCRIPTION
File stat through a snapshot handle returned live timestamps because
daos_array_stat() queries VOS which returns the latest write epoch to get mtime
without bounding it by the transaction handle's snapshot epoch.
  
Fixed by unifying both to use the transaction handle's epoch directly,
which is already bounded by the snapshot.



### Steps for the author:

* [X] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [X] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
