### PR TITLE
DAOS-18759 rebuild: reserve rpc bytes for future extention

### DIFF
--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -71,7 +71,7 @@ enum daos_module_id {
 #define DAOS_POOL_VERSION     7
 #define DAOS_CONT_VERSION     8
 #define DAOS_OBJ_VERSION      10
-#define DAOS_REBUILD_VERSION  4
+#define DAOS_REBUILD_VERSION  5
 #define DAOS_RSVC_VERSION     5
 #define DAOS_RDB_VERSION      5
 #define DAOS_RDBT_VERSION     3

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -1,6 +1,6 @@
 /**
- * (C) Copyright 2017-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * Copyright 2017-2024 Intel Corporation.
+ * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -318,20 +318,21 @@ struct rebuild_iv {
 	uint64_t	riv_size;
 	uint64_t	riv_leader_term;
 	uint64_t	riv_stable_epoch;
+	uint64_t        riv_reserve[3];
 	uint32_t	riv_seconds;
 	uint32_t	riv_dtx_resyc_version;
 	uint32_t	riv_global_dtx_resyc_version;
-	unsigned int	riv_rank;
-	unsigned int	riv_master_rank;
-	unsigned int	riv_ver;
-	unsigned int	riv_rebuild_gen;
+	uint32_t        riv_rank;
+	uint32_t        riv_master_rank;
+	uint32_t        riv_ver;
+	uint32_t        riv_rebuild_gen;
 	uint32_t	riv_global_done:1,
 			riv_global_scan_done:1,
 			riv_scan_done:1,
 			riv_pull_done:1,
 			riv_sync:1;
-	int		riv_status;
-
+	int32_t  riv_status;
+	uint32_t riv_bukid; /* bucket ID */
 };
 
 extern struct dss_module_key rebuild_module_key;

--- a/src/rebuild/rpc.h
+++ b/src/rebuild/rpc.h
@@ -1,6 +1,6 @@
 /**
- * (C) Copyright 2017-2022 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * Copyright 2017-2022 Intel Corporation.
+ * Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -44,6 +44,7 @@ enum rebuild_operation {
 
 extern struct crt_proto_format rebuild_proto_fmt;
 
+/* clang-format off */
 #define DAOS_ISEQ_REBUILD_SCAN	/* input fields */		 \
 	((uuid_t)		(rsi_pool_uuid)		CRT_VAR) \
 	((uint64_t)		(rsi_leader_term)	CRT_VAR) \
@@ -54,10 +55,13 @@ extern struct crt_proto_format rebuild_proto_fmt;
 	((uint32_t)		(rsi_rebuild_ver)	CRT_VAR) \
 	((uint32_t)		(rsi_master_rank)	CRT_VAR) \
 	((uint32_t)		(rsi_rebuild_gen)	CRT_VAR) \
-	((uint32_t)		(rsi_layout_ver)	CRT_VAR)
+	((uint32_t)		(rsi_layout_ver)	CRT_VAR) \
+	((uint32_t)		(rsi_phase)		CRT_VAR) \
+	((uint64_t)		(rsi_padding)		CRT_VAR)
 
 #define DAOS_OSEQ_REBUILD_SCAN	/* output fields */		 \
 	((uint64_t)		(rso_stable_epoch)	CRT_VAR) \
+	((uint64_t)		(rso_padding)		CRT_VAR) \
 	((int32_t)		(rso_status)		CRT_VAR)
 
 CRT_RPC_DECLARE(rebuild_scan, DAOS_ISEQ_REBUILD_SCAN, DAOS_OSEQ_REBUILD_SCAN)
@@ -69,9 +73,11 @@ CRT_RPC_DECLARE(rebuild_scan, DAOS_ISEQ_REBUILD_SCAN, DAOS_OSEQ_REBUILD_SCAN)
 	((daos_unit_oid_t)	(roi_oids)		CRT_ARRAY) \
 	((uint64_t)		(roi_ephs)		CRT_ARRAY) \
 	((uuid_t)		(roi_uuids)		CRT_ARRAY) \
+	((uint64_t)		(roi_padding)		CRT_VAR) \
 	((uint32_t)		(roi_shards)		CRT_ARRAY)
 
 #define DAOS_OSEQ_REBUILD	/* output fields */		 \
+	((uint64_t)		(roo_padding)		CRT_VAR) \
 	((int32_t)		(roo_status)		CRT_VAR)
 
 CRT_RPC_DECLARE(rebuild, DAOS_ISEQ_REBUILD, DAOS_OSEQ_REBUILD)


### PR DESCRIPTION
Reserve some bytes in rebuild RPC protocol for future extension.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
