### PR TITLE
DAOS-18086 control: Fix data race in drpc unit test

### DIFF
--- a/src/control/drpc/drpc_server.go
+++ b/src/control/drpc/drpc_server.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2018-2023 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -30,6 +30,13 @@ type DomainSocketServer struct {
 	service       *ModuleService
 	sessions      map[net.Conn]*Session
 	sessionsMutex sync.Mutex
+}
+
+// GetNumSessions gets the number of current sessions in the server.
+func (d *DomainSocketServer) GetNumSessions() int {
+	d.sessionsMutex.Lock()
+	defer d.sessionsMutex.Unlock()
+	return len(d.sessions)
 }
 
 // closeSession cleans up the session and removes it from the list of active

--- a/src/control/drpc/drpc_server_test.go
+++ b/src/control/drpc/drpc_server_test.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2023 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -303,14 +303,17 @@ func TestServer_Listen_AcceptConnection(t *testing.T) {
 
 	lis := newMockListener()
 	lis.setNumConnsToAccept(3)
-	dss, _ := NewDomainSocketServer(log, "dontcare.sock", testFileMode)
+	dss, err := NewDomainSocketServer(log, "dontcare.sock", testFileMode)
+	if err != nil {
+		t.Fatal(err)
+	}
 	dss.listener = lis
 
 	dss.Listen(test.Context(t)) // will return when error is sent
 
 	test.AssertEqual(t, lis.acceptCallCount, lis.acceptNumConns+1,
 		"should have returned after listener errored")
-	test.AssertEqual(t, len(dss.sessions), lis.acceptNumConns,
+	test.AssertEqual(t, dss.GetNumSessions(), lis.acceptNumConns,
 		"server should have made connections into sessions")
 }
 


### PR DESCRIPTION
This issue was only affecting unit tests.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
