### PR TITLE
DAOS-18236 test: overhaul daos_racer usage

### DIFF
--- a/src/tests/ftest/daos_racer/multi.yaml
+++ b/src/tests/ftest/daos_racer/multi.yaml
@@ -23,4 +23,4 @@ server_config:
 
 daos_racer:
   runtime: 7200
-  clush_timeout: 10080
+  daos_racer_timeout: 10080

--- a/src/tests/ftest/daos_racer/parallel.py
+++ b/src/tests/ftest/daos_racer/parallel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 """
 (C) Copyright 2021-2022 Intel Corporation.
 (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
@@ -10,7 +9,6 @@ from apricot import TestWithServers
 from daos_racer_utils import DaosRacerCommand
 from exception_utils import CommandFailure
 from job_manager_utils import get_job_manager
-from run_utils import run_remote
 
 
 class DaosRacerParallelTest(TestWithServers):
@@ -35,39 +33,24 @@ class DaosRacerParallelTest(TestWithServers):
         :avocado: tags=io,daos_racer
         :avocado: tags=DaosRacerParallelTest,test_daos_racer_parallel
         """
-        # DAOS-18236 - Debug missing libdpar_mpi.so
-        run_remote(
-            self.log, self.hostlist_clients,
-            'ls -l /usr/mpi/gcc/openmpi-4.1.7rc1/lib | grep -i libdpar')
-        run_remote(
-            self.log, self.hostlist_clients,
-            'ls -l /usr/mpi/gcc/openmpi-4.1.7rc1/lib64 | grep -i libdpar')
-        run_remote(
-            self.log, self.hostlist_clients,
-            'ls -l /usr/lib | grep -i libdpar')
-        run_remote(
-            self.log, self.hostlist_clients,
-            'ls -l /usr/lib64 | grep -i libdpar')
-
         # Create the daos_racer command
         daos_racer = DaosRacerCommand(self.bin, self.hostlist_clients, self.get_dmg_command())
         daos_racer.get_params(self)
 
-        # Create the orterun command
+        # Create the mpi command
         job_manager = get_job_manager(self)
         job_manager.assign_hosts(self.hostlist_clients, self.workdir, None)
-        job_manager.assign_processes(len(self.hostlist_clients))
+        job_manager.assign_processes(ppn=self.params.get('ppn', daos_racer.namespace))
         job_manager.assign_environment(daos_racer.env)
         job_manager.job = daos_racer
-        job_manager.check_results_list = ["<stderr>"]
-        job_manager.timeout = daos_racer.clush_timeout.value
-        self.log.info("Multi-process command: %s", str(job_manager))
+        job_manager.check_results_list = ["<stderr>", "No MPI found"]
+        job_manager.timeout = daos_racer.daos_racer_timeout.value
 
-        # Run the daos_racer command and check for errors
+        self.log_step("Run daos_racer with multiple clients")
         try:
             job_manager.run()
 
         except CommandFailure as error:
             self.fail(f"daos_racer failed: {error}")
 
-        self.log.info("Test passed!")
+        self.log_step("Test passed!")

--- a/src/tests/ftest/daos_racer/parallel.yaml
+++ b/src/tests/ftest/daos_racer/parallel.yaml
@@ -24,8 +24,9 @@ server_config:
 job_manager:
   class_name: Orterun
   mpi_type: openmpi
-  manager_timeout: 630
+  manager_timeout: 1000
 
 daos_racer:
+  ppn: 1
   runtime: 600
-  clush_timeout: 900
+  daos_racer_timeout: 900

--- a/src/tests/ftest/daos_racer/simple.yaml
+++ b/src/tests/ftest/daos_racer/simple.yaml
@@ -23,4 +23,4 @@ server_config:
 
 daos_racer:
   runtime: 600
-  clush_timeout: 900
+  daos_racer_timeout: 900

--- a/src/tests/ftest/osa/online_extend.yaml
+++ b/src/tests/ftest/osa/online_extend.yaml
@@ -92,7 +92,7 @@ mdtest:
 
 daos_racer:
   runtime: 480
-  clush_timeout: 1000
+  daos_racer_timeout: 1000
 
 test_obj_class:
   oclass:

