### PR TITLE
DAOS-18585 test: Adding more workloads for soak harasser

### DIFF
--- a/src/tests/ftest/soak/harassers.yaml
+++ b/src/tests/ftest/soak/harassers.yaml
@@ -7,8 +7,8 @@ hosts:
   # client_reservation: daos-test
 orterun:
   allow_run_as_root: true
-# This timeout must be longer than the test_timeout param (+15minutes)
-timeout: 24H30M
+# This timeout must be longer than the test_timeout param (+30minutes)
+timeout: 48H30M
 setup:
   start_servers: true
   start_agents: true
@@ -75,13 +75,17 @@ soak_harassers:
   # harasser test timeout in hours
   single_test_pool: false
   test_timeout:
-    test_soak_online_harassers: 24
-    test_soak_offline_harassers: 24
+    test_soak_online_harassers: 48
+    test_soak_offline_harassers: 48
   # maximum timeout for a single job in test in minutes
   joblist:
     - ior_harasser
     - fio_harasser
     - mdtest_harasser
+    - vpic_harasser
+    - lammps_harasser
+    - macsio_harasser
+    - datamover_harasser
   # one harrasser is run during each pass of soak jobs
   harasserlist:
     test_soak_offline_harassers:
@@ -175,6 +179,43 @@ fio_harasser:
   dfuse:
     mount_dir: "/tmp/soak_dfuse_fio/"
     disable_caching: true
+vpic_harasser:
+  # Requires opeapi
+  job_timeout: 20
+  nodesperjob:
+    - 1
+  taskspernode:
+    - 32
+  cmdline: "${DAOS_TEST_APP_DIR}/vpic-install/bin/harris.Linux"
+  api:
+    - POSIX
+    - POSIX-LIBIOIL
+    - POSIX-LIBPIL4DFS
+  workdir: "/tmp/soak_dfuse_vpic/"
+  dfuse:
+    mount_dir: "/tmp/soak_dfuse_vpic/"
+    disable_caching: true
+  oclass:
+    - ["EC_2P1GX", "RP_2GX"]
+lammps_harasser:
+  job_timeout: 55
+  nodesperjob:
+    - 8
+  taskspernode:
+    - 32
+  cmdline: "${DAOS_TEST_APP_DIR}/lammps/src/lmp_mpi -i ${DAOS_TEST_APP_DIR}/lammps/bench/in.lj"
+  api:
+    - POSIX
+    - POSIX-LIBIOIL
+    - POSIX-LIBPIL4DFS
+  workdir: "/tmp/soak_dfuse_lammps/"
+  dfuse:
+    mount_dir: "/tmp/soak_dfuse_lammps/"
+    disable_caching: true
+    thread_count: 8
+    cores: '0-7'
+  oclass:
+    - ["EC_2P1GX", "RP_2GX"]
 mdtest_harasser:
   # maximum timeout for a single job in test in minutes
   job_timeout: 30
@@ -207,6 +248,75 @@ mdtest_harasser:
   dfuse:
     mount_dir: "/tmp/soak_dfuse_mdtest/"
     disable_caching: true
+macsio_harasser:
+  job_timeout: 30
+  nodesperjob:
+    - 1
+    - 4
+    - 8
+  taskspernode:
+    - 16
+  api:
+    - HDF5
+    - HDF5-VOL
+  interface: hdf5
+  parallel_file_mode: SIF 1
+  filebase: daos
+  units_prefix_system: decimal
+  part_size: 10M
+  avg_num_parts: 2.5
+  num_dumps: 2
+  debug_level: 1
+  oclass:
+    - ["SX","SX"]
+    - ["EC_2P1GX", "RP_2GX"]
+    #  - ["EC_4P1G1", "RP_2GX"]
+    - ["EC_4P2GX", "RP_3GX"]
+    #  - ["EC_8P2G1", "RP_3GX"]
+    #  - ["EC_16P2GX", "RP_3GX"]
+  dfuse:
+    mount_dir: "/tmp/soak_dfuse_macsio/"
+    disable_caching: true
+    thread_count: 8
+    cores: '0-7'
+datamover_harasser:
+  job_timeout: 10
+  nodesperjob:
+    - 8
+  taskspernode:
+    - 32
+  oclass:
+    - ["SX","SX"]
+    - ["EC_2P1GX", "RP_2GX"]
+    #  - ["EC_4P1G1", "RP_2GX"]
+    - ["EC_4P2GX", "RP_3GX"]
+    #  - ["EC_8P2G1", "RP_3GX"]
+    #  - ["EC_16P2GX", "RP_3GX"]
+  dcp:
+    bufsize: 1M
+    chunksize: 1M
+  ior_write:
+    api:
+      - DFS
+    flags: "-w -F -k"
+    signature: "5"
+    transfer_size:
+      - 1M
+    block_size:
+      - 4G
+    test_file: "daos:/testFile"
+    dfs_destroy: false
+  ior_read:
+    api:
+      - DFS
+    flags: "-r -R -F -k"
+    signature: "5"
+    transfer_size:
+      - 1M
+    block_size:
+      - 4G
+    test_file: "daos:/testFile"
+    dfs_destroy: false
 hdf5_vol:
   plugin_path: "/usr/lib64/mpich/lib"
 events:


### PR DESCRIPTION
Increased timeout from 24hrs to 48hrs
Added vpic, lammps, macsio and datamover workloads to soak harasser

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
