### PR TITLE
DAOS-18487 rebuild: refine rebuild completion detecting

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1914,7 +1914,7 @@ ds_cont_tgt_refresh_track_eph(uuid_t pool_uuid, uuid_t cont_uuid,
 	rc = ds_pool_thread_collective(
 	    pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
 	    cont_refresh_track_eph_one, &arg, DSS_ULT_DEEP_STACK | DSS_ULT_FL_PERIODIC);
-	DL_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO, rc,
+	DL_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG, rc,
 		  DF_CONT ": refresh ec_agg_eph " DF_X64 ", "
 			  "stable_eph " DF_X64,
 		  DP_CONT(pool_uuid, cont_uuid), ec_agg_eph, stable_eph);

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -751,7 +751,7 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 	int			rc = 0;
 
 	if (tls->mpt_fini) {
-		D_WARN("someone aborted the rebuild " DF_UUID "\n", DP_UUID(mrone->mo_pool_uuid));
+		D_WARN(DF_RB " someone aborted the rebuild", DP_RB_MRO(mrone));
 		D_GOTO(out, rc = migrate_pool_tls_get_status(tls));
 	}
 
@@ -2017,7 +2017,7 @@ migrate_one_ult(void *arg)
 
 	tls = mrone->mo_tls;
 	if (tls->mpt_fini) {
-		D_WARN("someone aborted the rebuild " DF_UUID "\n", DP_UUID(mrone->mo_pool_uuid));
+		D_WARN(DF_RB " someone aborted the rebuild", DP_RB_MRO(mrone));
 		goto out;
 	}
 
@@ -2473,8 +2473,8 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dc_obj_enum_unpack_io *io
 	int			rc = 0;
 
 	if (tls->mpt_fini) {
-		D_WARN("someone aborted the rebuild " DF_UUID "dkey " DF_KEY "iod_nr %d\n",
-		       DP_UUID(iter_arg->pool_uuid), DP_KEY(dkey), iod_eph_total);
+		D_WARN("someone aborted the rebuild " DF_UUID " ver %d, dkey " DF_KEY "iod_nr %d\n",
+		       DP_UUID(iter_arg->pool_uuid), version, DP_KEY(dkey), iod_eph_total);
 		D_GOTO(out, rc = 0);
 	}
 	D_DEBUG(DB_REBUILD, DF_RB ": migrate dkey " DF_KEY " iod nr %d\n", DP_RB_MPT(tls),
@@ -2634,7 +2634,7 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 		return rc;
 
 	if (tls->mpt_fini) {
-		D_WARN("someone aborted the rebuild " DF_UUID "\n", DP_UUID(arg->arg->pool_uuid));
+		D_WARN(DF_RB " someone aborted the rebuild", DP_RB_MPT(tls));
 		D_GOTO(put, rc = 0);
 	}
 
@@ -2786,7 +2786,7 @@ migrate_obj_punch_one(void *data)
 
 	tls = arg->pool_tls;
 	if (tls->mpt_fini) {
-		D_WARN("someone aborted the rebuild " DF_UUID "\n", DP_UUID(arg->pool_uuid));
+		D_WARN(DF_RB " someone aborted the rebuild", DP_RB_MPT(tls));
 		D_GOTO(out, rc = 0);
 	}
 
@@ -2823,7 +2823,7 @@ migrate_start_ult(struct enum_unpack_arg *unpack_arg)
 	int			rc = 0;
 
 	if (tls->mpt_fini) {
-		D_WARN("someone aborted the rebuild " DF_UUID "\n", DP_UUID(arg->pool_uuid));
+		D_WARN(DF_RB " someone aborted the rebuild", DP_RB_MPT(tls));
 		D_GOTO(out, rc = 0);
 	}
 	d_list_for_each_entry_safe(mrone, tmp, &unpack_arg->merge_list,
@@ -3228,7 +3228,7 @@ migrate_obj_ult(void *data)
 	migrate_obj_get(arg);
 	tls = arg->pool_tls;
 	if (tls->mpt_fini) {
-		D_WARN("someone aborted the rebuild " DF_UUID "\n", DP_UUID(arg->pool_uuid));
+		D_WARN(DF_RB " someone aborted the rebuild", DP_RB_MPT(tls));
 		D_GOTO(free_notls, rc);
 	}
 


### PR DESCRIPTION
dms.dm_migrating status only can be trust when scan global done, so get rt_global_scan_done firstly before checking dms.dm_migrating. and some log refining.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
