### PR TITLE
DAOS-18792 ci: add release/2.8 to dependabot scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,20 @@ updates:
       prefix: "Doc-only: true \n"
 
   - package-ecosystem: github-actions
+    target-branch: release/2.8
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      gha-versions:
+        patterns:
+          - "*"
+    reviewers:
+      - daos-stack/actions-watchers
+    commit-message:
+      prefix: "Doc-only: true \n"
+
+  - package-ecosystem: github-actions
     target-branch: release/2.6.4-aurora
     directory: /
     schedule:
@@ -85,6 +99,20 @@ updates:
 
   - package-ecosystem: gomod
     target-branch: release/2.6
+    directory: /src/control
+    schedule:
+      interval: weekly
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+    reviewers:
+      - daos-stack/actions-watchers
+    commit-message:
+      prefix: "Doc-only: true \n"
+
+  - package-ecosystem: gomod
+    target-branch: release/2.8
     directory: /src/control
     schedule:
       interval: weekly


### PR DESCRIPTION

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
