### PR TITLE
SRE-3731 ci: Add NO_PROXY to docker file

### DIFF
--- a/utils/docker/Dockerfile.code_scanning
+++ b/utils/docker/Dockerfile.code_scanning
@@ -22,15 +22,6 @@ ENV NO_PROXY=${DAOS_NO_PROXY}
 RUN echo "no_proxy=${DAOS_NO_PROXY}" >> /etc/environment && \
     echo "NO_PROXY=${DAOS_NO_PROXY}" >> /etc/environment
 
-# Accept DAOS_HTTPS_PROXY at build time
-ARG DAOS_HTTPS_PROXY
-# Propagate into the build environment
-ENV https_proxy=${DAOS_HTTPS_PROXY}
-ENV HTTPS_PROXY=${DAOS_HTTPS_PROXY}
-# Persist into /etc/environment for use by shells and services
-RUN echo "https_proxy=${DAOS_HTTPS_PROXY}" >> /etc/environment && \
-    echo "HTTPS_PROXY=${DAOS_HTTPS_PROXY}" >> /etc/environment
-
 # Use local repo server if present
 ARG REPO_FILE_URL
 ARG DAOS_LAB_CA_FILE_URL
@@ -44,12 +35,7 @@ RUN chmod +x /tmp/repo-helper.sh &&                 \
     rm -f /tmp/repo-helper.sh
 
 # Install Python Bandit scanner.
-# The unset commands are currently needed for the combination of running
-# with a local repository, yet needing a proxy to reach outside repositories.
-# This needs to be moved to a shell script like above in the future to
-# properly only remove the proxy variables only when they need to be removed
-RUN unset HTTPS_PROXY && unset https_proxy && \
-    dnf -y upgrade && dnf -y install bandit && dnf clean all
+RUN dnf -y upgrade && dnf -y install bandit && dnf clean all
 
 ARG CB1
-RUN unset HTTPS_PROXY && unset https_proxy && dnf -y upgrade && dnf clean all
+RUN dnf -y upgrade && dnf clean all

--- a/utils/docker/Dockerfile.code_scanning
+++ b/utils/docker/Dockerfile.code_scanning
@@ -13,6 +13,24 @@ LABEL maintainer="daos@daos.groups.io"
 # Intermittent cache-bust.  Used to reduce load on the actual CACHEBUST later.
 ARG CB0
 
+# Accept DAOS_NO_PROXY at build time
+ARG DAOS_NO_PROXY
+# Propagate into the build environment
+ENV no_proxy=${DAOS_NO_PROXY}
+ENV NO_PROXY=${DAOS_NO_PROXY}
+# Persist into /etc/environment for use by shells and services
+RUN echo "no_proxy=${DAOS_NO_PROXY}" >> /etc/environment && \
+    echo "NO_PROXY=${DAOS_NO_PROXY}" >> /etc/environment
+
+# Accept DAOS_HTTPS_PROXY at build time
+ARG DAOS_HTTPS_PROXY
+# Propagate into the build environment
+ENV https_proxy=${DAOS_HTTPS_PROXY}
+ENV HTTPS_PROXY=${DAOS_HTTPS_PROXY}
+# Persist into /etc/environment for use by shells and services
+RUN echo "https_proxy=${DAOS_HTTPS_PROXY}" >> /etc/environment && \
+    echo "HTTPS_PROXY=${DAOS_HTTPS_PROXY}" >> /etc/environment
+
 # Use local repo server if present
 ARG REPO_FILE_URL
 ARG DAOS_LAB_CA_FILE_URL

--- a/utils/docker/Dockerfile.code_scanning
+++ b/utils/docker/Dockerfile.code_scanning
@@ -1,5 +1,6 @@
 #
 # Copyright 2018-2022, Intel Corporation
+# Copyright 2026 Hewlett Packard Enterprise Development LP
 #
 # 'recipe' for Docker for code scanning.
 #

--- a/utils/rpms/packaging/Dockerfile.mockbuild
+++ b/utils/rpms/packaging/Dockerfile.mockbuild
@@ -1,6 +1,6 @@
 #
 # Copyright 2018-2024 Intel Corporation
-# Copyright 2025 Hewlett Packard Enterprise Development LP
+# Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 #
 # 'recipe' for Docker to build an RPM
 #
@@ -11,8 +11,24 @@ FROM fedora:$FVERSION
 # Needed for later use of FVERSION
 ARG FVERSION
 LABEL maintainer="daos@daos.groups.io"
+
+# Accept DAOS_NO_PROXY at build time
 ARG DAOS_NO_PROXY
+# Propagate into the build environment
+ENV no_proxy=${DAOS_NO_PROXY}
 ENV NO_PROXY=${DAOS_NO_PROXY}
+# Persist into /etc/environment for use by shells and services
+RUN echo "no_proxy=${DAOS_NO_PROXY}" >> /etc/environment && \
+    echo "NO_PROXY=${DAOS_NO_PROXY}" >> /etc/environment
+
+# Accept DAOS_HTTPS_PROXY at build time
+ARG DAOS_HTTPS_PROXY
+# Propagate into the build environment
+ENV https_proxy=${DAOS_HTTPS_PROXY}
+ENV HTTPS_PROXY=${DAOS_HTTPS_PROXY}
+# Persist into /etc/environment for use by shells and services
+RUN echo "https_proxy=${DAOS_HTTPS_PROXY}" >> /etc/environment && \
+    echo "HTTPS_PROXY=${DAOS_HTTPS_PROXY}" >> /etc/environment
 
 # Use local repo server if present
 ARG REPO_FILE_URL

