### PR TITLE
DAOS-18487 rebuild: add VOS_OF_REBUILD for rec punch vos_obj_update

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1691,11 +1691,9 @@ migrate_punch(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 						      mrone->mo_oid.id_shard))
 			mrone_recx_daos2_vos(mrone, mrone->mo_punch_iods, mrone->mo_punch_iod_num);
 
-		rc = vos_obj_update(cont->sc_hdl, mrone->mo_oid,
-				    mrone->mo_rec_punch_eph,
-				    mrone->mo_version, 0, &mrone->mo_dkey,
-				    mrone->mo_punch_iod_num,
-				    mrone->mo_punch_iods, NULL, NULL);
+		rc = vos_obj_update(cont->sc_hdl, mrone->mo_oid, mrone->mo_rec_punch_eph,
+				    mrone->mo_version, VOS_OF_REBUILD, &mrone->mo_dkey,
+				    mrone->mo_punch_iod_num, mrone->mo_punch_iods, NULL, NULL);
 		D_DEBUG(DB_REBUILD,
 			DF_RB ": " DF_UOID " mrone %p punch %d eph " DF_U64 "records: " DF_RC "\n",
 			DP_RB_MPT(tls), DP_UOID(mrone->mo_oid), mrone, mrone->mo_punch_iod_num,


### PR DESCRIPTION
To avoid DER_VOS_PARTIAL_UPDATE() failure.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
