### PR TITLE
DAOS-18607 placement: generate partial layout for rebuild and EC aggregation (#17829)

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -155,7 +155,7 @@ struct daos_obj_md {
 	 * PO_COMP_TP_GRP and with PO_COMP_TP_GRP layer in pool map.
 	 */
 	uint32_t		omd_pdom_lvl;
-	/* extra flags for placement */
+	/* extra flags for placement, see pl_layout_gen_bits */
 	unsigned int            omd_flags;
 	/* it should be set when PL_FL_GRP_SPEC is set, it's the group ID that
 	 * layout computation should reach then return(reduce computation time).

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -1,6 +1,6 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
- * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2016-2023 Intel Corporation.
+ * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -140,7 +140,7 @@ typedef struct {
 /* Leave a few extra bits for now */
 #define MAX_OBJ_LAYOUT_VERSION		0xFFF0
 
-/** object metadata stored in the global OI table of container */
+/** metadata for object layout computation */
 struct daos_obj_md {
 	daos_obj_id_t		omd_id;
 	uint32_t		omd_ver;
@@ -155,6 +155,12 @@ struct daos_obj_md {
 	 * PO_COMP_TP_GRP and with PO_COMP_TP_GRP layer in pool map.
 	 */
 	uint32_t		omd_pdom_lvl;
+	/* extra flags for placement */
+	unsigned int            omd_flags;
+	/* it should be set when PL_FL_GRP_SPEC is set, it's the group ID that
+	 * layout computation should reach then return(reduce computation time).
+	 */
+	unsigned int            omd_grp_spec;
 };
 
 /** object shard metadata stored in each container shard */

--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -108,11 +108,11 @@ struct pl_map_attr {
 	int		pa_target_nr;
 };
 
-enum {
+enum pl_layout_gen_bits {
 	/* setting this flag allows placement algorithm to finish layout computation
 	 * after reaching the specified shard.
 	 */
-	PL_FL_GRP_SPEC,
+	PL_FL_GRP_SPEC = (1 << 0),
 };
 
 /* don't overflow integer */

--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -1,6 +1,6 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
- * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2016-2023 Intel Corporation.
+ * Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -107,6 +107,16 @@ struct pl_map_attr {
 	int		pa_domain_nr;
 	int		pa_target_nr;
 };
+
+enum {
+	/* setting this flag allows placement algorithm to finish layout computation
+	 * after reaching the specified shard.
+	 */
+	PL_FL_GRP_SPEC,
+};
+
+/* don't overflow integer */
+#define PL_GRP_MAX (1 << 30)
 
 int pl_init(void);
 void pl_fini(void);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1,6 +1,7 @@
 /**
- * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2016-2024 Intel Corporation.
+ * Copyright 2025 Google LLC
+ * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1573,6 +1574,7 @@ dc_obj_fetch_md(daos_obj_id_t oid, struct daos_obj_md *md)
 	md->omd_id	= oid;
 	md->omd_ver	= 0;
 	md->omd_pda	= 0;
+	md->omd_flags   = 0;
 	return 0;
 }
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1,7 +1,7 @@
 /**
- * (C) Copyright 2020-2024 Intel Corporation.
- * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2024 Intel Corporation.
+ * Copyright 2025 Google LLC
+ * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2516,6 +2516,8 @@ ec_agg_object(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *ag
 
 	props = dc_cont_hdl2props(info->api_cont_hdl);
 	md.omd_id = entry->ie_oid.id_pub;
+	md.omd_grp_spec = entry->ie_oid.id_shard / daos_oclass_grp_size(&oca);
+	md.omd_flags    = PL_FL_GRP_SPEC;
 	md.omd_ver = agg_param->ap_pool_info.api_pool->sp_map_version;
 	md.omd_fdom_lvl = props.dcp_redun_lvl;
 	md.omd_pdom_lvl = props.dcp_perf_domain;

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -1,7 +1,7 @@
 /**
  *
- * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2016-2024 Intel Corporation.
+ * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -703,12 +703,17 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 					D_GOTO(out, rc = -DER_NOMEM);
 
 				remap_add_one(&remap_list, shard);
+				/* remapping requires full layout */
+				if (i == md->omd_grp_spec)
+					md->omd_grp_spec = PL_GRP_MAX;
 			} else {
 				layout_set_shard_flags(layout, k, remap_flags);
 				if (domain != NULL)
 					setbit(dom_cur_grp_real, domain - root);
 			}
 		}
+		if (i >= md->omd_grp_spec)
+			break; /* caller doesn't require the full layout */
 	}
 
 	if (fail_tgt_cnt > 0)
@@ -776,6 +781,9 @@ obj_layout_alloc_and_get(struct pl_jump_map *jmap, uint32_t layout_ver,
 			DP_RC(rc));
 		return rc;
 	}
