### PR TITLE
DAOS-18696 test: Allow servers to continue running between variants

### DIFF
--- a/src/tests/ftest/osa/online_extend.py
+++ b/src/tests/ftest/osa/online_extend.py
@@ -1,5 +1,6 @@
 """
-  (C) Copyright 2020-2023 Intel Corporation.
+  Copyright 2020-2023 Intel Corporation.
+  Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -79,7 +80,7 @@ class OSAOnlineExtend(OSAUtils):
 
             # Start the additional servers and extend the pool
             self.log.info("Extra Servers = %s", self.extra_servers)
-            self.start_additional_servers(self.extra_servers)
+            self.start_additional_servers(self.extra_servers, format_storage=False)
             if self.test_during_aggregation is True:
                 for _ in range(0, 2):
                     self.run_ior_thread("Write", oclass, test_seq)

--- a/src/tests/ftest/osa/online_extend.yaml
+++ b/src/tests/ftest/osa/online_extend.yaml
@@ -14,9 +14,6 @@ timeout: 1000
 job_manager:
   manager_timeout: 330
 
-setup:
-  start_servers_once: false
-
 skip_add_log_msg: true
 
 server_config:

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -1,6 +1,6 @@
 """
-  (C) Copyright 2020-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  Copyright 2020-2024 Intel Corporation.
+  Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -1833,7 +1833,8 @@ class TestWithServers(TestWithoutServers):
             self.container.append(
                 self.get_container(pool=pool, namespace=namespace, create=create))
 
-    def start_additional_servers(self, additional_servers, index=0, mgmt_svc_replicas=None):
+    def start_additional_servers(self, additional_servers, index=0, mgmt_svc_replicas=None,
+                                 format_storage=True):
         """Start additional servers.
 
         This method can be used to start a new daos_server during a test.
@@ -1844,6 +1845,8 @@ class TestWithServers(TestWithoutServers):
                 the new server.
             mgmt_svc_replicas (NodeSet): MS replica hosts. Defaults to None which
                 uses self.mgmt_svc_replicas.
+            format_storage (bool): whether or not to format storage when starting the servers.
+                Defaults to True.
         """
         self.add_server_manager(
             self.server_managers[index].manager.job.get_config_value("name"),
@@ -1859,4 +1862,5 @@ class TestWithServers(TestWithoutServers):
             self.hostfile_servers_slots,
             mgmt_svc_replicas
         )
+        self.server_managers[-1].format_storage_on_start = format_storage
         self._start_manager_list("server", [self.server_managers[-1]])

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -142,6 +142,9 @@ class DaosServerManager(SubprocessManager):
         # defined in the self.manager.job.yaml object.
         self._external_yaml_data = None
 
+        # Option to format storage when starting the servers. Defaults to True.
+        self._format_storage_on_start = True
+
     @property
     def engines(self):
         """Get the total number of engines.
@@ -181,6 +184,20 @@ class DaosServerManager(SubprocessManager):
 
         """
         return self.get_host_ranks(self.management_service_hosts)
+
+    @property
+    def format_storage_on_start(self):
+        """Whether or not to format storage when starting the servers."""
+        return self._format_storage_on_start
+
+    @format_storage_on_start.setter
+    def format_storage_on_start(self, value):
+        """Set whether or not to format storage when starting the servers.
+
+        Args:
+            value (bool): whether or not to format storage when starting the servers
+        """
+        self._format_storage_on_start = value
 
     def get_params(self, test):
         """Get values for all of the command params from the yaml file.
@@ -660,18 +677,19 @@ class DaosServerManager(SubprocessManager):
         # Prepare the servers
         self.prepare()
 
-        # Start the servers and wait for them to be ready for storage format
-        self.detect_format_ready()
+        if self.format_storage_on_start:
+            # Start the servers and wait for them to be ready for storage format
+            self.detect_format_ready()
 
-        # Collect storage and network information from the servers.
-        self.information.collect_storage_information()
-        self.information.collect_network_information()
+            # Collect storage and network information from the servers.
+            self.information.collect_storage_information()
+            self.information.collect_network_information()
 
-        # Format storage and wait for server to change ownership
-        self.log.info("<SERVER> Formatting hosts: <%s>", self.dmg.hostlist)
-        # Temporarily increasing timeout to avoid CI errors until DAOS-5764 can
-        # be further investigated.
-        self.dmg.storage_format(timeout=self.storage_format_timeout.value)
+            # Format storage and wait for server to change ownership
+            self.log.info("<SERVER> Formatting hosts: <%s>", self.dmg.hostlist)
+            # Temporarily increasing timeout to avoid CI errors until DAOS-5764 can
+            # be further investigated.
+            self.dmg.storage_format(timeout=self.storage_format_timeout.value)
 
         # Wait for all the engines to start
         self.detect_engine_start()

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -507,6 +507,23 @@ class DaosServerManager(SubprocessManager):
             raise ServerFailed(
                 "Failed to start servers before format: {}".format(error)) from error
 
+    def detect_no_format_start(self):
+        """Detect when all the daos_servers have started without formatting storage.
+
+        Raises:
+            ServerFailed: if there was an error starting the servers.
+
+        """
+        self.log.info("<SERVER> Waiting for servers to start w/o storage format")
+        self.manager.job.update_pattern("normal", len(self._hosts))
+        try:
+            self.manager.run()
+        except CommandFailure as error:
+            self.manager.kill()
+            raise ServerFailed(
+                "Failed to start servers w/o storage format: {}".format(error)) from error
+        return True
+
     def detect_engine_start(self, hosts_qty=None):
         """Detect when all the engines have started.
 
@@ -677,19 +694,22 @@ class DaosServerManager(SubprocessManager):
         # Prepare the servers
         self.prepare()
 
-        if self.format_storage_on_start:
-            # Start the servers and wait for them to be ready for storage format
-            self.detect_format_ready()
+        if not self.format_storage_on_start:
+            self.detect_no_format_start()
+            return True
 
-            # Collect storage and network information from the servers.
-            self.information.collect_storage_information()
-            self.information.collect_network_information()
+        # Start the servers and wait for them to be ready for storage format
+        self.detect_format_ready()
 
-            # Format storage and wait for server to change ownership
-            self.log.info("<SERVER> Formatting hosts: <%s>", self.dmg.hostlist)
-            # Temporarily increasing timeout to avoid CI errors until DAOS-5764 can
-            # be further investigated.
-            self.dmg.storage_format(timeout=self.storage_format_timeout.value)
+        # Collect storage and network information from the servers.
+        self.information.collect_storage_information()
+        self.information.collect_network_information()
+
+        # Format storage and wait for server to change ownership
+        self.log.info("<SERVER> Formatting hosts: <%s>", self.dmg.hostlist)
+        # Temporarily increasing timeout to avoid CI errors until DAOS-5764 can
+        # be further investigated.
+        self.dmg.storage_format(timeout=self.storage_format_timeout.value)
 
         # Wait for all the engines to start
         self.detect_engine_start()


### PR DESCRIPTION
For cases where the servers remain in the joined state after an osa/online_extend.py test varaint completes, do not force the servers to be restarted.

Support starting additional servers without the need to format storage to enable this feature.

Skip-fault-injection-test: true
Skip-unit-tests: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
