### PR TITLE
DAOS-18681 rebuild: fix potential memory leaks in error paths

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1136,7 +1136,7 @@ crt_ivf_rpc_issue(d_rank_t dest_node, crt_iv_key_t *iv_key,
 	struct crt_iv_fetch_in		*input;
 	crt_bulk_t			local_bulk = CRT_BULK_NULL;
 	crt_endpoint_t			ep = {0};
-	crt_rpc_t			*rpc;
+	crt_rpc_t                       *rpc;
 	struct ivf_key_in_progress	*entry;
 	int				rc = 0;
 	struct crt_iv_ops		*iv_ops;
@@ -1236,6 +1236,7 @@ crt_ivf_rpc_issue(d_rank_t dest_node, crt_iv_key_t *iv_key,
 	} else {
 		D_DEBUG(DB_ALL, "Group Version Changed: From %d: To %d\n",
 			grp_ver, local_grp_ver);
+		RPC_PUB_DECREF(rpc);
 		D_GOTO(exit, rc = -DER_GRPVER);
 	}
 
@@ -2611,7 +2612,7 @@ crt_ivu_rpc_issue(d_rank_t dest_rank, crt_iv_key_t *iv_key,
 	struct crt_iv_update_in		*input;
 	crt_bulk_t			local_bulk = CRT_BULK_NULL;
 	crt_endpoint_t			ep = {0};
-	crt_rpc_t			*rpc;
+	crt_rpc_t                       *rpc;
 	int				rc = 0;
 	uint32_t			local_grp_ver;
 
@@ -2642,6 +2643,7 @@ crt_ivu_rpc_issue(d_rank_t dest_rank, crt_iv_key_t *iv_key,
 		}
 		if (rc != 0) {
 			D_ERROR("crt_bulk_create(): "DF_RC"\n", DP_RC(rc));
+			RPC_PUB_DECREF(rpc);
 			D_GOTO(exit, rc);
 		}
 	} else {
@@ -2677,6 +2679,7 @@ crt_ivu_rpc_issue(d_rank_t dest_rank, crt_iv_key_t *iv_key,
 			"On entry: %d: Changed to :%d\n",
 			ivns_internal->cii_gns.gn_ivns_id.ii_group_name,
 			grp_ver, local_grp_ver);
+		RPC_PUB_DECREF(rpc);
 		D_GOTO(exit, rc = -DER_GRPVER);
 	}
 	input->ivu_grp_ver = grp_ver;

--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2579,14 +2579,11 @@ adjust_array_size_cb(tse_task_t *task, void *data)
 		args->sgl->sg_nr = 1;
 		d_iov_set(&args->sgl->sg_iovs[0], props->buf, props->buf_len);
 
-		rc = tse_task_register_cbs(task, NULL, NULL, 0, adjust_array_size_cb, &props,
-					   sizeof(props));
+		rc = tse_task_register_comp_cb_and_reinit(task, adjust_array_size_cb, &props,
+							  sizeof(props), 0 /* delay */);
 		if (rc)
-			goto out;
-
-		rc = tse_task_reinit(task);
-		if (rc)
-			D_ERROR("FAILED to reinit task\n");
+			D_ERROR("FAILED to register comp cb and reinit task: " DF_RC "\n",
+				DP_RC(rc));
 
 		goto out;
 	}