--- a/utils/rpms/packaging/Dockerfile.mockbuild
+++ b/utils/rpms/packaging/Dockerfile.mockbuild
@@ -11,6 +11,8 @@ FROM fedora:$FVERSION
 # Needed for later use of FVERSION
 ARG FVERSION
 LABEL maintainer="daos@daos.groups.io"
+ARG DAOS_NO_PROXY
+ENV NO_PROXY=${DAOS_NO_PROXY}
 
 # Use local repo server if present
 ARG REPO_FILE_URL
@@ -38,8 +40,8 @@ RUN dnf -y install mock make                                        \
 ARG UID=1000
 
 # Add build user (to keep rpmbuild happy)
-ENV USER build
-ENV PASSWD build
+ENV USER=build
+ENV PASSWD=build
 RUN useradd -u $UID -ms /bin/bash $USER
 RUN echo "$USER:$PASSWD" | chpasswd
 # add the user to the mock group so it can run mock

--- a/utils/rpms/packaging/Dockerfile.mockbuild
+++ b/utils/rpms/packaging/Dockerfile.mockbuild
@@ -21,15 +21,6 @@ ENV NO_PROXY=${DAOS_NO_PROXY}
 RUN echo "no_proxy=${DAOS_NO_PROXY}" >> /etc/environment && \
     echo "NO_PROXY=${DAOS_NO_PROXY}" >> /etc/environment
 
-# Accept DAOS_HTTPS_PROXY at build time
-ARG DAOS_HTTPS_PROXY
-# Propagate into the build environment
-ENV https_proxy=${DAOS_HTTPS_PROXY}
-ENV HTTPS_PROXY=${DAOS_HTTPS_PROXY}
-# Persist into /etc/environment for use by shells and services
-RUN echo "https_proxy=${DAOS_HTTPS_PROXY}" >> /etc/environment && \
-    echo "HTTPS_PROXY=${DAOS_HTTPS_PROXY}" >> /etc/environment
-
 # Use local repo server if present
 ARG REPO_FILE_URL
 ARG DAOS_LAB_CA_FILE_URL

--- a/utils/scripts/helpers/repo-helper-fedora.sh
+++ b/utils/scripts/helpers/repo-helper-fedora.sh
@@ -16,8 +16,7 @@ is_fedora_eol() {
     local eol_url fedora_version eol_date today
     if [ -n "$REPO_FILE_URL" ]; then
         eol_url="${REPO_FILE_URL%repo-files/}eol-proxy/fedora.json"
-        fedora_version=$(grep VERSION_ID /etc/os-release | cut -d= -f2 | \
-                         tr -d '"')
+        fedora_version=$(. /etc/os-release; echo $VERSION_ID)
         eol_date=$(curl -s "$eol_url" | sed 's/},{/}\n{/g' | \
                    grep "cycle\":\"$fedora_version\"" | \
                    sed -n 's/.*"eol":"\([^"]*\)".*/\1/p')

--- a/utils/scripts/helpers/repo-helper-fedora.sh
+++ b/utils/scripts/helpers/repo-helper-fedora.sh
@@ -11,9 +11,26 @@ set -uex
 : "${FVERSION:=latest}"
 : "${REPOSITORY_NAME:=artifactory}"
 : "${archive:=}"
-if [ "$FVERSION" != "latest" ]; then
-    archive="-archive"
-fi
+
+is_fedora_eol() {
+    local eol_url fedora_version eol_date today
+    if [ -n "$REPO_FILE_URL" ]; then
+        eol_url="${REPO_FILE_URL%repo-files/}eol-proxy/fedora.json"
+        fedora_version=$(grep VERSION_ID /etc/os-release | cut -d= -f2 | \
+                         tr -d '"')
+        eol_date=$(curl -s "$eol_url" | sed 's/},{/}\n{/g' | \
+                   grep "cycle\":\"$fedora_version\"" | \
+                   sed -n 's/.*"eol":"\([^"]*\)".*/\1/p')
+        if [[ -z "$eol_date" ]]; then
+            return 1 # Assume NOT EOL if data missing
+        fi
+        today=$(date +%Y-%m-%d)
+        [[ "$today" > "$eol_date" ]]
+        return $?  # Return 0 if EOL, 1 if not
+    else
+        return 1 # Assume NOT EOL if url is missing
+    fi
+}
 
 # shellcheck disable=SC2120
 disable_repos () {
@@ -46,7 +63,7 @@ install_curl() {
 install_optional_ca() {
     ca_storage="/etc/pki/ca-trust/source/anchors/"
     if [ -n "$DAOS_LAB_CA_FILE_URL" ]; then
-        curl -k --noproxy '*' -sSf -o "${ca_storage}lab_ca_file.crt" \
+        curl -k -sSf -o "${ca_storage}lab_ca_file.crt" \
             "$DAOS_LAB_CA_FILE_URL"
         update-ca-trust
     fi
@@ -60,10 +77,12 @@ install_optional_ca() {
 if [ -n "$REPO_FILE_URL" ]; then
     install_curl
     install_optional_ca
+    if is_fedora_eol; then
+        archive="-archive"
+    fi
     mkdir -p /etc/yum.repos.d
     pushd /etc/yum.repos.d/
-    curl -k --noproxy '*' -sSf                                  \
-         -o "daos_ci-fedora${archive}-${REPOSITORY_NAME}.repo"  \
+    curl -k -sSf -o "daos_ci-fedora${archive}-${REPOSITORY_NAME}.repo" \
          "${REPO_FILE_URL}daos_ci-fedora${archive}-${REPOSITORY_NAME}.repo"
     disable_repos /etc/yum.repos.d/
     popd


### PR DESCRIPTION

Fix the build RPM stages for when the HPE proxy doesn't allow internal access.

Also, updated ENV definitions based on the feedback:
WARN: LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format


### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
