### PR TITLE
DAOS-18728 dtx: DTX participant during rebuild/reint can be as leader

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -2367,12 +2367,13 @@ int
 dtx_leader_get(struct ds_pool *pool, struct dtx_memberships *mbs, daos_unit_oid_t *oid,
 	       uint32_t version, struct pool_target **p_tgt)
 {
-	struct pl_map		*map = NULL;
-	struct pl_obj_layout	*layout = NULL;
-	struct dtx_coll_target	*dct;
-	struct daos_obj_md	 md = { 0 };
-	int			 rc = 0;
-	int			 i;
+	struct pl_map          *map    = NULL;
+	struct pool_target     *tmp    = NULL;
+	struct pl_obj_layout   *layout = NULL;
+	struct dtx_coll_target *dct;
+	struct daos_obj_md      md = {0};
+	int                     rc = 0;
+	int                     i;
 
 	D_ASSERT(mbs != NULL);
 
@@ -2383,9 +2384,13 @@ dtx_leader_get(struct ds_pool *pool, struct dtx_memberships *mbs, daos_unit_oid_
 		if (rc < 0)
 			D_GOTO(out, rc);
 
-		/* The target that (re-)joined the system after DTX cannot be the leader. */
-		if (rc == 1 && (*p_tgt)->ta_comp.co_in_ver <= version)
-			D_GOTO(out, rc = 0);
+		if (rc == 1) {
+			if ((*p_tgt)->ta_comp.co_in_ver <= version)
+				D_GOTO(out, rc = 0);
+
+			if (tmp == NULL || tmp->ta_comp.co_in_ver > (*p_tgt)->ta_comp.co_in_ver)
+				tmp = *p_tgt;
+		}
 	}
 
 	if (!(mbs->dm_flags & DMF_COLL_TARGET))
@@ -2419,14 +2424,28 @@ dtx_leader_get(struct ds_pool *pool, struct dtx_memberships *mbs, daos_unit_oid_
 		rc = pool_map_find_target(map->pl_poolmap, layout->ol_shards[i].po_target, p_tgt);
 		D_ASSERT(rc == 1);
 
-		/* The target that (re-)joined the system after DTX cannot be the leader. */
+		if ((*p_tgt)->ta_comp.co_status != PO_COMP_ST_UPIN)
+			continue;
+
 		if ((*p_tgt)->ta_comp.co_in_ver <= version)
 			D_GOTO(out, rc = 0);
+
+		if (tmp == NULL || tmp->ta_comp.co_in_ver > (*p_tgt)->ta_comp.co_in_ver)
+			tmp = *p_tgt;
 	}
 
 	rc = -DER_NONEXIST;
 
 out:
+	/*
+	 * If all alive participants were in rebuild/reint when DTX happened,
+	 * then the first one that became UPIN will be the DTX (new) leader.
+	 */
+	if (rc == -DER_NONEXIST && tmp != NULL) {
+		*p_tgt = tmp;
+		rc     = 0;
+	}
+
 	if (layout != NULL)
 		pl_obj_layout_free(layout);
 


### PR DESCRIPTION
For a given DTX, if all alive participants were in rebuild/reint when the DTX happened, then the first one which target's status became UPIN will be the DTX (new) leader.

Features: rebuild

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
