### PR TITLE
DAOS-18747 rebuild: wait rebuild epoch to be synchronized by IV

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1715,6 +1715,7 @@ cont_ec_agg_alloc(struct cont_svc *cont_svc, uuid_t cont_uuid,
 	for (i = 0; i < rank_nr; i++) {
 		ec_agg->ea_server_ephs[i].rank = doms[i].do_comp.co_rank;
 		ec_agg->ea_server_ephs[i].eph = 0;
+		ec_agg->ea_server_ephs[i].ee_update_ts = daos_gettime_coarse();
 	}
 	d_list_add(&ec_agg->ea_list, &cont_svc->cs_ec_agg_list);
 	*ec_aggp = ec_agg;
@@ -1772,8 +1773,10 @@ retry:
 
 	for (i = 0; i < ec_agg->ea_servers_num; i++) {
 		if (ec_agg->ea_server_ephs[i].rank == rank) {
-			if (ec_agg->ea_server_ephs[i].eph < eph)
+			if (ec_agg->ea_server_ephs[i].eph < eph) {
 				ec_agg->ea_server_ephs[i].eph = eph;
+				ec_agg->ea_server_ephs[i].ee_update_ts = daos_gettime_coarse();
+			}
 			break;
 		}
 	}
@@ -2002,6 +2005,7 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 	daos_epoch_t        cur_eph, new_eph;
 	daos_epoch_t        min_eph;
 	d_rank_t            rank;
+	uint64_t            cur_ts;
 	int                 i;
 	int                 rc;
 
@@ -2034,6 +2038,7 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 		}
 
 		min_eph = DAOS_EPOCH_MAX;
+		cur_ts  = daos_gettime_coarse();
 		for (i = 0; i < ec_agg->ea_servers_num; i++) {
 			rank = ec_agg->ea_server_ephs[i].rank;
 
@@ -2042,6 +2047,13 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 					DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid), rank);
 				continue;
 			}
+
+			if (pool->sp_reclaim != DAOS_RECLAIM_DISABLED &&
+			    cur_ts > ec_agg->ea_server_ephs[i].ee_update_ts + 600)
+				D_WARN(DF_CONT ": Sluggish EC boundary report from rank %d, " DF_U64
+					       " Seconds.",
+				       DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid), rank,
+				       cur_ts - ec_agg->ea_server_ephs[i].ee_update_ts);
 
 			if (ec_agg->ea_server_ephs[i].eph < min_eph)
 				min_eph = ec_agg->ea_server_ephs[i].eph;

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -61,6 +61,7 @@ extern bool ec_agg_disabled;
 struct ec_eph {
 	d_rank_t	rank;
 	daos_epoch_t	eph;
+	uint64_t        ee_update_ts; /* update timestamp */
 };
 
 /* container EC aggregation epoch control descriptor, which is only on leader */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4136,8 +4136,10 @@ anchor_update_check_eof(struct obj_auxi_args *obj_auxi, daos_anchor_t *anchor)
 	obj_auxi_shards_iterate(obj_auxi, update_sub_anchor_cb, NULL);
 
 	sub_anchors = (struct shard_anchors *)anchor->da_sub_anchors;
-	if (!d_list_empty(&sub_anchors->sa_merged_list))
+	if (!d_list_empty(&sub_anchors->sa_merged_list)) {
+		D_ASSERT(obj_auxi->opc != DAOS_OBJ_RPC_ENUMERATE);
 		return;
+	}
 
 	if (sub_anchors_is_eof(sub_anchors)) {
 		daos_obj_list_t *obj_args;
@@ -4146,6 +4148,18 @@ anchor_update_check_eof(struct obj_auxi_args *obj_auxi, daos_anchor_t *anchor)
 
 		obj_args = dc_task_get_args(obj_auxi->obj_task);
 		sub_anchors_free(obj_args, obj_auxi->opc);
+	} else if (obj_auxi->opc == DAOS_OBJ_RPC_ENUMERATE && D_LOG_ENABLED(DB_REBUILD)) {
+		for (int i = 0; i < sub_anchors->sa_anchors_nr; i++) {
+			daos_anchor_t *sub_anchor;
+
+			sub_anchor = &sub_anchors->sa_anchors[i].ssa_anchor;
+			if (!daos_anchor_is_eof(sub_anchor)) {
+				D_DEBUG(DB_REBUILD, "shard %d sub_anchor %d/%d non EOF",
+					sub_anchors->sa_anchors[i].ssa_shard, i,
+					sub_anchors->sa_anchors_nr);
+				break;
+			}
+		}
 	}
 }
 
