### PR TITLE
DAOS-18487 object: hulk data only consumes 1 unit

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2216,7 +2216,7 @@ migrate_one_ult(void *arg)
 
 	data_units = data_size * ioa->ioa_fanout;
 	if (migr_res_is_hulk(data_units))
-		rc = migrate_res_hold(tls, MIGR_HULK, data_units, &mrone->mo_data_rsh);
+		rc = migrate_res_hold(tls, MIGR_HULK, 1, &mrone->mo_data_rsh);
 	else
 		rc = migrate_res_hold(tls, MIGR_DATA, data_units, &mrone->mo_data_rsh);
 	if (rc)


### PR DESCRIPTION
The idea of adding hulk data is supporting degraded read with unlimited size: one engine only allows 2 inflight unlimited degraded reads, and each consumes one unit.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
