### PR TITLE
DAOS-18607 object: make EC aggregation yield more frequently

### DIFF
--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -60,6 +60,9 @@
 #include "srv_internal.h"
 
 #define EC_AGG_ITERATION_MAX	1024
+#define EC_AGG_PROCESS_CREDITS  128
+#define EC_AGG_FILTER_CREDITS   1
+#define EC_AGG_SCAN_CREDITS     20
 
 /* Pool/container info. Shared handle UUIDs, and service list are initialized
  * in system Xstream.
@@ -2151,6 +2154,7 @@ agg_data_extent(struct ec_agg_param *agg_param, vos_iter_entry_t *entry,
 					DP_RC(rc));
 				D_GOTO(out, rc);
 			}
+			agg_param->ap_credits += EC_AGG_PROCESS_CREDITS;
 			D_ASSERT(agg_entry->ae_cur_stripe.as_extent_cnt == 0);
 		}
 	}
@@ -2173,6 +2177,7 @@ agg_akey_post(daos_handle_t ih, struct ec_agg_param *agg_param,
 				DP_RC(rc));
 			return rc;
 		}
+		agg_param->ap_credits += EC_AGG_PROCESS_CREDITS;
 
 		agg_entry->ae_cur_stripe.as_stripenum	= 0UL;
 		agg_entry->ae_cur_stripe.as_hi_epoch	= 0UL;
@@ -2446,14 +2451,14 @@ agg_filter(daos_handle_t ih, vos_iter_desc_t *desc, void *cb_arg, unsigned int *
 			DP_OID(desc->id_oid.id_pub),
 			daos_obj_id2class(desc->id_oid.id_pub));
 		*acts = VOS_ITER_CB_SKIP;
-		agg_param->ap_credits++;
+		agg_param->ap_credits += EC_AGG_FILTER_CREDITS;
 		goto done;
 	}
 
 	if (!daos_oclass_is_ec(&oca)) { /* Skip non-EC object */
 		D_DEBUG(DB_EPC, "Skip oid:"DF_UOID" non-ec obj\n",
 			DP_UOID(desc->id_oid));
-		agg_param->ap_credits++;
+		agg_param->ap_credits += EC_AGG_FILTER_CREDITS;
 		*acts = VOS_ITER_CB_SKIP;
 		goto done;
 	}
@@ -2468,14 +2473,14 @@ check:
 			D_DEBUG(DB_EPC, "Skip key:"DF_KEY" agg_epoch="DF_X64" filter="DF_X64"\n",
 				DP_KEY(&desc->id_key), desc->id_agg_write,
 				agg_param->ap_filter_eph);
-		agg_param->ap_credits++;
+		agg_param->ap_credits += EC_AGG_FILTER_CREDITS;
 		*acts = VOS_ITER_CB_SKIP;
 		goto done;
 	}
 
 	/* This MUST be the last check */
 	if (desc->id_type == VOS_ITER_OBJ && vos_bkt_iter_skip(ih, desc)) {
-		agg_param->ap_credits++;
+		agg_param->ap_credits += EC_AGG_FILTER_CREDITS;
 		*acts |= VOS_ITER_CB_SKIP;
 		goto done;
 	}
@@ -2590,7 +2595,7 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		return rc;
 	}
 
-	agg_param->ap_credits += 20;
+	agg_param->ap_credits += EC_AGG_SCAN_CREDITS;
 	if (agg_param->ap_credits > agg_param->ap_credits_max) {
 		agg_param->ap_credits = 0;
 		D_DEBUG(DB_EPC, "EC aggregation yield type %d. acts %u\n",


### PR DESCRIPTION
Under space pressure, a 1 MB update can take about 3~4 ms. Currently,
EC aggregation may not yield the CPU until it has processed more than 30
remove operations.

Although the scheduler gives aggregation more CPU time under space
pressure, EC aggregation should still yield more frequently to avoid holding
the CPU for too long.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
