### PR TITLE
DAOS-18487 rebuild: disallow reint/extend when with DOWN targets

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7926,7 +7926,6 @@ ds_pool_reint_extend_allowed(struct pool_svc *svc)
 	struct ds_pool     *pool          = svc->ps_pool;
 	struct pool_target *targets       = NULL;
 	uint32_t            down_tgts_cnt = 0;
-	uint64_t            sys_self_heal = 0;
 	int                 rc;
 	bool                ret = true;
 
@@ -7948,27 +7947,6 @@ ds_pool_reint_extend_allowed(struct pool_svc *svc)
 		D_DEBUG(DB_REBUILD,
 			DF_UUID " with DOWN tgt in delay_rebuild node, "
 				"REINT/EXTEND allowed",
-			DP_UUID(pool->sp_uuid));
-		goto out;
-	}
-
-	rc = ds_mgmt_get_self_heal_policy(pool_svc_abort_gshp, svc, &sys_self_heal);
-	if (rc != 0) {
-		DL_ERROR(rc, DF_UUID ": failed to get self-heal policy", DP_UUID(svc->ps_uuid));
-		/*
-		 * Another PS replica might be able reach the MS. If I'm
-		 * not the PS leader of the specified term, this
-		 * rdb_resign call does nothing.
-		 */
-		rdb_resign(svc->ps_rsvc.s_db, svc->ps_rsvc.s_term);
-		ret = false;
-		goto out;
-	}
-
-	if (!(sys_self_heal & DS_MGMT_SELF_HEAL_POOL_REBUILD)) {
-		D_DEBUG(DB_REBUILD,
-			DF_UUID " with DOWN tgt, pool_rebuild disabled in "
-				"sys_self_heal, REINT/EXTEND allowed",
 			DP_UUID(pool->sp_uuid));
 		goto out;
 	}

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -7920,6 +7920,68 @@ out:
 	return rc;
 }
 
+static bool
+ds_pool_reint_extend_allowed(struct pool_svc *svc)
+{
+	struct ds_pool     *pool          = svc->ps_pool;
+	struct pool_target *targets       = NULL;
+	uint32_t            down_tgts_cnt = 0;
+	uint64_t            sys_self_heal = 0;
+	int                 rc;
+	bool                ret = true;
+
+	ABT_rwlock_rdlock(pool->sp_lock);
+	rc = pool_map_find_down_tgts(pool->sp_map, &targets, &down_tgts_cnt);
+	ABT_rwlock_unlock(pool->sp_lock);
+	if (rc) {
+		DL_ERROR(rc, DF_UUID " pool_map_find_down_tgts failed", DP_UUID(pool->sp_uuid));
+		ret = false;
+		goto out;
+	}
+	if (targets == NULL || down_tgts_cnt == 0) {
+		D_DEBUG(DB_REBUILD, DF_UUID " no DOWN tgt, REINT/EXTEND allowed",
+			DP_UUID(pool->sp_uuid));
+		goto out;
+	}
+
+	if (pool->sp_self_heal & DAOS_SELF_HEAL_DELAY_REBUILD) {
+		D_DEBUG(DB_REBUILD,
+			DF_UUID " with DOWN tgt in delay_rebuild node, "
+				"REINT/EXTEND allowed",
+			DP_UUID(pool->sp_uuid));
+		goto out;
+	}
+
+	rc = ds_mgmt_get_self_heal_policy(pool_svc_abort_gshp, svc, &sys_self_heal);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_UUID ": failed to get self-heal policy", DP_UUID(svc->ps_uuid));
+		/*
+		 * Another PS replica might be able reach the MS. If I'm
+		 * not the PS leader of the specified term, this
+		 * rdb_resign call does nothing.
+		 */
+		rdb_resign(svc->ps_rsvc.s_db, svc->ps_rsvc.s_term);
+		ret = false;
+		goto out;
+	}
+
+	if (!(sys_self_heal & DS_MGMT_SELF_HEAL_POOL_REBUILD)) {
+		D_DEBUG(DB_REBUILD,
+			DF_UUID " with DOWN tgt, pool_rebuild disabled in "
+				"sys_self_heal, REINT/EXTEND allowed",
+			DP_UUID(pool->sp_uuid));
+		goto out;
+	}
+
+	ret = false;
+	D_INFO(DF_UUID " with %d DOWN tgts, REINT/EXTEND disallowed until rebuild done.",
+	       DP_UUID(pool->sp_uuid), down_tgts_cnt);
+
+out:
+	D_FREE(targets);
+	return ret;
+}
+
 void
 ds_pool_extend_handler(crt_rpc_t *rpc)
 {
@@ -7953,6 +8015,13 @@ ds_pool_extend_handler(crt_rpc_t *rpc)
 	rc = pool_svc_lookup_leader(in->pei_op.pi_uuid, &svc, &out->peo_op.po_hint);
 	if (rc != 0)
 		goto out;
+
+	if (!ds_pool_reint_extend_allowed(svc)) {
+		rc = -DER_BUSY;
+		DL_ERROR(rc, DF_UUID "pool extend not allowed, wait rebuild done and try later.",
+			 DP_UUID(pool_uuid));
+		goto failed;
+	}
 
 	rc = pool_discard(rpc->cr_ctx, svc, &tgt_addr_list, false);
 	if (rc) {
@@ -8116,6 +8185,15 @@ pool_update_handler(crt_rpc_t *rpc, int handler_version)
 		goto out;
 
 	if (opc_get(rpc->cr_opc) == POOL_REINT) {
+		if (!ds_pool_reint_extend_allowed(svc)) {
+			rc = -DER_BUSY;
+			DL_ERROR(rc,
+				 DF_UUID "pool reintegration not allowed, "
+					 "wait rebuild done and try later.",
+				 DP_UUID(in->pti_op.pi_uuid));
+			goto out_svc;
+		}
+
 		if (svc->ps_pool->sp_reint_mode == DAOS_REINT_MODE_DATA_SYNC) {
 			rc = pool_discard(rpc->cr_ctx, svc, &list, true);
 		} else if (svc->ps_pool->sp_reint_mode == DAOS_REINT_MODE_INCREMENTAL) {


### PR DESCRIPTION
If not in delay_rebuild mode disallow reint/extend if with DOWN targets, user should try later after rebuild done.

Features: rebuild

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
