### PR TITLE
DAOS-18487 rebuild: don't change dom fseq for MAP_REVERT_REBUILD

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1877,7 +1877,7 @@ child_status_check(struct pool_domain *domain, uint32_t status)
 /* Domain status update state machine */
 static int
 update_dom_status(struct pool_domain *domain, uint32_t id, uint32_t status, uint32_t version,
-		  bool *updated)
+		  bool *updated, bool for_revert)
 {
 	int i;
 
@@ -1893,7 +1893,7 @@ update_dom_status(struct pool_domain *domain, uint32_t id, uint32_t status, uint
 		struct pool_domain *child = &domain->do_children[i];
 		int found;
 
-		found = update_dom_status(child, id, status, version, updated);
+		found = update_dom_status(child, id, status, version, updated, for_revert);
 		if (!found)
 			continue;
 
@@ -1947,14 +1947,14 @@ update_dom_status(struct pool_domain *domain, uint32_t id, uint32_t status, uint
 			/* Only change to DOWNOUT/DOWN if all of children are DOWNOUT/DOWN */
 			if (child_status_check(child, PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT) &&
 			    (child->do_comp.co_status != status)) {
-				D_DEBUG(DB_MD, "rank %u id %u status %u --> %u\n",
+				D_DEBUG(DB_MD, "rank %u id %u status %u --> %u, for_revert %d",
 					child->do_comp.co_rank, child->do_comp.co_id,
-					child->do_comp.co_status, status);
+					child->do_comp.co_status, status, for_revert);
 				if (child->do_comp.co_status == PO_COMP_ST_DOWN)
 					child->do_comp.co_flags = PO_COMPF_DOWN2OUT;
 
 				child->do_comp.co_status = status;
-				if (status == PO_COMP_ST_DOWN)
+				if (status == PO_COMP_ST_DOWN && !for_revert)
 					child->do_comp.co_fseq = version;
 				*updated = true;
 			}
@@ -1975,12 +1975,12 @@ update_dom_status(struct pool_domain *domain, uint32_t id, uint32_t status, uint
 
 int
 update_dom_status_by_tgt_id(struct pool_map *map, uint32_t tgt_id, uint32_t status,
-			    uint32_t version, bool *updated)
+			    uint32_t version, bool *updated, bool for_revert)
 {
 	int rc;
 
 	D_ASSERT(map->po_tree != NULL);
-	rc = update_dom_status(map->po_tree, tgt_id, status, version, updated);
+	rc = update_dom_status(map->po_tree, tgt_id, status, version, updated, for_revert);
 	if (rc < 0)
 		return rc;
 	return 0;

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -309,7 +309,7 @@ int pool_map_find_failed_tgts_by_rank(struct pool_map *map,
 				  unsigned int *tgt_cnt, d_rank_t rank);
 int
 update_dom_status_by_tgt_id(struct pool_map *map, uint32_t tgt_id, uint32_t status,
-			    uint32_t version, bool *updated);
+			    uint32_t version, bool *updated, bool for_revert);
 bool
 pool_map_node_status_match(struct pool_domain *dom, unsigned int status);
 

--- a/src/pool/srv_pool_map.c
+++ b/src/pool/srv_pool_map.c
@@ -1,7 +1,7 @@
 /**
  * (C) Copyright 2021-2024 Intel Corporation.
  * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  *
@@ -318,12 +318,12 @@ update_one_dom(struct pool_map *map, struct pool_domain *dom, struct pool_target
 		if (dom->do_comp.co_status == PO_COMP_ST_DOWNOUT ||
 		    dom->do_comp.co_status == PO_COMP_ST_DOWN)
 			update_dom_status_by_tgt_id(map, tgt->ta_comp.co_id, PO_COMP_ST_UP,
-						    *version, &updated);
+						    *version, &updated, false);
 		break;
 	case MAP_EXTEND:
 		if (dom->do_comp.co_status == PO_COMP_ST_NEW)
 			update_dom_status_by_tgt_id(map, tgt->ta_comp.co_id, PO_COMP_ST_UP,
-						    *version, &updated);
+						    *version, &updated, false);
 		break;
 	case MAP_EXCLUDE:
 		/* Only change the dom status if it is from SWIM eviction */
@@ -331,27 +331,29 @@ update_one_dom(struct pool_map *map, struct pool_domain *dom, struct pool_target
 		    !(dom->do_comp.co_status & (PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT)) &&
 		    pool_map_node_status_match(dom, PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT))
 			update_dom_status_by_tgt_id(map, tgt->ta_comp.co_id, PO_COMP_ST_DOWN,
-						    *version, &updated);
+						    *version, &updated, false);
 		break;
 	case MAP_FINISH_REBUILD:
 		if (dom->do_comp.co_status == PO_COMP_ST_UP)
 			update_dom_status_by_tgt_id(map, tgt->ta_comp.co_id, PO_COMP_ST_UPIN,
-						    *version, &updated);
+						    *version, &updated, false);
 		else if (dom->do_comp.co_status == PO_COMP_ST_DOWN && exclude_rank)
 			update_dom_status_by_tgt_id(map, tgt->ta_comp.co_id, PO_COMP_ST_DOWNOUT,
-						    *version, &updated);
+						    *version, &updated, false);
 		break;
 	case MAP_REVERT_REBUILD:
 		if (dom->do_comp.co_status == PO_COMP_ST_UP) {
 			if (dom->do_comp.co_fseq == 1)
 				update_dom_status_by_tgt_id(map, tgt->ta_comp.co_id, PO_COMP_ST_NEW,
-							    *version, &updated);
+							    *version, &updated, true);
 			else if (dom->do_comp.co_flags == PO_COMPF_DOWN2UP)
 				update_dom_status_by_tgt_id(map, tgt->ta_comp.co_id,
-							    PO_COMP_ST_DOWN, *version, &updated);
+							    PO_COMP_ST_DOWN, *version, &updated,
+							    true);
 			else
 				update_dom_status_by_tgt_id(map, tgt->ta_comp.co_id,
-							    PO_COMP_ST_DOWNOUT, *version, &updated);
+							    PO_COMP_ST_DOWNOUT, *version, &updated,
+							    true);
 		}
 		break;
 	default:

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -289,8 +289,8 @@ rebuild_leader_set_status(struct rebuild_global_pool_tracker *rgt,
 	}
 
 	if (status->dtx_resync_version != resync_ver)
