### PR TITLE
DAOS-18236 test: run daos_racer/parallel with mpich

### DIFF
--- a/src/tests/ftest/daos_racer/parallel.py
+++ b/src/tests/ftest/daos_racer/parallel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 """
 (C) Copyright 2021-2022 Intel Corporation.
 (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
@@ -10,7 +9,6 @@ from apricot import TestWithServers
 from daos_racer_utils import DaosRacerCommand
 from exception_utils import CommandFailure
 from job_manager_utils import get_job_manager
-from run_utils import run_remote
 
 
 class DaosRacerParallelTest(TestWithServers):
@@ -35,39 +33,24 @@ class DaosRacerParallelTest(TestWithServers):
         :avocado: tags=io,daos_racer
         :avocado: tags=DaosRacerParallelTest,test_daos_racer_parallel
         """
-        # DAOS-18236 - Debug missing libdpar_mpi.so
-        run_remote(
-            self.log, self.hostlist_clients,
-            'ls -l /usr/mpi/gcc/openmpi-4.1.7rc1/lib | grep -i libdpar')
-        run_remote(
-            self.log, self.hostlist_clients,
-            'ls -l /usr/mpi/gcc/openmpi-4.1.7rc1/lib64 | grep -i libdpar')
-        run_remote(
-            self.log, self.hostlist_clients,
-            'ls -l /usr/lib | grep -i libdpar')
-        run_remote(
-            self.log, self.hostlist_clients,
-            'ls -l /usr/lib64 | grep -i libdpar')
-
         # Create the daos_racer command
         daos_racer = DaosRacerCommand(self.bin, self.hostlist_clients, self.get_dmg_command())
         daos_racer.get_params(self)
 
-        # Create the orterun command
+        # Create the mpi command
         job_manager = get_job_manager(self)
         job_manager.assign_hosts(self.hostlist_clients, self.workdir, None)
         job_manager.assign_processes(len(self.hostlist_clients))
         job_manager.assign_environment(daos_racer.env)
         job_manager.job = daos_racer
-        job_manager.check_results_list = ["<stderr>"]
+        job_manager.check_results_list = ["<stderr>", "No MPI found"]
         job_manager.timeout = daos_racer.clush_timeout.value
-        self.log.info("Multi-process command: %s", str(job_manager))
 
-        # Run the daos_racer command and check for errors
+        self.log_step("Run daos_racer with multiple clients")
         try:
             job_manager.run()
 
         except CommandFailure as error:
             self.fail(f"daos_racer failed: {error}")
 
-        self.log.info("Test passed!")
+        self.log_step("Test passed!")

--- a/src/tests/ftest/daos_racer/parallel.yaml
+++ b/src/tests/ftest/daos_racer/parallel.yaml
@@ -21,11 +21,6 @@ server_config:
       log_mask: "ERR"
       storage: auto
 
-job_manager:
-  class_name: Orterun
-  mpi_type: openmpi
-  manager_timeout: 630
-
 daos_racer:
   runtime: 600
   clush_timeout: 900

--- a/src/tests/ftest/util/daos_racer_utils.py
+++ b/src/tests/ftest/util/daos_racer_utils.py
@@ -76,20 +76,21 @@ class DaosRacerCommand(ExecutableCommand):
         super().get_params(test)
         default_env = {
             "D_LOG_FILE": get_log_file("{}_daos.log".format(self.command)),
-            "OMPI_MCA_btl_openib_warn_default_gid_prefix": "0",
-            "OMPI_MCA_btl": "tcp,self",
-            "OMPI_MCA_oob": "tcp",
-            "OMPI_MCA_pml": "ob1",
-            "D_LOG_MASK": "ERR"
+            # "OMPI_MCA_btl_openib_warn_default_gid_prefix": "0",
+            # "OMPI_MCA_btl": "tcp,self",
+            # "OMPI_MCA_oob": "tcp",
+            # "OMPI_MCA_pml": "ob1",
+            # "D_LOG_MASK": "ERR"
         }
         for key, val in default_env.items():
             if key not in self.env:
                 self.env[key] = val
 
-        if not load_mpi("openmpi"):
-            raise MPILoadError("openmpi")
+        # if not load_mpi("openmpi"):
+        #     raise MPILoadError("openmpi")
 
-        self.env["LD_LIBRARY_PATH"] = os.environ["LD_LIBRARY_PATH"]
+        if "LD_LIBRARY_PATH" in os.environ:
+            self.env["LD_LIBRARY_PATH"] = os.environ["LD_LIBRARY_PATH"]
 
     def run(self, raise_exception=None):
         """Run the daos_racer command remotely.


### PR DESCRIPTION
Run daos_racer/parallel with mpich instead of openmpi.
Also verify MPI is found when running.

Test-tag: DaosRacerParallelTest
Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