+
+	if (gen_mode != PRE_REBUILD || !(md->omd_flags & PL_FL_GRP_SPEC))
+		md->omd_grp_spec = PL_GRP_MAX; /* full layout */
 
 	rc = get_object_layout(jmap, layout_ver, *layout_p, jmop, allow_version, gen_mode, md);
 	if (rc) {

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -166,21 +166,32 @@ jm_obj_shard_pd(struct jm_obj_placement *jmop, uint32_t shard)
  *				recent pool map changes, like reintegration.
  * \param[in]	new_lo		The new layout that contains changes in layout
  *				that occurred due to pool status changes.
- * \param[in]	rebuilding	diff calls to extract the rebuilding shards for scanner.
  * \param[out]	diff		The d_list that contains the differences that
  *				were calculated.
+ * \param[in]	rebuilding	diff calls to extract the rebuilding shards for scanner.
+ * \param[in]	grp_spec	only get diff for the specified group, PL_GRP_MAX
+ * 				means comparing full layout.
  */
 static inline int
 layout_find_diff(struct pl_jump_map *jmap, struct pl_obj_layout *old_lo,
-		 struct pl_obj_layout *new_lo, d_list_t *diff, bool rebuilding)
+		 struct pl_obj_layout *new_lo, d_list_t *diff, bool rebuilding, int grp_spec)
 {
 	int index;
+	int end;
 	int rc;
 
 	/* We assume they are the same size */
 	D_ASSERT(old_lo->ol_nr == new_lo->ol_nr);
 
-	for (index = 0; index < old_lo->ol_nr; ++index) {
+	if (grp_spec == PL_GRP_MAX) {
+		index = 0;
+		end   = old_lo->ol_nr;
+	} else {
+		index = grp_spec * old_lo->ol_grp_size;
+		end   = index + old_lo->ol_grp_size;
+	}
+
+	for (; index < end; ++index) {
 		uint32_t            old_tgt = old_lo->ol_shards[index].po_target;
 		uint32_t            new_tgt = new_lo->ol_shards[index].po_target;
 		bool                remap   = false;
@@ -570,6 +581,7 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 	bool			spec_oid = false;
 	bool			realloc_grp_used = false;
 	d_list_t		remap_list;
+	int                      grp_spec;
 	int			fdom_lvl;
 	int			i, j, k;
 	int			rc = 0;
@@ -618,6 +630,8 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 
 	if (daos_obj_is_srank(oid))
 		spec_oid = true;
+
+	grp_spec = md->omd_grp_spec;
 
 	fdom_lvl = pool_map_failure_domain_level(jmap->jmp_map.pl_poolmap, jmop->jmop_fdom_lvl);
 	D_ASSERT(fdom_lvl > 0);
@@ -704,16 +718,23 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 
 				remap_add_one(&remap_list, shard);
 				/* remapping requires full layout */
-				if (i == md->omd_grp_spec)
-					md->omd_grp_spec = PL_GRP_MAX;
+				if (i == grp_spec)
+					grp_spec = PL_GRP_MAX;
 			} else {
 				layout_set_shard_flags(layout, k, remap_flags);
 				if (domain != NULL)
 					setbit(dom_cur_grp_real, domain - root);
 			}
 		}
-		if (i >= md->omd_grp_spec)
+
+		if (i >= grp_spec)
 			break; /* caller doesn't require the full layout */
+	}
+
+	if (md->omd_grp_spec != PL_GRP_MAX) {
+		/* may have generated the full layout, but ignore other parts */
+		layout->ol_grp_nr = md->omd_grp_spec + 1;
+		layout->ol_nr     = (layout->ol_grp_nr * layout->ol_grp_size);
 	}
 
 	if (fail_tgt_cnt > 0)
