### PR TITLE
DAOS-18763 cq: revert githook change that removes (C)

### DIFF
--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1,7 +1,7 @@
 /**
- * Copyright 2016-2024 Intel Corporation.
- * Copyright 2025 Hewlett Packard Enterprise Development LP
- * Copyright 2025-2026 Google LLC.
+ * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Google LLC.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/control/cmd/ddb/main.go
+++ b/src/control/cmd/ddb/main.go
@@ -1,6 +1,6 @@
 //
-// Copyright 2022-2024 Intel Corporation.
-// Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2022-2024 Intel Corporation.
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //

--- a/src/dtx/tests/dts_aggregate.c
+++ b/src/dtx/tests/dts_aggregate.c
@@ -1,6 +1,6 @@
 /**
- * Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
- * Copyright 2026 Google LLC
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
+ * (C) Copyright 2026 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/dtx/tests/dts_discard_invalid.c
+++ b/src/dtx/tests/dts_discard_invalid.c
@@ -1,6 +1,6 @@
 /**
- * Copyright 2025 Hewlett Packard Enterprise Development LP.
- * Copyright 2026 Google LLC
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
+ * (C) Copyright 2026 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/engine/drpc_ras.c
+++ b/src/engine/drpc_ras.c
@@ -1,6 +1,6 @@
 /*
- * Copyright 2021-2023 Intel Corporation.
- * Copyright 2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2021-2023 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/gurt/tests/d_log_memory_ut.c
+++ b/src/gurt/tests/d_log_memory_ut.c
@@ -1,6 +1,6 @@
 /**
- * Copyright 2025 Hewlett Packard Enterprise Development LP
- * Copyright 2026 Google LLC
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2026 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -1,7 +1,7 @@
 /*
- * Copyright 2016-2024 Intel Corporation.
- * Copyright 2026 Google LLC
- * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2026 Google LLC
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/include/gurt/types.h
+++ b/src/include/gurt/types.h
@@ -1,6 +1,6 @@
 /*
- * Copyright 2016-2022 Intel Corporation.
- * Copyright 2026 Google LLC
+ * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2026 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -1,7 +1,7 @@
 /**
- * Copyright 2016-2024 Intel Corporation.
- * Copyright 2026 Google LLC
- * Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2026 Google LLC
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/pool/srv_pool_chkpt.c
+++ b/src/pool/srv_pool_chkpt.c
@@ -1,6 +1,6 @@
 /*
- * Copyright 2023 Intel Corporation.
- * Copyright 2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2023 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/tests/ftest/rebuild/interactive.py
+++ b/src/tests/ftest/rebuild/interactive.py
@@ -1,5 +1,5 @@
 """
-  Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -1,6 +1,6 @@
 """
-Copyright 2018-2024 Intel Corporation.
-Copyright 2026 Hewlett Packard Enterprise Development LP
+(C) Copyright 2018-2024 Intel Corporation.
+(C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -1,6 +1,6 @@
 /**
- * Copyright 2016-2024 Intel Corporation.
- * Copyright 2026 Google LLC
+ * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2026 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/tests/suite/dfs_par_test.c
+++ b/src/tests/suite/dfs_par_test.c
@@ -1,6 +1,6 @@
 /**
- * Copyright 2019-2024 Intel Corporation.
- * Copyright 2026 Google LLC
+ * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2026 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -1,7 +1,7 @@
 /**
- * Copyright 2021-2024 Intel Corporation.
- * Copyright 2026 Google LLC
- * Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2021-2024 Intel Corporation.
+ * (C) Copyright 2026 Google LLC
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/utils/ddb/ddb_commands.c
+++ b/src/utils/ddb/ddb_commands.c
@@ -1,7 +1,7 @@
 /**
- * Copyright 2022-2024 Intel Corporation.
- * Copyright 2025 Vdura Inc.
- * Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
+ * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025 Vdura Inc.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/utils/ddb/ddb_main.c
+++ b/src/utils/ddb/ddb_main.c
@@ -1,7 +1,7 @@
 /**
- * Copyright 2022-2024 Intel Corporation.
- * Copyright 2026 Hewlett Packard Enterprise Development LP
- * Copyright 2025 Vdura Inc.
+ * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Vdura Inc.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/utils/ddb/ddb_parse.c
+++ b/src/utils/ddb/ddb_parse.c
@@ -1,6 +1,6 @@
 /**
- * Copyright 2019-2024 Intel Corporation.
- * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -1,7 +1,7 @@
 /**
- * Copyright 2022-2025 Intel Corporation.
- * Copyright 2025 Vdura Inc.
- * Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
+ * (C) Copyright 2022-2025 Intel Corporation.
+ * (C) Copyright 2025 Vdura Inc.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/utils/ddb/ddb_vos.h
+++ b/src/utils/ddb/ddb_vos.h
@@ -1,7 +1,7 @@
 /**
- * Copyright 2022-2024 Intel Corporation.
- * Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
- * Copyright 2025 Vdura Inc.
+ * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
+ * (C) Copyright 2025 Vdura Inc.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/utils/ddb/tests/ddb_commands_tests.c
+++ b/src/utils/ddb/tests/ddb_commands_tests.c
@@ -1,6 +1,6 @@
 /**
- * Copyright 2022-2024 Intel Corporation.
- * Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
+ * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/utils/ddb/tests/ddb_main_tests.c
+++ b/src/utils/ddb/tests/ddb_main_tests.c
@@ -1,7 +1,7 @@
 /**
- * Copyright 2022-2024 Intel Corporation.
- * Copyright 2026 Hewlett Packard Enterprise Development LP
- * Copyright 2025 Vdura Inc.
+ * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Vdura Inc.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/utils/ddb/tests/ddb_parse_tests.c
+++ b/src/utils/ddb/tests/ddb_parse_tests.c
@@ -1,6 +1,6 @@
 /**
- * Copyright 2022-2024 Intel Corporation.
- * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/utils/ddb/tests/ddb_test_driver.c
+++ b/src/utils/ddb/tests/ddb_test_driver.c
@@ -1,6 +1,6 @@
 /**
- * Copyright 2022-2024 Intel Corporation.
- * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/utils/ddb/tests/ddb_ut.c
+++ b/src/utils/ddb/tests/ddb_ut.c
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/utils/ddb/tests/ddb_vos_tests.c
+++ b/src/utils/ddb/tests/ddb_vos_tests.c
@@ -1,7 +1,7 @@
 /**
- * Copyright 2022-2024 Intel Corporation.
- * Copyright 2026 Hewlett Packard Enterprise Development LP
- * Copyright 2025 Vdura Inc.
+ * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Vdura Inc.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/utils/dlck/tests/dlck_args_ut.c
+++ b/src/utils/dlck/tests/dlck_args_ut.c
@@ -1,6 +1,6 @@
 /**
- * Copyright 2025 Hewlett Packard Enterprise Development LP.
- * Copyright 2026 Google LLC
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
+ * (C) Copyright 2026 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -1,6 +1,6 @@
 /**
- * Copyright 2017-2023 Intel Corporation.
- * Copyright 2026 Google LLC
+ * (C) Copyright 2017-2023 Intel Corporation.
+ * (C) Copyright 2026 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/vos/tests/vts_wal.c
+++ b/src/vos/tests/vts_wal.c
@@ -1,7 +1,7 @@
 /**
- * Copyright 2022-2024 Intel Corporation.
- * Copyright 2026 Google LLC
- * Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2026 Google LLC
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -1,6 +1,6 @@
 /**
- * Copyright 2019-2023 Intel Corporation.
- * Copyright 2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1,7 +1,7 @@
 /**
- * Copyright 2016-2024 Intel Corporation.
- * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
- * Copyright 2025 Google LLC
+ * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/utils/cq/check_update_copyright.sh
+++ b/utils/cq/check_update_copyright.sh
@@ -158,7 +158,7 @@ for file in $files; do
                 sed -i '' -re 's/^([[:blank:]]*)\/\*[[:blank:]]*(.*Copyright.*Intel Corporation.*)[[:blank:]]*\*\//\1\/\*\n\1 \* \2\n\1 \*\//' "$file"
             fi
         fi
-        # 2. Fix Intel copyright format (comma vs dot, remove (C), ensure dot at end)
+        # 2. Fix Intel copyright format (comma vs dot, ensure dot at end)
         if grep -qE '^[[:blank:]]*[\*/#]*[[:blank:]]*Copyright [0-9]{4}(-[0-9]{4})?,[[:blank:]]*Intel Corporation' "$file"; then
             if [[ "$os" == 'Linux' ]]; then
                 sed -i -re 's/^([[:blank:]]*[\*/#]*[[:blank:]]*)Copyright ([0-9]{4}(-[0-9]{4})?),[[:blank:]]*Intel Corporation/\1Copyright \2 Intel Corporation./' "$file"

