### PR TITLE
SRE-3654 ci: move out FI tests from docker to HW

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -996,14 +996,7 @@ pipeline {
                         expression { !skipStage() }
                     }
                     agent {
-                        dockerfile {
-                            filename 'utils/docker/Dockerfile.el.8'
-                            label 'docker_runner'
-                            additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
-                                                                parallel_build: true,
-                                                                deps_build: true)
-                            args '--tmpfs /mnt/daos_0'
-                        }
+                        label params.CI_NLT_1_LABEL
                     }
                     steps {
                         job_step_update(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1000,6 +1000,10 @@ pipeline {
                     }
                     steps {
                         job_step_update(
+                            sh(label: 'Install scons',
+                               script: 'sudo dnf -y install scons',
+                               returnStdout: true).trim())
+                        job_step_update(
                             sconsBuild(parallel_build: true,
                                        scons_args: 'PREFIX=/opt/daos TARGET_TYPE=release BUILD_TYPE=debug',
                                        build_deps: 'no'))


### PR DESCRIPTION
FI tests put a lot of strain on the nodes with `docker_runner` label. `docker_runner` nodes (primary fox-108) are design for light/short work items like software builds.
FI tests may consume up to 6 cores for more than 2 hours in one execution.

Signed-off-by: Tomasz Gromadzki <tomasz.gromadzki@hpe.com>

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
