### PR TITLE
DAOS-623 test: add allowed error for FI (#17959)

### DIFF
--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 #
 # (C) Copyright 2018-2024 Intel Corporation
+# (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -225,6 +226,7 @@ class LogTest():
         self.fi_triggered = False
         self.fi_location = None
         self.skip_suffixes = []
+        self.skip_substrings = []
         self._tracers = []
         self.ftest_mode = False
 
@@ -443,6 +445,10 @@ class LogTest():
                         show = False
                     if show and any(map(line.get_msg().endswith, self.skip_suffixes)):
                         show = False
+                    if show:
+                        line_msg = line.get_msg().casefold()
+                        if any(sub in line_msg for sub in self.skip_substrings):
+                            show = False
                     if show:
                         # Allow WARNING or ERROR messages, but anything higher like assert should
                         # trigger a failure.

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -623,7 +623,7 @@ class DaosServer():
             os.unlink(server_file)
         for log in self.server_logs:
             if os.path.exists(log.name):
-                log_test(self.conf, log.name)
+                log_test(self.conf, log.name, skip_fi=self._fi)
         try:
             os.unlink(join(self.agent_dir, 'nlt_agent.yaml'))
             os.rmdir(self.agent_dir)
@@ -4884,6 +4884,14 @@ def log_test(conf,
 
     if ignore_busy:
         lto.skip_suffixes.append(" DER_BUSY(-1012): 'Device or resource busy'")
+
+    if skip_fi:
+        lto.skip_substrings.extend([
+            'sluggish ec boundary report from rank',
+            'sluggish stable epoch reporting',
+            'progress callback was not called for too long',
+            'rpc failed; rc:',
+        ])
 
     try:
         lto.check_log_file(abort_on_warning=True,


### PR DESCRIPTION
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
