### PR TITLE
DAOS-18728 pool: not bump pool_component::co_in_ver when UP to UPIN

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1938,7 +1938,6 @@ update_dom_status(struct pool_domain *domain, uint32_t id, uint32_t status, uint
 					child->do_comp.co_rank, child->do_comp.co_id,
 					child->do_comp.co_status, status);
 				child->do_comp.co_status = status;
-				child->do_comp.co_in_ver = version;
 				*updated = true;
 			}
 			break;

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -2420,7 +2420,8 @@ dtx_leader_get(struct ds_pool *pool, struct dtx_memberships *mbs, daos_unit_oid_
 		D_ASSERT(rc == 1);
 
 		/* The target that (re-)joined the system after DTX cannot be the leader. */
-		if ((*p_tgt)->ta_comp.co_in_ver <= version)
+		if ((*p_tgt)->ta_comp.co_status == PO_COMP_ST_UPIN &&
+		    (*p_tgt)->ta_comp.co_in_ver <= version)
 			D_GOTO(out, rc = 0);
 	}
 

--- a/src/pool/srv_pool_map.c
+++ b/src/pool/srv_pool_map.c
@@ -19,7 +19,7 @@ update_tgt_up_to_upin(uuid_t pool_uuid, struct pool_map *map, struct pool_target
 	D_DEBUG(DB_MD, DF_MAP ": change " DF_TARGET " to UPIN\n", DP_MAP(pool_uuid, map),
 		DP_TARGET(target));
 	target->ta_comp.co_flags = 0;
-	target->ta_comp.co_in_ver = ++(*version);
+	++(*version);
 	target->ta_comp.co_status = PO_COMP_ST_UPIN;
 	if (print_changes)
 		D_PRINT(DF_MAP ": " DF_TARGET " is reintegrated.\n", DP_MAP(pool_uuid, map),


### PR DESCRIPTION
The pool_component::co_in_ver is used to record the pool map version when the target status (co_status) is set as UP. Do not bump it when be changed from UP to UPIN. Otherwise, it will misguide DTX logic as to DTX resync may leak DTX entry.

Another fix is for DTX logic: only UPIN target can be as DTX leader.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