@@ -782,8 +803,9 @@ obj_layout_alloc_and_get(struct pl_jump_map *jmap, uint32_t layout_ver,
 		return rc;
 	}
 
-	if (gen_mode != PRE_REBUILD || !(md->omd_flags & PL_FL_GRP_SPEC))
-		md->omd_grp_spec = PL_GRP_MAX; /* full layout */
+	/* CURRENT mode always require full layout */
+	if (gen_mode == CURRENT || !(md->omd_flags & PL_FL_GRP_SPEC))
+		md->omd_grp_spec = PL_GRP_MAX;
 
 	rc = get_object_layout(jmap, layout_ver, *layout_p, jmop, allow_version, gen_mode, md);
 	if (rc) {
@@ -791,7 +813,6 @@ obj_layout_alloc_and_get(struct pl_jump_map *jmap, uint32_t layout_ver,
 			DP_RC(rc));
 		D_GOTO(out, rc);
 	}
-
 out:
 	if (rc != 0) {
 		if (*layout_p != NULL)
@@ -939,7 +960,7 @@ jump_map_obj_extend_layout(struct pl_jump_map *jmap, struct jm_obj_placement *jm
 
 	obj_layout_dump(md->omd_id, new_layout);
 
-	rc = layout_find_diff(jmap, layout, new_layout, &extend_list, false);
+	rc = layout_find_diff(jmap, layout, new_layout, &extend_list, false, PL_GRP_MAX);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -1110,7 +1131,8 @@ jump_map_obj_find_diff(struct pl_map *map, uint32_t layout_ver, struct daos_obj_
 		D_GOTO(out, rc);
 
 	obj_layout_dump(md->omd_id, reint_layout);
-	rc = layout_find_diff(jmap, layout, reint_layout, &reint_list, true);
+	rc = layout_find_diff(jmap, layout, reint_layout, &reint_list, true,
+			      (md->omd_flags & PL_FL_GRP_SPEC) ? md->omd_grp_spec : PL_GRP_MAX);
 	if (rc)
 		D_GOTO(out, rc);
 

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -1,6 +1,6 @@
 /**
- * (C) Copyright 2017-2024 Intel Corporation.
- * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2017-2024 Intel Corporation.
+ * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -671,7 +671,7 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 	struct rebuild_scan_arg		*arg = data;
 	struct rebuild_tgt_pool_tracker *rpt = arg->rpt;
 	struct pl_map			*map = NULL;
-	struct daos_obj_md		md;
+	struct daos_obj_md               md  = {0};
 	daos_unit_oid_t			oid = ent->ie_oid;
 	unsigned int			tgt_array[LOCAL_ARRAY_SIZE];
 	unsigned int			shard_array[LOCAL_ARRAY_SIZE];
@@ -718,6 +718,10 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 	md.omd_fdom_lvl = arg->co_props.dcp_redun_lvl;
 	md.omd_pdom_lvl = arg->co_props.dcp_perf_domain;
 	md.omd_pda = daos_cont_props2pda(&arg->co_props, daos_oclass_is_ec(oc_attr));
+	/* only generate layout up to this group and skip remaining part */
+	md.omd_flags    = PL_FL_GRP_SPEC;
+	md.omd_grp_spec = oid.id_shard / grp_size;
+
 	tgts = tgt_array;
 	shards = shard_array;
 	switch (rpt->rt_rebuild_op) {


### PR DESCRIPTION
Rebuild and EC aggregation do not require the full object layout;
instead, they only need the localities of the shards within the
same redundancy group as the current shard.

This patch stops the layout computation after generating the layout
for the requested redundancy group, saving a significant amount of
computation resources.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
