### PR TITLE
DAOS-18487 placement: fix a bug in shard remapping chain

### DIFF
--- a/src/object/obj_layout.c
+++ b/src/object/obj_layout.c
@@ -115,8 +115,8 @@ obj_dump_grp_layout(daos_handle_t oh, uint32_t shard)
 	}
 
 	grp_idx = shard / obj->cob_grp_size;
-	D_INFO(DF_OID " shard %d, grp_idx %d, grp_size %d", DP_OID(obj->cob_md.omd_id), shard,
-	       grp_idx, obj->cob_grp_size);
+	D_INFO(DF_OID " shard %d, grp_idx %d, grp_size %d, map_ver %d", DP_OID(obj->cob_md.omd_id),
+	       shard, grp_idx, obj->cob_grp_size, obj->cob_version);
 	for (i = grp_idx * obj->cob_grp_size, nr = 0; nr < obj->cob_grp_size; i++, nr++) {
 		obj_shard = &obj->cob_shards->do_shards[i];
 		D_INFO("shard %d/%d/%d, tgt_id %d, rank %d, tgt_idx %d, "


### PR DESCRIPTION
For the case of 2nd remap, if the spare target is DOWN2UP need to set fs_down2up flag, to make it be able to set shard's po_rebuilding flag at the end.
One example case -
Target A is DOWN, rebuild completed and status changed to DOWNOUT
Target B is DOWN, rebuild started but not completed but admin do the reint,
its status change to UP and with DOWN2UP flag.

In object layout calculation, one shard firstly located in Target A, but 1st remap to Target B, but still need to do 2nd remap. In this case should set fs_down2up flag which is not set in the 1st remap, to avoid not be able to set shard's po_rebuilding flag so will cause read from it (invalid place).

This bug could cause data corruption (mostly like with cause shard losing).

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
