### PR TITLE
DAOS-17515 pool: cleanup usage help text

### DIFF
--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -73,7 +73,7 @@ type poolBaseCmd struct {
 	cPoolHandle C.daos_handle_t
 
 	Args struct {
-		Pool PoolID `positional-arg-name:"pool label or UUID" description:"required if --path is not used"`
+		Pool PoolID `positional-arg-name:"<pool label or UUID>" description:"required"`
 	} `positional-args:"yes"`
 }
 


### PR DESCRIPTION
- pool get-attr doesn't have '--path' option
- backport to 2.6

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