--- a/src/tests/ftest/osa/online_parallel_test.yaml
+++ b/src/tests/ftest/osa/online_parallel_test.yaml
@@ -63,4 +63,4 @@ ior:
 
 daos_racer:
   runtime: 480
-  clush_timeout: 1000
+  daos_racer_timeout: 1000

--- a/src/tests/ftest/osa/online_reintegration.yaml
+++ b/src/tests/ftest/osa/online_reintegration.yaml
@@ -63,7 +63,7 @@ ior:
 
 daos_racer:
   runtime: 480
-  clush_timeout: 1000
+  daos_racer_timeout: 1000
 
 mdtest:
   api: DFS

--- a/src/tests/ftest/util/daos_racer_utils.py
+++ b/src/tests/ftest/util/daos_racer_utils.py
@@ -9,8 +9,7 @@ import os
 from ClusterShell.NodeSet import NodeSet
 from command_utils import ExecutableCommand
 from command_utils_base import BasicParameter, FormattedParameter
-from env_modules import load_mpi
-from exception_utils import CommandFailure, MPILoadError
+from exception_utils import CommandFailure
 from general_utils import get_log_file
 from run_utils import run_remote
 
@@ -18,7 +17,7 @@ from run_utils import run_remote
 class DaosRacerCommand(ExecutableCommand):
     """Defines a object representing a daos_racer command."""
 
-    def __init__(self, path, hosts, dmg=None):
+    def __init__(self, path, hosts, dmg=None, namespace="/run/daos_racer/*"):
         """Create a daos_racer command object.
 
         Args:
@@ -26,8 +25,9 @@ class DaosRacerCommand(ExecutableCommand):
             hosts (str/NodeSet): hosts on which to run the daos_racer command
             dmg (DmgCommand): a DmgCommand object used to obtain the
                 configuration file and certificate
+            namespace (str): yaml namespace (path to parameters). Defaults to "/run/daos_racer/*".
         """
-        super().__init__("/run/daos_racer/*", "daos_racer", path)
+        super().__init__(namespace, "daos_racer", path)
         if not isinstance(hosts, NodeSet):
             hosts = NodeSet(hosts)
         self._hosts = NodeSet(hosts)
@@ -42,14 +42,17 @@ class DaosRacerCommand(ExecutableCommand):
             dmg.copy_certificates(get_log_file("daosCA/certs"), self._hosts)
             dmg.copy_configuration(self._hosts)
 
-        # Optional timeout for the clush command running the daos_racer command.
+        # Optional timeout for running the daos_racer command.
         # This should be set greater than the 'runtime' value but less than the
         # avocado test timeout value to allow for proper cleanup.  Using a value
         # of None will result in no timeout being used.
-        self.clush_timeout = BasicParameter(None)
+        self.daos_racer_timeout = BasicParameter(None)
 
         # Include bullseye coverage file environment
         self.env["COVFILE"] = os.path.join(os.sep, "tmp", "test.cov")
+
+        # Use a separate log file by default
+        self.env["D_LOG_FILE"] = get_log_file(f"{self.command}.log")
 
     def get_str_param_names(self):
         """Get a sorted list of the names of the command attributes.
@@ -63,33 +66,6 @@ class DaosRacerCommand(ExecutableCommand):
 
         """
         return self.get_attribute_names(FormattedParameter)