@@ -6465,7 +6479,7 @@ shard_anchors_check_alloc_bufs(struct obj_auxi_args *obj_auxi, struct shard_anch
 		}
 
 		if (obj_args->recxs != NULL) {
-			if (sub_anchor->ssa_recxs != NULL && sub_anchors->sa_nr == nr)
+			if (sub_anchor->ssa_recxs != NULL && sub_anchors->sa_nr != nr)
 				D_FREE(sub_anchor->ssa_recxs);
 
 			if (sub_anchor->ssa_recxs == NULL) {

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -689,9 +690,8 @@ obj_enum_iterate(daos_key_desc_t *kdss, d_sg_list_t *sgl, int nr,
 		ptr = sgl_indexed_byte(sgl, &sgl_idx);
 		D_ASSERTF(ptr != NULL, "kds and sgl don't line up");
 
-		D_DEBUG(DB_REBUILD, "process %d, type %d, ptr %p, len "DF_U64
-			", total %zd\n", i, kds->kd_val_type, ptr,
-			kds->kd_key_len, sgl->sg_iovs[0].iov_len);
+		D_DEBUG(DB_REBUILD, "process %d/%d, type %d, ptr %p, len " DF_U64 ", total %zd\n",
+			i, nr, kds->kd_val_type, ptr, kds->kd_key_len, sgl->sg_iovs[0].iov_len);
 		if (kds->kd_val_type == 0 ||
 		    (kds->kd_val_type != type && type != -1)) {
 			sgl_move_forward(sgl, &sgl_idx, kds->kd_key_len);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2453,7 +2453,7 @@ obj_inflight_io_check(struct ds_cont_child *child, uint32_t opc,
 	struct ds_pool *pool = child->sc_pool->spc_pool;
 
 	if (opc == DAOS_OBJ_RPC_ENUMERATE && flags & ORF_FOR_MIGRATION) {
-		/* EC aggregation is still inflight, rebuild should wait until it's paused */
+		/* EC aggregation is still in-flight, rebuild should wait until it's paused */
 		if (ds_cont_child_ec_aggregating(child)) {
 			D_ERROR(DF_CONT " ec aggregate still active, rebuilding %d\n",
 				DP_CONT(pool->sp_uuid, child->sc_uuid),
@@ -3300,6 +3300,27 @@ obj_enum_complete(crt_rpc_t *rpc, int status, int map_version,
 	D_FREE(oeo->oeo_csum_iov.iov_buf);
 }
 
+static void
+dump_enum_anchor(daos_unit_oid_t uoid, daos_anchor_t *anchor, char *str)
+{
+	int      nr = DAOS_ANCHOR_BUF_MAX / 8;
+	int      i;
+	uint64_t data[nr];
+
+	D_DEBUG(DB_REBUILD, DF_UOID "%s anchor -", DP_UOID(uoid), str);
+	D_DEBUG(DB_REBUILD, "type %d, shard %d, flags 0x%x\n", anchor->da_type, anchor->da_shard,
+		anchor->da_flags);
+	for (i = 0; i < nr; i++)
+		data[i] = *(uint64_t *)((char *)anchor->da_buf + i * 8);
+	if (nr >= 13)
+		D_DEBUG(DB_REBUILD,
+			"da_buf " DF_X64 "," DF_X64 "," DF_X64 "," DF_X64 "," DF_X64 "," DF_X64
+			"," DF_X64 "," DF_X64 "," DF_X64 "," DF_X64 "," DF_X64 "," DF_X64
+			"," DF_X64,
+			data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+			data[8], data[9], data[10], data[11], data[12]);
+}
+
 static int
 obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 	       struct vos_iter_anchors *anchors, struct ds_obj_enum_arg *enum_arg,
@@ -3368,6 +3389,10 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		D_ASSERT(opc == DAOS_OBJ_RPC_ENUMERATE);
 		type = VOS_ITER_DKEY;
 		param.ip_flags |= VOS_IT_RECX_VISIBLE;
+		if (D_LOG_ENABLED(DB_REBUILD)) {
+			dump_enum_anchor(oei->oei_oid, &anchors->ia_dkey, "dkey");
+			dump_enum_anchor(oei->oei_oid, &anchors->ia_akey, "akey");
+		}
 		if (daos_anchor_get_flags(&anchors->ia_dkey) &
 		      DIOF_WITH_SPEC_EPOCH) {
 			/* For obj verification case. */
@@ -3385,7 +3410,12 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		enum_arg->chk_key2big = 1;
 		enum_arg->need_punch = 1;
 		enum_arg->copy_data_cb = vos_iter_copy;
-		fill_oid(oei->oei_oid, enum_arg);
+		rc                     = fill_oid(oei->oei_oid, enum_arg);
+		if (rc != 0) {
+			rc = -DER_KEY2BIG;
+			DL_ERROR(rc, DF_UOID "fill oid failed", DP_UOID(oei->oei_oid));
+			goto failed;
+		}
 	}
 
 	/*

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2832,9 +2832,15 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	if (rc == 1 &&
 	     (is_ec_data_shard_by_tgt_off(unpack_tgt_off, &arg->oc_attr) ||
 	     (io->ui_oid.id_layout_ver > 0 && io->ui_oid.id_shard != parity_shard))) {
-		D_DEBUG(DB_REBUILD, DF_UOID" ignore shard "DF_KEY"/%u/%d/%u/%d.\n",
-			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard,
-			(int)obj_ec_shard_off(obj, io->ui_dkey_hash, 0), parity_shard, rc);
+		if (daos_is_dkey_uint64(io->ui_oid.id_pub) && io->ui_dkey.iov_len == 8)
+			D_DEBUG(DB_REBUILD,
+				DF_UOID " ignore shard, int dkey " DF_U64 "/%u/%d/%u/%d.",
+				DP_UOID(io->ui_oid), *(uint64_t *)io->ui_dkey.iov_buf, shard,
+				(int)obj_ec_shard_off(obj, io->ui_dkey_hash, 0), parity_shard, rc);
+		else
+			D_DEBUG(DB_REBUILD, DF_UOID " ignore shard " DF_KEY "/%u/%d/%u/%d.",
+				DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard,
+				(int)obj_ec_shard_off(obj, io->ui_dkey_hash, 0), parity_shard, rc);
 		D_GOTO(put, rc = 0);
 	}
 	rc = 0;
@@ -2850,9 +2856,17 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 			continue;
 		}
 
-		D_DEBUG(DB_REBUILD, DF_UOID" unpack "DF_KEY" for shard %u/%u/%u/"DF_X64"/%u\n",
-			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard, unpack_tgt_off,
-			migrate_tgt_off, io->ui_dkey_hash, parity_shard);
+		if (daos_is_dkey_uint64(io->ui_oid.id_pub) && io->ui_dkey.iov_len == 8)
+			D_DEBUG(DB_REBUILD,
+				DF_UOID " unpack int dkey " DF_U64 " for shard %u/%u/%u/" DF_X64
+					"/%u",
+				DP_UOID(io->ui_oid), *(uint64_t *)io->ui_dkey.iov_buf, shard,
+				unpack_tgt_off, migrate_tgt_off, io->ui_dkey_hash, parity_shard);
+		else
+			D_DEBUG(DB_REBUILD,
+				DF_UOID " unpack " DF_KEY " for shard %u/%u/%u/" DF_X64 "/%u",
+				DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard, unpack_tgt_off,
+				migrate_tgt_off, io->ui_dkey_hash, parity_shard);
 
 		/**
 		 * Since we do not need split the rebuild into parity rebuild
@@ -2889,8 +2903,13 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	if (!create_migrate_one) {
 		struct ds_cont_child *cont = NULL;
 
-		D_DEBUG(DB_REBUILD, DF_UOID"/"DF_KEY" does not need rebuild.\n",
-			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey));
+		if (daos_is_dkey_uint64(io->ui_oid.id_pub) && io->ui_dkey.iov_len == 8)
+			D_DEBUG(DB_REBUILD,
+				DF_UOID "/int dkey: " DF_U64 " does not need rebuild.\n",
+				DP_UOID(io->ui_oid), *(uint64_t *)io->ui_dkey.iov_buf);
+		else
+			D_DEBUG(DB_REBUILD, DF_UOID "/" DF_KEY " does not need rebuild.\n",
+				DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey));
 
 		/* Create the vos container when no record need to be rebuilt for this shard,
 		 * for the case of reintegrate the container was discarded ahead.

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -236,14 +236,12 @@ obj_layout_dump(daos_obj_id_t oid, struct pl_obj_layout *layout)
 		DP_OID(oid), layout->ol_ver);
 
 	for (i = 0; i < layout->ol_nr; i++)
-		D_DEBUG(DB_PL, "%d: shard_id %d, tgt_id %d, f_seq %d, %s %s\n",
-			i, layout->ol_shards[i].po_shard,
-			layout->ol_shards[i].po_target,
+		D_DEBUG(DB_PL, "%d: shard_id %d, tgt_id %d (rank %d vos %d), f_seq %d, %s %s\n", i,
+			layout->ol_shards[i].po_shard, layout->ol_shards[i].po_target,
+			layout->ol_shards[i].po_rank, layout->ol_shards[i].po_index,
 			layout->ol_shards[i].po_fseq,
-			layout->ol_shards[i].po_rebuilding ?
-			"rebuilding" : "healthy",
-			layout->ol_shards[i].po_reintegrating ?
-			"reintegrating" : "healthy");
+			layout->ol_shards[i].po_rebuilding ? "rebuilding" : "healthy",
+			layout->ol_shards[i].po_reintegrating ? "reintegrating" : "healthy");
 }
 
 /**

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -537,6 +537,8 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 	if (rc != 0)
 		return rc;
 
+	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
+	D_ASSERT(tls != NULL);
 	/* If there are further targets failure during reintegration/extend/drain,
 	 * rebuild will choose replacement targets for the impacted objects anyway,
 	 * so we do not need reclaim these impacted shards by @ignore_rebuild_shard.
@@ -545,6 +547,7 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 					      mytarget, oid.id_shard,
 					      rpt->rt_rebuild_op == RB_OP_RECLAIM ? false : true);
 	pl_obj_layout_free(layout);
+	tls->rebuild_pool_obj_count++;
 	if (still_needed) {
 		if (new_layout_ver > 0) {
 			/* upgrade job reclaim */
@@ -563,10 +566,8 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 		return 0;
 	}
 
-	D_DEBUG(DB_REBUILD, "deleting stale object "DF_UOID" rank %u tgt %u oid layout %u/%u",
+	D_DEBUG(DB_REBUILD, "deleting stale object " DF_UOID " rank %u tgt %u oid layout %u/%u",
 		DP_UOID(oid), myrank, mytarget, oid.id_layout_ver, new_layout_ver);
-	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
-	D_ASSERT(tls != NULL);
 	tls->rebuild_pool_reclaim_obj_count++;
 
 	discard_epr.epr_hi = rpt->rt_reclaim_epoch;

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -1,6 +1,6 @@
 /**
- * (C) Copyright 2017-2024 Intel Corporation.
- * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2017-2024 Intel Corporation.
+ * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -263,6 +263,25 @@ rebuild_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 	return rc;
 }
 
+/* rebuild_leader_status_check() will sync IV by rebuild_leader_status_notify() riv_stable_epoch
+ * every RBLD_CHECK_INTV (2000mS), and update to rpt->rt_stable_epoch in rebuild_iv_ent_refresh().
+ */
+static int
+rpt_wait_rebuild_epoch(struct rebuild_tgt_pool_tracker *rpt)
+{
+	int wait_cnt     = 0;
+	int wait_intv    = 200; /* milliseconds */
+	int wait_cnt_max = 180;
+
+	while (rpt->rt_stable_epoch == 0 && wait_cnt++ < wait_cnt_max)
+		dss_sleep(wait_intv);
+
+	if (rpt->rt_stable_epoch != 0)
+		return 0;
+
+	return -DER_TIMEDOUT;
+}
+
 static void
 rebuild_objects_send_ult(void *data)
 {
@@ -278,6 +297,14 @@ rebuild_objects_send_ult(void *data)
 	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
 				      rpt->rt_rebuild_gen);
 	D_ASSERT(tls != NULL);
+
+	if (rpt->rt_stable_epoch == 0) {
+		rc = rpt_wait_rebuild_epoch(rpt);
+		if (rc != 0) {
+			DL_ERROR(rc, DF_RB " rpt_wait_rebuild_epoch failed", DP_RB_RPT(rpt));
+			goto out;
+		}
+	}
 
 	D_ALLOC_ARRAY(oids, REBUILD_SEND_LIMIT);
 	if (oids == NULL)
@@ -586,10 +613,25 @@ rebuild_obj_ult(void *data)
 	struct rebuild_obj_arg		*arg = data;
 	struct rebuild_tgt_pool_tracker	*rpt = arg->rpt;
 
+	if (rpt->rt_stable_epoch == 0) {
+		int rc;
+
+		rc = rpt_wait_rebuild_epoch(rpt);
+		if (rc != 0) {
+			DL_ERROR(rc, DF_RB " rpt_wait_rebuild_epoch failed, abort the rebuild",
+				 DP_RB_RPT(rpt));
+			if (rpt->rt_errno == 0)
+				rpt->rt_errno = rc;
+			rpt->rt_abort = 1;
+		}
+		goto out;
+	}
+
 	ds_migrate_object(rpt->rt_pool_uuid, rpt->rt_poh_uuid, rpt->rt_coh_uuid, arg->co_uuid,
 			  rpt->rt_rebuild_ver, rpt->rt_rebuild_gen, rpt->rt_stable_epoch,
 			  rpt->rt_rebuild_op, &arg->oid, &arg->epoch, &arg->punched_epoch,
 			  &arg->shard, 1, arg->tgt_index, rpt->rt_new_layout_ver);
+out:
 	rpt_put(rpt);
 	D_FREE(arg);
 }

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -446,7 +446,12 @@ dss_rebuild_check_one(void *data)
 	if (pool_tls->rebuild_pool_status != 0 && status->status == 0)
 		status->status = pool_tls->rebuild_pool_status;
 
-	status->obj_count += pool_tls->rebuild_pool_reclaim_obj_count;
+	if (rpt->rt_rebuild_op == RB_OP_RECLAIM || rpt->rt_rebuild_op == RB_OP_FAIL_RECLAIM) {
+		status->obj_count += pool_tls->rebuild_pool_reclaim_obj_count;
+		/* use rec_count to simulate progress when no object need to be reclaim */
+		status->rec_count += pool_tls->rebuild_pool_obj_count;
+	}
+
 	status->tobe_obj_count += pool_tls->rebuild_pool_obj_count;
 	ABT_mutex_unlock(status->lock);
 
@@ -2506,14 +2511,14 @@ rebuild_tgt_status_check_ult(void *arg)
 			}
 		}
 
-		D_INFO(DF_UUID" ver %d gen %u obj "DF_U64" rec "DF_U64" size "
-		       DF_U64" scan done %d pull done %d scan gl done %d"
-		       " gl done %d status %d abort %s\n",
+		D_INFO(DF_UUID " ver %d gen %u obj " DF_U64 "/" DF_U64 " rec " DF_U64
+			       " size " DF_U64 " scan done %d pull done %d scan gl done %d"
+			       " gl done %d status %d abort %s\n",
 		       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver,
-		       rpt->rt_pool->sp_rebuild_gen,
-		       iv.riv_obj_count, iv.riv_rec_count, iv.riv_size, rpt->rt_scan_done,
-		       iv.riv_pull_done, rpt->rt_global_scan_done,
-		       rpt->rt_global_done, iv.riv_status, rpt->rt_abort ? "yes" : "no");
+		       rpt->rt_pool->sp_rebuild_gen, iv.riv_toberb_obj_count, iv.riv_obj_count,
+		       iv.riv_rec_count, iv.riv_size, rpt->rt_scan_done, iv.riv_pull_done,
+		       rpt->rt_global_scan_done, rpt->rt_global_done, iv.riv_status,
+		       rpt->rt_abort ? "yes" : "no");
 		if (rpt->rt_global_done || rpt->rt_abort)
 			break;
 


### PR DESCRIPTION
To fix possible assertion in rebuild -
EMRG src/object/srv_obj_migrate.c:3238 migrate_obj_ult() Assertion 'tls->mpt_max_eph != 0' failed

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
