### PR TITLE
DAOS-18690 vos: emergency buffer for GC

### DIFF
--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -1,6 +1,6 @@
 /**
- * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2016-2024 Intel Corporation.
+ * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1003,6 +1003,23 @@ pmem_tx_stage(void)
 	return pmemobj_tx_stage();
 }
 
+static int
+pmem_tx_set_snapbuf(struct umem_instance *umm, umem_off_t snapbuf, size_t size)
+{
+	void *buf = umem_off2ptr(umm, snapbuf);
+	int   rc;
+
+	rc = pmemobj_tx_log_append_buffer(TX_LOG_TYPE_SNAPSHOT, buf, size);
+	if (rc)
+		return rc;
+
+	rc = pmemobj_tx_log_auto_alloc(TX_LOG_TYPE_SNAPSHOT, 0);
+	if (rc)
+		return rc;
+
+	return 0;
+}
+
 static umem_off_t
 pmem_reserve(struct umem_instance *umm, void *act, size_t size, unsigned int type_num,
 	     unsigned int unused)
@@ -1135,27 +1152,27 @@ umem_tx_add_cb(struct umem_instance *umm, struct umem_tx_stage_data *txd,
 	return 0;
 }
 
-static umem_ops_t	pmem_ops = {
-	.mo_tx_free		= pmem_tx_free,
-	.mo_tx_alloc		= pmem_tx_alloc,
-	.mo_tx_add		= pmem_tx_add,
-	.mo_tx_xadd		= pmem_tx_xadd,
-	.mo_tx_add_ptr		= pmem_tx_add_ptr,
-	.mo_tx_abort		= pmem_tx_abort,
-	.mo_tx_begin		= pmem_tx_begin,
-	.mo_tx_commit		= pmem_tx_commit,
-	.mo_tx_stage		= pmem_tx_stage,
-	.mo_reserve		= pmem_reserve,
-	.mo_defer_free		= pmem_defer_free,
-	.mo_cancel		= pmem_cancel,
-	.mo_tx_publish		= pmem_tx_publish,
-	.mo_atomic_copy		= pmem_atomic_copy,
-	.mo_atomic_alloc	= pmem_atomic_alloc,
-	.mo_atomic_free		= pmem_atomic_free,
-	.mo_atomic_flush	= pmem_atomic_flush,
-	.mo_tx_add_callback	= umem_tx_add_cb,
+static umem_ops_t pmem_ops = {
+    .mo_tx_free         = pmem_tx_free,
+    .mo_tx_alloc        = pmem_tx_alloc,
+    .mo_tx_add          = pmem_tx_add,
+    .mo_tx_xadd         = pmem_tx_xadd,
+    .mo_tx_add_ptr      = pmem_tx_add_ptr,
+    .mo_tx_abort        = pmem_tx_abort,
+    .mo_tx_begin        = pmem_tx_begin,
+    .mo_tx_commit       = pmem_tx_commit,
+    .mo_tx_stage        = pmem_tx_stage,
+    .mo_tx_set_snapbuf  = pmem_tx_set_snapbuf,
+    .mo_reserve         = pmem_reserve,
+    .mo_defer_free      = pmem_defer_free,
+    .mo_cancel          = pmem_cancel,
+    .mo_tx_publish      = pmem_tx_publish,
+    .mo_atomic_copy     = pmem_atomic_copy,
+    .mo_atomic_alloc    = pmem_atomic_alloc,
+    .mo_atomic_free     = pmem_atomic_free,
+    .mo_atomic_flush    = pmem_atomic_flush,
+    .mo_tx_add_callback = umem_tx_add_cb,
 };
-
 
 /** BMEM operations (depends on dav) */
 

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -1,6 +1,6 @@
 /**
- * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2016-2024 Intel Corporation.
+ * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -751,6 +751,8 @@ typedef struct {
 	int		 (*mo_tx_commit)(struct umem_instance *umm, void *data);
 
 #ifdef DAOS_PMEM_BUILD
+	/** Set emergency buffer for transaction snapshot */
+	int (*mo_tx_set_snapbuf)(struct umem_instance *umm, umem_off_t snap_buf, size_t size);
 	/** get TX stage */
 	int		 (*mo_tx_stage)(void);
 
@@ -1079,6 +1081,13 @@ bool umem_tx_inprogress(struct umem_instance *umm);
 bool umem_tx_none(struct umem_instance *umm);
 
 int umem_tx_errno(int err);
+
+static inline void
+umem_tx_set_snapbuf(struct umem_instance *umm, umem_off_t snap_buf, size_t size)
+{
+	if (umm->umm_ops->mo_tx_set_snapbuf)
+		umm->umm_ops->mo_tx_set_snapbuf(umm, snap_buf, size);
+}
 
 static inline int
 umem_tx_stage(struct umem_instance *umm)

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -851,6 +851,7 @@ gc_update_stats(struct vos_pool *pool)
 static int
 gc_reclaim_pool(struct vos_pool *pool, int *credits, bool *empty_ret)
 {
+	struct vos_pool_df      *pool_df = pool->vp_pool_df;
 	struct vos_container	*cont = gc_get_container(pool);
 	struct vos_gc		*gc    = &gc_table[0]; /* start from akey */
 	struct vos_gc_bin_df	*bin;
@@ -874,6 +875,16 @@ gc_reclaim_pool(struct vos_pool *pool, int *credits, bool *empty_ret)
 			vos_cont_decref(cont);
 		*empty_ret = false;
 		goto done;
+	}
+
+	if (pool->vp_gc_nospc != 0) {
+		struct vos_pool_ext_df *ext;
+
+		ext = umem_off2ptr(&pool->vp_umm, pool_df->pd_ext);
+		if (!UMOFF_IS_NULL(ext->ped_gc_emerg)) {
+			/* ignore the returned value */
+			umem_tx_set_snapbuf(&pool->vp_umm, ext->ped_gc_emerg, VOS_GC_SNAPBUF_EMERG);
+		}
 	}
 
 	*empty_ret = false;