--- a/src/common/drpc.c
+++ b/src/common/drpc.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2018-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -573,7 +573,9 @@ drpc_call(struct drpc *ctx, int flags, Drpc__Call *msg, Drpc__Response **resp)
 		return ret;
 
 	if (!(flags & R_SYNC)) {
-		response         = drpc_response_create(msg);
+		response = drpc_response_create(msg);
+		if (response == NULL)
+			return -DER_NOMEM;
 		response->status = DRPC__STATUS__SUBMITTED;
 		*resp            = response;
 		return 0;

--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -384,8 +384,8 @@ tse_task_complete_locked(struct tse_task_private *dtp,
 }
 
 static int
-register_cb(tse_task_t *task, bool is_comp, tse_task_cb_t cb,
-	    void *arg, daos_size_t arg_size)
+register_cb(tse_task_t *task, bool is_comp, tse_task_cb_t cb, void *arg, daos_size_t arg_size,
+	    struct tse_task_cb **dtcp)
 {
 	struct tse_task_private *dtp = tse_task2priv(task);
 	struct tse_task_cb *dtc;
@@ -411,9 +411,10 @@ register_cb(tse_task_t *task, bool is_comp, tse_task_cb_t cb,
 		d_list_add(&dtc->dtc_list, &dtp->dtp_comp_cb_list);
 	else /** MSC - don't see a need for more than 1 prep cb */
 		d_list_add_tail(&dtc->dtc_list, &dtp->dtp_prep_cb_list);
-
 	D_MUTEX_UNLOCK(&dtp->dtp_sched->dsp_lock);
 
+	if (dtcp != NULL)
+		*dtcp = dtc;
 	return 0;
 }
 
@@ -422,7 +423,41 @@ tse_task_register_comp_cb(tse_task_t *task, tse_task_cb_t comp_cb,
 			  void *arg, daos_size_t arg_size)
 {
 	D_ASSERT(comp_cb != NULL);
-	return register_cb(task, true, comp_cb, arg, arg_size);
+	return register_cb(task, true, comp_cb, arg, arg_size, NULL);
+}
+
+static void
+unregister_cb(tse_task_t *task, struct tse_task_cb *dtc)
+{
+	struct tse_task_private *dtp;
+
+	if (dtc == NULL)
+		return;
+
+	dtp = tse_task2priv(task);
+	D_MUTEX_LOCK(&dtp->dtp_sched->dsp_lock);
+	d_list_del(&dtc->dtc_list);
+	D_MUTEX_UNLOCK(&dtp->dtp_sched->dsp_lock);
+	D_FREE(dtc);
+}
+
+int
+tse_task_register_comp_cb_and_reinit(tse_task_t *task, tse_task_cb_t comp_cb, void *arg,
+				     daos_size_t arg_size, uint64_t delay)
+{
+	struct tse_task_cb *dtc = NULL;
+	int                 rc;
+
+	D_ASSERT(comp_cb != NULL);
+	rc = register_cb(task, true, comp_cb, arg, arg_size, &dtc);
+	if (rc != 0)
+		return rc;
+
+	rc = tse_task_reinit_with_delay(task, delay);
+	if (rc != 0)
+		unregister_cb(task, dtc);
+
+	return rc;
 }
 
 int
@@ -431,15 +466,20 @@ tse_task_register_cbs(tse_task_t *task, tse_task_cb_t prep_cb,
 		      tse_task_cb_t comp_cb, void *comp_data,
 		      daos_size_t comp_data_size)
 {
-	int	rc = 0;
+	int                 rc  = 0;
+	struct tse_task_cb *dtc = NULL;
 
 	D_ASSERT(prep_cb != NULL || comp_cb != NULL);
-	if (prep_cb)
-		rc = register_cb(task, false, prep_cb, prep_data,
-				 prep_data_size);
-	if (comp_cb && !rc)
-		rc = register_cb(task, true, comp_cb, comp_data,
-				 comp_data_size);
+	if (prep_cb) {
+		rc = register_cb(task, false, prep_cb, prep_data, prep_data_size, &dtc);
+		if (rc != 0)
+			return rc;
+	}
+	if (comp_cb) {
+		rc = register_cb(task, true, comp_cb, comp_data, comp_data_size, NULL);
+		if (rc != 0)
+			unregister_cb(task, dtc);
+	}
 	return rc;
 }
 

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -717,26 +717,17 @@ pmap_refresh_cb(tse_task_t *task, void *data)
 		else
 			delay = 0;
 
-		rc = tse_task_register_comp_cb(task, pmap_refresh_cb, cb_arg,
-					       sizeof(*cb_arg));
-		if (rc) {
-			D_ERROR(DF_UUID": pmap_refresh version (%d:%d), failed "
-				"to reg_comp_cb, "DF_RC"\n",
-				DP_UUID(pool->dp_pool), pm_ver,
-				cb_arg->pra_pm_ver, DP_RC(rc));
-			goto out;
-		}
-
 		cb_arg->pra_retry_nr++;
 		D_DEBUG(DB_TRACE, DF_UUID": pmap_refresh version (%d:%d), "
 			"in %d retry\n", DP_UUID(pool->dp_pool), pm_ver,
 			cb_arg->pra_pm_ver, cb_arg->pra_retry_nr);
 
-		rc = tse_task_reinit_with_delay(task, delay);
+		rc = tse_task_register_comp_cb_and_reinit(task, pmap_refresh_cb, cb_arg,
+							  sizeof(*cb_arg), delay);
 		if (rc) {
-			D_ERROR(DF_UUID": pmap_refresh version (%d:%d), resched"
-				" failed, "DF_RC"\n", DP_UUID(pool->dp_pool),
-				pm_ver, cb_arg->pra_pm_ver, DP_RC(rc));
+			D_ERROR(DF_UUID ": pmap_refresh version (%d:%d), reg_comp_cb/reinit"
+					" failed, " DF_RC "\n",
+				DP_UUID(pool->dp_pool), pm_ver, cb_arg->pra_pm_ver, DP_RC(rc));
 			goto out;
 		}
 

--- a/src/include/daos/tse.h
+++ b/src/include/daos/tse.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2015-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -223,6 +224,24 @@ tse_task_schedule_with_delay(tse_task_t *task, bool instant, uint64_t delay);
 int
 tse_task_register_comp_cb(tse_task_t *task, tse_task_cb_t comp_cb,
 			  void *arg, size_t arg_size);
+
+/**
+ * Atomically register a completion callback and reinitialize the task for
+ * retry with an optional scheduling delay.  If the reinitialization fails the
+ * newly registered callback is removed and freed so the caller never leaks a
+ * dangling tse_task_cb node.
+ *
+ * \param[in] task	Task to reinitialize for retry
+ * \param[in] comp_cb	Completion callback to register for the retried run
+ * \param[in] arg	Callback argument (copied internally, like tse_task_register_comp_cb)
+ * \param[in] arg_size	Size of the argument
+ * \param[in] delay	Scheduling delay in microseconds (0 = immediate)
+ *
+ * \return		0 on success, negative errno on failure.
+ */
+int
+tse_task_register_comp_cb_and_reinit(tse_task_t *task, tse_task_cb_t comp_cb, void *arg,
+				     size_t arg_size, uint64_t delay);
 
 /**
  * Mark task as completed.

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5413,18 +5413,6 @@ args_fini:
 			D_ASSERT(d_list_empty(head));
 		}
 
-		/* Free sub_anchors on final task completion (error or non-EOF success).
-		 * For the EOF case, anchor_update_check_eof() already freed and NULLed it,
-		 * so sub_anchors_free() is a no-op (obj_get_sub_anchors returns NULL).
-		 * KEY2ANCHOR also uses sub_anchors but is not an enum opc, handle separately.
-		 */
-		if ((obj_is_enum_opc(obj_auxi->opc) || obj_auxi->opc == DAOS_OBJ_RPC_KEY2ANCHOR) &&
-		    obj_auxi->sub_anchors) {
-			daos_obj_list_t *list_args = dc_task_get_args(task);
-
-			sub_anchors_free(list_args, obj_auxi->opc);
-		}
-
 		if (obj_auxi->is_ec_obj)
 			obj_ec_comp_cb(obj_auxi);
 		else

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5413,6 +5413,18 @@ args_fini:
 			D_ASSERT(d_list_empty(head));
 		}
 
+		/* Free sub_anchors on final task completion (error or non-EOF success).
+		 * For the EOF case, anchor_update_check_eof() already freed and NULLed it,
+		 * so sub_anchors_free() is a no-op (obj_get_sub_anchors returns NULL).
+		 * KEY2ANCHOR also uses sub_anchors but is not an enum opc, handle separately.
+		 */
+		if ((obj_is_enum_opc(obj_auxi->opc) || obj_auxi->opc == DAOS_OBJ_RPC_KEY2ANCHOR) &&
+		    obj_auxi->sub_anchors) {
+			daos_obj_list_t *list_args = dc_task_get_args(task);
+
+			sub_anchors_free(list_args, obj_auxi->opc);
+		}
+
 		if (obj_auxi->is_ec_obj)
 			obj_ec_comp_cb(obj_auxi);
 		else

--- a/src/object/srv_cli.c
+++ b/src/object/srv_cli.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2022 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -72,8 +73,10 @@ dsc_obj_list_akey(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
 
 	rc = dc_obj_list_akey_task_create(oh, th, dkey, nr, kds, sgl, anchor,
 					  NULL, dsc_scheduler(), &task);
-	if (rc)
+	if (rc) {
+		dc_tx_local_close(th);
 		return rc;
+	}
 
 	rc = tse_task_register_comp_cb(task, tx_close_cb, &th, sizeof(th));
 	if (rc) {
@@ -103,8 +106,10 @@ dsc_obj_fetch(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
 	rc = dc_obj_fetch_task_create(oh, th, 0, dkey, nr, extra_flag,
 				      iods, sgls, maps, extra_arg, csum_iov,
 				      NULL, dsc_scheduler(), &task);
-	if (rc)
+	if (rc) {
+		dc_tx_local_close(th);
 		return rc;
+	}
 
 	rc = tse_task_register_comp_cb(task, tx_close_cb, &th, sizeof(th));
 	if (rc) {

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1064,11 +1064,11 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 				    VOS_OF_REBUILD, &mrone->mo_dkey, iod_cnt,
 				    &mrone->mo_iods[start], iod_csums,
 				    &sgls[start]);
+		daos_csummer_free_ic(csummer, &iod_csums);
 		if (rc) {
 			DL_ERROR(rc, DF_RB ": migrate failed", DP_RB_MRO(mrone));
 			D_GOTO(out, rc);
 		}
-		daos_csummer_free_ic(csummer, &iod_csums);
 	}
 
 out:
@@ -4615,8 +4615,10 @@ migrate_check_one(void *data)
 		migrate_pool_tls_get(tls);
 		tls->mpt_post_process_started = 1;
 		D_ALLOC_PTR(ult_arg);
-		if (ult_arg == NULL)
+		if (ult_arg == NULL) {
+			migrate_pool_tls_put(tls);
 			D_GOTO(out, rc = -DER_NOMEM);
+		}
 
 		ult_arg->rpa_tls = tls;
 		ult_arg->rpa_migrated_root = &tls->mpt_migrated_root;
@@ -4757,10 +4759,6 @@ ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_h
 		return -DER_NONEXIST;
 	}
 
-	/* NB: let's send object list to 0 xstream to simplify the migrate
-	 * object handling process for now, for example avoid lock to insert
-	 * objects in the object tree.
-	 */
 	tgt_ep.ep_rank = target->ta_comp.co_rank;
 	index = target->ta_comp.co_index;
 	ABT_rwlock_unlock(pool->sp_lock);

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -291,7 +291,7 @@ rebuild_objects_send_ult(void *data)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	D_ALLOC_ARRAY(punched_ephs, REBUILD_SEND_LIMIT);
-	if (ephs == NULL)
+	if (punched_ephs == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	arg.count = 0;


### PR DESCRIPTION
Fix potential memory leaks in error cases in rebuild and IV path. Also Fixed a memmory allocation check typo to avoid potential crash

Removed stale comments

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
