### PR TITLE
Liang/b aurora p5

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1707,6 +1707,7 @@ cont_ec_agg_alloc(struct cont_svc *cont_svc, uuid_t cont_uuid,
 	for (i = 0; i < rank_nr; i++) {
 		ec_agg->ea_server_ephs[i].rank = doms[i].do_comp.co_rank;
 		ec_agg->ea_server_ephs[i].eph = 0;
+		ec_agg->ea_server_ephs[i].ee_update_ts = daos_gettime_coarse();
 	}
 	d_list_add(&ec_agg->ea_list, &cont_svc->cs_ec_agg_list);
 	*ec_aggp = ec_agg;
@@ -1764,8 +1765,10 @@ retry:
 
 	for (i = 0; i < ec_agg->ea_servers_num; i++) {
 		if (ec_agg->ea_server_ephs[i].rank == rank) {
-			if (ec_agg->ea_server_ephs[i].eph < eph)
+			if (ec_agg->ea_server_ephs[i].eph < eph) {
 				ec_agg->ea_server_ephs[i].eph = eph;
+				ec_agg->ea_server_ephs[i].ee_update_ts = daos_gettime_coarse();
+			}
 			break;
 		}
 	}
@@ -1989,6 +1992,7 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 	daos_epoch_t        cur_eph, new_eph;
 	daos_epoch_t        min_eph;
 	d_rank_t            rank;
+	uint64_t            cur_ts;
 	int                 i;
 	int                 rc;
 
@@ -2015,6 +2019,7 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 		}
 
 		min_eph = DAOS_EPOCH_MAX;
+		cur_ts  = daos_gettime_coarse();
 		for (i = 0; i < ec_agg->ea_servers_num; i++) {
 			rank = ec_agg->ea_server_ephs[i].rank;
 
@@ -2023,6 +2028,13 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 					DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid), rank);
 				continue;
 			}
+
+			if (pool->sp_reclaim != DAOS_RECLAIM_DISABLED &&
+			    cur_ts > ec_agg->ea_server_ephs[i].ee_update_ts + 600)
+				D_WARN(DF_CONT ": Sluggish EC boundary report from rank %d, " DF_U64
+					       " Seconds.",
+				       DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid), rank,
+				       cur_ts - ec_agg->ea_server_ephs[i].ee_update_ts);
 
 			if (ec_agg->ea_server_ephs[i].eph < min_eph)
 				min_eph = ec_agg->ea_server_ephs[i].eph;

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -61,6 +61,7 @@ extern bool ec_agg_disabled;
 struct ec_eph {
 	d_rank_t	rank;
 	daos_epoch_t	eph;
+	uint64_t        ee_update_ts; /* update timestamp */
 };
 
 /* container EC aggregation epoch control descriptor, which is only on leader */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -4122,8 +4122,10 @@ anchor_update_check_eof(struct obj_auxi_args *obj_auxi, daos_anchor_t *anchor)
 	obj_auxi_shards_iterate(obj_auxi, update_sub_anchor_cb, NULL);
 
 	sub_anchors = (struct shard_anchors *)anchor->da_sub_anchors;
-	if (!d_list_empty(&sub_anchors->sa_merged_list))
+	if (!d_list_empty(&sub_anchors->sa_merged_list)) {
+		D_ASSERT(obj_auxi->opc != DAOS_OBJ_RPC_ENUMERATE);
 		return;
+	}
 
 	if (sub_anchors_is_eof(sub_anchors)) {
 		daos_obj_list_t *obj_args;
@@ -4132,6 +4134,18 @@ anchor_update_check_eof(struct obj_auxi_args *obj_auxi, daos_anchor_t *anchor)
 
 		obj_args = dc_task_get_args(obj_auxi->obj_task);
 		sub_anchors_free(obj_args, obj_auxi->opc);
+	} else if (obj_auxi->opc == DAOS_OBJ_RPC_ENUMERATE && D_LOG_ENABLED(DB_REBUILD)) {
+		for (int i = 0; i < sub_anchors->sa_anchors_nr; i++) {
+			daos_anchor_t *sub_anchor;
+
+			sub_anchor = &sub_anchors->sa_anchors[i].ssa_anchor;
+			if (!daos_anchor_is_eof(sub_anchor)) {
+				D_DEBUG(DB_REBUILD, "shard %d sub_anchor %d/%d non EOF",
+					sub_anchors->sa_anchors[i].ssa_shard, i,
+					sub_anchors->sa_anchors_nr);
+				break;
+			}
+		}
 	}
 }
 
