### PR TITLE
DAOS-xxxx cq: update clang-format GHA to latest OS

### DIFF
--- a/.github/actions/clang-format/Dockerfile
+++ b/.github/actions/clang-format/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM fedora:latest
 
 RUN dnf -y install clang-tools-extra git-clang-format
 


### PR DESCRIPTION
Update from Fedora:38 to Fedora:latest to see if that installs a newer clang-format.

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