@@ -1981,6 +1992,7 @@ int
 vos_gc_pool(daos_handle_t poh, int credits, int (*yield_func)(void *arg),
 	    void *yield_arg)
 {
+	static const int         gc_emerg_cycles = 32;
 	struct d_tm_node_t      *duration = NULL;
 	struct d_tm_node_t      *tight    = NULL;
 	struct d_tm_node_t      *slack    = NULL;
@@ -2025,7 +2037,7 @@ vos_gc_pool(daos_handle_t poh, int credits, int (*yield_func)(void *arg),
 			d_tm_inc_counter(slack, 1);
 
 		/* Try small credits when GC failed to allocate space */
-		if (pool->vp_gc_nospc)
+		if (pool->vp_gc_nospc > 0)
 			creds = 2;
 
 		if (credits > 0 && (credits - total) < creds)
@@ -2036,8 +2048,15 @@ vos_gc_pool(daos_handle_t poh, int credits, int (*yield_func)(void *arg),
 
 		if (rc) {
 			D_ERROR("GC pool failed: " DF_RC "\n", DP_RC(rc));
-			if (rc == -DER_NOSPACE)
-				pool->vp_gc_nospc = 1;
+			if (rc == -DER_NOSPACE) {
+				if (pool->vp_gc_nospc == 0) {
+					D_INFO("Enter GC emergency mode (pool=" DF_UUID ")\n",
+					       DP_UUID(pool->vp_id));
+					pool->vp_gc_nospc = gc_emerg_cycles;
+				} else { /* switch back, nothing else we can do */
+					pool->vp_gc_nospc = 0;
+				}
+			}
 			d_tm_mark_duration_end(duration);
 			break;
 		}
@@ -2062,8 +2081,8 @@ vos_gc_pool(daos_handle_t poh, int credits, int (*yield_func)(void *arg),
 
 	if (total != 0) { /* did something */
 		D_DEBUG(DB_TRACE, "GC consumed %d credits\n", total);
-		if (rc == 0)
-			pool->vp_gc_nospc = 0;
+		if (rc == 0 && pool->vp_gc_nospc > 0)
+			pool->vp_gc_nospc--;
 	}
 
 	D_ASSERT(tls->vtl_gc_running > 0);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -297,11 +297,10 @@ struct vos_pool {
 	struct d_ulink		vp_hlink;
 	/** number of openers */
 	uint32_t                vp_opened;
-	uint32_t                vp_dying:1,
-				vp_opening:1,
-	/** exclusive handle (see VOS_POF_EXCL) */
-				vp_excl:1,
-				vp_gc_nospc:1;
+	uint32_t                vp_dying : 1, vp_opening : 1,
+	    /** exclusive handle (see VOS_POF_EXCL) */
+	    vp_excl : 1;
+	unsigned int             vp_gc_nospc;
 	ABT_mutex		vp_mutex;
 	ABT_cond		vp_cond;
 	/* this pool is for sysdb */

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -1,6 +1,6 @@
 /**
- * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * Copyright 2016-2024 Intel Corporation.
+ * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -116,7 +116,12 @@ struct vos_gc_bkt_df {
 /** 2.8 features */
 #define VOS_POOL_FEAT_2_8			(VOS_POOL_FEAT_GANG_SV)
 
-#define VOS_POOL_EXT_DF_PADDING_SIZE            53
+#define VOS_POOL_EXT_DF_PADDING_SIZE            52
+
+/* 512K preallocated buffer for GC snapshot in case of emergency.
+ * NB: workload of GC is deterministic (tree operations), 512K should be sufficient.
+ */
+#define VOS_GC_SNAPBUF_EMERG                    (1 << 19)
 
 /* VOS pool durable format extension */
 struct vos_pool_ext_df {
@@ -124,6 +129,8 @@ struct vos_pool_ext_df {
 	struct vos_gc_bkt_df	ped_gc_bkt;
 	/* Memory file size for md-on-ssd phase2 pool */
 	uint64_t                ped_mem_sz;
+	/* emergency buffer for GC */
+	umem_off_t              ped_gc_emerg;
 	/* Paddings for other potential new feature */
 	uint64_t                ped_paddings[VOS_POOL_EXT_DF_PADDING_SIZE];
 	/* Reserved for future extension */

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -1,6 +1,6 @@
 /**
- * (C) Copyright 2016-2025 Intel Corporation.
- * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2016-2025 Intel Corporation.
+ * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1444,6 +1444,13 @@ vos_pool_create_ex(const char *path, uuid_t uuid, daos_size_t scm_sz, daos_size_
 	/* pd_ext is newly allocated, no need to call tx_add_ptr() */
 	pd_ext_df             = umem_off2ptr(&umem, pool_df->pd_ext);
 	pd_ext_df->ped_mem_sz = scm_sz;
+	pd_ext_df->ped_gc_emerg = umem_zalloc(&umem, VOS_GC_SNAPBUF_EMERG);
+	if (UMOFF_IS_NULL(pd_ext_df->ped_gc_emerg)) {
+		D_ERROR("Failed to allocate pool GC emergency buffer.\n");
+		rc = -DER_NOSPACE;
+		goto end;
+	}
+
 end:
 	/**
 	 * The transaction can in reality be aborted


### PR DESCRIPTION
GC may require extra space for TX snapshots, and it can't reclaim any space
if it failed to get the space for snapshots.

This patch preallocates space for TX snapshots, GC switches to emergency
mode and use the preallocated buffer in case of ENOSPACE.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