--- a/utils/cq/check_update_copyright.sh
+++ b/utils/cq/check_update_copyright.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 #  Copyright 2024 Intel Corporation.
-#  Copyright 2025 Hewlett Packard Enterprise Development LP
+#  Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 #  Copyright 2025-2026 Google LLC
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -159,19 +159,11 @@ for file in $files; do
             fi
         fi
         # 2. Fix Intel copyright format (comma vs dot, remove (C), ensure dot at end)
-        if grep -qE '^[[:blank:]]*[\*/#]*[[:blank:]]*(\(C\)[[:blank:]]*)?Copyright [0-9]{4}(-[0-9]{4})?,[[:blank:]]*Intel Corporation' "$file"; then
+        if grep -qE '^[[:blank:]]*[\*/#]*[[:blank:]]*Copyright [0-9]{4}(-[0-9]{4})?,[[:blank:]]*Intel Corporation' "$file"; then
             if [[ "$os" == 'Linux' ]]; then
-                sed -i -re 's/^([[:blank:]]*[\*/#]*[[:blank:]]*)(\(C\)[[:blank:]]*)?Copyright ([0-9]{4}(-[0-9]{4})?),[[:blank:]]*Intel Corporation/\1Copyright \3 Intel Corporation./' "$file"
+                sed -i -re 's/^([[:blank:]]*[\*/#]*[[:blank:]]*)Copyright ([0-9]{4}(-[0-9]{4})?),[[:blank:]]*Intel Corporation/\1Copyright \2 Intel Corporation./' "$file"
             else
