### PR TITLE
DAOS-17946 doc: update space_rb default in comment

### DIFF
--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2015-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -38,7 +38,7 @@ enum daos_pool_props {
 	DAOS_PROP_PO_ACL,
 	/**
 	 * Reserve space ratio: amount of space to be reserved on each target
-	 * for rebuild purpose. default = 0%.
+	 * for rebuild purpose. default = 5%.
 	 */
 	DAOS_PROP_PO_SPACE_RB,
 	/**


### PR DESCRIPTION
Per #17032, default space_rb is now 5%.

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
