### PR TITLE
DAOS-18579 vos: reserve_space() include NVMe info in ERR log

### DIFF
--- a/src/tests/ftest/util/soak_utils.py
+++ b/src/tests/ftest/util/soak_utils.py
@@ -1,6 +1,6 @@
 """
 (C) Copyright 2019-2024 Intel Corporation.
-(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+(C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -870,8 +870,56 @@ def launch_server_stop_start(self, pools, name, results, args):
     if name == "SVR_STOP":
         exclude_servers = (
             len(self.hostlist_servers) * int(engine_count)) - 1
-        # Exclude one rank.
-        rank = self.random.randint(0, exclude_servers)
+
+        # Query all targets for every rank on the harasser pool (pools[1])
+        # and log per-target space info. For each rank, sum the NVMe free space
+        # across all its targets. Select the rank with the smallest aggregate
+        # NVMe free space to drain, so the rebuild relocates the most data.
+        total_ranks = exclude_servers + 1
+        rank_nvme_free_total = {}
+        harasser_pool = pools[1] if len(pools) > 1 else pools[0]
+        self.log.info(
+            "<<<PASS %s: %s - querying pool %s target space before drain >>>",
+            self.loop, name, harasser_pool.identifier)
+        for qrank in range(total_ranks):
+            try:
+                result = harasser_pool.query_targets(rank=qrank)
+                nvme_free_sum = 0
+                for tgt_idx, tgt_info in enumerate(result['response']['Infos']):
+                    for tier in tgt_info['space']:
+                        self.log.info(
+                            "  Pool %s rank %d target %d %s: total=%d free=%d used=%d",
+                            harasser_pool.identifier, qrank, tgt_idx,
+                            tier['media_type'],
+                            tier['total'], tier['free'],
+                            tier['total'] - tier['free'])
+                        if tier['media_type'] == 'nvme':
+                            nvme_free_sum += tier['free']
+                rank_nvme_free_total[qrank] = nvme_free_sum
+                self.log.info(
+                    "  Pool %s rank %d aggregate NVMe free: %d bytes",
+                    harasser_pool.identifier, qrank, nvme_free_sum)
+            except (TestFail, CommandFailure) as error:
+                self.log.warning(
+                    "  Pool %s query-targets rank %d failed: %s",
+                    harasser_pool.identifier, qrank, error)
+
+        # Select the rank with the least aggregate NVMe free space to drain,
+        # maximizing the amount of data relocated during rebuild.
+        if rank_nvme_free_total:
+            rank = min(rank_nvme_free_total, key=rank_nvme_free_total.get)
+            self.log.info(
+                "<<<PASS %s: %s - selecting rank %d for drain "
+                "(lowest aggregate NVMe free: %d bytes) >>>",
+                self.loop, name, rank, rank_nvme_free_total[rank])
+        else:
+            # Fallback to random selection if query-targets failed
+            rank = self.random.randint(0, exclude_servers)
+            self.log.info(
+                "<<<PASS %s: %s - query-targets unavailable, "
+                "falling back to random rank %d >>>",
+                self.loop, name, rank)
+
         # init the status dictionary
         params = {"name": name,
                   "status": status,

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2232,7 +2232,19 @@ reserve_space(struct vos_io_context *ioc, uint16_t media, daos_size_t size,
 	if (rc == -DER_NOSPACE) {
 		now = daos_gettime_coarse();
 		if (now - ioc->ic_cont->vc_io_nospc_ts > VOS_NOSPC_ERROR_INTVL) {
-			D_ERROR("Reserve "DF_U64" from NVMe failed. "DF_RC"\n", size, DP_RC(rc));
+			struct vos_pool_space vps = {0};
+			int                   qrc;
+
+			qrc = vos_space_query(vos_cont2pool(ioc->ic_cont), &vps, false);
+			if (qrc == 0)
+				D_ERROR("Reserve " DF_U64 " from NVMe failed (nvme_free:" DF_U64
+					" nvme_tot:" DF_U64 " nvme_sys:" DF_U64 "). " DF_RC "\n",
+					size, NVME_FREE(&vps), NVME_TOTAL(&vps), NVME_SYS(&vps),
+					DP_RC(rc));
+			else
+				D_ERROR("Reserve " DF_U64 " from NVMe failed. " DF_RC
+					" (space query also failed: " DF_RC ")\n",
+					size, DP_RC(rc), DP_RC(qrc));
 			ioc->ic_cont->vc_io_nospc_ts = now;
 		}
 	} else if (rc) {


### PR DESCRIPTION
When vos_reserve_blocks() fails, in addition to the allocation request size, include additional information about NVMe space: free, total, and system-reserved bytes.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
