### PR TITLE
DAOS-18685 object: fix a bug of tag set when retry in agg_peer_update…

### DIFF
--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1428,10 +1428,10 @@ agg_peer_update_ult(void *arg)
 
 		if (peer == pidx)
 			continue;
+retry:
 		D_ASSERT(entry->ae_peer_pshards[peer].sd_rank != DAOS_TGT_IGNORE);
 		tgt_ep.ep_rank = entry->ae_peer_pshards[peer].sd_rank;
 		tgt_ep.ep_tag  = entry->ae_peer_pshards[peer].sd_tgt_idx;
-retry:
 		peer_retry = false;
 		rc = ds_obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
 				       DAOS_OBJ_RPC_EC_AGGREGATE, &rpc);


### PR DESCRIPTION
…_ult

Should get ep_tag from layout rather than directly reuse previous RPC's value because ds_obj_req_create() will calculate/change it every time.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