-                sed -i '' -re 's/^([[:blank:]]*[\*/#]*[[:blank:]]*)(\(C\)[[:blank:]]*)?Copyright ([0-9]{4}(-[0-9]{4})?),[[:blank:]]*Intel Corporation/\1Copyright \3 Intel Corporation./' "$file"
-            fi
-        fi
-        # 3. Just remove (C) from any copyright if present
-        if grep -qE '^[[:blank:]]*[\*/#]*[[:blank:]]*\(C\)[[:blank:]]*Copyright' "$file"; then
-            if [[ "$os" == 'Linux' ]]; then
-                sed -i -re 's/^([[:blank:]]*[\*/#]*[[:blank:]]*)\(C\)[[:blank:]]*(Copyright)/\1\2/' "$file"
-            else
-                sed -i '' -re 's/^([[:blank:]]*[\*/#]*[[:blank:]]*)\(C\)[[:blank:]]*(Copyright)/\1\2/' "$file"
+                sed -i '' -re 's/^([[:blank:]]*[\*/#]*[[:blank:]]*)Copyright ([0-9]{4}(-[0-9]{4})?),[[:blank:]]*Intel Corporation/\1Copyright \2 Intel Corporation./' "$file"
             fi
         fi
     fi


### PR DESCRIPTION
Revert the githook change that removes (C) from copyrights because the (C) is okay and it is better to be consistent.

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
