### PR TITLE
DAOS-623 test: ignore the server errors in client FI tests too

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -636,7 +636,7 @@ class DaosServer():
             os.unlink(server_file)
         for log in self.server_logs:
             if os.path.exists(log.name):
-                log_test(self.conf, log.name, skip_fi=self._fi)
+                log_test(self.conf, log.name)
         try:
             os.unlink(join(self.agent_dir, 'nlt_agent.yaml'))
             os.rmdir(self.agent_dir)
@@ -5022,13 +5022,12 @@ def log_test(conf,
     if ignore_busy:
         lto.skip_suffixes.append(" DER_BUSY(-1012): 'Device or resource busy'")
 
-    if skip_fi:
-        lto.skip_substrings.extend([
-            'sluggish ec boundary report from rank',
-            'sluggish stable epoch reporting',
-            'progress callback was not called for too long',
-            'rpc failed; rc:',
-        ])
+    lto.skip_substrings.extend([
+        'sluggish ec boundary report from rank',
+        'sluggish stable epoch reporting',
+        'progress callback was not called for too long',
+        'rpc failed; rc:',
+    ])
 
     try:
         lto.check_log_file(abort_on_warning=True,


### PR DESCRIPTION
The client FI and NLT tests can also fail on server network related errors.
Need to ignore those too.

Skip-func-hw-test: true
Skip-unit-test: true
Skip-unit-test-memcheck: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