@@ -6445,7 +6459,7 @@ shard_anchors_check_alloc_bufs(struct obj_auxi_args *obj_auxi, struct shard_anch
 		}
 
 		if (obj_args->recxs != NULL) {
-			if (sub_anchor->ssa_recxs != NULL && sub_anchors->sa_nr == nr)
+			if (sub_anchor->ssa_recxs != NULL && sub_anchors->sa_nr != nr)
 				D_FREE(sub_anchor->ssa_recxs);
 
 			if (sub_anchor->ssa_recxs == NULL) {

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -689,9 +690,8 @@ obj_enum_iterate(daos_key_desc_t *kdss, d_sg_list_t *sgl, int nr,
 		ptr = sgl_indexed_byte(sgl, &sgl_idx);
 		D_ASSERTF(ptr != NULL, "kds and sgl don't line up");
 
-		D_DEBUG(DB_REBUILD, "process %d, type %d, ptr %p, len "DF_U64
-			", total %zd\n", i, kds->kd_val_type, ptr,
-			kds->kd_key_len, sgl->sg_iovs[0].iov_len);
+		D_DEBUG(DB_REBUILD, "process %d/%d, type %d, ptr %p, len " DF_U64 ", total %zd\n",
+			i, nr, kds->kd_val_type, ptr, kds->kd_key_len, sgl->sg_iovs[0].iov_len);
 		if (kds->kd_val_type == 0 ||
 		    (kds->kd_val_type != type && type != -1)) {
 			sgl_move_forward(sgl, &sgl_idx, kds->kd_key_len);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -2423,7 +2423,7 @@ obj_inflight_io_check(struct ds_cont_child *child, uint32_t opc,
 		      uint32_t rpc_map_ver, uint32_t flags)
 {
 	if (opc == DAOS_OBJ_RPC_ENUMERATE && flags & ORF_FOR_MIGRATION) {
-		/* EC aggregation is still inflight, rebuild should wait until it's paused */
+		/* EC aggregation is still in-flight, rebuild should wait until it's paused */
 		if (ds_cont_child_ec_aggregating(child)) {
 			D_ERROR(DF_CONT" ec aggregate still active, rebuilding %d\n",
 				DP_CONT(child->sc_pool->spc_uuid, child->sc_uuid),
@@ -3258,6 +3258,27 @@ obj_enum_complete(crt_rpc_t *rpc, int status, int map_version,
 	D_FREE(oeo->oeo_csum_iov.iov_buf);
 }
 
+static void
+dump_enum_anchor(daos_unit_oid_t uoid, daos_anchor_t *anchor, char *str)
+{
+	int      nr = DAOS_ANCHOR_BUF_MAX / 8;
+	int      i;
+	uint64_t data[nr];
+
+	D_DEBUG(DB_REBUILD, DF_UOID "%s anchor -", DP_UOID(uoid), str);
+	D_DEBUG(DB_REBUILD, "type %d, shard %d, flags 0x%x\n", anchor->da_type, anchor->da_shard,
+		anchor->da_flags);
+	for (i = 0; i < nr; i++)
+		data[i] = *(uint64_t *)((char *)anchor->da_buf + i * 8);
+	if (nr >= 13)
+		D_DEBUG(DB_REBUILD,
+			"da_buf " DF_X64 "," DF_X64 "," DF_X64 "," DF_X64 "," DF_X64 "," DF_X64
+			"," DF_X64 "," DF_X64 "," DF_X64 "," DF_X64 "," DF_X64 "," DF_X64
+			"," DF_X64,
+			data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+			data[8], data[9], data[10], data[11], data[12]);
+}
+
 static int
 obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 	       struct vos_iter_anchors *anchors, struct ds_obj_enum_arg *enum_arg,
@@ -3326,6 +3347,10 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		D_ASSERT(opc == DAOS_OBJ_RPC_ENUMERATE);
 		type = VOS_ITER_DKEY;
 		param.ip_flags |= VOS_IT_RECX_VISIBLE;
+		if (D_LOG_ENABLED(DB_REBUILD)) {
+			dump_enum_anchor(oei->oei_oid, &anchors->ia_dkey, "dkey");
+			dump_enum_anchor(oei->oei_oid, &anchors->ia_akey, "akey");
+		}
 		if (daos_anchor_get_flags(&anchors->ia_dkey) &
 		      DIOF_WITH_SPEC_EPOCH) {
 			/* For obj verification case. */
@@ -3343,7 +3368,12 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		enum_arg->chk_key2big = 1;
 		enum_arg->need_punch = 1;
 		enum_arg->copy_data_cb = vos_iter_copy;
-		fill_oid(oei->oei_oid, enum_arg);
+		rc                     = fill_oid(oei->oei_oid, enum_arg);
+		if (rc != 0) {
+			rc = -DER_KEY2BIG;
+			DL_ERROR(rc, DF_UOID "fill oid failed", DP_UOID(oei->oei_oid));
+			goto failed;
+		}
 	}
 
 	/*

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2651,9 +2651,15 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	if (rc == 1 &&
 	     (is_ec_data_shard_by_tgt_off(unpack_tgt_off, &arg->oc_attr) ||
 	     (io->ui_oid.id_layout_ver > 0 && io->ui_oid.id_shard != parity_shard))) {
-		D_DEBUG(DB_REBUILD, DF_UOID" ignore shard "DF_KEY"/%u/%d/%u/%d.\n",
-			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard,
-			(int)obj_ec_shard_off(obj, io->ui_dkey_hash, 0), parity_shard, rc);
+		if (daos_is_dkey_uint64(io->ui_oid.id_pub) && io->ui_dkey.iov_len == 8)
+			D_DEBUG(DB_REBUILD,
+				DF_UOID " ignore shard, int dkey " DF_U64 "/%u/%d/%u/%d.",
+				DP_UOID(io->ui_oid), *(uint64_t *)io->ui_dkey.iov_buf, shard,
+				(int)obj_ec_shard_off(obj, io->ui_dkey_hash, 0), parity_shard, rc);
+		else
+			D_DEBUG(DB_REBUILD, DF_UOID " ignore shard " DF_KEY "/%u/%d/%u/%d.",
+				DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard,
+				(int)obj_ec_shard_off(obj, io->ui_dkey_hash, 0), parity_shard, rc);
 		D_GOTO(put, rc = 0);
 	}
 	rc = 0;
@@ -2669,9 +2675,17 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 			continue;
 		}
 
-		D_DEBUG(DB_REBUILD, DF_UOID" unpack "DF_KEY" for shard %u/%u/%u/"DF_X64"/%u\n",
-			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard, unpack_tgt_off,
-			migrate_tgt_off, io->ui_dkey_hash, parity_shard);
+		if (daos_is_dkey_uint64(io->ui_oid.id_pub) && io->ui_dkey.iov_len == 8)
+			D_DEBUG(DB_REBUILD,
+				DF_UOID " unpack int dkey " DF_U64 " for shard %u/%u/%u/" DF_X64
+					"/%u",
+				DP_UOID(io->ui_oid), *(uint64_t *)io->ui_dkey.iov_buf, shard,
+				unpack_tgt_off, migrate_tgt_off, io->ui_dkey_hash, parity_shard);
+		else
+			D_DEBUG(DB_REBUILD,
+				DF_UOID " unpack " DF_KEY " for shard %u/%u/%u/" DF_X64 "/%u",
+				DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard, unpack_tgt_off,
+				migrate_tgt_off, io->ui_dkey_hash, parity_shard);
 
 		/**
 		 * Since we do not need split the rebuild into parity rebuild
@@ -2708,8 +2722,13 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	if (!create_migrate_one) {
 		struct ds_cont_child *cont = NULL;
 
-		D_DEBUG(DB_REBUILD, DF_UOID"/"DF_KEY" does not need rebuild.\n",
-			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey));
+		if (daos_is_dkey_uint64(io->ui_oid.id_pub) && io->ui_dkey.iov_len == 8)
+			D_DEBUG(DB_REBUILD,
+				DF_UOID "/int dkey: " DF_U64 " does not need rebuild.\n",
+				DP_UOID(io->ui_oid), *(uint64_t *)io->ui_dkey.iov_buf);
+		else
+			D_DEBUG(DB_REBUILD, DF_UOID "/" DF_KEY " does not need rebuild.\n",
+				DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey));
 
 		/* Create the vos container when no record need to be rebuilt for this shard,
 		 * for the case of reintegrate the container was discarded ahead.

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2257,6 +2257,11 @@ static int pool_svc_schedule_reconf(struct pool_svc *svc, struct pool_map *map,
 				    uint32_t map_version_for, bool sync_remove);
 static void pool_svc_rfcheck_ult(void *arg);
 
+#define RESTART_RB_DELAY_ENV "D_RESTART_RB_DELAY"
+#define RESTART_RB_DELAY_MIN (60)
+#define RESTART_RB_DELAY_DEF (100)
+#define RESTART_RB_DELAY_MAX (600)
+
 static int
 pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 {
@@ -2268,6 +2273,8 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	daos_prop_t	       *prop = NULL;
 	bool			cont_svc_up = false;
 	bool			events_initialized = false;
+	uint64_t                age_sec, delay;
+	uint32_t                restart_rb_delay   = RESTART_RB_DELAY_DEF;
 	d_rank_t                rank               = dss_self_rank();
 	int			rc;
 
@@ -2367,7 +2374,18 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	if (rc != 0)
 		goto out;
 
-	rc = ds_rebuild_regenerate_task(svc->ps_pool, prop, 0);
+	rc = d_getenv_uint(RESTART_RB_DELAY_ENV, &restart_rb_delay);
+	if (rc == 0) {
+		if (restart_rb_delay < RESTART_RB_DELAY_MIN)
+			restart_rb_delay = RESTART_RB_DELAY_MIN;
+		if (restart_rb_delay > RESTART_RB_DELAY_MAX)
+			restart_rb_delay = RESTART_RB_DELAY_MAX;
+	}
+	age_sec = d_hlc_age2sec(dss_get_start_epoch());
+	delay   = age_sec < restart_rb_delay ? (restart_rb_delay - age_sec) : 0;
+	D_INFO("delay %d, " DF_U64 " seconds for ds_rebuild_regenerate_task\n", restart_rb_delay,
+	       delay);
+	rc = ds_rebuild_regenerate_task(svc->ps_pool, prop, delay);
 	if (rc != 0)
 		goto out;
 

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -247,6 +247,7 @@ struct rebuild_pool_tls {
 	d_list_t	rebuild_pool_list;
 	uint64_t	rebuild_pool_obj_count;
 	uint64_t	rebuild_pool_reclaim_obj_count;
+	uint64_t        rebuild_pool_reclaim_skipped;
 	unsigned int	rebuild_pool_ver;
 	uint32_t	rebuild_pool_gen;
 	uint64_t	rebuild_pool_leader_term;

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -516,6 +516,8 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 	if (rc != 0)
 		return rc;
 
+	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
+	D_ASSERT(tls != NULL);
 	/* If there are further targets failure during reintegration/extend/drain,
 	 * rebuild will choose replacement targets for the impacted objects anyway,
 	 * so we do not need reclaim these impacted shards by @ignore_rebuild_shard.
@@ -524,6 +526,7 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 					      mytarget, oid.id_shard,
 					      rpt->rt_rebuild_op == RB_OP_RECLAIM ? false : true);
 	pl_obj_layout_free(layout);
+	tls->rebuild_pool_obj_count++;
 	if (still_needed) {
 		if (new_layout_ver > 0) {
 			/* upgrade job reclaim */
@@ -542,10 +545,8 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 		return 0;
 	}
 
-	D_DEBUG(DB_REBUILD, "deleting stale object "DF_UOID" rank %u tgt %u oid layout %u/%u",
+	D_DEBUG(DB_REBUILD, "deleting stale object " DF_UOID " rank %u tgt %u oid layout %u/%u",
 		DP_UOID(oid), myrank, mytarget, oid.id_layout_ver, new_layout_ver);
-	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
-	D_ASSERT(tls != NULL);
 	tls->rebuild_pool_reclaim_obj_count++;
 
 	discard_epr.epr_hi = rpt->rt_reclaim_epoch;

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -488,6 +488,10 @@ out:
 	return rc;
 }
 
+#define RECLAIM_SKIPPED_MAX    50           /* skipped too many objects may cause ENOSPACE */
+#define RECLAIM_LOG_INTERVAL   1800         /* 30 minutes */
+#define RECLAIM_BUSY_THRESHOLD (300 * 1000) /* 300 seconds */
+
 static int
 obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 	    struct daos_obj_md *md, struct rebuild_tgt_pool_tracker *rpt,
@@ -499,6 +503,8 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 	struct rebuild_pool_tls *tls;
 	daos_epoch_range_t	discard_epr;
 	bool			still_needed;
+	unsigned int             busy_tried = 0;
+	uint64_t                 log_since  = 0;
 	int			rc;
 
 	/*
@@ -550,17 +556,40 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 	 * to delete
 	 */
 	do {
+		uint64_t now;
+
 		/* Inform the iterator and delete the object */
 		*acts |= VOS_ITER_CB_DELETE;
 		rc = vos_discard(param->ip_hdl, &oid, &discard_epr, NULL, NULL);
 		if (rc != -DER_BUSY && rc != -DER_INPROGRESS)
 			break;
 
-		D_DEBUG(DB_REBUILD, "retry by "DF_RC"/"DF_UOID"\n",
-			DP_RC(rc), DP_UOID(oid));
+		busy_tried++;
+		if (busy_tried >= RECLAIM_BUSY_THRESHOLD) { /* too many retries, time to skip */
+			busy_tried = 0;
+			if (tls->rebuild_pool_reclaim_skipped < RECLAIM_SKIPPED_MAX) {
+				tls->rebuild_pool_reclaim_skipped++;
+				D_ERROR(DF_RB " stop retrying reclaim after 5 minutes (rc=%d), "
+					      "skip busy object=" DF_UOID ", total skipped=" DF_U64
+					      "\n",
+					DP_RB_RPT(rpt), rc, DP_UOID(oid),
+					tls->rebuild_pool_reclaim_skipped);
+				rc = 0;
+				break;
+			}
+		}
+		D_DEBUG(DB_REBUILD, "retry by " DF_RC "/" DF_UOID "\n", DP_RC(rc), DP_UOID(oid));
 		/* Busy - inform iterator and yield */
 		*acts |= VOS_ITER_CB_YIELD;
-		dss_sleep(0);
+		dss_sleep(1); /* 1 ms */
+
+		now = daos_gettime_coarse();
+		if (now - log_since >= RECLAIM_LOG_INTERVAL &&
+		    tls->rebuild_pool_reclaim_skipped > 0) {
+			D_INFO(DF_RB " reclaim skipped total " DF_U64 " busy objects\n",
+			       DP_RB_RPT(rpt), tls->rebuild_pool_reclaim_skipped);
+			log_since = now;
+		}
 	} while (1);
 
 	if (rc != 0)

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -127,6 +127,7 @@ rebuild_pool_tls_create(uuid_t pool_uuid, uuid_t poh_uuid, uuid_t coh_uuid,
 	rebuild_pool_tls->rebuild_pool_scanning = 1;
 	rebuild_pool_tls->rebuild_pool_scan_done = 0;
 	rebuild_pool_tls->rebuild_pool_obj_count = 0;
+	rebuild_pool_tls->rebuild_pool_reclaim_skipped   = 0;
 	rebuild_pool_tls->rebuild_pool_reclaim_obj_count = 0;
 	rebuild_pool_tls->rebuild_tree_hdl = DAOS_HDL_INVAL;
 	/* Only 1 thread will access the list, no need lock */

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -439,7 +439,12 @@ dss_rebuild_check_one(void *data)
 	if (pool_tls->rebuild_pool_status != 0 && status->status == 0)
 		status->status = pool_tls->rebuild_pool_status;
 
-	status->obj_count += pool_tls->rebuild_pool_reclaim_obj_count;
+	if (rpt->rt_rebuild_op == RB_OP_RECLAIM || rpt->rt_rebuild_op == RB_OP_FAIL_RECLAIM) {
+		status->obj_count += pool_tls->rebuild_pool_reclaim_obj_count;
+		/* use rec_count to simulate progress when no object need to be reclaim */
+		status->rec_count += pool_tls->rebuild_pool_obj_count;
+	}
+
 	status->tobe_obj_count += pool_tls->rebuild_pool_obj_count;
 	ABT_mutex_unlock(status->lock);
 
@@ -2471,14 +2476,14 @@ rebuild_tgt_status_check_ult(void *arg)
 			}
 		}
 
-		D_INFO(DF_UUID" ver %d gen %u obj "DF_U64" rec "DF_U64" size "
-		       DF_U64" scan done %d pull done %d scan gl done %d"
-		       " gl done %d status %d abort %s\n",
+		D_INFO(DF_UUID " ver %d gen %u obj " DF_U64 "/" DF_U64 " rec " DF_U64
+			       " size " DF_U64 " scan done %d pull done %d scan gl done %d"
+			       " gl done %d status %d abort %s\n",
 		       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver,
-		       rpt->rt_pool->sp_rebuild_gen,
-		       iv.riv_obj_count, iv.riv_rec_count, iv.riv_size, rpt->rt_scan_done,
-		       iv.riv_pull_done, rpt->rt_global_scan_done,
-		       rpt->rt_global_done, iv.riv_status, rpt->rt_abort ? "yes" : "no");
+		       rpt->rt_pool->sp_rebuild_gen, iv.riv_toberb_obj_count, iv.riv_obj_count,
+		       iv.riv_rec_count, iv.riv_size, rpt->rt_scan_done, iv.riv_pull_done,
+		       rpt->rt_global_scan_done, rpt->rt_global_done, iv.riv_status,
+		       rpt->rt_abort ? "yes" : "no");
 		if (rpt->rt_global_done || rpt->rt_abort)
 			break;
 

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -287,8 +288,10 @@ gc_drain_cont(struct vos_gc *gc, struct vos_pool *pool, daos_handle_t coh,
 	 * the container (that may yield).
 	 */
 	rc = vos_dtx_table_destroy(&pool->vp_umm, cont);
-	if (rc != 0)
+	if (rc != 0) {
+		DL_ERROR(rc, "Failed to destroy DTX table.");
 		return rc;
+	}
 
 	/** Move any leftover bags to the pool gc */
 	for (i = GC_AKEY; i < GC_CONT; i++) {
@@ -299,8 +302,10 @@ gc_drain_cont(struct vos_gc *gc, struct vos_pool *pool, daos_handle_t coh,
 
 		rc = gc_bags_move(pool, &pool->vp_pool_df->pd_gc_bins[i],
 				  src_bin);
-		if (rc != 0)
+		if (rc != 0) {
+			DL_ERROR(rc, "Failed to move GC bags.");
 			return rc;
+		}
 
 		/** Indicate to caller that we've taken over container bags */
 		return 1;
@@ -473,8 +478,10 @@ gc_bin_add_item(struct umem_instance *umm, struct vos_gc_bin_df *bin,
 	int		      rc;
 
 	bag = gc_bin_find_bag(umm, bin);
-	if (!bag)
+	if (!bag) {
+		D_ERROR("Failed to find GC bag\n");
 		return -DER_NOSPACE;
+	}
 
 	D_ASSERT(bag->bag_item_nr < bin->bin_bag_size);
 	/* NB: umem_tx_add with UMEM_XADD_NO_SNAPSHOT, this is totally
@@ -1201,6 +1208,10 @@ vos_gc_pool(daos_handle_t poh, int credits, int (*yield_func)(void *arg),
 		else
 			d_tm_inc_counter(slack, 1);
 
+		/* Try small credits when GC failed to allocate space */
+		if (pool->vp_gc_nospc)
+			creds = 2;
+
 		if (credits > 0 && (credits - total) < creds)
 			creds = credits - total;
 
@@ -1209,6 +1220,8 @@ vos_gc_pool(daos_handle_t poh, int credits, int (*yield_func)(void *arg),
 
 		if (rc) {
 			D_ERROR("GC pool failed: " DF_RC "\n", DP_RC(rc));
+			if (rc == -DER_NOSPACE)
+				pool->vp_gc_nospc = 1;
 			d_tm_mark_duration_end(duration);
 			break;
 		}
@@ -1231,8 +1244,11 @@ vos_gc_pool(daos_handle_t poh, int credits, int (*yield_func)(void *arg),
 		}
 	}
 
-	if (total != 0) /* did something */
+	if (total != 0) { /* did something */
 		D_DEBUG(DB_TRACE, "GC consumed %d credits\n", total);
+		if (rc == 0)
+			pool->vp_gc_nospc = 0;
+	}
 
 	D_ASSERT(tls->vtl_gc_running > 0);
 	tls->vtl_gc_running--;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -264,7 +264,7 @@ struct vos_pool {
 	uint32_t                 vp_opened : 30;
 	uint32_t                 vp_dying  : 1;
 	/** exclusive handle (see VOS_POF_EXCL) */
-	int			vp_excl:1;
+	unsigned int             vp_excl : 1, vp_gc_nospc : 1;
 	/* this pool is for sysdb */
 	bool			vp_sysdb;
 	/** this pool is for rdb */


### PR DESCRIPTION
This PR includes three commits:
- Add a latency for the first rebuild task, so it wouldn't be scheduled before SWIM gets stable
- Add more debug messages for reclaim failures
- Only require 2 credits for GC if it's under space pressure, so it can run with minimum
   space overhead
- Skip limited number of EBUSY objects during fail reclaim, instead of blocking rebuild forever,
  These objects will be reclaimed by other rebuilds. 

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
