### PR TITLE
DAOS-18487 rebuild: refine rebuild completion detecting

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -746,8 +746,7 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 	int			rc = 0;
 
 	if (tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(mrone->mo_pool_uuid));
+		D_WARN(DF_RB " someone aborted the rebuild", DP_RB_MRO(mrone));
 		D_GOTO(out, rc = migrate_pool_tls_get_status(tls));
 	}
 
@@ -2004,7 +2003,7 @@ migrate_one_ult(void *arg)
 
 	tls = mrone->mo_tls;
 	if (tls->mpt_fini) {
-		D_WARN("some one abort the rebuild " DF_UUID "\n", DP_UUID(mrone->mo_pool_uuid));
+		D_WARN(DF_RB " someone aborted the rebuild", DP_RB_MRO(mrone));
 		goto out;
 	}
 
@@ -2457,8 +2456,7 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dc_obj_enum_unpack_io *io
 		iod_eph_total);
 
 	if (tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(iter_arg->pool_uuid));
+		D_WARN(DF_RB " someone aborted the rebuild", DP_RB_MPT(tls));
 		D_GOTO(out, rc = 0);
 	}
 	if (iod_eph_total == 0 || tls->mpt_fini) {
@@ -2616,8 +2614,7 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 		return rc;
 
 	if (tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(arg->arg->pool_uuid));
+		D_WARN(DF_RB " someone aborted the rebuild", DP_RB_MPT(tls));
 		D_GOTO(put, rc = 0);
 	}
 
@@ -2742,8 +2739,7 @@ migrate_obj_punch_one(void *data)
 
 	tls = arg->pool_tls;
 	if (tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(arg->pool_uuid));
+		D_WARN(DF_RB " someone aborted the rebuild", DP_RB_MPT(tls));
 		D_GOTO(out, rc = 0);
 	}
 
@@ -2781,8 +2777,7 @@ migrate_start_ult(struct enum_unpack_arg *unpack_arg)
 	int			rc = 0;
 
 	if (tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(arg->pool_uuid));
+		D_WARN(DF_RB " someone aborted the rebuild", DP_RB_MPT(tls));
 		D_GOTO(out, rc = 0);
 	}
 	d_list_for_each_entry_safe(mrone, tmp, &unpack_arg->merge_list,
@@ -3182,8 +3177,7 @@ migrate_obj_ult(void *data)
 	migrate_obj_get(arg);
 	tls = arg->pool_tls;
 	if (tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(arg->pool_uuid));
+		D_WARN(DF_RB " someone aborted the rebuild", DP_RB_MPT(tls));
 		D_GOTO(free_notls, rc);
 	}
 
@@ -3941,7 +3935,7 @@ migrate_check_one(void *data)
 	arg->dms.dm_total_size += tls->mpt_size;
 	if (arg->dms.dm_status == 0)
 		arg->dms.dm_status = tls->mpt_status;
-	arg->total_ult_cnt = tls->mpt_tgt_obj_ult_cnt + tls->mpt_tgt_dkey_ult_cnt;
+	arg->total_ult_cnt += (tls->mpt_tgt_obj_ult_cnt + tls->mpt_tgt_dkey_ult_cnt);
 	arg->ult_running += tls->mpt_ult_running;
 	ABT_mutex_unlock(arg->status_lock);
 	D_DEBUG(DB_REBUILD,

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -225,10 +225,14 @@ rebuild_leader_set_status(struct rebuild_global_pool_tracker *rgt,
 		D_DEBUG(DB_REBUILD, DF_RB " rank %d, update dtx_resync_version from %d to %d",
 			DP_RB_RGT(rgt), rank, status->dtx_resync_version, resync_ver);
 	status->dtx_resync_version = resync_ver;
-	if (flags & SCAN_DONE)
+	if ((flags & SCAN_DONE) && !status->scan_done) {
+		D_DEBUG(DB_REBUILD, DF_RB " rank %d is scan_done", DP_RB_RGT(rgt), rank);
 		status->scan_done = 1;
-	if (flags & PULL_DONE)
+	}
+	if ((flags & PULL_DONE) && !status->pull_done) {
+		D_DEBUG(DB_REBUILD, DF_RB " rank %d is pull_done", DP_RB_RGT(rgt), rank);
 		status->pull_done = 1;
+	}
 }
 
 #define RB_DTX_RESYNC_VER_SKIP ((uint32_t)-1)
@@ -456,10 +460,14 @@ rebuild_tgt_query(struct rebuild_tgt_pool_tracker *rpt,
 	struct ds_migrate_status	dms = { 0 };
 	struct rebuild_pool_tls		*tls;
 	struct rebuild_tgt_query_arg	arg;
+	bool                             global_scan_done;
 	int				rc;
 
 	arg.rpt = rpt;
 	arg.status = status;
+
+	/* Get rt_global_scan_done before querying dms.dm_migrating status */
+	global_scan_done = rpt->rt_global_scan_done;
 
 	if (rpt->rt_rebuild_op != RB_OP_RECLAIM && rpt->rt_rebuild_op != RB_OP_FAIL_RECLAIM) {
 		rc = ds_migrate_query_status(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
@@ -485,7 +493,7 @@ rebuild_tgt_query(struct rebuild_tgt_pool_tracker *rpt,
 	status->obj_count += dms.dm_obj_count;
 	status->rec_count = dms.dm_rec_count;
 	status->size = dms.dm_total_size;
-	if (status->scanning || dms.dm_migrating)
+	if (!global_scan_done || status->scanning || dms.dm_migrating)
 		status->rebuilding = true;
 	else
 		status->rebuilding = false;


### PR DESCRIPTION
dms.dm_migrating status only can be trust when scan global done, so get rt_global_scan_done firstly before checking dms.dm_migrating.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
