### PR TITLE
DAOS-18487 placement: state machine fixes for jump-map (#17789)

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -2389,7 +2389,7 @@ update_failed_cnt_helper(struct pool_domain *dom,
 
 	if (dom->do_children == NULL) {
 		for (i = 0; i < dom->do_target_nr; ++i) {
-			if (pool_target_down(&dom->do_targets[i]))
+			if (pool_target_is_down(&dom->do_targets[i]))
 				num_failed++;
 		}
 	} else {

--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -74,6 +75,8 @@ struct pl_obj_layout {
 	uint32_t		 ol_grp_size;
 	uint32_t		 ol_grp_nr;
 	uint32_t		 ol_nr;
+	/* number of peer targets, this field is added for reint/extension/drain placement */
+	unsigned int             ol_shard_peers;
 	struct pl_obj_shard	*ol_shards;
 };
 

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -396,9 +396,9 @@ pool_target_avail(struct pool_target *tgt, uint32_t allow_status)
 }
 
 static inline bool
-pool_target_is_up_or_drain(struct pool_target *tgt)
+pool_target_is_drain(struct pool_target *tgt)
 {
-	return tgt->ta_comp.co_status & (PO_COMP_ST_UP | PO_COMP_ST_DRAIN);
+	return (tgt->ta_comp.co_status & PO_COMP_ST_DRAIN);
 }
 
 static inline bool
@@ -416,7 +416,7 @@ pool_target_is_down2up(struct pool_target *tgt)
 
 /** Check if the target is in PO_COMP_ST_DOWN status */
 static inline bool
-pool_target_down(struct pool_target *tgt)
+pool_target_is_down(struct pool_target *tgt)
 {
 	struct pool_component	*comp = &tgt->ta_comp;
 	uint8_t			 status = comp->co_status;

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -1,7 +1,7 @@
 /**
  *
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -162,68 +162,54 @@ jm_obj_shard_pd(struct jm_obj_placement *jmop, uint32_t shard)
  *
  * \param[in]	jmap		A pointer to the jump map used to retrieve a
  *				reference to the pool map target.
- * \param[in]	original	The original layout calculated not including any
+ * \param[in]	old_lo		The original layout calculated not including any
  *				recent pool map changes, like reintegration.
- * \param[in]	new		The new layout that contains changes in layout
+ * \param[in]	new_lo		The new layout that contains changes in layout
  *				that occurred due to pool status changes.
- * \param[in]	for_reint	diff calls from find_reint() to extract the reintegrating
- *                              shards.
+ * \param[in]	rebuilding	diff calls to extract the rebuilding shards for scanner.
  * \param[out]	diff		The d_list that contains the differences that
  *				were calculated.
  */
-static inline void
-layout_find_diff(struct pl_jump_map *jmap, struct pl_obj_layout *original,
-		 struct pl_obj_layout *new, d_list_t *diff, bool for_reint)
+static inline int
+layout_find_diff(struct pl_jump_map *jmap, struct pl_obj_layout *old_lo,
+		 struct pl_obj_layout *new_lo, d_list_t *diff, bool rebuilding)
 {
 	int index;
+	int rc;
 
 	/* We assume they are the same size */
-	D_ASSERT(original->ol_nr == new->ol_nr);
+	D_ASSERT(old_lo->ol_nr == new_lo->ol_nr);
 
-	for (index = 0; index < original->ol_nr; ++index) {
-		uint32_t original_target = original->ol_shards[index].po_target;
-		uint32_t reint_tgt = new->ol_shards[index].po_target;
-		struct pool_target *temp_tgt;
+	for (index = 0; index < old_lo->ol_nr; ++index) {
+		uint32_t            old_tgt = old_lo->ol_shards[index].po_target;
+		uint32_t            new_tgt = new_lo->ol_shards[index].po_target;
+		bool                remap   = false;
+		struct pool_target *new_pot;
 
-		/* For reintegration, rebuilding shards should be added to the
-		 * reintegrated shards, since "DOWN" shard is being considered
-		 * during layout recalculation.
-		 */
+		if (new_tgt != old_tgt)
+			remap = true; /* migrate to a new target, e.g. drain, regular reint */
+		else if (rebuilding && old_lo->ol_shards[index].po_rebuilding)
+			remap = true; /* rebuild or down2up reintegration */
 
-		pool_map_find_target(jmap->jmp_map.pl_poolmap, original_target,
-				     &temp_tgt);
+		if (remap) {
+			rc = pool_map_find_target(jmap->jmp_map.pl_poolmap, new_tgt, &new_pot);
+			D_ASSERT(rc == 1);
 
-		/* Note: the delay rebuild targets(DOWN2UP target) should be
-		 * chosen to be rebuilt as well.
-		 */
-		if (reint_tgt != original_target ||
-		    (for_reint && original->ol_shards[index].po_rebuilding) ||
-		    (temp_tgt->ta_comp.co_flags & PO_COMPF_DOWN2UP &&
-		     temp_tgt->ta_comp.co_status == PO_COMP_ST_UP)) {
-			pool_map_find_target(jmap->jmp_map.pl_poolmap,
-					     reint_tgt, &temp_tgt);
-			if (pool_target_avail(temp_tgt, PO_COMP_ST_UPIN | PO_COMP_ST_UP |
-					      PO_COMP_ST_DRAIN))
-				remap_alloc_one(diff, index, temp_tgt, true, NULL);
-			else
-				/* XXX: This isn't desirable - but it can happen
-				 * when a reintegration is happening when
-				 * something else fails. Placement will do a
-				 * pass to determine what failed (good), and
-				 * then do another pass to figure out where
-				 * things moved to. But that 2nd pass will
-				 * re-find failed things, and this diff function
-				 * will cause the failed targets to be re-added
-				 * to the layout as rebuilding. This should be
-				 * removed when placement is able to handle
-				 * this situation better
-				 */
-				D_DEBUG(DB_PL,
-					"skip remap %d to unavail tgt %u\n",
-					index, reint_tgt);
+			if (pool_target_avail(new_pot,
+					      PO_COMP_ST_UPIN | PO_COMP_ST_UP | PO_COMP_ST_DRAIN)) {
+				struct failed_shard *shard;
 
+				shard = remap_alloc_one(index, new_pot, new_pot->ta_comp.co_id, 0,
+							NULL);
+				if (!shard)
+					return -DER_NOMEM;
+
+				d_list_add_tail(&shard->fs_list, diff);
+			}
+			/* else: it's a failure will be handled by later rebuild, just ignore it */
 		}
 	}
+	return 0;
 }
 
 /**
@@ -381,14 +367,11 @@ struct dom_grp_used {
  */
 static int
 obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_md *md,
-		 struct pl_obj_layout *layout, struct jm_obj_placement *jmop,
-		 d_list_t *remap_list, d_list_t *out_list, uint32_t allow_version,
-		 enum layout_gen_mode gen_mode, uint8_t *tgts_used, uint8_t *dom_used,
-		 uint8_t *dom_full, uint32_t failed_in_layout, bool *is_extending,
-		 uint32_t fdom_lvl)
+		 struct pl_obj_layout *layout, struct jm_obj_placement *jmop, d_list_t *remap_list,
+		 uint32_t allow_version, enum layout_gen_mode gen_mode, uint8_t *tgts_used,
+		 uint8_t *dom_used, uint8_t *dom_full, uint32_t failed_in_layout, uint32_t fdom_lvl)
 {
 	struct failed_shard     *f_shard;
-	struct pl_obj_shard     *l_shard;
 	struct pool_target      *spare_tgt = NULL;
 	struct pool_domain      *spare_dom = NULL;
 	struct pool_domain      *root, *curr_pd;
@@ -398,7 +381,6 @@ obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_
 	uint64_t                key;
 	uint32_t		spares_left;
 	int                     rc;
-
 
 	remap_dump(remap_list, md, "remap:");
 
@@ -419,7 +401,6 @@ obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_
 		f_shard = d_list_entry(current, struct failed_shard, fs_list);
 
 		shard_id = f_shard->fs_shard_idx;
-		l_shard = &layout->ol_shards[f_shard->fs_shard_idx];
 		D_DEBUG(DB_PL, "Attempting to remap failed shard: "
 			DF_FAILEDSHARD"\n", DP_FAILEDSHARD(*f_shard));
 
@@ -437,7 +418,7 @@ obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_
 
 			D_ASSERT(dgu != NULL);
 			if (layout_ver <= 1)
-				rebuild_key = crc(key, crc(key, f_shard->fs_shard_idx));
+				rebuild_key = crc(key, crc(key, shard_id));
 			else /* hash OID differently so we don't land to the same target */
 				rebuild_key = jm_crc(oid.lo, oid.hi, 0xDead2Bad);
 
@@ -460,20 +441,11 @@ obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_
 			}
 		}
 
-		rc = determine_valid_spares(spare_tgt, md, spare_avail, remap_list,
-					    allow_version, gen_mode, f_shard, l_shard,
-					    is_extending);
+		rc = determine_valid_spares(spare_tgt, md, spare_avail, remap_list, allow_version,
+					    gen_mode, f_shard, layout);
 		if (rc == 1) {
-			/* Current shard is remapped, move the remap to the output list or
-			 * delete it.
-			 */
-			if (out_list != NULL) {
-				d_list_move_tail(current, out_list);
-			} else {
-				d_list_del(&f_shard->fs_list);
-				D_FREE(f_shard);
-			}
-
+			d_list_del(&f_shard->fs_list);
+			D_FREE(f_shard);
 			if (spare_dom != NULL && dgu != NULL)
 				setbit(dgu->dgu_real, spare_dom - root);
 		}
@@ -565,12 +537,6 @@ remap_gpu_alloc_one(d_list_t *remap_list, uint8_t *dom_cur_grp_used,
  * \param[in]   md              Object metadata.
  * \param[in]	gen_mode	layout generation mode.
  * \param[out]  layout          This will contain the layout for the object
- * \param[out]  out_list	This will contain the targets that need to
- *                              be rebuilt and in the case of rebuild, may be
- *                              returned during the rebuild process.
- * \param[out]	is_extending	if there is drain/extending/reintegrating tgts
- *                              exists in this layout, which we might need
- *                              insert extra shards into the layout.
  *
  * \return                      An error code determining if the function
  *                              succeeded (0) or failed.
@@ -579,8 +545,8 @@ remap_gpu_alloc_one(d_list_t *remap_list, uint8_t *dom_cur_grp_used,
 #define	LOCAL_TGT_ARRAY_SIZE	4
 static int
 get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_layout *layout,
-		  struct jm_obj_placement *jmop, d_list_t *out_list, uint32_t allow_version,
-		  enum layout_gen_mode gen_mode, struct daos_obj_md *md, bool *is_extending)
+		  struct jm_obj_placement *jmop, uint32_t allow_version,
+		  enum layout_gen_mode gen_mode, struct daos_obj_md *md)
 {
 	struct pool_target      *target;
 	struct pool_domain      *domain;
@@ -672,6 +638,8 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 		}
 
 		for (j = 0; j < jmop->jmop_grp_size; j++, k++) {
+			unsigned int remap_flags = 0;
+
 			target = NULL;
 			domain = NULL;
 			if (spec_oid && i == 0 && j == 0) {
@@ -711,7 +679,10 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 			layout->ol_shards[k].po_index = target->ta_comp.co_index;
 
 			/** If target is failed queue it for remap*/
-			if (need_remap_comp(&target->ta_comp, allow_version, gen_mode)) {
+			if (comp_need_remap(&target->ta_comp, allow_version, gen_mode,
+					    &remap_flags)) {
+				struct failed_shard *shard;
+
 				fail_tgt_cnt++;
 				D_DEBUG(DB_PL, "Target unavailable " DF_TARGET
 					". Adding to remap_list: fail cnt %d\n",
@@ -726,25 +697,24 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 					realloc_grp_used = true;
 				}
 
-				rc = remap_alloc_one(&remap_list, k, target, false, remap_grp_used);
-				if (rc)
-					D_GOTO(out, rc);
+				/* will be remapped to another target, just pass in -1 */
+				shard = remap_alloc_one(k, target, -1, remap_flags, remap_grp_used);
+				if (!shard)
+					D_GOTO(out, rc = -DER_NOMEM);
+
+				remap_add_one(&remap_list, shard);
 			} else {
+				layout_set_shard_flags(layout, k, remap_flags);
 				if (domain != NULL)
 					setbit(dom_cur_grp_real, domain - root);
-				if (pool_target_down(target))
-					layout->ol_shards[k].po_rebuilding = 1;
 			}
-
-			if (is_extending != NULL && pool_target_is_up_or_drain(target))
-				*is_extending = true;
 		}
 	}
 
 	if (fail_tgt_cnt > 0)
-		rc = obj_remap_shards(jmap, layout_ver, md, layout, jmop, &remap_list, out_list,
+		rc = obj_remap_shards(jmap, layout_ver, md, layout, jmop, &remap_list,
 				      allow_version, gen_mode, tgts_used, dom_used, dom_full,
-				      fail_tgt_cnt, is_extending, fdom_lvl);
+				      fail_tgt_cnt, fdom_lvl);
 out:
 	if (rc)
 		D_ERROR("jump_map_obj_layout_fill failed, rc "DF_RC"\n", DP_RC(rc));
@@ -792,8 +762,7 @@ static int
 obj_layout_alloc_and_get(struct pl_jump_map *jmap, uint32_t layout_ver,
 			 struct jm_obj_placement *jmop, struct daos_obj_md *md,
 			 uint32_t allow_version, enum layout_gen_mode gen_mode,
-			 struct pl_obj_layout **layout_p, d_list_t *remap_list,
-			 bool *is_extending)
+			 struct pl_obj_layout **layout_p)
 {
 	int rc;
 
@@ -808,8 +777,7 @@ obj_layout_alloc_and_get(struct pl_jump_map *jmap, uint32_t layout_ver,
 		return rc;
 	}
 
-	rc = get_object_layout(jmap, layout_ver, *layout_p, jmop, remap_list,
-			       allow_version, gen_mode, md, is_extending);
+	rc = get_object_layout(jmap, layout_ver, *layout_p, jmop, allow_version, gen_mode, md);
 	if (rc) {
 		D_ERROR("get object layout failed, rc "DF_RC"\n",
 			DP_RC(rc));
@@ -953,8 +921,8 @@ jump_map_obj_extend_layout(struct pl_jump_map *jmap, struct jm_obj_placement *jm
 		DP_OID(md->omd_id), md->omd_ver, layout_version);
 
 	D_INIT_LIST_HEAD(&extend_list);
-	rc = obj_layout_alloc_and_get(jmap, layout_version, jmop, md,
-				      md->omd_ver, POST_REBUILD, &new_layout, NULL, NULL);
+	rc = obj_layout_alloc_and_get(jmap, layout_version, jmop, md, md->omd_ver, POST_REBUILD,
+				      &new_layout);
 	if (rc != 0) {
 		D_ERROR(DF_OID" get_layout_alloc failed, rc "DF_RC"\n",
 			DP_OID(md->omd_id), DP_RC(rc));
@@ -963,7 +931,10 @@ jump_map_obj_extend_layout(struct pl_jump_map *jmap, struct jm_obj_placement *jm
 
 	obj_layout_dump(md->omd_id, new_layout);
 
-	layout_find_diff(jmap, layout, new_layout, &extend_list, false);
+	rc = layout_find_diff(jmap, layout, new_layout, &extend_list, false);
+	if (rc)
+		D_GOTO(out, rc);
+
 	if (!d_list_empty(&extend_list)) {
 		rc = pl_map_extend(layout, &extend_list);
 		if (rc != 0) {
@@ -1004,9 +975,7 @@ jump_map_obj_place(struct pl_map *map, uint32_t layout_version, struct daos_obj_
 {
 	struct pl_jump_map	*jmap;
 	struct pl_obj_layout	*layout = NULL;
-	struct jm_obj_placement	jmop;
-	bool			is_extending = false;
-	bool			is_adding_new = false;
+	struct jm_obj_placement  jmop;
 	daos_obj_id_t		oid;
 	struct pool_domain	*root;
 	enum layout_gen_mode	gen_mode = CURRENT;
@@ -1033,36 +1002,31 @@ jump_map_obj_place(struct pl_map *map, uint32_t layout_version, struct daos_obj_
 	if (mode & DAOS_OO_RO)
 		gen_mode = PRE_REBUILD;
 
-	rc = obj_layout_alloc_and_get(jmap, layout_version, &jmop, md, md->omd_ver,
-				      gen_mode, &layout, NULL, &is_extending);
+	rc = obj_layout_alloc_and_get(jmap, layout_version, &jmop, md, md->omd_ver, gen_mode,
+				      &layout);
 	if (rc != 0) {
 		D_ERROR("get_layout_alloc failed, rc "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
 	}
-
 	obj_layout_dump(oid, layout);
 
-	rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, PO_COMP_TP_ROOT, PO_COMP_ID_ALL,
-				  &root);
+	rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, PO_COMP_TP_ROOT, PO_COMP_ID_ALL, &root);
 	D_ASSERT(rc == 1);
 	rc = 0;
 
 	if (is_pool_map_adding(jmap->jmp_map.pl_poolmap))
-		is_adding_new = true;
-
+		layout->ol_shard_peers++; /* may or may not, have to check */
 	/**
 	 * If the layout is being extended or drained, it need recreate the layout
 	 * strictly by rebuild version to make sure both new and old shards being
 	 * updated.
 	 */
-	if (unlikely(is_extending || is_adding_new) && !(mode & DAOS_OO_RO)) {
-		D_DEBUG(DB_PL, DF_OID"/%d is being extended: %s\n", DP_OID(oid),
-			md->omd_ver, is_extending ? "yes" : "no");
+	if (layout->ol_shard_peers > 0 && gen_mode == CURRENT) {
+		D_DEBUG(DB_PL, "Add shard peers for " DF_OID " ver=%d\n", DP_OID(oid), md->omd_ver);
 		rc = jump_map_obj_extend_layout(jmap, &jmop, layout_version, md, layout);
 		if (rc)
 			D_GOTO(out, rc);
 	}
-
 	*layout_pp = layout;
 out:
 	jm_obj_placement_fini(&jmop);
@@ -1127,22 +1091,23 @@ jump_map_obj_find_diff(struct pl_map *map, uint32_t layout_ver, struct daos_obj_
 	}
 
 	D_INIT_LIST_HEAD(&reint_list);
-	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jop, md, reint_ver,
-				      PRE_REBUILD, &layout, NULL, NULL);
+	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jop, md, reint_ver, PRE_REBUILD, &layout);
 	if (rc < 0)
 		D_GOTO(out, rc);
 
 	obj_layout_dump(md->omd_id, layout);
-	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jop, md, reint_ver,
-				      POST_REBUILD, &reint_layout, NULL, NULL);
+	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jop, md, reint_ver, POST_REBUILD,
+				      &reint_layout);
 	if (rc < 0)
 		D_GOTO(out, rc);
 
 	obj_layout_dump(md->omd_id, reint_layout);
-	layout_find_diff(jmap, layout, reint_layout, &reint_list, true);
+	rc = layout_find_diff(jmap, layout, reint_layout, &reint_list, true);
+	if (rc)
+		D_GOTO(out, rc);
 
-	rc = remap_list_fill(map, md, shard_md, reint_ver, tgt_rank, shard_id,
-			     array_size, &idx, reint_layout, &reint_list, false);
+	rc = remap_list_fill(map, md, shard_md, reint_ver, tgt_rank, shard_id, array_size, &idx,
+			     reint_layout, &reint_list);
 out:
 	jm_obj_placement_fini(&jop);
 	remap_list_free_all(&reint_list);

--- a/src/placement/jump_map_versions.c
+++ b/src/placement/jump_map_versions.c
@@ -654,7 +654,7 @@ dom_tgts_are_avaible(struct pool_domain *dom, uint32_t allow_version, enum layou
 		struct pool_target *tgt;
 
 		tgt = &dom->do_targets[i];
-		if (is_comp_avaible(&tgt->ta_comp, allow_version, gen_mode))
+		if (!comp_need_remap(&tgt->ta_comp, allow_version, gen_mode, NULL))
 			return true;
 	}
 	return false;

--- a/src/placement/pl_map.h
+++ b/src/placement/pl_map.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -71,8 +72,8 @@ struct failed_shard {
 	uint32_t        fs_tgt_id;
 	uint16_t	fs_rank;
 	uint8_t		fs_index;
-	uint8_t         fs_status;
-	uint32_t	fs_down2up:1;
+	uint8_t          fs_status;
+	unsigned int     fs_remap_flags;
 };
 
 #define	DF_FAILEDSHARD "shard_idx: %d, fseq: %d, tgt_id: %d, status: %d"
@@ -111,12 +112,10 @@ crc(uint64_t data, uint32_t init_val)
 
 void
 remap_add_one(d_list_t *remap_list, struct failed_shard *f_new);
-void
-reint_add_one(d_list_t *remap_list, struct failed_shard *f_new);
 
-int
-remap_alloc_one(d_list_t *remap_list, unsigned int shard_idx,
-		struct pool_target *tgt, bool for_reint, void *data);
+struct failed_shard *
+remap_alloc_one(unsigned int shard_idx, struct pool_target *tgt, int tgt_id,
+		unsigned int remap_flags, void *data);
 
 int
 remap_insert_copy_one(d_list_t *remap_list, struct failed_shard *original);
@@ -133,18 +132,15 @@ op_get_grp_size(unsigned int domain_nr, unsigned int *grp_size,
 		daos_obj_id_t oid);
 
 int
-remap_list_fill(struct pl_map *map, struct daos_obj_md *md,
-		struct daos_obj_shard_md *shard_md, uint32_t rebuild_ver,
-		uint32_t *tgt_id, uint32_t *shard_idx,
-		unsigned int array_size, int *idx,
-		struct pl_obj_layout *layout, d_list_t *remap_list,
-		bool fill_addition);
+remap_list_fill(struct pl_map *map, struct daos_obj_md *md, struct daos_obj_shard_md *shard_md,
+		uint32_t rebuild_ver, uint32_t *tgt_id, uint32_t *shard_idx,
+		unsigned int array_size, int *idx, struct pl_obj_layout *layout,
+		d_list_t *remap_list);
 
 int
-determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md,
-		       bool spare_avail, d_list_t *remap_list, uint32_t allow_version,
-		       enum layout_gen_mode gen_mode, struct failed_shard *f_shard,
-		       struct pl_obj_shard *l_shard, bool *is_extending);
+determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md, bool spare_avail,
+		       d_list_t *remap_list, uint32_t allow_version, enum layout_gen_mode gen_mode,
+		       struct failed_shard *f_shard, struct pl_obj_layout *layout);
 
 int
 spec_place_rank_get(unsigned int *pos, daos_obj_id_t oid,
@@ -154,10 +150,29 @@ int
 pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list);
 
 bool
-is_comp_avaible(struct pool_component *comp, uint32_t allow_version,
-		enum layout_gen_mode gen_mode);
-bool
-need_remap_comp(struct pool_component *comp, uint32_t allow_status,
-		enum layout_gen_mode gen_mode);
+comp_need_remap(struct pool_component *comp, uint32_t allow_status, enum layout_gen_mode gen_mode,
+		unsigned int *remap_flags);
+
+enum {
+	/* rebuilding this shard */
+	PL_IS_REBUILDING = (1 << 0),
+	/* integrating this shard */
+	PL_IS_REINTEGRATING = (1 << 1),
+	/* has peer shard for rebuild (writes land to both of shards) */
+	PL_HAS_PEER = (1 << 2),
+};
+
+static inline void
+layout_set_shard_flags(struct pl_obj_layout *layout, int shard_idx, unsigned int remap_flags)
+{
+	if (remap_flags & PL_IS_REBUILDING)
+		layout->ol_shards[shard_idx].po_rebuilding = 1;
+
+	if (remap_flags & PL_IS_REINTEGRATING)
+		layout->ol_shards[shard_idx].po_reintegrating = 1;
+
+	if (remap_flags & PL_HAS_PEER)
+		layout->ol_shard_peers++;
+}
 
 #endif /* __PL_MAP_H__ */

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -14,19 +15,20 @@
  * Add a new failed shard into remap list
  *
  * \param[in] remap_list        List for the failed shard to be added onto.
- * \param[in] f_new             Failed shard to be added.
+ * \param[in] shard             Failed shard to be added.
  */
 void
 remap_add_one(d_list_t *remap_list, struct failed_shard *f_new)
 {
 	struct failed_shard     *f_shard;
-
 	d_list_t                *tmp;
 
 	D_DEBUG(DB_PL, "fnew: %u/%d/%u/%u", f_new->fs_shard_idx,
 		f_new->fs_tgt_id, f_new->fs_fseq, f_new->fs_status);
 
-	/* All failed shards are sorted by fseq in ascending order */
+	/* layout computation, enforce remapping order:
+	 * All failed shards are sorted by fseq in ascending order.
+	 */
 	d_list_for_each(tmp, remap_list) {
 		f_shard = d_list_entry(tmp, struct failed_shard, fs_list);
 		/*
@@ -56,20 +58,19 @@ remap_add_one(d_list_t *remap_list, struct failed_shard *f_new)
 /**
  * Allocate a new failed shard then add it into remap list
  *
- * \param[in] remap_list        List for the failed shard to be added onto.
  * \param[in] shard_idx         The shard number of the failed shard.
  * \param[in] tgt               The failed target that will be added to the
  *                              remap list.
  */
-int
-remap_alloc_one(d_list_t *remap_list, unsigned int shard_idx,
-		struct pool_target *tgt, bool for_reint, void *data)
+struct failed_shard *
+remap_alloc_one(unsigned int shard_idx, struct pool_target *tgt, int tgt_id,
+		unsigned int remap_flags, void *data)
 {
 	struct failed_shard *f_new;
 
 	D_ALLOC_PTR(f_new);
 	if (f_new == NULL)
-		return -DER_NOMEM;
+		return NULL;
 
 	D_INIT_LIST_HEAD(&f_new->fs_list);
 	f_new->fs_shard_idx = shard_idx;
@@ -77,21 +78,13 @@ remap_alloc_one(d_list_t *remap_list, unsigned int shard_idx,
 	f_new->fs_rank = tgt->ta_comp.co_rank;
 	f_new->fs_index = tgt->ta_comp.co_index;
 	f_new->fs_status = tgt->ta_comp.co_status;
-	f_new->fs_data = data;
-	if (pool_target_is_down2up(tgt))
-		f_new->fs_down2up = 1;
+	f_new->fs_data        = data;
+	f_new->fs_remap_flags = remap_flags;
+	f_new->fs_tgt_id      = tgt_id;
 
-	D_DEBUG(DB_PL, "tgt %u status %u flags %u reint %s\n", tgt->ta_comp.co_id,
-		tgt->ta_comp.co_status, tgt->ta_comp.co_flags, for_reint ? "yes" : "no");
-	if (!for_reint) {
-		f_new->fs_tgt_id = -1;
-		remap_add_one(remap_list, f_new);
-	} else {
-		f_new->fs_tgt_id = tgt->ta_comp.co_id;
-		d_list_add_tail(&f_new->fs_list, remap_list);
-	}
-
-	return 0;
+	D_DEBUG(DB_PL, "tgt %u status %u flags %u order %s\n", tgt->ta_comp.co_id,
+		tgt->ta_comp.co_status, tgt->ta_comp.co_flags, tgt_id == -1 ? "yes" : "no");
+	return f_new;
 }
 
 /**
@@ -188,12 +181,9 @@ spec_place_rank_get(unsigned int *pos, daos_obj_id_t oid,
 }
 
 int
-remap_list_fill(struct pl_map *map, struct daos_obj_md *md,
-		struct daos_obj_shard_md *shard_md, uint32_t r_ver,
-		uint32_t *tgt_id, uint32_t *shard_idx,
-		unsigned int array_size, int *idx,
-		struct pl_obj_layout *layout, d_list_t *remap_list,
-		bool fill_addition)
+remap_list_fill(struct pl_map *map, struct daos_obj_md *md, struct daos_obj_shard_md *shard_md,
+		uint32_t r_ver, uint32_t *tgt_id, uint32_t *shard_idx, unsigned int array_size,
+		int *idx, struct pl_obj_layout *layout, d_list_t *remap_list)
 {
 	struct failed_shard     *f_shard;
 	struct pl_obj_shard     *l_shard;
@@ -209,11 +199,9 @@ remap_list_fill(struct pl_map *map, struct daos_obj_md *md,
 		 * shard might need move to, so let's include
 		 * UPIN status here as well.
 		 */
-		if (f_shard->fs_status == PO_COMP_ST_DOWN ||
-		    f_shard->fs_status == PO_COMP_ST_UP ||
+		if (f_shard->fs_status == PO_COMP_ST_DOWN || f_shard->fs_status == PO_COMP_ST_UP ||
 		    f_shard->fs_status == PO_COMP_ST_DRAIN ||
-		    f_shard->fs_status == PO_COMP_ST_UPIN ||
-		    fill_addition == true) {
+		    f_shard->fs_status == PO_COMP_ST_UPIN) {
 			/*
 			 * Target id is used for rw, but rank is used
 			 * for rebuild, perhaps they should be unified.
@@ -240,80 +228,105 @@ remap_list_fill(struct pl_map *map, struct daos_obj_md *md,
 	return 0;
 }
 
+/* State-machine of remapping component
+ *
+ * ┌──────────────┬──────────────┬────────┬──────────────────────────────────────────────┐
+ * │   Status     │   gen_mode   │ remap  │  flags / effect                              │
+ * ├──────────────┼──────────────┼────────┼──────────────────────────────────────────────┤
+ * │ UPIN         │ ANY          │ false  │ —  (target healthy, nothing to do)           │
+ * │ DOWNOUT      │ ANY          │ true   │ —  (always remap, early return)              │
+ * ├──────────────┼──────────────┼────────┼──────────────────────────────────────────────┤
+ * │ DOWN         │ PRE_REBUILD  │ false  │ IS_REBUILDING  (mark no-read, no migration)  │
+ * │ DOWN         │ CURRENT      │ true   │ IS_REBUILDING  (migrate to spare, write-only)│
+ * │ DOWN         │ POST_REBUILD │ true   │ -  (rebuild complete, treat as DOWNOUT)      │
+ * ├──────────────┼──────────────┼────────┼──────────────────────────────────────────────┤
+ * │ DRAIN        │ PRE_REBUILD  │ false  │ —  (still UPIN from pre-drain view)          │
+ * │ DRAIN        │ CURRENT      │ false  │ HAS_PEER  (keep in place, extend layout)     │
+ * │ DRAIN        │ POST_REBUILD │ true   │ —  (drain complete, treat as DOWNOUT)        │
+ * ├──────────────┼──────────────┼────────┼──────────────────────────────────────────────┤
+ * │ UP (down2up) │ PRE_REBUILD  │ false  │ IS_REBUILDING | IS_REINTEGRATING             │
+ * │ UP (down2up) │ CURRENT      │ false  │ IS_REBUILDING | IS_REINTEGRATING             │
+ * │ UP (down2up) │ POST_REBUILD │ false  │ -  (reintegration complete, treat as UPIN)   │
+ * ├──────────────┼──────────────┼────────┼──────────────────────────────────────────────┤
+ * │ UP (regular) │ PRE_REBUILD  │ true   │ —  (not yet reintegrated, use fallback)      │
+ * │ UP (regular) │ CURRENT      │ true   │ HAS_PEER  (migrate + extend layout)          │
+ * │ UP (regular) │ POST_REBUILD │ false  │ —  (reintegration complete, treat as UPIN)   │
+ * └──────────────┴──────────────┴────────┴──────────────────────────────────────────────┘
+ *
+ * Flags:
+ *   IS_REBUILDING    → po_rebuilding=1     skip shard on read
+ *   IS_REINTEGRATING → po_reintegrating=1  shard is being reintegrated
+ *   HAS_PEER         → ol_shard_peers++    triggers extend_layout (dual-write to old+new)
+ */
 bool
-is_comp_avaible(struct pool_component *comp, uint32_t allow_version,
-		enum layout_gen_mode gen_mode)
+comp_need_remap(struct pool_component *comp, uint32_t allow_version, enum layout_gen_mode gen_mode,
+		unsigned int *remap_flags)
 {
 	unsigned int status = comp->co_status;
+	unsigned int flags  = 0;
+	bool         remap  = true;
 
+	if (status == PO_COMP_ST_UPIN)
+		return false; /* do nothing for UPIN */
+
+	if (status == PO_COMP_ST_DOWNOUT)
+		return true; /* always remap */
+
+	/* NB: if @remap is false, @flags is applied to the current shard/target, otherwise
+	 * it's applied to the remapped shard/target.
+	 */
 	if (gen_mode == PRE_REBUILD) {
-		/* For pre rebuild mode, it needs to revert the status
-		 * to the original state first, then check if the component
-		 * is available.
+		/* remap decision is based on the target status before transition */
+		if (status == PO_COMP_ST_DOWN) {
+			remap = false;            /* transited from UPIN, no remap */
+			flags = PL_IS_REBUILDING; /* no read */
+
+		} else if (status == PO_COMP_ST_DRAIN) {
+			remap = false; /* transited from UPIN, no remap */
+
+		} else if (status == PO_COMP_ST_UP && (comp->co_flags & PO_COMPF_DOWN2UP)) {
+			remap = false; /* transited UPIN->DOWN->UP, no remap */
+			flags = PL_IS_REBUILDING | PL_IS_REINTEGRATING;
+		}
+	} else {
+		/* Check if the target state is within the allow version, otherwise
+		 * it needs to revert the target state to its original state first.
 		 */
-		if (status & (PO_COMP_ST_DOWN | PO_COMP_ST_DRAIN)) {
-			status = PO_COMP_ST_UPIN;
+		if (status == PO_COMP_ST_DOWN) {
+			if (comp->co_fseq > allow_version)
+				remap = false; /* future failure, don't handle it */
+			else
+				flags = PL_IS_REBUILDING; /* remap, write only */
+
+		} else if (status == PO_COMP_ST_DRAIN) {
+			if (comp->co_fseq > allow_version) {
+				remap = false; /* futuren drain, don't handle it */
+
+			} else if (gen_mode == CURRENT) {
+				flags = PL_HAS_PEER;
+				remap = false;
+			}
 		} else if (status == PO_COMP_ST_UP) {
-			if (comp->co_flags & PO_COMPF_DOWN2UP) {
-				/* PO_COMP_ST_UP status with PO_COMPF_DOWN2UP flag
-				 * is the case of delay_rebuild exclude+reint.
-				 * Cannot mark it as UPIN to avoid it be used for
-				 * rebuild enumerate/fetch, as the data will be
-				 * discarded in reintegrate.
-				 */
-				/* status = PO_COMP_ST_UPIN; */
-			} else {
-				if (comp->co_fseq <= 1)
-					status = PO_COMP_ST_NEW;
-				else
-					status = PO_COMP_ST_DOWNOUT;
-			}
-		}
+			if (comp->co_in_ver > allow_version) {
+				/* future reintegration, do nothing but remap */
 
-		return status & PO_COMP_ST_UPIN;
-	}
+			} else if (comp->co_flags & PO_COMPF_DOWN2UP) {
+				/* no remap, write only */
+				flags = PL_IS_REBUILDING | PL_IS_REINTEGRATING;
+				remap = false;
 
-	/**
-	 * Check if the target state is within the allow version, otherwise
-	 * it needs to revert the target state to its original state first.
-	 */
-	if (status & (PO_COMP_ST_DOWN | PO_COMP_ST_DRAIN)) {
-		if (comp->co_fseq > allow_version)
-			status = PO_COMP_ST_UPIN;
-	} else if (status == PO_COMP_ST_UP) {
-		if (comp->co_in_ver > allow_version) {
-			if (comp->co_flags & PO_COMPF_DOWN2UP) {
-			       status = PO_COMP_ST_DOWN;
-			} else {
-				if (comp->co_fseq <= 1)
-					status = PO_COMP_ST_NEW;
+			} else { /* regular reintegration */
+				if (gen_mode == CURRENT)
+					flags = PL_HAS_PEER; /* remap to fallback for CURRENT */
 				else
-					status = PO_COMP_ST_DOWNOUT;
+					remap = false;
 			}
 		}
 	}
+	if (remap_flags)
+		*remap_flags |= flags;
 
-	if (gen_mode == POST_REBUILD) {
-		if (status & (PO_COMP_ST_DOWN | PO_COMP_ST_DRAIN))
-			status = PO_COMP_ST_DOWNOUT;
-		else if (status & PO_COMP_ST_UP)
-			status = PO_COMP_ST_UPIN;
-
-		return status & PO_COMP_ST_UPIN;
-	}
-
-	/* If the layout is generated by current pool map, then both
-	 * UPIN and DRAIN target are avalid, i.e. it does not need to
-	 * be remapped anymore.
-	 */
-	return status & (PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN);
-}
-
-bool
-need_remap_comp(struct pool_component *comp, uint32_t allow_version,
-		enum layout_gen_mode gen_mode)
-{
-	return !is_comp_avaible(comp, allow_version, gen_mode);
+	return remap;
 }
 
 /**
@@ -323,19 +336,18 @@ need_remap_comp(struct pool_component *comp, uint32_t allow_version,
  * spare target.
  */
 int
-determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md,
-		       bool spare_avail, d_list_t *remap_list, uint32_t allow_version,
-		       enum layout_gen_mode gen_mode, struct failed_shard *f_shard,
-		       struct pl_obj_shard *l_shard, bool *is_extending)
+determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md, bool spare_avail,
+		       d_list_t *remap_list, uint32_t allow_version, enum layout_gen_mode gen_mode,
+		       struct failed_shard *f_shard, struct pl_obj_layout *layout)
 {
+	struct pl_obj_shard *l_shard = &layout->ol_shards[f_shard->fs_shard_idx];
+
 	if (!spare_avail)
 		goto next_fail;
 
-	if (is_extending != NULL && pool_target_is_up_or_drain(spare_tgt))
-		*is_extending = true;
-
 	/* The selected spare target is down as well */
-	if (need_remap_comp(&spare_tgt->ta_comp, allow_version, gen_mode)) {
+	if (comp_need_remap(&spare_tgt->ta_comp, allow_version, gen_mode,
+			    &f_shard->fs_remap_flags)) {
 		D_DEBUG(DB_PL, "Spare target is also unavailable " DF_TARGET
 			".\n", DP_TARGET(spare_tgt));
 
@@ -392,20 +404,11 @@ determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md,
 
 next_fail:
 	if (spare_avail) {
-		/* The selected spare target is up and ready */
 		l_shard->po_target = spare_tgt->ta_comp.co_id;
-		l_shard->po_fseq = f_shard->fs_fseq;
-		l_shard->po_rank = spare_tgt->ta_comp.co_rank;
-		l_shard->po_index = spare_tgt->ta_comp.co_index;
-
-		/*
-		 * Mark the shard as 'rebuilding' so that read will skip this shard.
-		 * f_shard->fs_down2up is the case of delay_rebuild exclude+reint.
-		 */
-		if (f_shard->fs_status == PO_COMP_ST_DOWN ||
-		    f_shard->fs_status == PO_COMP_ST_DRAIN ||
-		    f_shard->fs_down2up || pool_target_down(spare_tgt))
-			l_shard->po_rebuilding = 1;
+		l_shard->po_fseq   = f_shard->fs_fseq;
+		l_shard->po_rank   = spare_tgt->ta_comp.co_rank;
+		l_shard->po_index  = spare_tgt->ta_comp.co_index;
+		layout_set_shard_flags(layout, f_shard->fs_shard_idx, f_shard->fs_remap_flags);
 	} else {
 		l_shard->po_shard = -1;
 		l_shard->po_target = -1;

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -985,8 +986,7 @@ ring_obj_remap_shards(struct pl_ring_map *rimap, struct daos_obj_md *md,
 {
 	struct failed_shard *f_shard;
 	struct pool_map		 *map = rimap->rmp_map.pl_poolmap;
-	struct pl_target	 *plts;
-	struct pl_obj_shard	 *l_shard;
+	struct pl_target         *plts;
 	struct pool_target	 *tgts;
 	struct pool_target	 *spare_tgt;
 	d_list_t		 *current;
@@ -1005,9 +1005,7 @@ ring_obj_remap_shards(struct pl_ring_map *rimap, struct daos_obj_md *md,
 	spare_idx = rop->rop_begin;
 
 	while (current != remap_list) {
-		f_shard = d_list_entry(current, struct failed_shard,
-				       fs_list);
-		l_shard = &layout->ol_shards[f_shard->fs_shard_idx];
+		f_shard = d_list_entry(current, struct failed_shard, fs_list);
 
 		spare_avail = ring_remap_next_spare(rimap, rop, &spare_idx);
 		D_DEBUG(DB_PL, "obj:"DF_OID", select spare:%d grp_size:%u, "
@@ -1021,9 +1019,8 @@ ring_obj_remap_shards(struct pl_ring_map *rimap, struct daos_obj_md *md,
 			ring_map_dump(&rimap->rmp_map, true);
 
 		spare_tgt = &tgts[plts[spare_idx].pt_pos];
-		determine_valid_spares(spare_tgt, md, spare_avail,
-				       remap_list, -1, -1, f_shard, l_shard,
-				       NULL);
+		determine_valid_spares(spare_tgt, md, spare_avail, remap_list, -1, -1, f_shard,
+				       layout);
 	}
 
 	remap_dump(remap_list, md, "after remap:");
@@ -1083,9 +1080,13 @@ ring_obj_layout_fill(struct pl_map *map, struct daos_obj_md *md,
 			layout->ol_shards[k].po_index = tgt->ta_comp.co_index;
 
 			if (pool_target_unavail(tgt, for_reint)) {
-				rc = remap_alloc_one(remap_list, k, tgt, for_reint, NULL);
-				if (rc)
+				struct failed_shard *shard =
+				    remap_alloc_one(k, tgt, tgt->ta_comp.co_id, 0, NULL);
+
+				if (!shard)
 					D_GOTO(out, rc);
+
+				d_list_add_tail(&shard->fs_list, remap_list);
 			}
 		}
 		grp_start += grp_dist;
@@ -1196,8 +1197,8 @@ ring_obj_find_rebuild(struct pl_map *map, uint32_t gl_layout_ver, struct daos_ob
 	if (rc)
 		goto out;
 
-	remap_list_fill(map, md, shard_md, rebuild_ver, tgt_id, shard_idx,
-			array_size, &idx, layout, &remap_list, false);
+	remap_list_fill(map, md, shard_md, rebuild_ver, tgt_id, shard_idx, array_size, &idx, layout,
+			&remap_list);
 out:
 	remap_list_free_all(&remap_list);
 	if (shards_count > SHARDS_ON_STACK_COUNT)

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1630,7 +1630,7 @@ rebuild_task_ult(void *arg)
 	uint32_t				map_dist_ver = 0;
 	struct rebuild_global_pool_tracker	*rgt = NULL;
 	d_rank_t				myrank;
-	uint64_t				cur_ts = 0;
+	uint64_t                                 cur_ts          = 0;
 	uint32_t                                 obj_reclaim_ver = 0;
 	int					rc;
 


### PR DESCRIPTION
This patch fixes the state machine of jump map for rebuild:

- significantly simplifies logic in state transiting function
- rebuilding DOWN2UP target does not require extra target anymore
- properly set rebuilding/reintegrating flags for all cases.
- remove some obsolete function parameters

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