-
-    def get_params(self, test):
-        """Get values for all of the command params from the yaml file.
-
-        Also sets default daos_racer environment.
-
-        Args:
-            test (Test): avocado Test object
-
-        """
-        super().get_params(test)
-        default_env = {
-            "D_LOG_FILE": get_log_file("{}_daos.log".format(self.command)),
-            "OMPI_MCA_btl_openib_warn_default_gid_prefix": "0",
-            "OMPI_MCA_btl": "tcp,self",
-            "OMPI_MCA_oob": "tcp",
-            "OMPI_MCA_pml": "ob1",
-            "D_LOG_MASK": "ERR"
-        }
-        for key, val in default_env.items():
-            if key not in self.env:
-                self.env[key] = val
-
-        if not load_mpi("openmpi"):
-            raise MPILoadError("openmpi")
-
-        self.env["LD_LIBRARY_PATH"] = os.environ["LD_LIBRARY_PATH"]
 
     def run(self, raise_exception=None):
         """Run the daos_racer command remotely.
@@ -110,10 +86,10 @@ class DaosRacerCommand(ExecutableCommand):
         self.log.info(
             "Running %s on %s with %s timeout",
             str(self), self._hosts,
-            "no" if self.clush_timeout.value is None else
-            "a {}s".format(self.clush_timeout.value))
+            "no" if self.daos_racer_timeout.value is None
+            else f"a {self.daos_racer_timeout.value}s")
         result = run_remote(
-            self.log, self._hosts, self.with_exports, timeout=self.clush_timeout.value)
+            self.log, self._hosts, self.with_exports, timeout=self.daos_racer_timeout.value)
         if not result.passed:
             if result.timeout:
                 self.log.info("Stopping timed out daos_racer process on %s", result.timeout_hosts)
@@ -121,5 +97,3 @@ class DaosRacerCommand(ExecutableCommand):
 
             if raise_exception:
                 raise CommandFailure(f"Error running '{self._command}'")
-
-        self.log.info("Test passed!")

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -392,13 +392,18 @@ class Orterun(JobManager):
         super().assign_hosts(hosts, path, slots, hostfile)
         self.hostfile.value = self._setup_hostfile(path, slots, hostfile)
 
-    def assign_processes(self, processes):
-        """Assign the number of processes (-np).
+    def assign_processes(self, processes=None, ppn=None):
+        """Assign the number of processes (-np) and processes per node (-ppn).
 
         Args:
-            processes (int): number of processes
+            processes (int, optional): number of processes. Defaults to None.
+                if not specified, auto-calculated from ppn.
+            ppn (int, optional): number of processes per node. Defaults to None.
         """
-        self.processes.value = processes
+        if ppn is not None and processes is None:
+            processes = ppn * len(self._hosts)
+        self.processes.update(processes, "mpirun.np")
+        self.pprnode.update(ppn, "mpirun.ppn")
 
     def assign_environment(self, env_vars, append=False):
         """Assign or add environment variables to the command.

--- a/src/tests/ftest/util/soak_utils.py
+++ b/src/tests/ftest/util/soak_utils.py
@@ -1346,10 +1346,8 @@ def create_racer_cmdline(self, job_spec):
     # daos_racer needs its own pool; does not run using jobs pool
     add_pools(self, ["pool_racer"])
     add_containers(self, self.pool[-1], "SX")
-    racer_namespace = os.path.join(os.sep, "run", job_spec, "*")
     daos_racer = DaosRacerCommand(
-        self.bin, self.hostlist_clients[0])
-    daos_racer.namespace = racer_namespace
+        self.bin, self.hostlist_clients[0], namespace=os.path.join(os.sep, "run", job_spec, "*"))
     daos_racer.get_params(self)
     daos_racer.pool_uuid.update(self.pool[-1].uuid)
     daos_racer.cont_uuid.update(self.container[-1].uuid)

--- a/src/tests/ftest/util/yaml_utils.py
+++ b/src/tests/ftest/util/yaml_utils.py
@@ -1,6 +1,6 @@
 """
 (C) Copyright 2020-2024 Intel Corporation.
-(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+(C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -108,7 +108,7 @@ class YamlUpdater():
         ("bdev_list", "_storage", list),
         ("timeout", "_timeout", int),
         ("timeouts", "_timeout", dict),
-        ("clush_timeout", "_timeout", int),
+        ("daos_racer_timeout", "_timeout", int),
         ("ior_timeout", "_timeout", int),
         ("job_manager_timeout", "_timeout", int),
         ("pattern_timeout", "_timeout", int),


### PR DESCRIPTION
- Change clush_timeout to daos_racer_timeout to be clear
- Removing debug logging from daos_racer/parallel.py
- Use ppn in daos_racer/parallel.py
- Remove hardcoded envs and openmpi load from daos_racer_utils.py
  because this is done by the job manager
- Adjust Orterun.assign_processes to accept ppn

Test-tag: daos_racer
Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
