### PR TITLE
DAOS-18633 rebuild: fix hang when leader switch and gen change happen…

### DIFF
--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -129,8 +129,12 @@ rebuild_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	/* Gathering the rebuild status here */
 	rgt = rebuild_global_pool_tracker_lookup(src_iv->riv_pool_uuid,
 						 src_iv->riv_ver, src_iv->riv_rebuild_gen);
-	if (rgt == NULL)
+	if (rgt == NULL) {
+		D_WARN(DF_UUID " ver %u gen %u: rgt not found, IV update from rank %d dropped\n",
+		       DP_UUID(src_iv->riv_pool_uuid), src_iv->riv_ver,
+		       src_iv->riv_rebuild_gen, src_iv->riv_rank);
 		D_GOTO(out, rc);
+	}
 
 	if (rgt->rgt_leader_term == src_iv->riv_leader_term) {
 		/* update the rebuild global status */

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -1198,19 +1198,34 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 			  "rsi_rebuild_ver %d != rt_rebuild_ver %d\n",
 			  rsi->rsi_rebuild_ver, rpt->rt_rebuild_ver);
 
-		/* The same PS leader request rebuild with higher rsi_rebuild_gen.
-		 * Is the case of massive failure case, see pool_restart_rebuild_if_rank_wip().
+		/* New leader or same leader requests rebuild with higher rsi_rebuild_gen.
+		 * This can happen in two cases:
+		 * 1. Same leader: massive failure case, see pool_restart_rebuild_if_rank_wip().
+		 * 2. Leader switch + gen change: PS leader changed and the new leader
+		 *    starts rebuild with a higher gen. Must abort old rpt and start new
+		 *    one, otherwise the old status_check_ult keeps reporting with stale
+		 *    gen which gets silently dropped by the new leader's IV handler.
 		 */
-		if (rpt->rt_leader_rank == rsi->rsi_master_rank &&
-		    rpt->rt_leader_term == rsi->rsi_leader_term &&
-		    rpt->rt_rebuild_gen < rsi->rsi_rebuild_gen) {
+		if (rpt->rt_rebuild_gen < rsi->rsi_rebuild_gen &&
+		    rpt->rt_leader_term <= rsi->rsi_leader_term) {
 			/* rebuild_leader_status_notify(LAZY rebuild_iv_update),
 			 * it will set rpt->rt_global_done to abort rpt.
 			 * set rt_abort here just for safe.
 			 */
 			rpt->rt_abort = 1;
-			D_INFO(DF_RBF ", start new rebuild, gen %d -> %d.\n",
-			       DP_RBF_RPT(rpt), rpt->rt_rebuild_gen, rsi->rsi_rebuild_gen);
+			if (rpt->rt_leader_rank != rsi->rsi_master_rank) {
+				D_INFO(DF_RBF ", leader switch + gen change, gen %d -> %d,"
+				       " new leader " DF_RBF "\n",
+				       DP_RBF_RPT(rpt), rpt->rt_rebuild_gen,
+				       rsi->rsi_rebuild_gen, DP_RBF_RSI(rsi));
+				rebuild_leader_abort(rsi->rsi_pool_uuid,
+						     rsi->rsi_rebuild_ver, -1,
+						     rpt->rt_leader_term);
+			} else {
+				D_INFO(DF_RBF ", start new rebuild, gen %d -> %d.\n",
+				       DP_RBF_RPT(rpt), rpt->rt_rebuild_gen,
+				       rsi->rsi_rebuild_gen);
+			}
 			rpt_put(rpt);
 			rpt = NULL;
 			goto tls_lookup;


### PR DESCRIPTION
… together

The gen upgrade path in rebuild_tgt_scan_handler required an exact match on both leader rank and term, which fails when either the leader changes or the same leader gets re-elected with a higher Raft term. This causes rt_rebuild_gen to remain stale, so IV updates from targets are silently dropped by the new leader, resulting in an infinite hang.

Fix: relax the condition to rt_rebuild_gen < rsi_rebuild_gen && rt_leader_term <= rsi_leader_term.
Also add D_WARN when the IV handler drops an update due to rgt lookup miss.

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
