### PR TITLE
DAOS-18779 client: reset per-thread based variable after fork

### DIFF
--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -1,7 +1,7 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -18,6 +18,7 @@
 #include "client_internal.h"
 #include <daos/mgmt.h>
 #include <daos/rpc.h>
+#include <daos/tls.h>
 
 /** thread-private event */
 static __thread daos_event_t	ev_thpriv;
@@ -47,6 +48,9 @@ int
 daos_eq_lib_init(crt_init_options_t *crt_info)
 {
 	int rc;
+
+	dc_tls_reset();
+	daos_dti_reset();
 
 	D_MUTEX_LOCK(&daos_eq_lock);
 	if (eq_ref > 0) {
@@ -92,8 +96,6 @@ daos_eq_lib_init(crt_init_options_t *crt_info)
 
 unlock:
 	D_MUTEX_UNLOCK(&daos_eq_lock);
-	if (rc == 0)
-		daos_dti_reset();
 
 	return rc;
 crt:
@@ -106,6 +108,8 @@ daos_eq_lib_reset_after_fork(void)
 {
 	crt_init_options_t *crt_info;
 	int                 rc;
+
+	d_log_reset();
 
 	eq_ref            = 0;
 	ev_thpriv_is_init = false;

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -826,6 +827,8 @@ child_hdlr(void)
 
 	/** Reset event queue */
 	ioil_eqh = ioil_iog.iog_main_eqh = DAOS_HDL_INVAL;
+
+	saved_errno = 0;
 
 	if (ioil_iog.iog_eq_count_max) {
 		rc = daos_eq_create(&ioil_eqh);

--- a/src/common/tls.c
+++ b/src/common/tls.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -204,6 +205,15 @@ dc_tls_get(unsigned int tag)
 		return dc_tls_init(tag, getpid());
 
 	return (struct daos_thread_local_storage *)pthread_getspecific(dc_tls_key);
+}
+
+void
+dc_tls_reset(void)
+{
+	if (dc_tls_thread_init)
+		dc_tls_fini();
+
+	dc_tls_thread_init = false;
 }
 
 struct daos_thread_local_storage *

--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -551,6 +551,9 @@ d_log_disable_logging(void)
 	mst.log_old_fd = -1;
 }
 
+static __thread uint32_t dlog_tid = -1;
+static __thread uint32_t dlog_pid = -1;
+
 /**
  * d_vlog: core log function, front-ended by d_log
  * we vsnprintf the message into a holding buffer to format it.  then we
@@ -569,8 +572,6 @@ void d_vlog(int flags, const char *fmt, va_list ap)
 {
 #define DLOG_TBSIZ    1024	/* bigger than any line should be */
 	static __thread char b[DLOG_TBSIZ];
-	static __thread uint32_t tid = -1;
-	static __thread uint32_t pid = -1;
 	static uint64_t	last_flush;
 
 	uint64_t uid = 0;
@@ -608,14 +609,14 @@ void d_vlog(int flags, const char *fmt, va_list ap)
 
 	if ((mst.oflags & DLOG_FLV_TAG) && (mst.oflags & DLOG_FLV_LOGPID)) {
 		/* Init static members in ahead of lock */
-		if (pid == (uint32_t)(-1))
-			pid = (uint32_t)getpid();
+		if (unlikely(dlog_pid == (uint32_t)(-1)))
+			dlog_pid = (uint32_t)getpid();
 
-		if (tid == (uint32_t)(-1)) {
+		if (unlikely(dlog_tid == (uint32_t)(-1))) {
 			if (mst.log_id_cb)
-				mst.log_id_cb(&tid, NULL);
+				mst.log_id_cb(&dlog_tid, NULL);
 			else
-				tid = (uint32_t)syscall(SYS_gettid);
+				dlog_tid = (uint32_t)syscall(SYS_gettid);
 		}
 
 		if (mst.log_id_cb)
@@ -653,9 +654,8 @@ void d_vlog(int flags, const char *fmt, va_list ap)
 
 	if (mst.oflags & DLOG_FLV_TAG) {
 		if (mst.oflags & DLOG_FLV_LOGPID) {
-			hlen += snprintf(b + hlen, sizeof(b) - hlen,
-					 "%s%d/%d/"DF_U64"] ", d_log_xst.tag,
-					 pid, tid, uid);
+			hlen += snprintf(b + hlen, sizeof(b) - hlen, "%s%d/%d/" DF_U64 "] ",
+					 d_log_xst.tag, dlog_pid, dlog_tid, uid);
 		} else {
 			hlen += snprintf(b + hlen, sizeof(b) - hlen, "%s ",
 					 d_log_xst.tag);
@@ -1404,4 +1404,14 @@ int d_log_getmasks(char *buf, int discard, int len, int unterm)
 		clog_bput(&bp, &skipcnt, &resid, &total, NULL);
 	/* buf == NULL means probe for length ... */
 	return ((buf == NULL) ? total : len - resid);
+}
+
+void
+d_log_reset(void)
+{
+	dlog_tid     = -1;
+	dlog_pid     = -1;
+	pre_err      = 0;
+	pre_err_line = 0;
+	pre_err_time = 0;
 }

--- a/src/include/daos/tls.h
+++ b/src/include/daos/tls.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -62,6 +63,8 @@ struct daos_thread_local_storage *
 dss_tls_get(void);
 struct daos_thread_local_storage *
 dc_tls_get(unsigned int tag);
+void
+dc_tls_reset(void);
 
 int
 ds_tls_key_create(void);

--- a/src/include/gurt/dlog.h
+++ b/src/include/gurt/dlog.h
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -455,6 +455,12 @@ void d_log_sync(void);
  */
 void
 d_log_disable_logging(void);
+
+/**
+ * Reset __thread variables (after fork).
+ */
+void
+d_log_reset(void);
 
 #if defined(__cplusplus)
 }

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -958,11 +958,7 @@ pool_req_create_common(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode
 {
 	int                    rc;
 	crt_opcode_t           opcode;
-	static __thread uuid_t cli_id;
 	struct pool_op_in     *in;
-
-	if (uuid_is_null(cli_id))
-		uuid_generate(cli_id);
 
 	opcode = DAOS_RPC_OPCODE(opc, DAOS_POOL_MODULE, proto_ver);
 	/* call daos_rpc_tag to get the target tag/context idx */
@@ -982,7 +978,7 @@ pool_req_create_common(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode
 		*req_timep = d_hlc_get();
 
 	if (req_timep) {
-		uuid_copy(in->pi_cli_id, cli_id);
+		daos_get_client_uuid(&in->pi_cli_id);
 		in->pi_time = *req_timep;
 	}
 	return 0;


### PR DESCRIPTION
DAOS maintains some per-thread based variables on client. They are usually used to distinguish current process from the others. If application creates new process (such as via fork()), these per-thread variables will inherit the values from parents, and if without reset, we cannot distinguish the children processes from the parents via these per-thread based variables. That is not only confused but also may cause correctness issues.

The patch offers related reset interfaces, and application can trigger them via after_fork() callback.

Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