-		D_INFO(DF_RB " rank %d, update dtx_resync_version from %d to %d", DP_RB_RGT(rgt),
-		       rank, status->dtx_resync_version, resync_ver);
+		D_DEBUG(DB_REBUILD, DF_RB " rank %d, update dtx_resync_version from %d to %d",
+			DP_RB_RGT(rgt), rank, status->dtx_resync_version, resync_ver);
 	status->dtx_resync_version = resync_ver;
 	if (flags & SCAN_DONE)
 		status->scan_done = 1;
@@ -2906,8 +2906,9 @@ rebuild_tgt_status_check_ult(void *arg)
 				rpt->rt_reported_rec_cnt = status.rec_count;
 				rpt->rt_reported_size = status.size;
 				if (iv.riv_dtx_resyc_version > reported_dtx_resyc_ver) {
-					D_INFO(DF_RB "reported riv_dtx_resyc_version %d",
-					       DP_RB_RPT(rpt), iv.riv_dtx_resyc_version);
+					D_DEBUG(DB_REBUILD,
+						DF_RB "reported riv_dtx_resyc_version %d",
+						DP_RB_RPT(rpt), iv.riv_dtx_resyc_version);
 					reported_dtx_resyc_ver = iv.riv_dtx_resyc_version;
 				}
 			} else {


### PR DESCRIPTION
Should not change domain's do_comp.co_fseq when revert pool map for rebuild err handling, that may cause do_comp.co_fseq be higher than retried rebuild version and always abort+retry.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
