### PR TITLE
DAOS-18487 rebuild: synchronously wait for completion of interrupted …

### DIFF
--- a/src/include/daos_srv/object.h
+++ b/src/include/daos_srv/object.h
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2022 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -93,5 +93,7 @@ ds_migrate_object(uuid_t pool_uuid, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_uuid
 		  uint32_t count, unsigned int tgt_idx, uint32_t new_gl_ver);
 void
 ds_migrate_stop(struct ds_pool *pool, uint32_t ver, unsigned int generation);
+void
+ds_migrate_abort(struct ds_pool *pool, uint32_t ver, unsigned int generation);
 
 #endif /* __DAOS_SRV_OBJ_H__ */

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -3131,6 +3131,7 @@ struct migrate_stop_arg {
 	unsigned int version;
 	unsigned int generation;
 	unsigned int stop_count;
+	bool         stop_sync;
 	ABT_mutex    stop_lock;
 };
 
@@ -3139,14 +3140,19 @@ migrate_fini_one_ult(void *data)
 {
 	struct migrate_stop_arg *arg = data;
 	struct migrate_pool_tls *tls;
-	int			 rc;
+	int                      xid;
+	int                      rc = 0;
 
 	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
 	if (tls == NULL)
 		return 0;
 
-	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
+	xid = dss_get_module_info()->dmi_xs_id;
+	D_ASSERT(xid != 0);
+
 	tls->mpt_fini = 1;
+	if (!arg->stop_sync)
+		goto out;
 
 	ABT_mutex_lock(arg->stop_lock);
 	arg->stop_count++;
@@ -3173,15 +3179,16 @@ migrate_fini_one_ult(void *data)
 		rc = 0;
 	}
 
+out:
 	migrate_pool_tls_put(tls); /* destroy */
-
-	D_INFO("migrate fini one ult "DF_UUID"\n", DP_UUID(arg->pool_uuid));
+	D_INFO(DF_UUID "migration is %s ult(xs=%d) \n", DP_UUID(arg->pool_uuid),
+	       arg->stop_sync ? "aborting" : "stopped", xid);
 	return rc;
 }
 
 /* stop the migration */
-void
-ds_migrate_stop(struct ds_pool *pool, unsigned int version, unsigned int generation)
+static void
+migrate_stop(struct ds_pool *pool, unsigned int version, unsigned int generation, bool sync)
 {
 	struct migrate_stop_arg arg;
 	int			 rc;
@@ -3189,6 +3196,7 @@ ds_migrate_stop(struct ds_pool *pool, unsigned int version, unsigned int generat
 	uuid_copy(arg.pool_uuid, pool->sp_uuid);
 	arg.version = version;
 	arg.generation = generation;
+	arg.stop_sync  = sync;
 	arg.stop_count = 0;
 	rc             = ABT_mutex_create(&arg.stop_lock);
 	if (rc != ABT_SUCCESS) {
@@ -3200,11 +3208,26 @@ ds_migrate_stop(struct ds_pool *pool, unsigned int version, unsigned int generat
 	if (rc)
 		D_ERROR(DF_UUID" migrate stop: %d\n", DP_UUID(pool->sp_uuid), rc);
 
-	D_ASSERT(atomic_load(&pool->sp_rebuilding) >= arg.stop_count);
-	atomic_fetch_sub(&pool->sp_rebuilding, arg.stop_count);
+	if (sync) {
+		D_ASSERT(atomic_load(&pool->sp_rebuilding) >= arg.stop_count);
+		atomic_fetch_sub(&pool->sp_rebuilding, arg.stop_count);
+	}
 	ABT_mutex_free(&arg.stop_lock);
 
 	D_INFO(DF_UUID" migrate stopped\n", DP_UUID(pool->sp_uuid));
+}
+
+void
+ds_migrate_stop(struct ds_pool *pool, unsigned int version, unsigned int generation)
+{
+	migrate_stop(pool, version, generation, true);
+}
+
+/* abort the migration */
+void
+ds_migrate_abort(struct ds_pool *pool, unsigned int version, unsigned int generation)
+{
+	migrate_stop(pool, version, generation, false);
 }
 
 static int

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -92,14 +92,10 @@ struct rebuild_tgt_pool_tracker {
 	/* new layout version for upgrade rebuild */
 	uint32_t		rt_new_layout_ver;
 
-	unsigned int		rt_lead_puller_running:1,
-				rt_abort:1,
-				/* re-report #rebuilt cnt per master change */
-				rt_re_report:1,
-				rt_finishing:1,
-				rt_scan_done:1,
-				rt_global_scan_done:1,
-				rt_global_done:1;
+	unsigned int             rt_lead_puller_running : 1, rt_abort : 1, rt_abort_notified : 1,
+	    /* re-report #rebuilt cnt per master change */
+	    rt_re_report : 1, rt_finishing : 1, rt_scan_done : 1, rt_global_abort : 1,
+	    rt_global_scan_done : 1, rt_global_done : 1;
 };
 
 struct rebuild_server_status {
@@ -325,11 +321,8 @@ struct rebuild_iv {
 	unsigned int	riv_master_rank;
 	unsigned int	riv_ver;
 	unsigned int	riv_rebuild_gen;
-	uint32_t	riv_global_done:1,
-			riv_global_scan_done:1,
-			riv_scan_done:1,
-			riv_pull_done:1,
-			riv_sync:1;
+	uint32_t        riv_global_done : 1, riv_global_abort : 1, riv_global_scan_done : 1,
+	    riv_scan_done : 1, riv_pull_done : 1, riv_sync : 1;
 	int		riv_status;
 
 };

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -196,11 +196,12 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	uuid_copy(dst_iv->riv_pool_uuid, src_iv->riv_pool_uuid);
 	dst_iv->riv_master_rank = src_iv->riv_master_rank;
 	dst_iv->riv_global_done = src_iv->riv_global_done;
+	dst_iv->riv_global_abort             = src_iv->riv_global_abort;
 	dst_iv->riv_global_scan_done = src_iv->riv_global_scan_done;
 	dst_iv->riv_stable_epoch = src_iv->riv_stable_epoch;
 	dst_iv->riv_global_dtx_resyc_version = src_iv->riv_global_dtx_resyc_version;
 
-	if (dst_iv->riv_global_done || dst_iv->riv_global_scan_done ||
+	if (dst_iv->riv_global_done || dst_iv->riv_global_abort || dst_iv->riv_global_scan_done ||
 	    dst_iv->riv_stable_epoch || dst_iv->riv_dtx_resyc_version) {
 		D_DEBUG(DB_REBUILD, DF_UUID"/%u/%u/"DF_U64" gsd/gd/stable/ver %d/%d/"DF_X64"/%u\n",
 			DP_UUID(src_iv->riv_pool_uuid), src_iv->riv_ver,
@@ -215,6 +216,7 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			       DF_U64 "\n", rpt->rt_stable_epoch,
 			       dst_iv->riv_stable_epoch);
 		rpt->rt_global_done = dst_iv->riv_global_done;
+		rpt->rt_global_abort     = dst_iv->riv_global_abort;
 		rpt->rt_global_scan_done = dst_iv->riv_global_scan_done;
 		old_ver = rpt->rt_global_dtx_resync_version;
 		if (rpt->rt_global_dtx_resync_version < dst_iv->riv_global_dtx_resyc_version)


### PR DESCRIPTION
…rebuild

In the current implementation, rebuild leader doesn't wait for completion of interrupted rebuild, this patch changes the behavior and rebuild leader always wait for completions of all engines.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
