### PR TITLE
DAOS-18618 tests: fix rebuild_object_with_csum_error tests

### DIFF
--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -23,7 +23,7 @@ timeouts:
   test_daos_capability: 104
   test_daos_epoch_recovery: 104
   test_daos_md_replication: 104
-  test_daos_rebuild_simple: 1950
+  test_daos_rebuild_simple: 2400
   test_daos_drain_simple: 3720
   test_daos_extend_simple: 3600
   test_daos_oid_allocator: 640

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1378,7 +1378,6 @@ rebuild_object_with_csum_error(void **state)
 	int		 i, j;
 	daos_handle_t	 poh = arg->pool.poh;
 	/* only injection to rank 0, increase to 3 when rebuild could handle checksum error */
-	int              ranks = 1;
 	daos_key_t	 dkey, akey;
 	uint64_t	 dkey_val;
 	char		*akey_val = "0";
@@ -1394,7 +1393,7 @@ rebuild_object_with_csum_error(void **state)
 
 	/* test params */
 	daos_size_t	transfer_size = 1 * MB;
-	daos_size_t	block_size = 2L * GB;
+	daos_size_t      block_size    = 200L * MB;
 	daos_size_t	io_count = block_size / transfer_size;
 	uint32_t	iterations = 2;
 
@@ -1453,8 +1452,8 @@ rebuild_object_with_csum_error(void **state)
 	for (j = 0; j < iterations && rc == 0; j++) {
 		print_message("iteration: %d\n", j);
 		for (i = 0; i < io_count && rc == 0; i++) {
-			if (i % 100 == 0)
-				inject_corruption(arg->myrank, (i / 100) % ranks, arg->group, 2);
+			if (i % 10 == 0)
+				inject_corruption(arg->myrank, 0, arg->group, 2);
 			dkey_val = i;
 			rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
 			if (rc != 0)
@@ -1473,6 +1472,8 @@ rebuild_object_with_csum_error(void **state)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_NUM, 0, 0, NULL);
 	}
+
+	test_rebuild_wait(&arg, 1);
 
 	/* clean up */
 	assert_success(daos_cont_close(coh, NULL));


### PR DESCRIPTION
Wait for rebuild to start during the I/O loop once enough corruption
injections have been issued, so fast providers such as verbs can
also observe scrubber- triggered rebuild.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
