### PR TITLE
DAOS-18524 object: fix EC checksum in rebuild, aggregation

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1567,6 +1567,15 @@ __migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 		D_GOTO(post, rc);
 	}
 
+	/*
+	 * Convert recxs back to VOS-space before computing checksums, so that
+	 * csum chunk boundaries match the VOS offsets where data and csums will
+	 * be stored. Must happen after fetch (needs DAOS-space) and before
+	 * migrate_csum_calc().
+	 */
+	if (daos_oclass_is_ec(&mrone->mo_oca))
+		mrone_recx_daos2_vos(mrone, iods, iod_num);
+
 	csummer = dsc_cont2csummer(dc_obj_hdl2cont_hdl(oh));
 	rc = migrate_csum_calc(csummer, mrone, iods, iod_num, sgls, p_csum_iov, &iod_csums);
 	if (rc != 0) {
@@ -1578,9 +1587,6 @@ __migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 post:
 	for (i = 0; i < sgl_cnt; i++)
 		d_sgl_fini(&sgls[i], false);
-
-	if (daos_oclass_is_ec(&mrone->mo_oca))
-		mrone_recx_daos2_vos(mrone, iods, iod_num);
 
 	rc = bio_iod_post(vos_ioh2desc(ioh), rc);
 	if (rc)

--- a/src/vos/vos_csum_recalc.c
+++ b/src/vos/vos_csum_recalc.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -39,16 +40,13 @@
  */
 
 /* Determine checksum parameters for verification of an input segment. */
-static unsigned int
+static uint64_t
 calc_csum_params(struct dcs_csum_info *csum_info, struct csum_recalc *recalc,
-		 unsigned int prefix_len, unsigned int suffix_len,
-		 unsigned int rec_size)
+		 unsigned int prefix_len, unsigned int suffix_len, unsigned int rec_size)
 {
-
-	unsigned int cs_cnt, low_idx = recalc->cr_log_ext.ex_lo -
-							prefix_len / rec_size;
-	unsigned int high_idx = recalc->cr_log_ext.ex_hi +
-							suffix_len / rec_size;
+	unsigned int cs_cnt;
+	uint64_t     low_idx  = recalc->cr_log_ext.ex_lo - prefix_len / rec_size;
+	uint64_t     high_idx = recalc->cr_log_ext.ex_hi + suffix_len / rec_size;
 
 	assert(prefix_len % rec_size == 0);
 	cs_cnt = csum_chunk_count(recalc->cr_phy_csum->cs_chunksize,
@@ -80,20 +78,16 @@ csum_agg_verify(struct csum_recalc *recalc, struct dcs_csum_info *new_csum,
 	 * matches the offset of the (csum-extended) output segment.
 	 */
 	if (new_csum->cs_nr != recalc->cr_phy_csum->cs_nr) {
-		unsigned int chunksize = new_csum->cs_chunksize;
-		unsigned int orig_offset =
-			(recalc->cr_phy_ext->ex_lo +
-			 recalc->cr_phy_off)  * rec_size;
-		unsigned int out_offset = recalc->cr_log_ext.ex_lo * rec_size -
-								prefix_len;
+		uint64_t chunksize   = new_csum->cs_chunksize;
+		uint64_t orig_offset = (recalc->cr_phy_ext->ex_lo + recalc->cr_phy_off) * rec_size;
+		uint64_t out_offset  = recalc->cr_log_ext.ex_lo * rec_size - prefix_len;
 
 		D_ASSERT(new_csum->cs_nr <
 				 recalc->cr_phy_csum->cs_nr);
 		D_ASSERT(orig_offset <= out_offset);
 		if (orig_offset != out_offset) {
-			unsigned int add_start = chunksize -
-							orig_offset % chunksize;
-			unsigned int offset = orig_offset + add_start;
+			uint64_t add_start = chunksize - orig_offset % chunksize;
+			uint64_t offset    = orig_offset + add_start;
 
 			if (add_start)
 				j++;
@@ -154,7 +148,8 @@ vos_csum_recalc_fn(void *recalc_args)
 				    csum_info.cs_chunksize, 0);
 	for (i = 0; i < args->cra_seg_cnt; i++) {
 		bool		is_valid = false;
-		unsigned int	this_rec_nr, this_rec_idx;
+		unsigned int    this_rec_nr;
+		uint64_t        this_rec_idx;
 
 		biov = &bsgl->bs_iovs[i];
 		/* Number of records in this input segment */


### PR DESCRIPTION
Fix two bugs causing -DER_CSUM failures with non-power-of-2 checksum chunk sizes on EC objects:

1. In __migrate_fetch_update_bulk(), checksums were computed while IOD recxs were still in DAOS-space (needed for the preceding fetch), but stored at VOS-space offsets. When cksum_size does not evenly divide ec_cell_sz, chunk boundaries differ between coordinate spaces, producing mismatched checksums. Move mrone_recx_daos2_vos() before migrate_csum_calc() so checksums align with VOS storage offsets.

2. In vos_csum_recalc.c, calc_csum_params() and csum_agg_verify() used unsigned int for extent offsets, truncating the PARITY_INDICATOR bit (0x8000000000000000) on parity extents. With non-power-of-2 chunk sizes, this truncation shifts chunk boundaries, causing aggregation checksum verification to always fail. Widen to uint64_t.

Allow-unstable-test: true
Features: checksum rebuild ec aggregation

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
