### PR TITLE
Janekmi/daos 18597 set spdk rpc startup manually makito

### DIFF
--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -382,6 +382,7 @@ def define_components(reqs):
                            '--with-shared',
                            '--without-nvme-cuse',
                            '--without-crypto',
+                           '--enable-debug',
                            f'--target-arch={spdk_arch}'] + spdk_conf,
                           ['make', f'CONFIG_ARCH={spdk_arch}'],
                           ['make', 'libdir=$SPDK_PREFIX/lib64/daos_srv',

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -176,6 +176,7 @@ bio_spdk_env_init(void)
 
 	/* Set SPDK log print level to configured value */
 	spdk_log_set_print_level(spdk_level);
+	spdk_log_set_flag("all");
 
 	/* Build DPDK options with specified log level for all DPDK log facilities */
 	dpdk_opts = dpdk_cli_build_opts(dpdk_level, dpdk_level);

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -1714,7 +1714,7 @@ bio_xsctxt_init_by_config(struct common_cp_arg *cp_arg)
 	 * Initially, this was called internally spdk_subsystem_load_config() -> ... ->
 	 * spdk_rpc_initialize(). However, since commit
 	 * https://github.com/spdk/spdk/commit/fba209c7324a11b9230533144c02e7a66bc738ea (>=v24.01)
-	 * SPDK_RPC_STARTUP has become the initial value of the underlaying global variable and it
+	 * SPDK_RPC_STARTUP has become the initial value of the underlying global variable and it
 	 * is no longer reset automatically. This makes no difference for applications that
 	 * initialize SPDK only once during the lifetime of the process. But some BIO module
 	 * consumers—such as DDB—expect to be able to initialize, finalize, and then reinitialize

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -1710,6 +1710,19 @@ bio_xsctxt_init_by_config(struct common_cp_arg *cp_arg)
 		return -DER_NOMEM;
 	}
 
+	/**
+	 * Initially, this was called internally spdk_subsystem_load_config() -> ... ->
+	 * spdk_rpc_initialize(). However, since commit
+	 * https://github.com/spdk/spdk/commit/fba209c7324a11b9230533144c02e7a66bc738ea (>=v24.01)
+	 * SPDK_RPC_STARTUP has become the initial value of the underlaying global variable and it
+	 * is no longer reset automatically. This makes no difference for applications that
+	 * initialize SPDK only once during the lifetime of the process. But some BIO module
+	 * consumers—such as DDB—expect to be able to initialize, finalize, and then reinitialize
+	 * SPDK multiple times within the same process, for example when inspecting multiple pools
+	 * sequentially. For those use cases, the RPC state must now be reset explicitly.
+	 */
+	spdk_rpc_set_state(SPDK_RPC_STARTUP);
+
 	D_ALLOC_PTR(init_arg);
 	if (init_arg == NULL) {
 		free(json_data);


### PR DESCRIPTION
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
