### PR TITLE
DAOS-18676 test: rebuild/continues_after_stop.yaml - Increase timeout…

### DIFF
--- a/src/tests/ftest/rebuild/continues_after_stop.yaml
+++ b/src/tests/ftest/rebuild/continues_after_stop.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 2
   test_clients: 1
 
-timeout: 300
+timeout: 390
 
 server_config:
   name: daos_server


### PR DESCRIPTION
… by 90 sec

The test (test_continuous_after_stop) timed out during tearDown because the disconnect-pool operation from pydaos/raw to daos_pool_disconnect() in libdaos timed out and have been retried. The retry interval is 1 min, so increase the test timeout by 90 sec.

This is a minor intermittent issue and not related to this particular test, so increase the timeout.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-medium: false
Test-tag: test_continuous_after_stop
Test-repeat: 5

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
