### PR TITLE
DAOS-18425 rebuild: coalesce tasks for multi-rank operations (#17382)

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7426,6 +7426,14 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 		delay = -1;
 	else if (daos_fail_check(DAOS_REBUILD_DELAY))
 		delay = 5;
+	else if ((opc == MAP_EXCLUDE) || (opc == MAP_REINT) || (opc == MAP_DRAIN)) {
+		/* Delay during queuing rebuild(s) if we may have multiple-rank event or command
+		 * (processed as a sequence of ranks). See ds_rebuild_schedule(), rebuild_ults().
+		 */
+		D_INFO(DF_UUID ": scheduling rebuild for map opc %d with 5 second delay\n",
+		       DP_UUID(svc->ps_pool->sp_uuid), opc);
+		delay = 5;
+	}
 
 	D_DEBUG(DB_MD, "map ver %u/%u\n", map_version ? *map_version : -1,
 		tgt_map_ver);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1635,11 +1635,9 @@ rebuild_task_ult(void *arg)
 	int					rc;
 
 	cur_ts = daos_gettime_coarse();
+	/* rebuild_ults() prevents dequeuing the task until schedule time is reached. */
 	D_ASSERT(task->dst_schedule_time != (uint64_t)-1);
-	if (cur_ts < task->dst_schedule_time) {
-		D_INFO("rebuild task sleep " DF_U64 " second\n", task->dst_schedule_time - cur_ts);
-		dss_sleep((task->dst_schedule_time - cur_ts) * 1000);
-	}
+	D_ASSERT(cur_ts >= task->dst_schedule_time);
 
 	rc = ds_pool_lookup(task->dst_pool_uuid, &pool);
 	if (pool == NULL) {
@@ -1850,12 +1848,13 @@ rebuild_ults(void *arg)
 
 		task = d_list_entry(rebuild_gst.rg_queue_list.next, struct rebuild_task, dst_list);
 		while (&rebuild_gst.rg_queue_list != &task->dst_list) {
-			/* If a pool is already handling a rebuild operation,
-			 * wait to start the next operation until the current
-			 * one completes
+			/* If a pool is currently handling a rebuild, wait for it to finish.
+			 * Skip this pool now if its rebuild task is scheduled for later
+			 * (allow for merging of other tasks into this one in ds_rebuild_schedule().
 			 */
 			if (pool_is_rebuilding(task->dst_pool_uuid) ||
-			    task->dst_schedule_time == (uint64_t)-1) {
+			    task->dst_schedule_time == (uint64_t)-1 ||
+			    (daos_gettime_coarse() < task->dst_schedule_time)) {
 				struct rebuild_task *head_task = task;
 
 				/* jump to next pool */

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -23,8 +23,8 @@ timeouts:
   test_daos_capability: 104
   test_daos_epoch_recovery: 104
   test_daos_md_replication: 104
-  test_daos_rebuild_simple: 1800
-  test_daos_drain_simple: 3600
+  test_daos_rebuild_simple: 1950
+  test_daos_drain_simple: 3720
   test_daos_extend_simple: 3600
   test_daos_oid_allocator: 640
   test_daos_checksum: 500

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -62,6 +62,8 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 	for (i = 0; i < arg_cnt; i++) {
 		rc = dmg_pool_exclude(args[i]->dmg_config, args[i]->pool.pool_uuid,
 				      args[i]->group, rank, tgt_idx);
+		print_message("dmg pool exclude rank %u tgt_idx=%d " DF_UUID ", rc=%d\n", rank,
+			      tgt_idx, DP_UUID(args[i]->pool.pool_uuid), rc);
 		assert_success(rc);
 	}
 }
@@ -83,6 +85,9 @@ rebuild_reint_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 		if (!args[i]->pool.destroyed) {
 			rc = dmg_pool_reintegrate(args[i]->dmg_config, args[i]->pool.pool_uuid,
 						  args[i]->group, rank, tgt_idx);
+			print_message("dmg pool reintegrate rank %u tgt_idx=%d " DF_UUID
+				      ", rc=%d\n",
+				      rank, tgt_idx, DP_UUID(args[i]->pool.pool_uuid), rc);
 			assert_success(rc);
 		}
 		sleep(2);
@@ -100,6 +105,8 @@ rebuild_extend_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 		if (!args[i]->pool.destroyed) {
 			rc = dmg_pool_extend(args[i]->dmg_config, args[i]->pool.pool_uuid,
 					     args[i]->group, &rank, 1);
+			print_message("dmg pool extend rank %u " DF_UUID ", rc=%d\n", rank,
+				      DP_UUID(args[i]->pool.pool_uuid), rc);
 			assert_success(rc);
 		}
 		sleep(2);
@@ -117,6 +124,8 @@ rebuild_drain_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 		if (!args[i]->pool.destroyed) {
 			rc = dmg_pool_drain(args[i]->dmg_config, args[i]->pool.pool_uuid,
 					    args[i]->group, rank, tgt_idx);
+			print_message("dmg pool drain rank %u tgt_idx=%d " DF_UUID ", rc=%d\n",
+				      rank, tgt_idx, DP_UUID(args[i]->pool.pool_uuid), rc);
 			assert_success(rc);
 		}
 		sleep(2);
@@ -135,6 +144,7 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 		daos_pool_info_t	pool_info;
 
 		/* refresh the pool information */
+		pool_info.pi_bits = DPI_REBUILD_STATUS;
 		rc = test_pool_get_info(args[i], &pool_info, NULL /* engine_ranks */);
 		if (rc) {
 			print_message("get pool "DF_UUIDF" info failed: %d\n",
@@ -142,6 +152,7 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 			return;
 		}
 		args[i]->rebuild_pre_pool_ver = pool_info.pi_map_ver;
+		memcpy(&args[i]->pool.pool_info, &pool_info, sizeof(pool_info));
 		if (op_type == RB_OP_TYPE_FAIL)
 			print_message("before exclude, got pool " DF_UUIDF "info, map_ver=%d\n",
 				      DP_UUID(args[i]->pool.pool_uuid), pool_info.pi_map_ver);
@@ -158,20 +169,35 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 			for (i = 0; i < rank_nr; i++)
 				rebuild_exclude_tgt(args, args_cnt, ranks[i],
 						    tgts ? tgts[i] : -1, kill);
+			if (args[0]->no_rebuild == 0) {
+				print_message(
+				    "wait for %u rank excludes/rebuilds to start before invoking "
+				    "rebuild_cb\n",
+				    rank_nr);
+				test_rebuild_wait_to_start_next(args, args_cnt);
+			}
 		}
 		par_barrier(PAR_COMM_WORLD);
 
 		for (i = 0; i < args_cnt; i++)
-			if (args[i]->rebuild_cb)
+			if (args[i]->rebuild_cb) {
+				print_message("call rebuild_cb for exclude rebuilding pool " DF_UUID
+					      "\n",
+					      DP_UUID(args[i]->pool.pool_uuid));
 				args[i]->rebuild_cb(args[i]);
+			}
 
 		if (args[0]->myrank == 0 && !args[0]->no_rebuild)
 			test_rebuild_wait(args, args_cnt);
 
 		par_barrier(PAR_COMM_WORLD);
 		for (i = 0; i < args_cnt; i++) {
-			if (args[i]->rebuild_post_cb)
+			if (args[i]->rebuild_post_cb) {
+				print_message(
+				    "call rebuild_post_cb for exclude rebuilt pool " DF_UUID "\n",
+				    DP_UUID(args[i]->pool.pool_uuid));
 				args[i]->rebuild_post_cb(args[i]);
+			}
 		}
 		return;
 
@@ -179,6 +205,7 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 
 	for (i = 0; i < rank_nr; i++) {
 		int j;
+		const char *op_type_str = NULL;
 
 		/* No concurrent drain/extend/reintegration are allowed, so
 		 * it has to reintegrate/extend one by one.
@@ -187,15 +214,18 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 		if (args[0]->myrank == 0) {
 			switch (op_type) {
 			case RB_OP_TYPE_REINT:
+				op_type_str = "reintegrate";
 				rebuild_reint_tgt(args, args_cnt, ranks[i],
 						  tgts ? tgts[i] : -1, kill);
 				break;
 			case RB_OP_TYPE_ADD:
+				op_type_str = "extend";
 				rebuild_extend_tgt(args, args_cnt, ranks[i],
 						   tgts ? tgts[i] : -1,
 						   args[i]->pool.pool_size);
 				break;
 			case RB_OP_TYPE_DRAIN:
+				op_type_str = "drain";
 				rebuild_drain_tgt(args, args_cnt, ranks[i],
 						tgts ? tgts[i] : -1);
 				break;
@@ -208,20 +238,36 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 				D_ASSERT(op_type != RB_OP_TYPE_RECLAIM);
 				break;
 			default:
+				op_type_str = "UNKNOWN";
 				break;
+			}
+			if (args[0]->no_rebuild == 0) {
+				print_message("wait for 1 rank (%u) rebuilds to start before "
+					      "invoking rebuild_cb\n",
+					      ranks[i]);
+				test_rebuild_wait_to_start_next(args, args_cnt);
 			}
 		}
 		par_barrier(PAR_COMM_WORLD);
 		for (j = 0; j < args_cnt; j++)
-			if (args[j]->rebuild_cb)
+			if (args[j]->rebuild_cb) {
+				print_message("call rebuild_cb for %s rebuilding pool " DF_UUID
+					      "\n",
+					      op_type_str, DP_UUID(args[j]->pool.pool_uuid));
+
 				args[j]->rebuild_cb(args[j]);
+			}
 
 		if (args[0]->myrank == 0 && !args[0]->no_rebuild)
 			test_rebuild_wait(args, args_cnt);
 
 		for (j = 0; j < args_cnt; j++) {
-			if (args[j]->rebuild_post_cb)
+			if (args[j]->rebuild_post_cb) {
+				print_message("call rebuild_post_cb for %s rebuilt pool " DF_UUID
+					      "\n",
+					      op_type_str, DP_UUID(args[j]->pool.pool_uuid));
 				args[j]->rebuild_post_cb(args[j]);
+			}
 		}
 	}
 }
@@ -972,8 +1018,8 @@ reintegrate_inflight_io(void *data)
 
 	}
 	ioreq_fini(&req);
-	sleep(12);
 	print_message("sleep 12 seconds to wait for the stable epoch update.\n");
+	sleep(12);
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0,
 				      NULL);
@@ -1218,7 +1264,7 @@ rebuild_sub_setup_common(void **state, daos_size_t pool_size, int node_nr, uint3
 		 */
 		print_message("It can not create the pool, probably due"
 			      " to not enough ranks %d\n", rc);
-		return 0;
+		return rc;
 	}
 
 	arg = *state;

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -393,6 +393,8 @@ int test_pool_get_info(test_arg_t *arg, daos_pool_info_t *pinfo, d_rank_list_t *
 int test_get_leader(test_arg_t *arg, d_rank_t *rank);
 bool test_rebuild_query(test_arg_t **args, int args_cnt);
 void test_rebuild_wait(test_arg_t **args, int args_cnt);
+void
+    test_rebuild_wait_to_start_next(test_arg_t **args, int args_cnt);
 int daos_pool_set_prop(const uuid_t pool_uuid, const char *name,
 		       const char *value);
 int

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -27,6 +27,7 @@ unsigned int svc_nreplicas = 1;
 unsigned int	dt_csum_type;
 unsigned int	dt_csum_chunksize;
 bool		dt_csum_server_verify;
+
 /** container cell size */
 unsigned int	dt_cell_size;
 int		dt_obj_class;
@@ -501,6 +502,7 @@ pool_destroy_safe(test_arg_t *arg, struct test_pool *extpool)
 			continue;
 		}
 
+		print_message("done waiting for rebuild, state %d\n", rstat->rs_state);
 		/* no rebuild */
 		break;
 	}
@@ -757,8 +759,45 @@ test_pool_get_info(test_arg_t *arg, daos_pool_info_t *pinfo, d_rank_list_t **eng
 	return rc;
 }
 
+/* Determine if pool rebuild is busy (or finished already), and rebuild version > rs_version */
 static bool
-rebuild_pool_wait(test_arg_t *arg)
+rebuild_pool_started_after_ver(test_arg_t *arg, uint32_t rs_version)
+{
+	daos_pool_info_t            pinfo = {0};
+	struct daos_rebuild_status *rst;
+	int                         rc;
+
+	pinfo.pi_bits = DPI_REBUILD_STATUS;
+	rc            = test_pool_get_info(arg, &pinfo, NULL /* engine_ranks */);
+	rst           = &pinfo.pi_rebuild_st;
+
+	if (rc != 0) {
+		print_message("pool query for rebuild status failed, rc=%d, pool " DF_UUIDF "\n",
+			      rc, DP_UUID(arg->pool.pool_uuid));
+		return false;
+	} else {
+		bool in_progress = (rst->rs_state == DRS_IN_PROGRESS);
+		bool done        = (rst->rs_state == DRS_COMPLETED);
+
+		/* NB: check for done (e.g., test killed leader, query times out during rebuild. */
+		print_message("rebuild for pool " DF_UUIDF "%s, rs_version=%u (waiting for > %d)\n",
+			      DP_UUID(arg->pool.pool_uuid),
+			      in_progress ? "started"
+			      : done      ? "finished already"
+					  : "not yet started",
+			      rst->rs_version, rs_version);
+		if ((in_progress || done) && (rst->rs_version > rs_version)) {
+			/* save final pool query info to be able to inspect rebuild status */
+			memcpy(&arg->pool.pool_info, &pinfo, sizeof(pinfo));
+
+			return true;
+		}
+		return false;
+	}
+}
+
+static bool
+rebuild_pool_done(test_arg_t *arg)
 {
 	daos_pool_info_t	   pinfo = {0};
 	struct daos_rebuild_status *rst;
@@ -771,17 +810,25 @@ rebuild_pool_wait(test_arg_t *arg)
 	if ((rst->rs_state == DRS_COMPLETED || rc != 0) &&
 	    (rst->rs_version > arg->rebuild_pre_pool_ver ||
 	     pinfo.pi_map_ver > arg->rebuild_pre_pool_ver)) {
-		print_message("Rebuild "DF_UUIDF" (ver=%u pi_ver = %u orig_ver=%u) is done %d/%d,"
-			      "obj="DF_U64", rec="DF_U64".\n", DP_UUID(arg->pool.pool_uuid),
-			      rst->rs_version, pinfo.pi_map_ver, arg->rebuild_pre_pool_ver,
-			      rc, rst->rs_errno, rst->rs_obj_nr, rst->rs_rec_nr);
+		print_message("Rebuild " DF_UUIDF
+			      " (ver=%u pi_ver=%u orig_ver=%u) %d/%d, query %s rc=%d, "
+			      "obj=" DF_U64 ", rec=" DF_U64 ".\n",
+			      DP_UUID(arg->pool.pool_uuid), rst->rs_version, pinfo.pi_map_ver,
+			      arg->rebuild_pre_pool_ver, rst->rs_state, rst->rs_errno,
+			      rc ? "ERRORED" : "done", rc, rst->rs_obj_nr, rst->rs_rec_nr);
+
+		/* save final pool query info to be able to inspect rebuild status */
+		if (rc == 0)
+			memcpy(&arg->pool.pool_info, &pinfo, sizeof(pinfo));
 		done = true;
 	} else {
-		print_message("wait for rebuild pool "DF_UUIDF"(ver=%u pi_ver=%u orig_ver=%u),"
-			      "to-be-rebuilt obj="DF_U64", already rebuilt obj="DF_U64","
-			      "rec="DF_U64"\n", DP_UUID(arg->pool.pool_uuid), rst->rs_version,
-			      pinfo.pi_map_ver, arg->rebuild_pre_pool_ver, rst->rs_toberb_obj_nr,
-			      rst->rs_obj_nr, rst->rs_rec_nr);
+		print_message("wait for rebuild pool " DF_UUIDF
+			      "(ver=%u pi_ver=%u orig_ver=%u) %d/%d, "
+			      "to-be-rebuilt obj=" DF_U64 ", already rebuilt obj=" DF_U64 ","
+			      "rec=" DF_U64 "\n",
+			      DP_UUID(arg->pool.pool_uuid), rst->rs_version, pinfo.pi_map_ver,
+			      arg->rebuild_pre_pool_ver, rst->rs_state, rst->rs_errno,
+			      rst->rs_toberb_obj_nr, rst->rs_obj_nr, rst->rs_rec_nr);
 	}
 
 	return done;
@@ -820,6 +867,45 @@ test_get_last_svr_rank(test_arg_t *arg)
 	return arg->srv_nnodes - disable_nodes - 1;
 }
 
+static bool
+test_rebuild_started_after(test_arg_t **args, int args_cnt, uint32_t *cur_versions)
+{
+	bool all_started = true;
+	int  i;
+
+	for (i = 0; i < args_cnt; i++) {
+		bool started = true;
+
+		if (!args[i]->pool.destroyed)
+			started = rebuild_pool_started_after_ver(args[i], cur_versions[i]);
+
+		if (!started)
+			all_started = false;
+	}
+	return all_started;
+}
+
+/* wait until pools start rebuilds with rs_version > current (e.g.,. expecting op:Rebuild) */
+void
+test_rebuild_wait_to_start_next(test_arg_t **args, int args_cnt)
+{
+	uint32_t *cur_versions;
+	int       i;
+
+	D_ALLOC_ARRAY(cur_versions, args_cnt);
+	assert_true(cur_versions != NULL);
+	for (i = 0; i < args_cnt; i++)
+		cur_versions[i] = args[i]->pool.pool_info.pi_rebuild_st.rs_version;
+
+	while (!test_rebuild_started_after(args, args_cnt, cur_versions))
+		sleep(2);
+
+	/* NB: when control reaches here, each pool's current rs_version has been updated
+	 * (for subsequent calls that will rely on it as a baseline)
+	 */
+	D_FREE(cur_versions);
+}
+
 bool
 test_rebuild_query(test_arg_t **args, int args_cnt)
 {
@@ -830,7 +916,7 @@ test_rebuild_query(test_arg_t **args, int args_cnt)
 		bool done = true;
 
 		if (!args[i]->pool.destroyed)
-			done = rebuild_pool_wait(args[i]);
+			done = rebuild_pool_done(args[i]);
 
 		if (!done)
 			all_done = false;


### PR DESCRIPTION
Many multiple rank failure events or those initiated by control plane commands (e.g., dmg) are processed in a rank-by-rank fashion. This leads to a (rapid) sequence of pool map updates and rebuild scheduling activities. It can lead to serialized rebuilds, one per rank, rather than consolidating the related operations into a single rebuild job. This can result in slower execution, and cause a confusion for an administrator trying to monitor rebuild progress via pool query.

With this change, exclude, reintegration, and drain pool map updates are changed to schedule a rebuild with a 5 second delay, causing the resulting entry in the rebuild_gst.rg_queue_list to specify a scheduling time (dst_schedule_time) in the near-future. And, logic in rebuild_ults() is changed to not dequeue a rebuild task if it has a future scheduling time. This allows compatible changes (that may be processed imminently) to be merged by their ds_rebuild_schedule() call.

Cherry-pick the specific change from master branch, including some common daos_test functions needed by the change. Also, a few other good-to-have common test code changes are brought over from master.

Features: rebuild

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
