### PR TITLE
DAOS-18811 build: Fix dependency syntax in mercury.sh

### DIFF
--- a/utils/rpms/mercury.sh
+++ b/utils/rpms/mercury.sh
@@ -43,7 +43,11 @@ clean_bin "${files[@]}"
 append_install_list "${files[@]}"
 
 ARCH="${isa}"
-DEPENDS=("(mercury-libfabric or mercury-ucx)")
+if [ "${OUTPUT_TYPE:-rpm}" = "rpm" ]; then
+	DEPENDS=("(mercury-libfabric or mercury-ucx)")
+else
+	DEPENDS=("mercury-libfabric | mercury-ucx")
+fi
 build_package "mercury"
 DEPENDS=()
 


### PR DESCRIPTION
### Description

Updated `mercury.sh` to use the correct dependency syntax for DEB packages by replacing `or` with `|`.
This ensures that package dependencies are specified properly for both RPM and DEB output types, improving cross-distribution compatibility.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
