### PR TITLE
DAOS-18487 object: remove extra newline from err log

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -828,7 +828,7 @@ retry:
 			res->res_data.mem_ser_err++; /* counted as serious error */
 			DL_ERROR(rc,
 				 DF_RB " waited for 10 minutes, total memory errors: %lu/%lu,"
-				       " total waiters: %lu, total revived: %lu\n",
+				       " total waiters: %lu, total revived: %lu",
 				 DP_RB_MRO(mrone), res->res_data.mem_ser_err, res->res_data.mem_err,
 				 res->res_data.mem_waiting, res->res_data.mem_revived);
 		}


### PR DESCRIPTION
Remove extra newline from err log since the macro DL_ERROR already adds it.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
