### PR TITLE
DAOS-17427 test: Auto-restart after self-terminate tests

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -1106,15 +1106,16 @@ the storage server has not changed the old rank can be "reused" by formatting us
 `dmg storage format --replace` option.
 
 An examples workflow would be:
-- `daos_server` is running and PMem NVDIMM fails causing an engine to enter excluded state.
-- `daos_server` is stopped, storage server powered down, faulty PMem NVDIMM is replaced.
-- After powering up storage server, `daos_server scm prepare` command is used to repair PMem.
-- Storage server is rebooted after running `daos_server scm prepare` and command is run again.
-- Now PMem is intact, clear with `wipefs -a /dev/pmemX` where "X" refers to the repaired PMem ID.
-- `daos_server` can be started again. On start-up repaired engine prompts for "SCM format required".
-- Run `dmg storage format --replace` to rejoin with existing rank (if --replace isn't used, a new
-  rank will be created).
-- Formatted engine will join using the existing (old) rank which is mapped to the engine's hardware.
+
+1. `daos_server` is running and PMem NVDIMM fails causing an engine to enter excluded state.
+2. `daos_server` is stopped, storage server powered down, faulty PMem NVDIMM is replaced.
+3. After powering up storage server, `daos_server scm prepare` command is used to repair PMem.
+4. Storage server is rebooted after running `daos_server scm prepare` and command is run again.
+5. Now PMem is intact, clear with `wipefs -a /dev/pmemX` where "X" refers to the repaired PMem ID.
+6. `daos_server` can be started again. On start-up repaired engine prompts for "SCM format required".
+7. Run `dmg storage format --replace` to rejoin with existing rank (if --replace isn't used, a new
+   rank will be created).
+8. Formatted engine will join using the existing (old) rank which is mapped to the engine's hardware.
 
 !!! note
     `dmg storage format --replace` can be used to replace a rank in `AdminExcluded` state. The

--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -975,6 +975,94 @@ specified on the command line:
 If the ranks were excluded from pools (e.g., unclean shutdown), they will need to
 be reintegrated. Please see the pool operation section for more information.
 
+### Engine Auto-Restart
+
+DAOS automatically restarts engines that self-terminate after being excluded from
+the system. This feature improves system availability by recovering from transient
+failures without administrator intervention.
+
+#### How It Works
+
+When an engine is excluded (e.g., due to network issues detected by SWIM), the
+engine detects the exclusion and performs a self-termination. The control plane
+monitors for these events and automatically restarts the affected engine after
+clearing the exclusion state, allowing it to rejoin the system.
+
+The automatic restart includes rate-limiting to prevent restart storms. By default,
+an engine must wait 5 minutes between automatic restarts.
+
+#### Configuration
+
+Control auto-restart behavior in `daos_server.yml`:
+
+```yaml
+# Disable automatic restart (default: enabled)
+disable_engine_auto_restart: false
+
+# Minimum delay between automatic restarts per rank (default: 300 seconds)
+engine_auto_restart_min_delay: 300
+```
+
+#### Manual Operations
+
+Manual `dmg system stop` and `dmg system start` operations are never affected by
+the rate-limiting mechanism. Administrators can always immediately stop and start
+ranks regardless of recent automatic restart activity.
+
+```bash
+# Manual operations always work immediately
+$ dmg system stop --ranks=0,1,2
+$ dmg system start --ranks=0,1,2
+```
+
+When you manually stop or start ranks, the restart history for those ranks is
+automatically cleared, ensuring no delays from previous automatic restarts.
+
+#### Monitoring
+
+The `engine_self_terminated` RAS event is logged when an engine self-terminates
+and triggers an automatic restart:
+
+```
+&&& RAS EVENT id: [engine_self_terminated] ... msg: [excluded rank self terminated detected]
+```
+
+Use `dmg system query` to check rank status and incarnation numbers. The
+incarnation number increments each time a rank restarts, helping track restart
+events:
+
+```bash
+$ dmg system query --ranks=0
+Rank UUID                                 Control Address  Fault Domain State  Reason Incarnation
+---- ----                                 --------------- ------------- -----  ------ -----------
+0    12345678-1234-1234-1234-123456789012 10.0.0.1:10001  /node1        Joined        3
+```
+
+#### Best Practices
+
+- **Leave enabled**: Automatic restart improves availability for transient failures
+- **Adjust timing**: For frequent exclusions, consider increasing `engine_auto_restart_min_delay`
+- **Monitor events**: Watch for repeated `engine_self_terminated` events indicating persistent issues
+- **Manual control**: Use `dmg system stop/start` for maintenance without worrying about delays
+
+#### Troubleshooting
+
+**Problem**: Rank keeps self-terminating and restarting
+
+**Solution**: Investigate root cause:
+1. Check network connectivity (SWIM may be detecting real failures)
+2. Review engine logs for errors
+3. Verify hardware health
+4. Consider disabling auto-restart temporarily for investigation
+
+**Problem**: Need immediate restart but recently auto-restarted
+
+**Solution**: Use manual operations (not affected by rate-limiting):
+```bash
+$ dmg system stop --ranks=X
+$ dmg system start --ranks=X
+```
+
 ### Storage Reformat
 
 To reformat the system after a controlled shutdown, run the command:

--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -206,6 +206,22 @@ func (svc *ControlService) StopRanks(ctx context.Context, req *ctlpb.RanksReq) (
 		return nil, err
 	}
 
+	// Clear restart history for manually stopped ranks on this server
+	// This prevents rate-limiting from interfering with manual operations
+	// Note: instances already filtered by FilterInstancesByRankSet() to match req.GetRanks()
+	if svc.restartMgr != nil {
+		ranks := make([]ranklist.Rank, 0, len(instances))
+		for _, ei := range instances {
+			rank, err := ei.GetRank()
+			if err == nil {
+				ranks = append(ranks, rank)
+			}
+		}
+		if len(ranks) > 0 {
+			svc.restartMgr.clearRankRestartHistory(ranks)
+		}
+	}
+
 	return resp, nil
 }
 
@@ -317,6 +333,22 @@ func (svc *ControlService) StartRanks(ctx context.Context, req *ctlpb.RanksReq) 
 	resp := &ctlpb.RanksResp{}
 	if err := convert.Types(results, &resp.Results); err != nil {
 		return nil, err
+	}
+
+	// Clear restart history for manually started ranks on this server
+	// This prevents rate-limiting from interfering with manual operations
+	// Note: instances already filtered by FilterInstancesByRankSet() to match req.GetRanks()
+	if svc.restartMgr != nil {
+		ranks := make([]ranklist.Rank, 0, len(instances))
+		for _, ei := range instances {
+			rank, err := ei.GetRank()
+			if err == nil {
+				ranks = append(ranks, rank)
+			}
+		}
+		if len(ranks) > 0 {
+			svc.restartMgr.clearRankRestartHistory(ranks)
+		}
 	}
 
 	return resp, nil

--- a/src/control/server/ctl_svc.go
+++ b/src/control/server/ctl_svc.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2018-2024 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -19,10 +20,11 @@ import (
 type ControlService struct {
 	ctlpb.UnimplementedCtlSvcServer
 	StorageControlService
-	harness *EngineHarness
-	srvCfg  *config.Server
-	events  *events.PubSub
-	fabric  *hardware.FabricScanner
+	harness    *EngineHarness
+	srvCfg     *config.Server
+	events     *events.PubSub
+	fabric     *hardware.FabricScanner
+	restartMgr *engineRestartManager
 }
 
 // NewControlService returns ControlService to be used as gRPC control service

--- a/src/control/server/instance_restart.go
+++ b/src/control/server/instance_restart.go
@@ -190,6 +190,33 @@ func (mgr *engineRestartManager) start(ctx context.Context) {
 	}()
 }
 
+// clearRankRestartHistory clears the restart history for specific ranks.
+// This is called when ranks are manually stopped or started to ensure
+// manual operations don't interfere with automatic restart rate limiting.
+func (mgr *engineRestartManager) clearRankRestartHistory(ranks []ranklist.Rank) {
+	if mgr == nil || len(ranks) == 0 {
+		return
+	}
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+
+	for _, rank := range ranks {
+		// Cancel any pending restart for this rank
+		if timer, exists := mgr.pendingRestart[rank]; exists {
+			timer.Stop()
+			delete(mgr.pendingRestart, rank)
+			mgr.log.Debugf("cancelled pending restart for rank %d during manual operation", rank)
+		}
+
+		// Clear restart history for this rank
+		if _, exists := mgr.lastRestart[rank]; exists {
+			delete(mgr.lastRestart, rank)
+			mgr.log.Debugf("cleared restart history for rank %d (manual operation)", rank)
+		}
+	}
+}
+
 // stop shuts down the restart manager.
 func (mgr *engineRestartManager) stop() {
 	mgr.log.Debug("stopping engine restart manager")

--- a/src/control/server/instance_restart_test.go
+++ b/src/control/server/instance_restart_test.go
@@ -631,3 +631,118 @@ func TestServer_NewEngineRestartManager(t *testing.T) {
 		t.Error("expected pendingRestart map to be initialized")
 	}
 }
+
+func TestServer_EngineRestartManager_ClearRankRestartHistory(t *testing.T) {
+	for name, tc := range map[string]struct {
+		setupRanks     []ranklist.Rank
+		clearRanks     []ranklist.Rank
+		expectLogMsgs  []string
+		remainingRanks []ranklist.Rank
+	}{
+		"nil manager": {
+			setupRanks: []ranklist.Rank{1, 2},
+			clearRanks: []ranklist.Rank{1},
+		},
+		"empty ranks": {
+			setupRanks: []ranklist.Rank{1, 2},
+			clearRanks: []ranklist.Rank{},
+		},
+		"clear single rank with history": {
+			setupRanks:     []ranklist.Rank{1, 2, 3},
+			clearRanks:     []ranklist.Rank{2},
+			expectLogMsgs:  []string{"cleared restart history for rank 2"},
+			remainingRanks: []ranklist.Rank{1, 3},
+		},
+		"clear multiple ranks with history": {
+			setupRanks:     []ranklist.Rank{1, 2, 3, 4},
+			clearRanks:     []ranklist.Rank{1, 3},
+			expectLogMsgs:  []string{"cleared restart history for rank 1", "cleared restart history for rank 3"},
+			remainingRanks: []ranklist.Rank{2, 4},
+		},
+		"clear all ranks": {
+			setupRanks:     []ranklist.Rank{1, 2, 3},
+			clearRanks:     []ranklist.Rank{1, 2, 3},
+			expectLogMsgs:  []string{"cleared restart history for rank 1", "cleared restart history for rank 2", "cleared restart history for rank 3"},
+			remainingRanks: []ranklist.Rank{},
+		},
+		"clear rank without history": {
+			setupRanks:     []ranklist.Rank{1, 2},
+			clearRanks:     []ranklist.Rank{5},
+			expectLogMsgs:  []string{},
+			remainingRanks: []ranklist.Rank{1, 2},
+		},
+		"clear rank with pending restart": {
+			setupRanks:     []ranklist.Rank{1, 2},
+			clearRanks:     []ranklist.Rank{1},
+			expectLogMsgs:  []string{"cancelled pending restart for rank 1", "cleared restart history for rank 1"},
+			remainingRanks: []ranklist.Rank{2},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := setupTestLogger(t)
+			var mgr *engineRestartManager
+
+			if name == "nil manager" {
+				// Test nil manager doesn't panic
+				var nilMgr *engineRestartManager
+				nilMgr.clearRankRestartHistory(tc.clearRanks)
+				return
+			}
+
+			mgr = setupTestManager(t, nil, log)
+
+			// Setup restart history for ranks
+			now := time.Now()
+			for i, rank := range tc.setupRanks {
+				mgr.lastRestart[rank] = now.Add(-time.Duration(i) * time.Minute)
+			}
+
+			// Setup pending restart for rank 1 if testing that case
+			if name == "clear rank with pending restart" {
+				timer := time.NewTimer(10 * time.Second)
+				t.Cleanup(func() { timer.Stop() })
+				mgr.pendingRestart[ranklist.Rank(1)] = timer
+			}
+
+			mgr.clearRankRestartHistory(tc.clearRanks)
+
+			// Verify expected log messages
+			for _, expectedMsg := range tc.expectLogMsgs {
+				if !strings.Contains(buf.String(), expectedMsg) {
+					t.Errorf("expected log message %q not found in: %s",
+						expectedMsg, buf.String())
+				}
+			}
+
+			// Verify remaining ranks still have history
+			for _, rank := range tc.remainingRanks {
+				if _, exists := mgr.lastRestart[rank]; !exists {
+					t.Errorf("expected rank %d to still have restart history", rank)
+				}
+			}
+
+			// Verify cleared ranks don't have history
+			for _, rank := range tc.clearRanks {
+				if _, exists := mgr.lastRestart[rank]; exists {
+					found := false
+					for _, remaining := range tc.remainingRanks {
+						if remaining.Equals(rank) {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("expected rank %d to have cleared restart history", rank)
+					}
+				}
+			}
+
+			// Verify pending restart was cleared for rank 1 in specific test
+			if name == "clear rank with pending restart" {
+				if _, exists := mgr.pendingRestart[ranklist.Rank(1)]; exists {
+					t.Error("expected pending restart for rank 1 to be cleared")
+				}
+			}
+		})
+	}
+}

--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2018-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -83,6 +83,7 @@ type mgmtSvc struct {
 	serialReqs        batchReqChan
 	groupUpdateReqs   chan bool
 	lastMapVer        uint32
+	restartMgr        *engineRestartManager
 }
 
 func newMgmtSvc(h *EngineHarness, m *system.Membership, s *raft.Database, c control.UnaryInvoker, p *events.PubSub) *mgmtSvc {

--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -83,7 +83,6 @@ type mgmtSvc struct {
 	serialReqs        batchReqChan
 	groupUpdateReqs   chan bool
 	lastMapVer        uint32
-	restartMgr        *engineRestartManager
 }
 
 func newMgmtSvc(h *EngineHarness, m *system.Membership, s *raft.Database, c control.UnaryInvoker, p *events.PubSub) *mgmtSvc {

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -1026,6 +1026,12 @@ func (svc *mgmtSvc) SystemStop(ctx context.Context, req *mgmtpb.SystemStopReq) (
 		return nil, err
 	}
 
+	// Clear restart history for manually stopped ranks
+	// This prevents rate-limiting from interfering with manual operations
+	if svc.restartMgr != nil && fReq.Ranks != nil {
+		svc.restartMgr.clearRankRestartHistory(fReq.Ranks.Ranks())
+	}
+
 	return resp, nil
 }
 
@@ -1120,6 +1126,12 @@ func (svc *mgmtSvc) SystemStart(ctx context.Context, req *mgmtpb.SystemStartReq)
 	resp, err := processStartResp(fResp, svc.events)
 	if err != nil {
 		return nil, err
+	}
+
+	// Clear restart history for manually started ranks
+	// This prevents rate-limiting from interfering with manual operations
+	if svc.restartMgr != nil && fReq.Ranks != nil {
+		svc.restartMgr.clearRankRestartHistory(fReq.Ranks.Ranks())
 	}
 
 	return resp, nil

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -1026,12 +1026,6 @@ func (svc *mgmtSvc) SystemStop(ctx context.Context, req *mgmtpb.SystemStopReq) (
 		return nil, err
 	}
 
-	// Clear restart history for manually stopped ranks
-	// This prevents rate-limiting from interfering with manual operations
-	if svc.restartMgr != nil && fReq.Ranks != nil {
-		svc.restartMgr.clearRankRestartHistory(fReq.Ranks.Ranks())
-	}
-
 	return resp, nil
 }
 
@@ -1126,12 +1120,6 @@ func (svc *mgmtSvc) SystemStart(ctx context.Context, req *mgmtpb.SystemStartReq)
 	resp, err := processStartResp(fResp, svc.events)
 	if err != nil {
 		return nil, err
-	}
-
-	// Clear restart history for manually started ranks
-	// This prevents rate-limiting from interfering with manual operations
-	if svc.restartMgr != nil && fReq.Ranks != nil {
-		svc.restartMgr.clearRankRestartHistory(fReq.Ranks.Ranks())
 	}
 
 	return resp, nil

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -268,6 +268,7 @@ func (srv *server) createServices(ctx context.Context) (err error) {
 	srv.ctlSvc = NewControlService(srv.log, srv.harness, srv.cfg, srv.pubSub,
 		network.DefaultFabricScanner(srv.log))
 	srv.mgmtSvc = newMgmtSvc(srv.harness, srv.membership, srv.sysdb, rpcClient, srv.pubSub)
+	srv.mgmtSvc.restartMgr = srv.restartMgr
 
 	if err := srv.mgmtSvc.systemProps.UpdateCompPropVal(daos.SystemPropertyDaosSystem, func() string {
 		return srv.cfg.SystemName

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -267,8 +267,8 @@ func (srv *server) createServices(ctx context.Context) (err error) {
 
 	srv.ctlSvc = NewControlService(srv.log, srv.harness, srv.cfg, srv.pubSub,
 		network.DefaultFabricScanner(srv.log))
+	srv.ctlSvc.restartMgr = srv.restartMgr
 	srv.mgmtSvc = newMgmtSvc(srv.harness, srv.membership, srv.sysdb, rpcClient, srv.pubSub)
-	srv.mgmtSvc.restartMgr = srv.restartMgr
 
 	if err := srv.mgmtSvc.systemProps.UpdateCompPropVal(daos.SystemPropertyDaosSystem, func() string {
 		return srv.cfg.SystemName

--- a/src/tests/ftest/control/engine_auto_restart.py
+++ b/src/tests/ftest/control/engine_auto_restart.py
@@ -69,7 +69,7 @@ class EngineAutoRestartTest(ControlTestBase):
         num_to_test = max(2, len(all_ranks) // 2)
         test_ranks = self.random.sample(all_ranks, num_to_test)
 
-        self.log_step("Step 1: Excluding %s ranks: %s", num_to_test, test_ranks)
+        self.log_step("Step 1: Excluding %s ranks: %s", (num_to_test, test_ranks))
 
         for rank in test_ranks:
             self.dmg.system_exclude(ranks=[rank], rank_hosts=None)

--- a/src/tests/ftest/control/engine_auto_restart.py
+++ b/src/tests/ftest/control/engine_auto_restart.py
@@ -104,22 +104,13 @@ class EngineAutoRestartTest(ControlTestBase):
         :avocado: tags=EngineAutoRestartTest,test_auto_restart_with_pool
         """
         all_ranks = self.get_all_ranks()
-        if len(all_ranks) < 2:
-            self.skipTest("Test requires at least 2 ranks")
+        if len(all_ranks) < 4:
+            self.skipTest("Test requires at least 4 ranks")
 
         # Create pool first
         self.add_pool(connect=False)
 
-        # Get pool service ranks to avoid excluding them
-        pool_svc_ranks = self.pool.svc_ranks
-        self.log.info("Pool service ranks: %s", pool_svc_ranks)
-
-        # Find a rank not in pool service
-        non_svc_ranks = [r for r in all_ranks if r not in pool_svc_ranks]
-        if not non_svc_ranks:
-            self.skipTest("All ranks are pool service ranks")
-
-        test_rank = self.random.choice(non_svc_ranks)
+        test_rank = all_ranks[-1]
 
         self.log_step("Excluding non-service rank %s while pool is active", test_rank)
 

--- a/src/tests/ftest/control/engine_auto_restart.py
+++ b/src/tests/ftest/control/engine_auto_restart.py
@@ -1,0 +1,229 @@
+"""
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+import time
+
+from control_test_base import ControlTestBase
+from general_utils import report_errors
+
+
+class EngineAutoRestartTest(ControlTestBase):
+    """Test automatic engine restart on self-termination.
+
+    Test Class Description:
+        Verify automatic engine restart behavior when engines self-terminate
+        after being excluded from the system.
+
+    :avocado: recursive
+    """
+
+    def setUp(self):
+        """Set up each test case."""
+        super().setUp()
+        self.dmg = self.get_dmg_command()
+
+    def get_all_ranks(self):
+        """Get list of all ranks in the system."""
+        return list(self.server_managers[0].ranks.keys())
+
+    def get_rank_state(self, rank):
+        """Get the state of a rank.
+
+        Args:
+            rank (int): Rank number
+
+        Returns:
+            str: Current state of the rank
+        """
+        data = self.dmg.system_query(ranks=f"{rank}")
+        if data["status"] != 0:
+            self.fail("Cmd dmg system query failed")
+        if "response" in data and "members" in data["response"]:
+            if data["response"]["members"] is None:
+                self.fail("No members returned from dmg system query")
+            for member in data["response"]["members"]:
+                return member["state"].lower()
+        self.fail("No member state returned from dmg system query")
+        return None
+
+    def exclude_rank_and_wait_restart(self, rank, expect_restart=True, timeout=30):
+        """Exclude a rank and wait for it to self-terminate and potentially restart.
+
+        Args:
+            rank (int): Rank to exclude
+            expect_restart (bool): Whether automatic restart is expected
+            timeout (int): Maximum seconds to wait for restart
+
+        Returns:
+            tuple: (restarted, final_state) - whether rank restarted and its final state
+        """
+        self.log_step("Excluding rank %s", rank)
+        self.dmg.system_exclude(ranks=[rank], rank_hosts=None)
+
+        # Wait for rank to self-terminate (should go to AdminExcluded state)
+        self.log_step("Waiting for rank %s to self-terminate", rank)
+        time.sleep(2)
+
+        # Check if rank is adminexcluded
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[rank], valid_states=["adminexcluded"], max_checks=10)
+        if failed_ranks:
+            self.fail("Rank %s did not reach AdminExcluded state after exclusion" % rank)
+
+        if expect_restart:
+            # After triggering rank exclusion with dmg system exclude, clear
+            # AdminExcluded state so rank can join on auto-restart. This enables
+            # mimic of rank exclusion via SWIM inactivity detection.
+            self.log_step("Clearing exclusion for rank %s", rank)
+            self.dmg.system_clear_exclude(ranks=[rank], rank_hosts=None)
+
+            # Wait for automatic restart (rank should go to Joined state)
+            self.log_step("Waiting for rank %s to automatically restart", rank)
+            start_time = time.time()
+            restarted = False
+
+            while time.time() - start_time < timeout:
+                time.sleep(2)
+                # Check if rank has rejoined
+                failed_ranks = self.server_managers[0].check_rank_state(
+                    ranks=[rank], valid_states=["joined"], max_checks=1)
+                if not failed_ranks:
+                    restarted = True
+                    break
+
+            if restarted:
+                self.log.info("Rank %s automatically restarted and rejoined", rank)
+                return (True, "joined")
+            state = self.get_rank_state(rank)
+            self.log.error("Rank %s (%s) did not restart within %ss", rank, state, timeout)
+            return (False, state)
+        # Verify rank stays AdminExcluded (no automatic restart)
+        self.log_step("Verifying rank %s does not automatically restart", rank)
+        time.sleep(timeout)
+
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[rank], valid_states=["adminexcluded"], max_checks=1)
+        if failed_ranks:
+            state = self.get_rank_state(rank)
+            self.log.error("Rank %s (%s) unexpectedly restarted", rank, state)
+            return (True, state)
+        return (False, "adminexcluded")
+
+    def test_auto_restart_basic(self):
+        """Test basic automatic engine restart after self-termination.
+
+        Test Description:
+            1. Exclude a rank from the system
+            2. Wait for rank to self-terminate
+            3. Verify rank automatically restarts and rejoins the system
+
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartTest,test_auto_restart_basic
+        """
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 2:
+            self.skipTest("Test requires at least 2 ranks")
+
+        test_rank = self.random.choice(all_ranks)
+
+        self.log_step("Testing automatic restart of rank %s", test_rank)
+
+        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
+
+        if not restarted:
+            self.fail("Rank %s did not automatically restart. Final state: %s"
+                      % (test_rank, final_state))
+
+        self.log.info("SUCCESS: Rank %s automatically restarted after self-termination",
+                      test_rank)
+
+    def test_auto_restart_multiple_ranks(self):
+        """Test automatic restart of multiple ranks.
+
+        Test Description:
+            1. Exclude multiple ranks simultaneously
+            2. Wait for all to self-terminate
+            3. Verify all automatically restart and rejoin
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartTest,test_auto_restart_multiple_ranks
+        """
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 3:
+            self.skipTest("Test requires at least 3 ranks")
+
+        # Exclude half the ranks (but keep at least one for quorum)
+        num_to_exclude = max(1, len(all_ranks) // 2)
+        ranks_to_test = self.random.sample(all_ranks, num_to_exclude)
+
+        self.log_step("Testing automatic restart of multiple ranks: %s", ranks_to_test)
+
+        errors = []
+        results = {}
+
+        for test_rank in ranks_to_test:
+            restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
+            results[test_rank] = (restarted, final_state)
+
+            if not restarted:
+                errors.append(
+                    "Rank %s did not automatically restart. State: %s" % (test_rank, final_state))
+
+        # Report results
+        self.log.info("=== Multiple Rank Restart Results ===")
+        for rank, (restarted, state) in results.items():
+            status = "PASS" if restarted else "FAIL"
+            self.log.info("Rank %s: %s (final state: %s)", rank, status, state)
+
+        report_errors(test=self, errors=errors)
+
+    def test_auto_restart_with_pool(self):
+        """Test automatic restart works with active pools.
+
+        Test Description:
+            1. Create a pool
+            2. Exclude a rank (not in pool service)
+            3. Verify rank automatically restarts
+            4. Verify pool remains accessible
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart,pool
+        :avocado: tags=EngineAutoRestartTest,test_auto_restart_with_pool
+        """
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 2:
+            self.skipTest("Test requires at least 2 ranks")
+
+        # Create pool first
+        self.add_pool(connect=False)
+
+        # Get pool service ranks to avoid excluding them
+        pool_svc_ranks = self.pool.svc_ranks
+        self.log.info("Pool service ranks: %s", pool_svc_ranks)
+
+        # Find a rank not in pool service
+        non_svc_ranks = [r for r in all_ranks if r not in pool_svc_ranks]
+        if not non_svc_ranks:
+            self.skipTest("All ranks are pool service ranks")
+
+        test_rank = self.random.choice(non_svc_ranks)
+
+        self.log_step("Excluding non-service rank %s while pool is active", test_rank)
+
+        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
+
+        if not restarted:
+            self.fail("Rank %s did not restart. State: %s" % (test_rank, final_state))
+
+        # Verify pool is still accessible
+        self.log_step("Verifying pool is still accessible after rank restart")
+        self.pool.query()
+
+        self.log.info("SUCCESS: Rank %s restarted and pool remains accessible", test_rank)

--- a/src/tests/ftest/control/engine_auto_restart.py
+++ b/src/tests/ftest/control/engine_auto_restart.py
@@ -18,6 +18,18 @@ class EngineAutoRestartTest(ControlTestBase):
     :avocado: recursive
     """
 
+    def tearDown(self):
+        """Clean up after each test method."""
+        # Reset restart state for next test method
+        # This ensures clean state between sequential tests
+        try:
+            self.reset_engine_restart_state()
+        except Exception as error:
+            self.log.error("Failed to reset engine restart state: %s", error)
+            self.fail("tearDown failed to reset engine restart state: {}".format(error))
+        finally:
+            super().tearDown()
+
     def test_auto_restart_basic(self):
         """Test basic automatic engine restart after self-termination.
 

--- a/src/tests/ftest/control/engine_auto_restart.py
+++ b/src/tests/ftest/control/engine_auto_restart.py
@@ -3,8 +3,6 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
-
 from control_test_base import ControlTestBase
 from general_utils import report_errors
 
@@ -18,98 +16,6 @@ class EngineAutoRestartTest(ControlTestBase):
 
     :avocado: recursive
     """
-
-    def setUp(self):
-        """Set up each test case."""
-        super().setUp()
-        self.dmg = self.get_dmg_command()
-
-    def get_all_ranks(self):
-        """Get list of all ranks in the system."""
-        return list(self.server_managers[0].ranks.keys())
-
-    def get_rank_state(self, rank):
-        """Get the state of a rank.
-
-        Args:
-            rank (int): Rank number
-
-        Returns:
-            str: Current state of the rank
-        """
-        data = self.dmg.system_query(ranks=f"{rank}")
-        if data["status"] != 0:
-            self.fail("Cmd dmg system query failed")
-        if "response" in data and "members" in data["response"]:
-            if data["response"]["members"] is None:
-                self.fail("No members returned from dmg system query")
-            for member in data["response"]["members"]:
-                return member["state"].lower()
-        self.fail("No member state returned from dmg system query")
-        return None
-
-    def exclude_rank_and_wait_restart(self, rank, expect_restart=True, timeout=30):
-        """Exclude a rank and wait for it to self-terminate and potentially restart.
-
-        Args:
-            rank (int): Rank to exclude
-            expect_restart (bool): Whether automatic restart is expected
-            timeout (int): Maximum seconds to wait for restart
-
-        Returns:
-            tuple: (restarted, final_state) - whether rank restarted and its final state
-        """
-        self.log_step("Excluding rank %s", rank)
-        self.dmg.system_exclude(ranks=[rank], rank_hosts=None)
-
-        # Wait for rank to self-terminate (should go to AdminExcluded state)
-        self.log_step("Waiting for rank %s to self-terminate", rank)
-        time.sleep(2)
-
-        # Check if rank is adminexcluded
-        failed_ranks = self.server_managers[0].check_rank_state(
-            ranks=[rank], valid_states=["adminexcluded"], max_checks=10)
-        if failed_ranks:
-            self.fail("Rank %s did not reach AdminExcluded state after exclusion" % rank)
-
-        if expect_restart:
-            # After triggering rank exclusion with dmg system exclude, clear
-            # AdminExcluded state so rank can join on auto-restart. This enables
-            # mimic of rank exclusion via SWIM inactivity detection.
-            self.log_step("Clearing exclusion for rank %s", rank)
-            self.dmg.system_clear_exclude(ranks=[rank], rank_hosts=None)
-
-            # Wait for automatic restart (rank should go to Joined state)
-            self.log_step("Waiting for rank %s to automatically restart", rank)
-            start_time = time.time()
-            restarted = False
-
-            while time.time() - start_time < timeout:
-                time.sleep(2)
-                # Check if rank has rejoined
-                failed_ranks = self.server_managers[0].check_rank_state(
-                    ranks=[rank], valid_states=["joined"], max_checks=1)
-                if not failed_ranks:
-                    restarted = True
-                    break
-
-            if restarted:
-                self.log.info("Rank %s automatically restarted and rejoined", rank)
-                return (True, "joined")
-            state = self.get_rank_state(rank)
-            self.log.error("Rank %s (%s) did not restart within %ss", rank, state, timeout)
-            return (False, state)
-        # Verify rank stays AdminExcluded (no automatic restart)
-        self.log_step("Verifying rank %s does not automatically restart", rank)
-        time.sleep(timeout)
-
-        failed_ranks = self.server_managers[0].check_rank_state(
-            ranks=[rank], valid_states=["adminexcluded"], max_checks=1)
-        if failed_ranks:
-            state = self.get_rank_state(rank)
-            self.log.error("Rank %s (%s) unexpectedly restarted", rank, state)
-            return (True, state)
-        return (False, "adminexcluded")
 
     def test_auto_restart_basic(self):
         """Test basic automatic engine restart after self-termination.

--- a/src/tests/ftest/control/engine_auto_restart.py
+++ b/src/tests/ftest/control/engine_auto_restart.py
@@ -37,16 +37,35 @@ class EngineAutoRestartTest(ControlTestBase):
 
         test_rank = self.random.choice(all_ranks)
 
-        self.log_step("Testing automatic restart of rank %s", test_rank)
+        self.log_step("testing automatic restart of rank %s", test_rank)
+
+        # get initial incarnation number
+        initial_incarnation = self.get_rank_incarnation(test_rank)
+        if initial_incarnation is None:
+            self.fail(f"failed to get initial incarnation for rank {test_rank}")
+
+        self.log.info("rank %s initial incarnation: %s", test_rank, initial_incarnation)
 
         restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
 
         if not restarted:
-            self.fail("Rank %s did not automatically restart. Final state: %s"
-                      % (test_rank, final_state))
+            self.fail(f"rank {test_rank} did not automatically restart. "
+                      f"final state: {final_state}")
 
-        self.log.info("SUCCESS: Rank %s automatically restarted after self-termination",
-                      test_rank)
+        # verify incarnation increased after restart
+        final_incarnation = self.get_rank_incarnation(test_rank)
+        if final_incarnation is None:
+            self.fail(f"failed to get final incarnation for rank {test_rank}")
+
+        self.log.info("rank %s final incarnation: %s", test_rank, final_incarnation)
+
+        if final_incarnation <= initial_incarnation:
+            self.fail(f"rank {test_rank} incarnation did not increase after restart. "
+                      f"before: {initial_incarnation}, after: {final_incarnation}")
+
+        self.log.info("SUCCESS: rank %s automatically restarted after self-termination "
+                      "(incarnation %s -> %s)",
+                      test_rank, initial_incarnation, final_incarnation)
 
     def test_auto_restart_multiple_ranks(self):
         """Test automatic restart of multiple ranks.
@@ -71,36 +90,50 @@ class EngineAutoRestartTest(ControlTestBase):
 
         self.log_step("Step 1: Excluding %s ranks: %s", (num_to_test, test_ranks))
 
+        incs = []
         for rank in test_ranks:
+            initial_incarnation = self.get_rank_incarnation(rank)
+            if initial_incarnation is None:
+                self.fail(f"failed to get initial incarnation for rank {rank}")
+            incs.append(initial_incarnation)
             self.dmg.system_exclude(ranks=[rank], rank_hosts=None)
-            time.sleep(1)  # Small delay between exclusions
-
-        # Step 2: Verify all reach adminexcluded state
-        self.log_step("Step 2: Verifying all ranks get excluded from system")
-        time.sleep(10)
-
-        for rank in test_ranks:
-            failed = self.server_managers[0].check_rank_state(
-                ranks=[rank], valid_states=["adminexcluded"], max_checks=5)
-            if failed:
-                self.fail("Rank %s did not get excluded from system" % rank)
+            time.sleep(1)  # small delay between exclusions
             self.dmg.system_clear_exclude(ranks=[rank], rank_hosts=None)
 
         # Step 3: Wait and verify all restart
-        wait_time = 20
+        wait_time = 35
+
         self.log_step("Step 3: Waiting %ss to verify all automatically restart", wait_time)
         time.sleep(wait_time)
 
         errors = []
+        end_incs = []
         for rank in test_ranks:
             failed = self.server_managers[0].check_rank_state(
                 ranks=[rank], valid_states=["joined"], max_checks=1)
             if failed:
                 errors.append("Rank %s unexpectedly not restarted when auto-restart enabled"
                               % rank)
+            end_incarnation = self.get_rank_incarnation(rank)
+            if end_incarnation is None:
+                self.fail(f"failed to get end incarnation for rank {rank}")
+            end_incs.append(end_incarnation)
 
         if errors:
             self.fail("\n".join(errors))
+
+        # Show changes
+        for idx, (old, new) in enumerate(zip(incs, end_incs)):
+            actual_rank = test_ranks[idx]
+            if new > old:
+                self.log.debug(f"Rank {actual_rank}: {old} -> {new} (restarted)")
+            else:
+                self.log.debug(f"Rank {actual_rank}: {old} -> {new} (NOT restarted!)")
+
+        # Verify all increased
+        all_increased = all(a > b for b, a in zip(incs, end_incs))
+        if not all_increased:
+            self.fail("ERROR: Not all ranks restarted!")
 
         self.log.info("SUCCESS: All of %s automatically restarted", test_ranks)
 
@@ -129,13 +162,28 @@ class EngineAutoRestartTest(ControlTestBase):
 
         self.log_step("Excluding non-service rank %s while pool is active", test_rank)
 
+        # Get initial incarnation
+        initial_incarnation = self.get_rank_incarnation(test_rank)
+        if initial_incarnation is None:
+            self.fail(f"Failed to get initial incarnation for rank {test_rank}")
+
         restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
 
         if not restarted:
-            self.fail("Rank %s did not restart. State: %s" % (test_rank, final_state))
+            self.fail(f"Rank {test_rank} did not restart. State: {final_state}")
+
+        # Verify incarnation increased
+        final_incarnation = self.get_rank_incarnation(test_rank)
+        if final_incarnation is None:
+            self.fail(f"Failed to get final incarnation for rank {test_rank}")
+
+        if final_incarnation <= initial_incarnation:
+            self.fail(f"Rank {test_rank} incarnation did not increase. "
+                      f"Before: {initial_incarnation}, After: {final_incarnation}")
 
         # Verify pool is still accessible
         self.log_step("Verifying pool is still accessible after rank restart")
         self.pool.query()
 
-        self.log.info("SUCCESS: Rank %s restarted and pool remains accessible", test_rank)
+        self.log.info("SUCCESS: Rank %s restarted (incarnation %s -> %s) and pool remains "
+                      "accessible", test_rank, initial_incarnation, final_incarnation)

--- a/src/tests/ftest/control/engine_auto_restart.py
+++ b/src/tests/ftest/control/engine_auto_restart.py
@@ -3,8 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import time
+
 from control_test_base import ControlTestBase
-from general_utils import report_errors
 
 
 class EngineAutoRestartTest(ControlTestBase):
@@ -70,24 +71,26 @@ class EngineAutoRestartTest(ControlTestBase):
 
         self.log_step("Testing automatic restart of multiple ranks: %s", ranks_to_test)
 
-        errors = []
-        results = {}
+        self.dmg.system_exclude(ranks=ranks_to_test, rank_hosts=None)
 
-        for test_rank in ranks_to_test:
-            restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
-            results[test_rank] = (restarted, final_state)
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=ranks_to_test, valid_states=["adminexcluded"], max_checks=10)
+        if failed_ranks:
+            self.fail("Ranks %s did not all reach AdminExcluded state after exclusion"
+                      % ranks_to_test)
 
-            if not restarted:
-                errors.append(
-                    "Rank %s did not automatically restart. State: %s" % (test_rank, final_state))
+        self.dmg.system_clear_exclude(ranks=ranks_to_test, rank_hosts=None)
 
-        # Report results
-        self.log.info("=== Multiple Rank Restart Results ===")
-        for rank, (restarted, state) in results.items():
-            status = "PASS" if restarted else "FAIL"
-            self.log.info("Rank %s: %s (final state: %s)", rank, status, state)
+        time.sleep(10)
 
-        report_errors(test=self, errors=errors)
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=ranks_to_test, valid_states=["joined"], max_checks=10)
+        if failed_ranks:
+            self.fail("Ranks %s did not all reach Joined state after auto-restart"
+                      % ranks_to_test)
+
+        self.log.info("SUCCESS: Ranks %s automatically restarted after self-termination",
+                      ranks_to_test)
 
     def test_auto_restart_with_pool(self):
         """Test automatic restart works with active pools.

--- a/src/tests/ftest/control/engine_auto_restart.py
+++ b/src/tests/ftest/control/engine_auto_restart.py
@@ -65,32 +65,44 @@ class EngineAutoRestartTest(ControlTestBase):
         if len(all_ranks) < 3:
             self.skipTest("Test requires at least 3 ranks")
 
-        # Exclude half the ranks (but keep at least one for quorum)
-        num_to_exclude = max(1, len(all_ranks) // 2)
-        ranks_to_test = self.random.sample(all_ranks, num_to_exclude)
+        # Exclude half the ranks
+        num_to_test = max(2, len(all_ranks) // 2)
+        test_ranks = self.random.sample(all_ranks, num_to_test)
 
-        self.log_step("Testing automatic restart of multiple ranks: %s", ranks_to_test)
+        self.log_step("Step 1: Excluding %s ranks: %s", num_to_test, test_ranks)
 
-        self.dmg.system_exclude(ranks=ranks_to_test, rank_hosts=None)
+        for rank in test_ranks:
+            self.dmg.system_exclude(ranks=[rank], rank_hosts=None)
+            time.sleep(1)  # Small delay between exclusions
 
-        failed_ranks = self.server_managers[0].check_rank_state(
-            ranks=ranks_to_test, valid_states=["adminexcluded"], max_checks=10)
-        if failed_ranks:
-            self.fail("Ranks %s did not all reach AdminExcluded state after exclusion"
-                      % ranks_to_test)
-
-        self.dmg.system_clear_exclude(ranks=ranks_to_test, rank_hosts=None)
-
+        # Step 2: Verify all reach adminexcluded state
+        self.log_step("Step 2: Verifying all ranks get excluded from system")
         time.sleep(10)
 
-        failed_ranks = self.server_managers[0].check_rank_state(
-            ranks=ranks_to_test, valid_states=["joined"], max_checks=10)
-        if failed_ranks:
-            self.fail("Ranks %s did not all reach Joined state after auto-restart"
-                      % ranks_to_test)
+        for rank in test_ranks:
+            failed = self.server_managers[0].check_rank_state(
+                ranks=[rank], valid_states=["adminexcluded"], max_checks=5)
+            if failed:
+                self.fail("Rank %s did not get excluded from system" % rank)
+            self.dmg.system_clear_exclude(ranks=[rank], rank_hosts=None)
 
-        self.log.info("SUCCESS: Ranks %s automatically restarted after self-termination",
-                      ranks_to_test)
+        # Step 3: Wait and verify all restart
+        wait_time = 20
+        self.log_step("Step 3: Waiting %ss to verify all automatically restart", wait_time)
+        time.sleep(wait_time)
+
+        errors = []
+        for rank in test_ranks:
+            failed = self.server_managers[0].check_rank_state(
+                ranks=[rank], valid_states=["joined"], max_checks=1)
+            if failed:
+                errors.append("Rank %s unexpectedly not restarted when auto-restart enabled"
+                              % rank)
+
+        if errors:
+            self.fail("\n".join(errors))
+
+        self.log.info("SUCCESS: All of %s automatically restarted", test_ranks)
 
     def test_auto_restart_with_pool(self):
         """Test automatic restart works with active pools.

--- a/src/tests/ftest/control/engine_auto_restart.py
+++ b/src/tests/ftest/control/engine_auto_restart.py
@@ -1,0 +1,215 @@
+"""
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+import time
+
+from control_test_base import ControlTestBase
+from general_utils import report_errors
+
+
+class EngineAutoRestartTest(ControlTestBase):
+    """Test automatic engine restart on self-termination.
+
+    Test Class Description:
+        Verify automatic engine restart behavior when engines self-terminate
+        after being excluded from the system.
+
+    :avocado: recursive
+    """
+
+    def setUp(self):
+        """Set up each test case."""
+        super().setUp()
+        self.dmg = self.get_dmg_command()
+
+    def get_all_ranks(self):
+        """Get list of all ranks in the system."""
+        return list(self.server_managers[0].ranks.keys())
+
+    def get_rank_state(self, rank):
+        data = self.dmg.system_query(ranks=f"{rank}")
+        if data["status"] != 0:
+            self.fail("Cmd dmg system query failed")
+        if "response" in data and "members" in data["response"]:
+            if data["response"]["members"] is None:
+                self.fail("No members returned from dmg system query")
+            for member in data["response"]["members"]:
+                return member["state"].lower()
+        self.fail("No member state returned from dmg system query")
+
+    def exclude_rank_and_wait_restart(self, rank, expect_restart=True, timeout=30):
+        """Exclude a rank and wait for it to self-terminate and potentially restart.
+
+        Args:
+            rank (int): Rank to exclude
+            expect_restart (bool): Whether automatic restart is expected
+            timeout (int): Maximum seconds to wait for restart
+
+        Returns:
+            tuple: (restarted, final_state) - whether rank restarted and its final state
+        """
+        self.log_step(f"Excluding rank {rank}")
+        self.dmg.system_exclude(ranks=[rank], rank_hosts=None)
+
+        # Wait for rank to self-terminate (should go to Excluded state)
+        self.log_step(f"Waiting for rank {rank} to self-terminate")
+        time.sleep(5)
+
+        # Check if rank is excluded
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[rank], valid_states=["excluded"], max_checks=10)
+        if failed_ranks:
+            self.fail(f"Rank {rank} did not reach Excluded state after exclusion")
+
+        if expect_restart:
+            # Wait for automatic restart (rank should go to Joined state)
+            self.log_step(f"Waiting for rank {rank} to automatically restart")
+            start_time = time.time()
+            restarted = False
+
+            while time.time() - start_time < timeout:
+                time.sleep(2)
+                # Check if rank has rejoined
+                failed_ranks = self.server_managers[0].check_rank_state(
+                    ranks=[rank], valid_states=["joined"], max_checks=1)
+                if not failed_ranks:
+                    restarted = True
+                    break
+
+            if restarted:
+                self.log.info(f"Rank {rank} automatically restarted and rejoined")
+                return (True, "joined")
+            else:
+                state = self.get_rank_state(rank)
+                self.log.error(f"Rank {rank} ({state}) did not restart within {timeout}s")
+                return (False, state)
+        else:
+            # Verify rank stays excluded (no automatic restart)
+            self.log_step(f"Verifying rank {rank} does not automatically restart")
+            time.sleep(timeout)
+
+            failed_ranks = self.server_managers[0].check_rank_state(
+                ranks=[rank], valid_states=["excluded"], max_checks=1)
+            if failed_ranks:
+                state = self.get_rank_state(rank)
+                self.log.error(f"Rank {rank} ({state}) unexpectedly restarted")
+                return (True, state)
+            else:
+                return (False, "excluded")
+
+    def test_auto_restart_basic(self):
+        """Test basic automatic engine restart after self-termination.
+
+        Test Description:
+            1. Exclude a rank from the system
+            2. Wait for rank to self-terminate
+            3. Verify rank automatically restarts and rejoins the system
+
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartTest,test_auto_restart_basic
+        """
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 2:
+            self.skipTest("Test requires at least 2 ranks")
+
+        test_rank = self.random.choice(all_ranks)
+
+        self.log_step(f"Testing automatic restart of rank {test_rank}")
+
+        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
+
+        if not restarted:
+            self.fail(f"Rank {test_rank} did not automatically restart. Final state: {final_state}")
+
+        self.log.info(f"SUCCESS: Rank {test_rank} automatically restarted after self-termination")
+
+    def test_auto_restart_multiple_ranks(self):
+        """Test automatic restart of multiple ranks.
+
+        Test Description:
+            1. Exclude multiple ranks simultaneously
+            2. Wait for all to self-terminate
+            3. Verify all automatically restart and rejoin
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartTest,test_auto_restart_multiple_ranks
+        """
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 3:
+            self.skipTest("Test requires at least 3 ranks")
+
+        # Exclude half the ranks (but keep at least one for quorum)
+        num_to_exclude = max(1, len(all_ranks) // 2)
+        ranks_to_test = self.random.sample(all_ranks, num_to_exclude)
+
+        self.log_step(f"Testing automatic restart of multiple ranks: {ranks_to_test}")
+
+        errors = []
+        results = {}
+
+        for test_rank in ranks_to_test:
+            restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
+            results[test_rank] = (restarted, final_state)
+
+            if not restarted:
+                errors.append(
+                    f"Rank {test_rank} did not automatically restart. State: {final_state}")
+
+        # Report results
+        self.log.info("=== Multiple Rank Restart Results ===")
+        for rank, (restarted, state) in results.items():
+            status = "PASS" if restarted else "FAIL"
+            self.log.info(f"Rank {rank}: {status} (final state: {state})")
+
+        report_errors(test=self, errors=errors)
+
+    def test_auto_restart_with_pool(self):
+        """Test automatic restart works with active pools.
+
+        Test Description:
+            1. Create a pool
+            2. Exclude a rank (not in pool service)
+            3. Verify rank automatically restarts
+            4. Verify pool remains accessible
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart,pool
+        :avocado: tags=EngineAutoRestartTest,test_auto_restart_with_pool
+        """
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 2:
+            self.skipTest("Test requires at least 2 ranks")
+
+        # Create pool first
+        self.add_pool(connect=False)
+
+        # Get pool service ranks to avoid excluding them
+        pool_svc_ranks = self.pool.svc_ranks
+        self.log.info(f"Pool service ranks: {pool_svc_ranks}")
+
+        # Find a rank not in pool service
+        non_svc_ranks = [r for r in all_ranks if r not in pool_svc_ranks]
+        if not non_svc_ranks:
+            self.skipTest("All ranks are pool service ranks")
+
+        test_rank = self.random.choice(non_svc_ranks)
+
+        self.log_step(f"Excluding non-service rank {test_rank} while pool is active")
+
+        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
+
+        if not restarted:
+            self.fail(f"Rank {test_rank} did not restart. State: {final_state}")
+
+        # Verify pool is still accessible
+        self.log_step("Verifying pool is still accessible after rank restart")
+        self.pool.query()
+
+        self.log.info(f"SUCCESS: Rank {test_rank} restarted and pool remains accessible")

--- a/src/tests/ftest/control/engine_auto_restart.yaml
+++ b/src/tests/ftest/control/engine_auto_restart.yaml
@@ -1,5 +1,5 @@
 hosts:
-  test_servers: 1
+  test_servers: 2
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/control/engine_auto_restart.yaml
+++ b/src/tests/ftest/control/engine_auto_restart.yaml
@@ -1,0 +1,25 @@
+hosts:
+  test_servers: 1
+server_config:
+  name: daos_server
+  engines_per_host: 2
+  engines:
+    0:
+      log_file: daos_server0.log
+      targets: 4
+      nr_xs_helpers: 0
+      storage:
+        0:
+          class: ram
+          scm_mount: /mnt/daos0
+    1:
+      log_file: daos_server1.log
+      targets: 4
+      nr_xs_helpers: 0
+      storage:
+        0:
+          class: ram
+          scm_mount: /mnt/daos1
+pool:
+  size: 2G
+timeout: 300

--- a/src/tests/ftest/control/engine_auto_restart_advanced.py
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.py
@@ -18,6 +18,18 @@ class EngineAutoRestartAdvanced(ControlTestBase):
     :avocado: recursive
     """
 
+    def tearDown(self):
+        """Clean up after each test method."""
+        # Reset restart state for next test method
+        # This ensures clean state between sequential tests
+        try:
+            self.reset_engine_restart_state()
+        except Exception as error:
+            self.log.error("Failed to reset engine restart state: %s", error)
+            self.fail("tearDown failed to reset engine restart state: {}".format(error))
+        finally:
+            super().tearDown()
+
     def wait_for_rank_state(self, rank, expected_state, timeout=30, check_interval=2):
         """Wait for a rank to reach expected state.
 

--- a/src/tests/ftest/control/engine_auto_restart_advanced.py
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.py
@@ -96,7 +96,7 @@ class EngineAutoRestartAdvanced(ControlTestBase):
         :avocado: tags=EngineAutoRestartAdvanced,test_deferred_restart
         """
         # Get configured restart delay from test params
-        restart_delay = self.params.get("engine_auto_restart_min_delay", "/run/server_config/*", 15)
+        restart_delay = 15
 
         all_ranks = self.get_all_ranks()
         if len(all_ranks) < 2:
@@ -104,18 +104,28 @@ class EngineAutoRestartAdvanced(ControlTestBase):
 
         test_rank = self.random.choice(all_ranks)
 
+#        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
+#
+#        if not restarted:
+#            self.fail("Rank %s did not automatically restart. Final state: %s"
+#                      % (test_rank, final_state))
+
         # First exclusion - should restart immediately (no previous restart)
         self.log_step("Step 1: First exclusion of rank %s", test_rank)
         self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
 
         # Wait for self-termination
-        if not self.wait_for_rank_state(test_rank, "excluded", timeout=10):
+        if not self.wait_for_rank_state(test_rank, "adminexcluded", timeout=10):
             self.fail("Rank %s did not self-terminate" % test_rank)
+
+        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
 
         # Wait for automatic restart
         self.log_step("Step 2: Waiting for first automatic restart of rank %s", test_rank)
         if not self.wait_for_rank_state(test_rank, "joined", timeout=30):
             self.fail("Rank %s did not automatically restart on first exclusion" % test_rank)
+
+#
 
         first_restart_time = time.time()
         self.log.info("First restart completed at T=%.1f", first_restart_time)
@@ -125,8 +135,10 @@ class EngineAutoRestartAdvanced(ControlTestBase):
         self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
 
         # Wait for self-termination
-        if not self.wait_for_rank_state(test_rank, "excluded", timeout=10):
+        if not self.wait_for_rank_state(test_rank, "adminexcluded", timeout=10):
             self.fail("Rank %s did not self-terminate on second exclusion" % test_rank)
+
+        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
 
         # Verify restart is NOT immediate (should be deferred)
         self.log_step("Step 4: Verifying restart is deferred (not immediate)")
@@ -141,7 +153,7 @@ class EngineAutoRestartAdvanced(ControlTestBase):
 
         # Wait for deferred restart to execute (after delay expires)
         # Add buffer time for processing
-        wait_time = restart_delay + 10
+        wait_time = restart_delay + 30  # 10
         self.log_step("Step 5: Waiting %ss for deferred restart to execute", wait_time)
 
         if not self.wait_for_rank_state(test_rank, "joined", timeout=wait_time):
@@ -175,8 +187,7 @@ class EngineAutoRestartAdvanced(ControlTestBase):
         :avocado: tags=EngineAutoRestartAdvanced,test_custom_restart_delay
         """
         # Get configured delay from test parameters
-        expected_delay = self.params.get("engine_auto_restart_min_delay",
-                                         "/run/server_config/*", 20)
+        expected_delay = 15
 
         all_ranks = self.get_all_ranks()
         if len(all_ranks) < 2:
@@ -184,13 +195,14 @@ class EngineAutoRestartAdvanced(ControlTestBase):
 
         test_rank = self.random.choice(all_ranks)
 
-        self.log_step("Testing custom restart delay of %ss for rank %s",
-                      expected_delay, test_rank)
+        self.log_step("Testing custom restart delay of %s s for rank %s",
+                      (expected_delay, test_rank))
 
         # First restart to establish baseline
         self.log_step("Step 1: First exclusion and restart")
         self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
-        self.wait_for_rank_state(test_rank, "excluded", timeout=10)
+        self.wait_for_rank_state(test_rank, "adminexcluded", timeout=10)
+        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
         self.wait_for_rank_state(test_rank, "joined", timeout=30)
 
         first_restart_time = time.time()
@@ -198,7 +210,8 @@ class EngineAutoRestartAdvanced(ControlTestBase):
         # Second restart to measure delay
         self.log_step("Step 2: Second exclusion to trigger deferred restart")
         self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
-        self.wait_for_rank_state(test_rank, "excluded", timeout=10)
+        self.wait_for_rank_state(test_rank, "adminexcluded", timeout=10)
+        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
 
         # Wait for deferred restart
         self.log_step("Step 3: Waiting for deferred restart (expected delay: %ss)",
@@ -227,38 +240,38 @@ class EngineAutoRestartAdvanced(ControlTestBase):
             self.log.info("SUCCESS: Restart delay within expected range [%.1fs, %.1fs]",
                           min_delay, max_delay)
 
-    def test_restart_after_clear_exclude(self):
-        """Test interaction between auto-restart and manual clear-exclude.
-
-        Test Description:
-            1. Exclude rank, wait for self-termination
-            2. Clear exclusion before auto-restart triggers
-            3. Verify rank rejoins successfully
-
-        :avocado: tags=all,daily_regression
-        :avocado: tags=hw,medium
-        :avocado: tags=dmg,control,engine_auto_restart
-        :avocado: tags=EngineAutoRestartAdvanced,test_restart_after_clear_exclude
-        """
-        all_ranks = self.get_all_ranks()
-        if len(all_ranks) < 2:
-            self.skipTest("Test requires at least 2 ranks")
-
-        test_rank = self.random.choice(all_ranks)
-
-        self.log_step("Step 1: Excluding rank %s", test_rank)
-        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
-
-        # Wait for self-termination
-        if not self.wait_for_rank_state(test_rank, "excluded", timeout=10):
-            self.fail("Rank %s did not self-terminate" % test_rank)
-
-        # Clear exclusion before auto-restart
-        self.log_step("Step 2: Clearing exclusion for rank %s", test_rank)
-        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
-
-        # Verify rank rejoins
-        if not self.wait_for_rank_state(test_rank, "joined", timeout=30):
-            self.fail("Rank %s did not rejoin after clear-exclude" % test_rank)
-
-        self.log.info("SUCCESS: Rank %s successfully rejoined after clear-exclude", test_rank)
+#    def test_restart_after_clear_exclude(self):
+#        """Test interaction between auto-restart and manual clear-exclude.
+#
+#        Test Description:
+#            1. Exclude rank, wait for self-termination
+#            2. Clear exclusion before auto-restart triggers
+#            3. Verify rank rejoins successfully
+#
+#        :avocado: tags=all,daily_regression
+#        :avocado: tags=hw,medium
+#        :avocado: tags=dmg,control,engine_auto_restart
+#        :avocado: tags=EngineAutoRestartAdvanced,test_restart_after_clear_exclude
+#        """
+#        all_ranks = self.get_all_ranks()
+#        if len(all_ranks) < 2:
+#            self.skipTest("Test requires at least 2 ranks")
+#
+#        test_rank = self.random.choice(all_ranks)
+#
+#        self.log_step("Step 1: Excluding rank %s", test_rank)
+#        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+#
+#        # Wait for self-termination
+#        if not self.wait_for_rank_state(test_rank, "adminexcluded", timeout=10):
+#            self.fail("Rank %s did not self-terminate" % test_rank)
+#
+#        # Clear exclusion before auto-restart
+#        self.log_step("Step 2: Clearing exclusion for rank %s", test_rank)
+#        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
+#
+#        # Verify rank rejoins
+#        if not self.wait_for_rank_state(test_rank, "joined", timeout=30):
+#            self.fail("Rank %s did not rejoin after clear-exclude" % test_rank)
+#
+#        self.log.info("SUCCESS: Rank %s successfully rejoined after clear-exclude", test_rank)

--- a/src/tests/ftest/control/engine_auto_restart_advanced.py
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.py
@@ -18,35 +18,6 @@ class EngineAutoRestartAdvanced(ControlTestBase):
     :avocado: recursive
     """
 
-    def setUp(self):
-        """Set up each test case."""
-        super().setUp()
-        self.dmg = self.get_dmg_command()
-
-    def get_all_ranks(self):
-        """Get list of all ranks in the system."""
-        return list(self.server_managers[0].ranks.keys())
-
-    def get_rank_state(self, rank):
-        """Get the state of a rank.
-
-        Args:
-            rank (int): Rank number
-
-        Returns:
-            str: Current state of the rank
-        """
-        data = self.dmg.system_query(ranks=f"{rank}")
-        if data["status"] != 0:
-            self.fail("Cmd dmg system query failed")
-        if "response" in data and "members" in data["response"]:
-            if data["response"]["members"] is None:
-                self.fail("No members returned from dmg system query")
-            for member in data["response"]["members"]:
-                return member["state"].lower()
-        self.fail("No member state returned from dmg system query")
-        return None
-
     def wait_for_rank_state(self, rank, expected_state, timeout=30, check_interval=2):
         """Wait for a rank to reach expected state.
 
@@ -96,7 +67,7 @@ class EngineAutoRestartAdvanced(ControlTestBase):
         :avocado: tags=EngineAutoRestartAdvanced,test_deferred_restart
         """
         # Get configured restart delay from test params
-        restart_delay = 15
+        restart_delay = 20
 
         all_ranks = self.get_all_ranks()
         if len(all_ranks) < 2:
@@ -104,57 +75,34 @@ class EngineAutoRestartAdvanced(ControlTestBase):
 
         test_rank = self.random.choice(all_ranks)
 
-#        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
-#
-#        if not restarted:
-#            self.fail("Rank %s did not automatically restart. Final state: %s"
-#                      % (test_rank, final_state))
+        self.log_step("Step 1: Automatic restart of rank %s", test_rank)
 
-        # First exclusion - should restart immediately (no previous restart)
-        self.log_step("Step 1: First exclusion of rank %s", test_rank)
-        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
 
-        # Wait for self-termination
-        if not self.wait_for_rank_state(test_rank, "adminexcluded", timeout=10):
-            self.fail("Rank %s did not self-terminate" % test_rank)
-
-        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
-
-        # Wait for automatic restart
-        self.log_step("Step 2: Waiting for first automatic restart of rank %s", test_rank)
-        if not self.wait_for_rank_state(test_rank, "joined", timeout=30):
-            self.fail("Rank %s did not automatically restart on first exclusion" % test_rank)
-
-#
+        if not restarted:
+            self.fail("Rank %s did not automatically restart. Final state: %s"
+                      % (test_rank, final_state))
 
         first_restart_time = time.time()
         self.log.info("First restart completed at T=%.1f", first_restart_time)
 
         # Second exclusion - should be deferred due to rate-limiting
-        self.log_step("Step 3: Second exclusion of rank %s (should be deferred)", test_rank)
-        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+        self.log_step("Step 2: Second exclusion of rank %s (should be deferred)", test_rank)
 
-        # Wait for self-termination
-        if not self.wait_for_rank_state(test_rank, "adminexcluded", timeout=10):
-            self.fail("Rank %s did not self-terminate on second exclusion" % test_rank)
+        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank,
+                                                                    expect_restart=False,
+                                                                    timeout=10)
 
-        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
+        if restarted:
+            self.fail("Rank %s unexpectedly restarted. Final state: %s"
+                      % (test_rank, final_state))
 
-        # Verify restart is NOT immediate (should be deferred)
-        self.log_step("Step 4: Verifying restart is deferred (not immediate)")
-        time.sleep(5)  # Wait a bit
-
-        current_state = self.get_rank_state(test_rank)
-        if current_state == "joined":
-            self.fail("Rank %s restarted immediately - rate-limiting not working" % test_rank)
-
-        self.log.info("Confirmed: Restart is deferred (rank still in '%s' state)",
-                      current_state)
+        self.log.info("Confirmed: Restart is deferred (rank still in excluded state)")
 
         # Wait for deferred restart to execute (after delay expires)
         # Add buffer time for processing
-        wait_time = restart_delay + 30  # 10
-        self.log_step("Step 5: Waiting %ss for deferred restart to execute", wait_time)
+        wait_time = restart_delay + 10
+        self.log_step("Step 3: Waiting %ss for deferred restart to execute", wait_time)
 
         if not self.wait_for_rank_state(test_rank, "joined", timeout=wait_time):
             self.fail("Rank %s did not restart after rate-limit delay" % test_rank)
@@ -200,31 +148,31 @@ class EngineAutoRestartAdvanced(ControlTestBase):
 
         # First restart to establish baseline
         self.log_step("Step 1: First exclusion and restart")
-        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
-        self.wait_for_rank_state(test_rank, "adminexcluded", timeout=10)
-        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
-        self.wait_for_rank_state(test_rank, "joined", timeout=30)
+
+        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
+
+        if not restarted:
+            self.fail("Rank %s did not automatically restart. Final state: %s"
+                      % (test_rank, final_state))
 
         first_restart_time = time.time()
 
-        # Second restart to measure delay
-        self.log_step("Step 2: Second exclusion to trigger deferred restart")
-        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
-        self.wait_for_rank_state(test_rank, "adminexcluded", timeout=10)
-        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
-
-        # Wait for deferred restart
-        self.log_step("Step 3: Waiting for deferred restart (expected delay: %ss)",
+        # Second restart to measure delay and wait for deferred restart
+        self.log_step("Step 2: Wait for deferred restart (expected delay: %ss)",
                       expected_delay)
-        wait_timeout = expected_delay + 20  # Add buffer
 
-        if not self.wait_for_rank_state(test_rank, "joined", timeout=wait_timeout):
-            self.fail("Rank %s did not restart within expected time" % test_rank)
+        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank,
+                                                                    timeout=35)
+
+        if not restarted:
+            self.fail("Rank %s did not automatically restart again. Final state: %s"
+                      % (test_rank, final_state))
 
         second_restart_time = time.time()
         actual_delay = second_restart_time - first_restart_time
 
-        self.log.info("Measured delay: %.1fs (expected: ~%ss)", actual_delay, expected_delay)
+        self.log.info("Measured delay: %.1fs (expected: ~%ss)", actual_delay,
+                      expected_delay)
 
         # Verify delay is within acceptable range (80% to 120% of expected)
         min_delay = expected_delay * 0.8
@@ -239,39 +187,3 @@ class EngineAutoRestartAdvanced(ControlTestBase):
         else:
             self.log.info("SUCCESS: Restart delay within expected range [%.1fs, %.1fs]",
                           min_delay, max_delay)
-
-#    def test_restart_after_clear_exclude(self):
-#        """Test interaction between auto-restart and manual clear-exclude.
-#
-#        Test Description:
-#            1. Exclude rank, wait for self-termination
-#            2. Clear exclusion before auto-restart triggers
-#            3. Verify rank rejoins successfully
-#
-#        :avocado: tags=all,daily_regression
-#        :avocado: tags=hw,medium
-#        :avocado: tags=dmg,control,engine_auto_restart
-#        :avocado: tags=EngineAutoRestartAdvanced,test_restart_after_clear_exclude
-#        """
-#        all_ranks = self.get_all_ranks()
-#        if len(all_ranks) < 2:
-#            self.skipTest("Test requires at least 2 ranks")
-#
-#        test_rank = self.random.choice(all_ranks)
-#
-#        self.log_step("Step 1: Excluding rank %s", test_rank)
-#        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
-#
-#        # Wait for self-termination
-#        if not self.wait_for_rank_state(test_rank, "adminexcluded", timeout=10):
-#            self.fail("Rank %s did not self-terminate" % test_rank)
-#
-#        # Clear exclusion before auto-restart
-#        self.log_step("Step 2: Clearing exclusion for rank %s", test_rank)
-#        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
-#
-#        # Verify rank rejoins
-#        if not self.wait_for_rank_state(test_rank, "joined", timeout=30):
-#            self.fail("Rank %s did not rejoin after clear-exclude" % test_rank)
-#
-#        self.log.info("SUCCESS: Rank %s successfully rejoined after clear-exclude", test_rank)

--- a/src/tests/ftest/control/engine_auto_restart_advanced.py
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.py
@@ -120,7 +120,6 @@ class EngineAutoRestartAdvanced(ControlTestBase):
         self.log_step("Step 2: Second exclusion of rank %s (should be deferred)", test_rank)
 
         restarted, final_state = self.exclude_rank_and_wait_restart(test_rank,
-                                                                    expect_restart=False,
                                                                     timeout=10)
 
         if restarted:

--- a/src/tests/ftest/control/engine_auto_restart_advanced.py
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.py
@@ -53,7 +53,7 @@ class EngineAutoRestartAdvanced(ControlTestBase):
 
         Test Description:
             This test requires custom server configuration with a short
-            engine_auto_restart_min_delay (e.g., 15 seconds) to avoid long test runtime.
+            engine_auto_restart_min_delay (20 seconds) to avoid long test runtime.
 
             1. Exclude rank and wait for automatic restart (first restart)
             2. Immediately exclude same rank again (second self-termination)
@@ -67,7 +67,8 @@ class EngineAutoRestartAdvanced(ControlTestBase):
         :avocado: tags=EngineAutoRestartAdvanced,test_deferred_restart
         """
         # Get configured restart delay from test params
-        restart_delay = 20
+        restart_delay = self.params.get("engine_auto_restart_min_delay",
+                                        "/run/server_config/*", 20)
 
         all_ranks = self.get_all_ranks()
         if len(all_ranks) < 2:

--- a/src/tests/ftest/control/engine_auto_restart_advanced.py
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.py
@@ -124,14 +124,12 @@ class EngineAutoRestartAdvanced(ControlTestBase):
                                                                     timeout=10)
 
         if restarted:
-            self.fail("Rank %s unexpectedly restarted. Final state: %s"
-                      % (test_rank, final_state))
+            self.fail("Rank %s unexpectedly restarted. Final state: %s" % (test_rank, final_state))
 
         self.log.info("Confirmed: Restart is deferred (rank still in excluded state)")
 
-        # Wait for deferred restart to execute (after delay expires)
-        # Add buffer time for processing
-        wait_time = expected_delay + 10
+        # Wait for deferred restart to execute (after delay expires), add buffer
+        wait_time = expected_delay + 5
         self.log_step("Step 3: Waiting %ss for deferred restart to execute", wait_time)
 
         if not self.wait_for_rank_state(test_rank, "joined", timeout=wait_time):

--- a/src/tests/ftest/control/engine_auto_restart_advanced.py
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.py
@@ -1,0 +1,253 @@
+"""
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+import time
+
+from control_test_base import ControlTestBase
+
+
+class EngineAutoRestartAdvanced(ControlTestBase):
+    """Test advanced automatic engine restart scenarios.
+
+    Test Class Description:
+        Verify automatic engine restart with custom configurations including
+        rate-limiting, deferred restarts, and disabled restart behavior.
+
+    :avocado: recursive
+    """
+
+    def setUp(self):
+        """Set up each test case."""
+        super().setUp()
+        self.dmg = self.get_dmg_command()
+
+    def get_all_ranks(self):
+        """Get list of all ranks in the system."""
+        return list(self.server_managers[0].ranks.keys())
+
+    def get_rank_state(self, rank):
+        data = self.dmg.system_query(ranks=f"{rank}")
+        if data["status"] != 0:
+            self.fail("Cmd dmg system query failed")
+        if "response" in data and "members" in data["response"]:
+            if data["response"]["members"] is None:
+                self.fail("No members returned from dmg system query")
+            for member in data["response"]["members"]:
+                return member["state"].lower()
+        self.fail("No member state returned from dmg system query")
+
+    def wait_for_rank_state(self, rank, expected_state, timeout=30, check_interval=2):
+        """Wait for a rank to reach expected state.
+
+        Args:
+            rank (int): Rank number
+            expected_state (str): Expected state
+            timeout (int): Maximum seconds to wait
+            check_interval (int): Seconds between state checks
+
+        Returns:
+            bool: True if state reached, False if timeout
+        """
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            failed_ranks = self.server_managers[0].check_rank_state(
+                ranks=[rank], valid_states=[expected_state], max_checks=1)
+
+            if not failed_ranks:
+                self.log.info(f"Rank {rank} reached state '{expected_state}' after "
+                              f"{time.time() - start_time:.1f}s")
+                return True
+
+            time.sleep(check_interval)
+
+        current_state = self.get_rank_state(rank)
+        self.log.warning(f"Rank {rank} did not reach '{expected_state}' within {timeout}s. "
+                         f"Current state: {current_state}")
+        return False
+
+    def test_deferred_restart(self):
+        """Test deferred restart when multiple self-terminations occur rapidly.
+
+        Test Description:
+            This test requires custom server configuration with a short
+            engine_auto_restart_min_delay (e.g., 15 seconds) to avoid long test runtime.
+
+            1. Exclude rank and wait for automatic restart (first restart)
+            2. Immediately exclude same rank again (second self-termination)
+            3. Verify restart is deferred, not immediate
+            4. Wait for deferred restart to execute after delay expires
+            5. Verify rank successfully rejoins
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartAdvanced,test_deferred_restart
+        """
+        # Get configured restart delay from test params
+        restart_delay = self.params.get("engine_auto_restart_min_delay", "/run/server_config/*", 15)
+
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 2:
+            self.skipTest("Test requires at least 2 ranks")
+
+        test_rank = self.random.choice(all_ranks)
+
+        # First exclusion - should restart immediately (no previous restart)
+        self.log_step(f"Step 1: First exclusion of rank {test_rank}")
+        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+
+        # Wait for self-termination
+        if not self.wait_for_rank_state(test_rank, "excluded", timeout=10):
+            self.fail(f"Rank {test_rank} did not self-terminate")
+
+        # Wait for automatic restart
+        self.log_step(f"Step 2: Waiting for first automatic restart of rank {test_rank}")
+        if not self.wait_for_rank_state(test_rank, "joined", timeout=30):
+            self.fail(f"Rank {test_rank} did not automatically restart on first exclusion")
+
+        first_restart_time = time.time()
+        self.log.info(f"First restart completed at T={first_restart_time:.1f}")
+
+        # Second exclusion - should be deferred due to rate-limiting
+        self.log_step(f"Step 3: Second exclusion of rank {test_rank} (should be deferred)")
+        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+
+        # Wait for self-termination
+        if not self.wait_for_rank_state(test_rank, "excluded", timeout=10):
+            self.fail(f"Rank {test_rank} did not self-terminate on second exclusion")
+
+        # Verify restart is NOT immediate (should be deferred)
+        self.log_step("Step 4: Verifying restart is deferred (not immediate)")
+        time.sleep(5)  # Wait a bit
+
+        current_state = self.get_rank_state(test_rank)
+        if current_state == "joined":
+            self.fail(f"Rank {test_rank} restarted immediately - rate-limiting not working")
+
+        self.log.info(f"Confirmed: Restart is deferred (rank still in '{current_state}' state)")
+
+        # Wait for deferred restart to execute (after delay expires)
+        # Add buffer time for processing
+        wait_time = restart_delay + 10
+        self.log_step(f"Step 5: Waiting {wait_time}s for deferred restart to execute")
+
+        if not self.wait_for_rank_state(test_rank, "joined", timeout=wait_time):
+            self.fail(f"Rank {test_rank} did not restart after rate-limit delay")
+
+        deferred_restart_time = time.time()
+        actual_delay = deferred_restart_time - first_restart_time
+
+        self.log.info(f"SUCCESS: Deferred restart executed after {actual_delay:.1f}s "
+                      f"(expected ~{restart_delay}s)")
+
+        # Verify delay was approximately correct (within tolerance)
+        if actual_delay < restart_delay * 0.8:
+            self.fail(f"Restart occurred too early: {actual_delay:.1f}s < {restart_delay}s")
+
+    def test_custom_restart_delay(self):
+        """Test custom engine_auto_restart_min_delay configuration.
+
+        Test Description:
+            This test requires server configuration with custom
+            engine_auto_restart_min_delay value.
+
+            1. Exclude rank and wait for first restart
+            2. Exclude same rank again
+            3. Measure time until deferred restart executes
+            4. Verify delay matches configured value
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartAdvanced,test_custom_restart_delay
+        """
+        # Get configured delay from test parameters
+        expected_delay = self.params.get("engine_auto_restart_min_delay",
+                                         "/run/server_config/*", 20)
+
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 2:
+            self.skipTest("Test requires at least 2 ranks")
+
+        test_rank = self.random.choice(all_ranks)
+
+        self.log_step(f"Testing custom restart delay of {expected_delay}s for rank {test_rank}")
+
+        # First restart to establish baseline
+        self.log_step("Step 1: First exclusion and restart")
+        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+        self.wait_for_rank_state(test_rank, "excluded", timeout=10)
+        self.wait_for_rank_state(test_rank, "joined", timeout=30)
+
+        first_restart_time = time.time()
+
+        # Second restart to measure delay
+        self.log_step("Step 2: Second exclusion to trigger deferred restart")
+        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+        self.wait_for_rank_state(test_rank, "excluded", timeout=10)
+
+        # Wait for deferred restart
+        self.log_step(f"Step 3: Waiting for deferred restart (expected delay: {expected_delay}s)")
+        wait_timeout = expected_delay + 20  # Add buffer
+
+        if not self.wait_for_rank_state(test_rank, "joined", timeout=wait_timeout):
+            self.fail(f"Rank {test_rank} did not restart within expected time")
+
+        second_restart_time = time.time()
+        actual_delay = second_restart_time - first_restart_time
+
+        self.log.info(f"Measured delay: {actual_delay:.1f}s (expected: ~{expected_delay}s)")
+
+        # Verify delay is within acceptable range (80% to 120% of expected)
+        min_delay = expected_delay * 0.8
+        max_delay = expected_delay * 1.2
+
+        if actual_delay < min_delay:
+            self.fail(f"Restart too early: {actual_delay:.1f}s < {min_delay:.1f}s")
+        elif actual_delay > max_delay:
+            self.log.warning(f"Restart delayed beyond expected: {actual_delay:.1f}s > "
+                             f"{max_delay:.1f}s (may be acceptable depending on system load)")
+        else:
+            self.log.info(f"SUCCESS: Restart delay within expected range "
+                          f"[{min_delay:.1f}s, {max_delay:.1f}s]")
+
+    def test_restart_after_clear_exclude(self):
+        """Test interaction between auto-restart and manual clear-exclude.
+
+        Test Description:
+            1. Exclude rank, wait for self-termination
+            2. Clear exclusion before auto-restart triggers
+            3. Verify rank rejoins successfully
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartAdvanced,test_restart_after_clear_exclude
+        """
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 2:
+            self.skipTest("Test requires at least 2 ranks")
+
+        test_rank = self.random.choice(all_ranks)
+
+        self.log_step(f"Step 1: Excluding rank {test_rank}")
+        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+
+        # Wait for self-termination
+        # FIXME: should this be checking for "adminexcluded" state?
+        if not self.wait_for_rank_state(test_rank, "excluded", timeout=10):
+            self.fail(f"Rank {test_rank} did not self-terminate")
+
+        # Clear exclusion before auto-restart
+        self.log_step(f"Step 2: Clearing exclusion for rank {test_rank}")
+        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
+
+        # Verify rank rejoins
+        if not self.wait_for_rank_state(test_rank, "joined", timeout=30):
+            self.fail(f"Rank {test_rank} did not rejoin after manual start")
+            self.fail(f"Rank {test_rank} did not automatically restart on admin exclusion")
+
+        self.log.info(f"SUCCESS: Rank {test_rank} successfully rejoined after clear-exclude")

--- a/src/tests/ftest/control/engine_auto_restart_advanced.py
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.py
@@ -80,14 +80,29 @@ class EngineAutoRestartAdvanced(ControlTestBase):
 
         self.log_step("Step 1: Automatic restart of rank %s", test_rank)
 
+        # Get initial incarnation
+        initial_incarnation = self.get_rank_incarnation(test_rank)
+        if initial_incarnation is None:
+            self.fail(f"Failed to get initial incarnation for rank {test_rank}")
+
         restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
 
         if not restarted:
-            self.fail("Rank %s did not automatically restart. Final state: %s"
-                      % (test_rank, final_state))
+            self.fail(f"Rank {test_rank} did not automatically restart. "
+                      f"Final state: {final_state}")
+
+        # Verify incarnation increased
+        first_restart_incarnation = self.get_rank_incarnation(test_rank)
+        if first_restart_incarnation is None:
+            self.fail(f"Failed to get incarnation after first restart for rank {test_rank}")
+
+        if first_restart_incarnation <= initial_incarnation:
+            self.fail(f"Rank {test_rank} incarnation did not increase after first restart. "
+                      f"Before: {initial_incarnation}, After: {first_restart_incarnation}")
 
         first_restart_time = time.time()
-        self.log.info("First restart completed at T=%.1f", first_restart_time)
+        self.log.info("First restart completed at T=%.1f (incarnation %s -> %s)",
+                      first_restart_time, initial_incarnation, first_restart_incarnation)
 
         # Second exclusion - should be deferred due to rate-limiting
         self.log_step("Step 2: Second exclusion of rank %s (should be deferred)", test_rank)
@@ -108,21 +123,33 @@ class EngineAutoRestartAdvanced(ControlTestBase):
         self.log_step("Step 3: Waiting %ss for deferred restart to execute", wait_time)
 
         if not self.wait_for_rank_state(test_rank, "joined", timeout=wait_time):
-            self.fail("Rank %s did not restart after rate-limit delay" % test_rank)
+            self.fail(f"Rank {test_rank} did not restart after rate-limit delay")
+
+        # Verify incarnation increased again after deferred restart
+        deferred_restart_incarnation = self.get_rank_incarnation(test_rank)
+        if deferred_restart_incarnation is None:
+            self.fail(f"Failed to get incarnation after deferred restart for rank {test_rank}")
+
+        if deferred_restart_incarnation <= first_restart_incarnation:
+            self.fail(f"Rank {test_rank} incarnation did not increase after deferred restart. "
+                      f"After first: {first_restart_incarnation}, "
+                      f"After deferred: {deferred_restart_incarnation}")
 
         self.log_step("Step 4: Measure time between initial and deferred restarts")
         deferred_restart_time = time.time()
         actual_delay = deferred_restart_time - first_restart_time
 
-        self.log.info("Confirmed: Deferred restart executed after %.1fs (expected ~%ss)",
-                      actual_delay, expected_delay)
+        self.log.info("Confirmed: Deferred restart executed after %.1fs (expected ~%ss), "
+                      "incarnation %s -> %s",
+                      actual_delay, expected_delay,
+                      first_restart_incarnation, deferred_restart_incarnation)
 
-        self.log_step("Step 5: Verify delay was approximately correct (80% to 120% of expected)")
+        self.log_step("Step 5: Verify delay was approximately correct (80%% to 120%% of expected)")
         min_delay = expected_delay * 0.8
         max_delay = expected_delay * 1.2
 
         if actual_delay < min_delay:
-            self.fail("Restart too early: %.1fs < %.1fs" % (actual_delay, min_delay))
+            self.fail(f"Restart too early: {actual_delay:.1f}s < {min_delay:.1f}s")
         elif actual_delay > max_delay:
             self.log.warning("Restart delayed beyond expected: %.1fs > %.1fs "
                              "(may be acceptable depending on system load)",

--- a/src/tests/ftest/control/engine_auto_restart_advanced.py
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.py
@@ -49,7 +49,7 @@ class EngineAutoRestartAdvanced(ControlTestBase):
         return False
 
     def test_deferred_restart(self):
-        """Test deferred restart when multiple self-terminations occur rapidly.
+        """Test deferred restart when multiple self-terminations occur rapidly. Use custom delay.
 
         Test Description:
             This test requires custom server configuration with a short
@@ -57,9 +57,11 @@ class EngineAutoRestartAdvanced(ControlTestBase):
 
             1. Exclude rank and wait for automatic restart (first restart)
             2. Immediately exclude same rank again (second self-termination)
-            3. Verify restart is deferred, not immediate
-            4. Wait for deferred restart to execute after delay expires
-            5. Verify rank successfully rejoins
+               Confirm restart is deferred, not immediate
+            3. Wait for deferred restart to execute after delay expires
+               Confirm deferred restart executes successfully and rank joined
+            4. Measure time until deferred restart executed
+            5. Verify delay matches configured value
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
@@ -67,8 +69,8 @@ class EngineAutoRestartAdvanced(ControlTestBase):
         :avocado: tags=EngineAutoRestartAdvanced,test_deferred_restart
         """
         # Get configured restart delay from test params
-        restart_delay = self.params.get("engine_auto_restart_min_delay",
-                                        "/run/server_config/*", 20)
+        expected_delay = self.params.get("engine_auto_restart_min_delay",
+                                         "/run/server_config/*", 20)
 
         all_ranks = self.get_all_ranks()
         if len(all_ranks) < 2:
@@ -102,80 +104,20 @@ class EngineAutoRestartAdvanced(ControlTestBase):
 
         # Wait for deferred restart to execute (after delay expires)
         # Add buffer time for processing
-        wait_time = restart_delay + 10
+        wait_time = expected_delay + 10
         self.log_step("Step 3: Waiting %ss for deferred restart to execute", wait_time)
 
         if not self.wait_for_rank_state(test_rank, "joined", timeout=wait_time):
             self.fail("Rank %s did not restart after rate-limit delay" % test_rank)
 
+        self.log_step("Step 4: Measure time between initial and deferred restarts")
         deferred_restart_time = time.time()
         actual_delay = deferred_restart_time - first_restart_time
 
-        self.log.info("SUCCESS: Deferred restart executed after %.1fs (expected ~%ss)",
-                      actual_delay, restart_delay)
+        self.log.info("Confirmed: Deferred restart executed after %.1fs (expected ~%ss)",
+                      actual_delay, expected_delay)
 
-        # Verify delay was approximately correct (within tolerance)
-        if actual_delay < restart_delay * 0.8:
-            self.fail("Restart occurred too early: %.1fs < %ss" % (actual_delay, restart_delay))
-
-    def test_custom_restart_delay(self):
-        """Test custom engine_auto_restart_min_delay configuration.
-
-        Test Description:
-            This test requires server configuration with custom
-            engine_auto_restart_min_delay value.
-
-            1. Exclude rank and wait for first restart
-            2. Exclude same rank again
-            3. Measure time until deferred restart executes
-            4. Verify delay matches configured value
-
-        :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium
-        :avocado: tags=dmg,control,engine_auto_restart
-        :avocado: tags=EngineAutoRestartAdvanced,test_custom_restart_delay
-        """
-        # Get configured delay from test parameters
-        expected_delay = 15
-
-        all_ranks = self.get_all_ranks()
-        if len(all_ranks) < 2:
-            self.skipTest("Test requires at least 2 ranks")
-
-        test_rank = self.random.choice(all_ranks)
-
-        self.log_step("Testing custom restart delay of %s s for rank %s",
-                      expected_delay, test_rank)
-
-        # First restart to establish baseline
-        self.log_step("Step 1: First exclusion and restart")
-
-        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank)
-
-        if not restarted:
-            self.fail("Rank %s did not automatically restart. Final state: %s"
-                      % (test_rank, final_state))
-
-        first_restart_time = time.time()
-
-        # Second restart to measure delay and wait for deferred restart
-        self.log_step("Step 2: Wait for deferred restart (expected delay: %ss)",
-                      expected_delay)
-
-        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank,
-                                                                    timeout=35)
-
-        if not restarted:
-            self.fail("Rank %s did not automatically restart again. Final state: %s"
-                      % (test_rank, final_state))
-
-        second_restart_time = time.time()
-        actual_delay = second_restart_time - first_restart_time
-
-        self.log.info("Measured delay: %.1fs (expected: ~%ss)", actual_delay,
-                      expected_delay)
-
-        # Verify delay is within acceptable range (80% to 120% of expected)
+        self.log_step("Step 5: Verify delay was approximately correct (80% to 120% of expected)")
         min_delay = expected_delay * 0.8
         max_delay = expected_delay * 1.2
 

--- a/src/tests/ftest/control/engine_auto_restart_advanced.py
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.py
@@ -145,7 +145,7 @@ class EngineAutoRestartAdvanced(ControlTestBase):
         test_rank = self.random.choice(all_ranks)
 
         self.log_step("Testing custom restart delay of %s s for rank %s",
-                      (expected_delay, test_rank))
+                      expected_delay, test_rank)
 
         # First restart to establish baseline
         self.log_step("Step 1: First exclusion and restart")

--- a/src/tests/ftest/control/engine_auto_restart_advanced.py
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.py
@@ -1,0 +1,264 @@
+"""
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+import time
+
+from control_test_base import ControlTestBase
+
+
+class EngineAutoRestartAdvanced(ControlTestBase):
+    """Test advanced automatic engine restart scenarios.
+
+    Test Class Description:
+        Verify automatic engine restart with custom configurations including
+        rate-limiting, deferred restarts, and disabled restart behavior.
+
+    :avocado: recursive
+    """
+
+    def setUp(self):
+        """Set up each test case."""
+        super().setUp()
+        self.dmg = self.get_dmg_command()
+
+    def get_all_ranks(self):
+        """Get list of all ranks in the system."""
+        return list(self.server_managers[0].ranks.keys())
+
+    def get_rank_state(self, rank):
+        """Get the state of a rank.
+
+        Args:
+            rank (int): Rank number
+
+        Returns:
+            str: Current state of the rank
+        """
+        data = self.dmg.system_query(ranks=f"{rank}")
+        if data["status"] != 0:
+            self.fail("Cmd dmg system query failed")
+        if "response" in data and "members" in data["response"]:
+            if data["response"]["members"] is None:
+                self.fail("No members returned from dmg system query")
+            for member in data["response"]["members"]:
+                return member["state"].lower()
+        self.fail("No member state returned from dmg system query")
+        return None
+
+    def wait_for_rank_state(self, rank, expected_state, timeout=30, check_interval=2):
+        """Wait for a rank to reach expected state.
+
+        Args:
+            rank (int): Rank number
+            expected_state (str): Expected state
+            timeout (int): Maximum seconds to wait
+            check_interval (int): Seconds between state checks
+
+        Returns:
+            bool: True if state reached, False if timeout
+        """
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            failed_ranks = self.server_managers[0].check_rank_state(
+                ranks=[rank], valid_states=[expected_state], max_checks=1)
+
+            if not failed_ranks:
+                self.log.info("Rank %s reached state '%s' after %.1fs",
+                              rank, expected_state, time.time() - start_time)
+                return True
+
+            time.sleep(check_interval)
+
+        current_state = self.get_rank_state(rank)
+        self.log.warning("Rank %s did not reach '%s' within %ss. Current state: %s",
+                         rank, expected_state, timeout, current_state)
+        return False
+
+    def test_deferred_restart(self):
+        """Test deferred restart when multiple self-terminations occur rapidly.
+
+        Test Description:
+            This test requires custom server configuration with a short
+            engine_auto_restart_min_delay (e.g., 15 seconds) to avoid long test runtime.
+
+            1. Exclude rank and wait for automatic restart (first restart)
+            2. Immediately exclude same rank again (second self-termination)
+            3. Verify restart is deferred, not immediate
+            4. Wait for deferred restart to execute after delay expires
+            5. Verify rank successfully rejoins
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartAdvanced,test_deferred_restart
+        """
+        # Get configured restart delay from test params
+        restart_delay = self.params.get("engine_auto_restart_min_delay", "/run/server_config/*", 15)
+
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 2:
+            self.skipTest("Test requires at least 2 ranks")
+
+        test_rank = self.random.choice(all_ranks)
+
+        # First exclusion - should restart immediately (no previous restart)
+        self.log_step("Step 1: First exclusion of rank %s", test_rank)
+        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+
+        # Wait for self-termination
+        if not self.wait_for_rank_state(test_rank, "excluded", timeout=10):
+            self.fail("Rank %s did not self-terminate" % test_rank)
+
+        # Wait for automatic restart
+        self.log_step("Step 2: Waiting for first automatic restart of rank %s", test_rank)
+        if not self.wait_for_rank_state(test_rank, "joined", timeout=30):
+            self.fail("Rank %s did not automatically restart on first exclusion" % test_rank)
+
+        first_restart_time = time.time()
+        self.log.info("First restart completed at T=%.1f", first_restart_time)
+
+        # Second exclusion - should be deferred due to rate-limiting
+        self.log_step("Step 3: Second exclusion of rank %s (should be deferred)", test_rank)
+        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+
+        # Wait for self-termination
+        if not self.wait_for_rank_state(test_rank, "excluded", timeout=10):
+            self.fail("Rank %s did not self-terminate on second exclusion" % test_rank)
+
+        # Verify restart is NOT immediate (should be deferred)
+        self.log_step("Step 4: Verifying restart is deferred (not immediate)")
+        time.sleep(5)  # Wait a bit
+
+        current_state = self.get_rank_state(test_rank)
+        if current_state == "joined":
+            self.fail("Rank %s restarted immediately - rate-limiting not working" % test_rank)
+
+        self.log.info("Confirmed: Restart is deferred (rank still in '%s' state)",
+                      current_state)
+
+        # Wait for deferred restart to execute (after delay expires)
+        # Add buffer time for processing
+        wait_time = restart_delay + 10
+        self.log_step("Step 5: Waiting %ss for deferred restart to execute", wait_time)
+
+        if not self.wait_for_rank_state(test_rank, "joined", timeout=wait_time):
+            self.fail("Rank %s did not restart after rate-limit delay" % test_rank)
+
+        deferred_restart_time = time.time()
+        actual_delay = deferred_restart_time - first_restart_time
+
+        self.log.info("SUCCESS: Deferred restart executed after %.1fs (expected ~%ss)",
+                      actual_delay, restart_delay)
+
+        # Verify delay was approximately correct (within tolerance)
+        if actual_delay < restart_delay * 0.8:
+            self.fail("Restart occurred too early: %.1fs < %ss" % (actual_delay, restart_delay))
+
+    def test_custom_restart_delay(self):
+        """Test custom engine_auto_restart_min_delay configuration.
+
+        Test Description:
+            This test requires server configuration with custom
+            engine_auto_restart_min_delay value.
+
+            1. Exclude rank and wait for first restart
+            2. Exclude same rank again
+            3. Measure time until deferred restart executes
+            4. Verify delay matches configured value
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartAdvanced,test_custom_restart_delay
+        """
+        # Get configured delay from test parameters
+        expected_delay = self.params.get("engine_auto_restart_min_delay",
+                                         "/run/server_config/*", 20)
+
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 2:
+            self.skipTest("Test requires at least 2 ranks")
+
+        test_rank = self.random.choice(all_ranks)
+
+        self.log_step("Testing custom restart delay of %ss for rank %s",
+                      expected_delay, test_rank)
+
+        # First restart to establish baseline
+        self.log_step("Step 1: First exclusion and restart")
+        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+        self.wait_for_rank_state(test_rank, "excluded", timeout=10)
+        self.wait_for_rank_state(test_rank, "joined", timeout=30)
+
+        first_restart_time = time.time()
+
+        # Second restart to measure delay
+        self.log_step("Step 2: Second exclusion to trigger deferred restart")
+        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+        self.wait_for_rank_state(test_rank, "excluded", timeout=10)
+
+        # Wait for deferred restart
+        self.log_step("Step 3: Waiting for deferred restart (expected delay: %ss)",
+                      expected_delay)
+        wait_timeout = expected_delay + 20  # Add buffer
+
+        if not self.wait_for_rank_state(test_rank, "joined", timeout=wait_timeout):
+            self.fail("Rank %s did not restart within expected time" % test_rank)
+
+        second_restart_time = time.time()
+        actual_delay = second_restart_time - first_restart_time
+
+        self.log.info("Measured delay: %.1fs (expected: ~%ss)", actual_delay, expected_delay)
+
+        # Verify delay is within acceptable range (80% to 120% of expected)
+        min_delay = expected_delay * 0.8
+        max_delay = expected_delay * 1.2
+
+        if actual_delay < min_delay:
+            self.fail("Restart too early: %.1fs < %.1fs" % (actual_delay, min_delay))
+        elif actual_delay > max_delay:
+            self.log.warning("Restart delayed beyond expected: %.1fs > %.1fs "
+                             "(may be acceptable depending on system load)",
+                             actual_delay, max_delay)
+        else:
+            self.log.info("SUCCESS: Restart delay within expected range [%.1fs, %.1fs]",
+                          min_delay, max_delay)
+
+    def test_restart_after_clear_exclude(self):
+        """Test interaction between auto-restart and manual clear-exclude.
+
+        Test Description:
+            1. Exclude rank, wait for self-termination
+            2. Clear exclusion before auto-restart triggers
+            3. Verify rank rejoins successfully
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartAdvanced,test_restart_after_clear_exclude
+        """
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 2:
+            self.skipTest("Test requires at least 2 ranks")
+
+        test_rank = self.random.choice(all_ranks)
+
+        self.log_step("Step 1: Excluding rank %s", test_rank)
+        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+
+        # Wait for self-termination
+        if not self.wait_for_rank_state(test_rank, "excluded", timeout=10):
+            self.fail("Rank %s did not self-terminate" % test_rank)
+
+        # Clear exclusion before auto-restart
+        self.log_step("Step 2: Clearing exclusion for rank %s", test_rank)
+        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
+
+        # Verify rank rejoins
+        if not self.wait_for_rank_state(test_rank, "joined", timeout=30):
+            self.fail("Rank %s did not rejoin after clear-exclude" % test_rank)
+
+        self.log.info("SUCCESS: Rank %s successfully rejoined after clear-exclude", test_rank)

--- a/src/tests/ftest/control/engine_auto_restart_advanced.yaml
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.yaml
@@ -3,7 +3,6 @@ hosts:
 server_config:
   name: daos_server
   engines_per_host: 2
-  # Custom restart delay for faster testing (15 seconds instead of default 300)
   engine_auto_restart_min_delay: 15
   engines:
     0:

--- a/src/tests/ftest/control/engine_auto_restart_advanced.yaml
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.yaml
@@ -3,7 +3,7 @@ hosts:
 server_config:
   name: daos_server
   engines_per_host: 2
-  engine_auto_restart_min_delay: 20
+  engine_auto_restart_min_delay: 30
   engines:
     0:
       log_file: daos_server0.log

--- a/src/tests/ftest/control/engine_auto_restart_advanced.yaml
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.yaml
@@ -1,0 +1,27 @@
+hosts:
+  test_servers: 1
+server_config:
+  name: daos_server
+  engines_per_host: 2
+  # Custom restart delay for faster testing (15 seconds instead of default 300)
+  engine_auto_restart_min_delay: 15
+  engines:
+    0:
+      log_file: daos_server0.log
+      targets: 4
+      nr_xs_helpers: 0
+      storage:
+        0:
+          class: ram
+          scm_mount: /mnt/daos0
+    1:
+      log_file: daos_server1.log
+      targets: 4
+      nr_xs_helpers: 0
+      storage:
+        0:
+          class: ram
+          scm_mount: /mnt/daos1
+pool:
+  size: 8G
+timeout: 400

--- a/src/tests/ftest/control/engine_auto_restart_advanced.yaml
+++ b/src/tests/ftest/control/engine_auto_restart_advanced.yaml
@@ -3,7 +3,7 @@ hosts:
 server_config:
   name: daos_server
   engines_per_host: 2
-  engine_auto_restart_min_delay: 15
+  engine_auto_restart_min_delay: 20
   engines:
     0:
       log_file: daos_server0.log

--- a/src/tests/ftest/control/engine_auto_restart_disabled.py
+++ b/src/tests/ftest/control/engine_auto_restart_disabled.py
@@ -93,7 +93,7 @@ class EngineAutoRestartDisabled(ControlTestBase):
         num_to_test = max(2, len(all_ranks) // 2)
         test_ranks = self.random.sample(all_ranks, num_to_test)
 
-        self.log_step("Step 1: Excluding %s ranks: %s", num_to_test, test_ranks)
+        self.log_step("Step 1: Excluding %s ranks: %s", (num_to_test, test_ranks))
 
         for rank in test_ranks:
             self.dmg.system_exclude(ranks=[rank], rank_hosts=None)

--- a/src/tests/ftest/control/engine_auto_restart_disabled.py
+++ b/src/tests/ftest/control/engine_auto_restart_disabled.py
@@ -19,6 +19,18 @@ class EngineAutoRestartDisabled(ControlTestBase):
     :avocado: recursive
     """
 
+    def tearDown(self):
+        """Clean up after each test method."""
+        # Reset restart state for next test method
+        # This ensures clean state between sequential tests
+        try:
+            self.reset_engine_restart_state()
+        except Exception as error:
+            self.log.error("Failed to reset engine restart state: %s", error)
+            self.fail("tearDown failed to reset engine restart state: {}".format(error))
+        finally:
+            super().tearDown()
+
     def test_no_restart_when_disabled(self):
         """Test that engines do not automatically restart when feature is disabled.
 

--- a/src/tests/ftest/control/engine_auto_restart_disabled.py
+++ b/src/tests/ftest/control/engine_auto_restart_disabled.py
@@ -56,16 +56,12 @@ class EngineAutoRestartDisabled(ControlTestBase):
 
         self.log_step("Step 1: Excluding rank %s (auto-restart is DISABLED)", test_rank)
 
-        restarted, _ = self.exclude_rank_and_wait_restart(test_rank,
-                                                          expect_restart=False,
-                                                          timeout=35)
+        restarted, _ = self.exclude_rank_and_wait_restart(test_rank, timeout=35)
 
         if restarted:
-            self.fail("Rank %s unexpectedly restarted when auto-restart disabled!"
-                      % test_rank)
+            self.fail("Rank %s unexpectedly restarted when auto-restart disabled!" % test_rank)
 
-        self.log.info("Confirmed: Rank %s did NOT automatically restart (as expected)",
-                      test_rank)
+        self.log.info("Confirmed: Rank %s did NOT automatically restart (as expected)", test_rank)
 
         # Step 4: Manually start the rank
         self.log_step("Step 2: Manually starting rank %s", test_rank)
@@ -77,8 +73,8 @@ class EngineAutoRestartDisabled(ControlTestBase):
         if failed_ranks:
             self.fail("Manual start of rank %s failed" % test_rank)
 
-        self.log.info("SUCCESS: Rank %s stayed excluded when auto-restart disabled, "
-                      "and manual start succeeded", test_rank)
+        self.log.info("SUCCESS: Rank %s stayed excluded when auto-restart disabled, and manual "
+                      "start succeeded", test_rank)
 
     def test_multiple_ranks_no_restart(self):
         """Test that multiple excluded ranks stay excluded when auto-restart disabled.

--- a/src/tests/ftest/control/engine_auto_restart_disabled.py
+++ b/src/tests/ftest/control/engine_auto_restart_disabled.py
@@ -1,0 +1,184 @@
+"""
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+import time
+
+from control_test_base import ControlTestBase
+from general_utils import report_errors
+
+
+class EngineAutoRestartDisabled(ControlTestBase):
+    """Test automatic engine restart disabled configuration.
+
+    Test Class Description:
+        Verify that automatic engine restart can be disabled and that
+        excluded ranks stay excluded when auto-restart is disabled.
+
+    :avocado: recursive
+    """
+
+    def setUp(self):
+        """Set up each test case."""
+        super().setUp()
+        self.dmg = self.get_dmg_command()
+
+    def get_all_ranks(self):
+        """Get list of all ranks in the system."""
+        return list(self.server_managers[0].ranks.keys())
+
+    def test_no_restart_when_disabled(self):
+        """Test that engines do not automatically restart when feature is disabled.
+
+        Test Description:
+            Server is configured with disable_engine_auto_restart: true.
+
+            1. Exclude a rank from the system
+            2. Wait for rank to self-terminate
+            3. Wait additional time to verify NO automatic restart occurs
+            4. Manually start the rank to verify it can still be started
+            5. Verify manual start succeeds
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartDisabled,test_no_restart_when_disabled
+        """
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 2:
+            self.skipTest("Test requires at least 2 ranks")
+
+        test_rank = self.random.choice(all_ranks)
+
+        self.log_step("Step 1: Excluding rank %s (auto-restart is DISABLED)", test_rank)
+        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+
+        # Step 2: Wait for self-termination
+        self.log_step("Step 2: Waiting for rank %s to self-terminate", test_rank)
+        time.sleep(5)
+
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[test_rank], valid_states=["excluded"], max_checks=10)
+        if failed_ranks:
+            self.fail("Rank %s did not reach Excluded state" % test_rank)
+
+        # Step 3: Wait to verify NO automatic restart
+        wait_time = 20  # Wait 20 seconds
+        self.log_step("Step 3: Waiting %ss to verify NO automatic restart occurs", wait_time)
+        time.sleep(wait_time)
+
+        # Verify rank is still excluded
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[test_rank], valid_states=["excluded"], max_checks=1)
+
+        if failed_ranks:
+            # Rank is NOT excluded, check if it restarted
+            check_joined = self.server_managers[0].check_rank_state(
+                ranks=[test_rank], valid_states=["joined"], max_checks=1)
+            if not check_joined:
+                self.fail("Rank %s unexpectedly restarted when auto-restart disabled!"
+                          % test_rank)
+            else:
+                self.fail("Rank %s in unexpected state (not excluded or joined)" % test_rank)
+
+        self.log.info("Confirmed: Rank %s did NOT automatically restart (as expected)",
+                      test_rank)
+
+        # Step 4: Manually clear exclusion
+        self.log_step("Step 4: Manually clearing exclusion for rank %s", test_rank)
+        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
+
+        # Step 5: Manually start the rank
+        self.log_step("Step 5: Manually starting rank %s", test_rank)
+        self.dmg.system_start(ranks=f"{test_rank}")
+
+        # Verify manual start succeeds
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[test_rank], valid_states=["joined"], max_checks=15)
+        if failed_ranks:
+            self.fail("Manual start of rank %s failed" % test_rank)
+
+        self.log.info("SUCCESS: Rank %s stayed excluded when auto-restart disabled, "
+                      "and manual start succeeded", test_rank)
+
+    def test_multiple_ranks_no_restart(self):
+        """Test that multiple excluded ranks stay excluded when auto-restart disabled.
+
+        Test Description:
+            Server configured with disable_engine_auto_restart: true.
+
+            1. Exclude multiple ranks
+            2. Verify all self-terminate and reach Excluded state
+            3. Wait to confirm none automatically restart
+            4. Manually restart all ranks
+            5. Verify all successfully rejoin
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartDisabled,test_multiple_ranks_no_restart
+        """
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 3:
+            self.skipTest("Test requires at least 3 ranks")
+
+        # Exclude half the ranks
+        num_to_test = max(2, len(all_ranks) // 2)
+        test_ranks = self.random.sample(all_ranks, num_to_test)
+
+        self.log_step("Step 1: Excluding %s ranks: %s", num_to_test, test_ranks)
+
+        for rank in test_ranks:
+            self.dmg.system_exclude(ranks=[rank], rank_hosts=None)
+            time.sleep(1)  # Small delay between exclusions
+
+        # Step 2: Verify all reach Excluded state
+        self.log_step("Step 2: Verifying all ranks self-terminate")
+        time.sleep(10)
+
+        for rank in test_ranks:
+            failed = self.server_managers[0].check_rank_state(
+                ranks=[rank], valid_states=["excluded"], max_checks=5)
+            if failed:
+                self.fail("Rank %s did not self-terminate" % rank)
+
+        # Step 3: Wait and verify none restart
+        wait_time = 20
+        self.log_step("Step 3: Waiting %ss to verify no automatic restarts", wait_time)
+        time.sleep(wait_time)
+
+        errors = []
+        for rank in test_ranks:
+            failed = self.server_managers[0].check_rank_state(
+                ranks=[rank], valid_states=["excluded"], max_checks=1)
+            if failed:
+                errors.append("Rank %s unexpectedly restarted when auto-restart disabled"
+                              % rank)
+
+        if errors:
+            self.fail("\n".join(errors))
+
+        self.log.info("Confirmed: None of %s automatically restarted", test_ranks)
+
+        # Step 4: Manually clear and restart all
+        self.log_step("Step 4: Manually clearing exclusion and restarting ranks")
+        self.dmg.system_clear_exclude(ranks=test_ranks, rank_hosts=None)
+
+        for rank in test_ranks:
+            self.dmg.system_start(ranks=f"{rank}")
+
+        # Step 5: Verify all rejoin
+        self.log_step("Step 5: Verifying all ranks successfully rejoin")
+        time.sleep(10)
+
+        for rank in test_ranks:
+            failed = self.server_managers[0].check_rank_state(
+                ranks=[rank], valid_states=["joined"], max_checks=10)
+            if failed:
+                errors.append("Manual restart of rank %s failed" % rank)
+
+        report_errors(test=self, errors=errors)
+
+        self.log.info("SUCCESS: All %s ranks stayed excluded and manual restart succeeded",
+                      num_to_test)

--- a/src/tests/ftest/control/engine_auto_restart_disabled.py
+++ b/src/tests/ftest/control/engine_auto_restart_disabled.py
@@ -19,15 +19,6 @@ class EngineAutoRestartDisabled(ControlTestBase):
     :avocado: recursive
     """
 
-    def setUp(self):
-        """Set up each test case."""
-        super().setUp()
-        self.dmg = self.get_dmg_command()
-
-    def get_all_ranks(self):
-        """Get list of all ranks in the system."""
-        return list(self.server_managers[0].ranks.keys())
-
     def test_no_restart_when_disabled(self):
         """Test that engines do not automatically restart when feature is disabled.
 
@@ -52,43 +43,20 @@ class EngineAutoRestartDisabled(ControlTestBase):
         test_rank = self.random.choice(all_ranks)
 
         self.log_step("Step 1: Excluding rank %s (auto-restart is DISABLED)", test_rank)
-        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
 
-        # Step 2: Wait for self-termination
-        self.log_step("Step 2: Waiting for rank %s to self-terminate", test_rank)
-        time.sleep(5)
+        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank,
+                                                                    expect_restart=False,
+                                                                    timeout=35)
 
-        failed_ranks = self.server_managers[0].check_rank_state(
-            ranks=[test_rank], valid_states=["adminexcluded"], max_checks=10)
-        if failed_ranks:
-            self.fail("Rank %s did not reach adminexcluded state" % test_rank)
-
-        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
-
-        # Step 3: Wait to verify NO automatic restart
-        wait_time = 20  # Wait 20 seconds
-        self.log_step("Step 3: Waiting %ss to verify NO automatic restart occurs", wait_time)
-        time.sleep(wait_time)
-
-        # Verify rank is still excluded
-        failed_ranks = self.server_managers[0].check_rank_state(
-            ranks=[test_rank], valid_states=["excluded"], max_checks=1)
-
-        if failed_ranks:
-            # Rank is NOT excluded, check if it restarted
-            check_joined = self.server_managers[0].check_rank_state(
-                ranks=[test_rank], valid_states=["joined"], max_checks=1)
-            if not check_joined:
-                self.fail("Rank %s unexpectedly restarted when auto-restart disabled!"
-                          % test_rank)
-            else:
-                self.fail("Rank %s in unexpected state (not excluded or joined)" % test_rank)
+        if restarted:
+            self.fail("Rank %s unexpectedly restarted when auto-restart disabled!"
+                      % test_rank)
 
         self.log.info("Confirmed: Rank %s did NOT automatically restart (as expected)",
                       test_rank)
 
         # Step 4: Manually start the rank
-        self.log_step("Step 5: Manually starting rank %s", test_rank)
+        self.log_step("Step 2: Manually starting rank %s", test_rank)
         self.dmg.system_start(ranks=f"{test_rank}")
 
         # Verify manual start succeeds

--- a/src/tests/ftest/control/engine_auto_restart_disabled.py
+++ b/src/tests/ftest/control/engine_auto_restart_disabled.py
@@ -59,9 +59,11 @@ class EngineAutoRestartDisabled(ControlTestBase):
         time.sleep(5)
 
         failed_ranks = self.server_managers[0].check_rank_state(
-            ranks=[test_rank], valid_states=["excluded"], max_checks=10)
+            ranks=[test_rank], valid_states=["adminexcluded"], max_checks=10)
         if failed_ranks:
-            self.fail("Rank %s did not reach Excluded state" % test_rank)
+            self.fail("Rank %s did not reach adminexcluded state" % test_rank)
+
+        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
 
         # Step 3: Wait to verify NO automatic restart
         wait_time = 20  # Wait 20 seconds
@@ -85,11 +87,7 @@ class EngineAutoRestartDisabled(ControlTestBase):
         self.log.info("Confirmed: Rank %s did NOT automatically restart (as expected)",
                       test_rank)
 
-        # Step 4: Manually clear exclusion
-        self.log_step("Step 4: Manually clearing exclusion for rank %s", test_rank)
-        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
-
-        # Step 5: Manually start the rank
+        # Step 4: Manually start the rank
         self.log_step("Step 5: Manually starting rank %s", test_rank)
         self.dmg.system_start(ranks=f"{test_rank}")
 
@@ -109,7 +107,7 @@ class EngineAutoRestartDisabled(ControlTestBase):
             Server configured with disable_engine_auto_restart: true.
 
             1. Exclude multiple ranks
-            2. Verify all self-terminate and reach Excluded state
+            2. Verify all self-terminate and reach AdminExcluded state
             3. Wait to confirm none automatically restart
             4. Manually restart all ranks
             5. Verify all successfully rejoin
@@ -127,21 +125,22 @@ class EngineAutoRestartDisabled(ControlTestBase):
         num_to_test = max(2, len(all_ranks) // 2)
         test_ranks = self.random.sample(all_ranks, num_to_test)
 
-        self.log_step("Step 1: Excluding %s ranks: %s", num_to_test, test_ranks)
+        self.log_step("Step 1: Excluding %s ranks: %s", (num_to_test, test_ranks))
 
         for rank in test_ranks:
             self.dmg.system_exclude(ranks=[rank], rank_hosts=None)
             time.sleep(1)  # Small delay between exclusions
 
-        # Step 2: Verify all reach Excluded state
+        # Step 2: Verify all reach adminexcluded state
         self.log_step("Step 2: Verifying all ranks self-terminate")
         time.sleep(10)
 
         for rank in test_ranks:
             failed = self.server_managers[0].check_rank_state(
-                ranks=[rank], valid_states=["excluded"], max_checks=5)
+                ranks=[rank], valid_states=["adminexcluded"], max_checks=5)
             if failed:
                 self.fail("Rank %s did not self-terminate" % rank)
+            self.dmg.system_clear_exclude(ranks=[rank], rank_hosts=None)
 
         # Step 3: Wait and verify none restart
         wait_time = 20
@@ -161,9 +160,8 @@ class EngineAutoRestartDisabled(ControlTestBase):
 
         self.log.info("Confirmed: None of %s automatically restarted", test_ranks)
 
-        # Step 4: Manually clear and restart all
-        self.log_step("Step 4: Manually clearing exclusion and restarting ranks")
-        self.dmg.system_clear_exclude(ranks=test_ranks, rank_hosts=None)
+        # Step 4: Manually restart all
+        self.log_step("Step 4: Manually restart ranks")
 
         for rank in test_ranks:
             self.dmg.system_start(ranks=f"{rank}")

--- a/src/tests/ftest/control/engine_auto_restart_disabled.py
+++ b/src/tests/ftest/control/engine_auto_restart_disabled.py
@@ -1,0 +1,181 @@
+"""
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+import time
+
+from control_test_base import ControlTestBase
+from general_utils import report_errors
+
+
+class EngineAutoRestartDisabled(ControlTestBase):
+    """Test automatic engine restart disabled configuration.
+
+    Test Class Description:
+        Verify that automatic engine restart can be disabled and that
+        excluded ranks stay excluded when auto-restart is disabled.
+
+    :avocado: recursive
+    """
+
+    def setUp(self):
+        """Set up each test case."""
+        super().setUp()
+        self.dmg = self.get_dmg_command()
+
+    def get_all_ranks(self):
+        """Get list of all ranks in the system."""
+        return list(self.server_managers[0].ranks.keys())
+
+    def test_no_restart_when_disabled(self):
+        """Test that engines do not automatically restart when feature is disabled.
+
+        Test Description:
+            Server is configured with disable_engine_auto_restart: true.
+
+            1. Exclude a rank from the system
+            2. Wait for rank to self-terminate
+            3. Wait additional time to verify NO automatic restart occurs
+            4. Manually start the rank to verify it can still be started
+            5. Verify manual start succeeds
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartDisabled,test_no_restart_when_disabled
+        """
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 2:
+            self.skipTest("Test requires at least 2 ranks")
+
+        test_rank = self.random.choice(all_ranks)
+
+        self.log_step(f"Step 1: Excluding rank {test_rank} (auto-restart is DISABLED)")
+        self.dmg.system_exclude(ranks=[test_rank], rank_hosts=None)
+
+        # Step 2: Wait for self-termination
+        self.log_step(f"Step 2: Waiting for rank {test_rank} to self-terminate")
+        time.sleep(5)
+
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[test_rank], valid_states=["excluded"], max_checks=10)
+        if failed_ranks:
+            self.fail(f"Rank {test_rank} did not reach Excluded state")
+
+        # Step 3: Wait to verify NO automatic restart
+        wait_time = 20  # Wait 20 seconds
+        self.log_step(f"Step 3: Waiting {wait_time}s to verify NO automatic restart occurs")
+        time.sleep(wait_time)
+
+        # Verify rank is still excluded
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[test_rank], valid_states=["excluded"], max_checks=1)
+
+        if failed_ranks:
+            # Rank is NOT excluded, check if it restarted
+            check_joined = self.server_managers[0].check_rank_state(
+                ranks=[test_rank], valid_states=["joined"], max_checks=1)
+            if not check_joined:
+                self.fail(f"Rank {test_rank} unexpectedly restarted when auto-restart disabled!")
+            else:
+                self.fail(f"Rank {test_rank} in unexpected state (not excluded or joined)")
+
+        self.log.info(f"Confirmed: Rank {test_rank} did NOT automatically restart (as expected)")
+
+        # Step 4: Manually clear exclusion
+        self.log_step(f"Step 4: Manually clearing exclusion for rank {test_rank}")
+        self.dmg.system_clear_exclude(ranks=[test_rank], rank_hosts=None)
+
+        # Step 5: Manually start the rank
+        self.log_step(f"Step 5: Manually starting rank {test_rank}")
+        self.dmg.system_start(ranks=f"{test_rank}")
+
+        # Verify manual start succeeds
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[test_rank], valid_states=["joined"], max_checks=15)
+        if failed_ranks:
+            self.fail(f"Manual start of rank {test_rank} failed")
+
+        self.log.info(f"SUCCESS: Rank {test_rank} stayed excluded when auto-restart disabled, "
+                      f"and manual start succeeded")
+
+    def test_multiple_ranks_no_restart(self):
+        """Test that multiple excluded ranks stay excluded when auto-restart disabled.
+
+        Test Description:
+            Server configured with disable_engine_auto_restart: true.
+
+            1. Exclude multiple ranks
+            2. Verify all self-terminate and reach Excluded state
+            3. Wait to confirm none automatically restart
+            4. Manually restart all ranks
+            5. Verify all successfully rejoin
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=dmg,control,engine_auto_restart
+        :avocado: tags=EngineAutoRestartDisabled,test_multiple_ranks_no_restart
+        """
+        all_ranks = self.get_all_ranks()
+        if len(all_ranks) < 3:
+            self.skipTest("Test requires at least 3 ranks")
+
+        # Exclude half the ranks
+        num_to_test = max(2, len(all_ranks) // 2)
+        test_ranks = self.random.sample(all_ranks, num_to_test)
+
+        self.log_step(f"Step 1: Excluding {num_to_test} ranks: {test_ranks}")
+
+        for rank in test_ranks:
+            self.dmg.system_exclude(ranks=[rank], rank_hosts=None)
+            time.sleep(1)  # Small delay between exclusions
+
+        # Step 2: Verify all reach Excluded state
+        self.log_step("Step 2: Verifying all ranks self-terminate")
+        time.sleep(10)
+
+        for rank in test_ranks:
+            failed = self.server_managers[0].check_rank_state(
+                ranks=[rank], valid_states=["excluded"], max_checks=5)
+            if failed:
+                self.fail(f"Rank {rank} did not self-terminate")
+
+        # Step 3: Wait and verify none restart
+        wait_time = 20
+        self.log_step(f"Step 3: Waiting {wait_time}s to verify no automatic restarts")
+        time.sleep(wait_time)
+
+        errors = []
+        for rank in test_ranks:
+            failed = self.server_managers[0].check_rank_state(
+                ranks=[rank], valid_states=["excluded"], max_checks=1)
+            if failed:
+                errors.append(f"Rank {rank} unexpectedly restarted when auto-restart disabled")
+
+        if errors:
+            self.fail("\n".join(errors))
+
+        self.log.info(f"Confirmed: None of {test_ranks} automatically restarted")
+
+        # Step 4: Manually clear and restart all
+        self.log_step("Step 4: Manually clearing exclusion and restarting ranks")
+        self.dmg.system_clear_exclude(ranks=test_ranks, rank_hosts=None)
+
+        for rank in test_ranks:
+            self.dmg.system_start(ranks=f"{rank}")
+
+        # Step 5: Verify all rejoin
+        self.log_step("Step 5: Verifying all ranks successfully rejoin")
+        time.sleep(10)
+
+        for rank in test_ranks:
+            failed = self.server_managers[0].check_rank_state(
+                ranks=[rank], valid_states=["joined"], max_checks=10)
+            if failed:
+                errors.append(f"Manual restart of rank {rank} failed")
+
+        report_errors(test=self, errors=errors)
+
+        self.log.info(f"SUCCESS: All {num_to_test} ranks stayed excluded and "
+                      f"manual restart succeeded")

--- a/src/tests/ftest/control/engine_auto_restart_disabled.py
+++ b/src/tests/ftest/control/engine_auto_restart_disabled.py
@@ -44,9 +44,9 @@ class EngineAutoRestartDisabled(ControlTestBase):
 
         self.log_step("Step 1: Excluding rank %s (auto-restart is DISABLED)", test_rank)
 
-        restarted, final_state = self.exclude_rank_and_wait_restart(test_rank,
-                                                                    expect_restart=False,
-                                                                    timeout=35)
+        restarted, _ = self.exclude_rank_and_wait_restart(test_rank,
+                                                          expect_restart=False,
+                                                          timeout=35)
 
         if restarted:
             self.fail("Rank %s unexpectedly restarted when auto-restart disabled!"
@@ -93,21 +93,21 @@ class EngineAutoRestartDisabled(ControlTestBase):
         num_to_test = max(2, len(all_ranks) // 2)
         test_ranks = self.random.sample(all_ranks, num_to_test)
 
-        self.log_step("Step 1: Excluding %s ranks: %s", (num_to_test, test_ranks))
+        self.log_step("Step 1: Excluding %s ranks: %s", num_to_test, test_ranks)
 
         for rank in test_ranks:
             self.dmg.system_exclude(ranks=[rank], rank_hosts=None)
             time.sleep(1)  # Small delay between exclusions
 
         # Step 2: Verify all reach adminexcluded state
-        self.log_step("Step 2: Verifying all ranks self-terminate")
+        self.log_step("Step 2: Verifying all ranks get excluded from system")
         time.sleep(10)
 
         for rank in test_ranks:
             failed = self.server_managers[0].check_rank_state(
                 ranks=[rank], valid_states=["adminexcluded"], max_checks=5)
             if failed:
-                self.fail("Rank %s did not self-terminate" % rank)
+                self.fail("Rank %s did not get excluded from system" % rank)
             self.dmg.system_clear_exclude(ranks=[rank], rank_hosts=None)
 
         # Step 3: Wait and verify none restart

--- a/src/tests/ftest/control/engine_auto_restart_disabled.yaml
+++ b/src/tests/ftest/control/engine_auto_restart_disabled.yaml
@@ -1,9 +1,8 @@
 hosts:
-  test_servers: 1
+  test_servers: 2
 server_config:
   name: daos_server
   engines_per_host: 2
-  # Disable automatic engine restart
   disable_engine_auto_restart: true
   engines:
     0:

--- a/src/tests/ftest/control/engine_auto_restart_disabled.yaml
+++ b/src/tests/ftest/control/engine_auto_restart_disabled.yaml
@@ -1,0 +1,27 @@
+hosts:
+  test_servers: 1
+server_config:
+  name: daos_server
+  engines_per_host: 2
+  # Disable automatic engine restart
+  disable_engine_auto_restart: true
+  engines:
+    0:
+      log_file: daos_server0.log
+      targets: 4
+      nr_xs_helpers: 0
+      storage:
+        0:
+          class: ram
+          scm_mount: /mnt/daos0
+    1:
+      log_file: daos_server1.log
+      targets: 4
+      nr_xs_helpers: 0
+      storage:
+        0:
+          class: ram
+          scm_mount: /mnt/daos1
+pool:
+  size: 8G
+timeout: 300

--- a/src/tests/ftest/util/control_test_base.py
+++ b/src/tests/ftest/util/control_test_base.py
@@ -193,3 +193,43 @@ class ControlTestBase(TestWithServers):
             # Catch all exceptions to prevent test framework crashes during rank queries
             self.log.error("Exception getting incarnation for rank %s: %s", rank, error)
             return None
+
+    def reset_engine_restart_state(self):
+        """Reset engine auto-restart state between tests.
+
+        The engine restart manager tracks last restart times for rate-limiting
+        automatic restarts. This state persists across test methods when servers
+        continue running, which can cause unexpected rate-limiting behavior in
+        sequential tests.
+
+        This method resets the state by restarting all servers via:
+        1. dmg system stop (automatically clears restart history for stopped ranks)
+        2. dmg system start (automatically clears restart history for started ranks)
+        3. Wait for all ranks to rejoin
+
+        The automatic clearing is handled by SystemStop/SystemStart in mgmt_system.go,
+        which calls clearRankRestartHistory() for affected ranks.
+
+        Usage:
+            Should be called in tearDown() of test classes that use engine restart
+            functionality. If this method fails, tearDown() should fail the test
+            to prevent subsequent tests from running with contaminated state.
+
+        Raises:
+            Exception: If server stop/start fails or ranks fail to rejoin
+
+        Note:
+            This operation adds ~5-10 seconds per test due to server restart overhead,
+            but is necessary to ensure test isolation and reliable results.
+        """
+        self.log.info("Restarting servers to reset engine restart manager state")
+        self.server_managers[0].system_stop()
+        time.sleep(2)
+        self.server_managers[0].system_start()
+
+        # Wait for all ranks to join
+        all_ranks = self.get_all_ranks()
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=all_ranks, valid_states=["joined"], max_checks=30)
+        if failed_ranks:
+            self.log.warning("Some ranks failed to rejoin after restart: %s", failed_ranks)

--- a/src/tests/ftest/util/control_test_base.py
+++ b/src/tests/ftest/util/control_test_base.py
@@ -77,12 +77,11 @@ class ControlTestBase(TestWithServers):
         self.fail("No member state returned from dmg system query")
         return None
 
-    def exclude_rank_and_wait_restart(self, rank, expect_restart=True, timeout=30):
+    def exclude_rank_and_wait_restart(self, rank, timeout=30):
         """Exclude a rank and wait for it to self-terminate and potentially restart.
 
         Args:
             rank (int): Rank to exclude
-            expect_restart (bool): Whether automatic restart is expected
             timeout (int): Maximum seconds to wait for restart
 
         Returns:
@@ -104,7 +103,7 @@ class ControlTestBase(TestWithServers):
         # After triggering rank exclusion with dmg system exclude, clear
         # AdminExcluded state so rank can join on auto-restart. This enables
         # mimic of rank exclusion via SWIM inactivity detection.
-        self.log_step("Clearing exclusion for rank %s", rank)
+        self.log_step("Clearing AdminExcluded state for rank %s", rank)
         self.dmg.system_clear_exclude(ranks=[rank], rank_hosts=None)
 
         # Check if rank is excluded
@@ -113,38 +112,27 @@ class ControlTestBase(TestWithServers):
         if failed_ranks:
             self.fail("Rank %s did not reach Excluded state after clear-excluded" % rank)
 
-        if expect_restart:
-            # Wait for automatic restart (rank should go to Joined state)
-            self.log_step("Waiting for rank %s to automatically restart", rank)
-            start_time = time.time()
-            restarted = False
+        # Wait for automatic restart (rank should go to Joined state)
+        self.log_step("Waiting for rank %s to automatically restart", rank)
+        start_time = time.time()
+        restarted = False
 
-            while time.time() - start_time < timeout:
-                time.sleep(2)
-                # Check if rank has rejoined
-                failed_ranks = self.server_managers[0].check_rank_state(
-                    ranks=[rank], valid_states=["joined"], max_checks=1)
-                if not failed_ranks:
-                    restarted = True
-                    break
+        while time.time() - start_time < timeout:
+            time.sleep(2)
+            # Check if rank has rejoined
+            failed_ranks = self.server_managers[0].check_rank_state(
+                ranks=[rank], valid_states=["joined"], max_checks=1)
+            if not failed_ranks:
+                restarted = True
+                break
 
-            if restarted:
-                self.log.info("Rank %s automatically restarted and rejoined", rank)
-                return (True, "joined")
-            state = self.get_rank_state(rank)
-            self.log.error("Rank %s (%s) did not restart within %ss", rank, state, timeout)
-            return (False, state)
-        # Verify rank stays AdminExcluded (no automatic restart)
-        self.log_step("Verifying rank %s does not automatically restart", rank)
-        time.sleep(timeout)
+        if restarted:
+            self.log.info("Rank %s automatically restarted and rejoined within %ss", rank, timeout)
+            return (True, "joined")
 
-        failed_ranks = self.server_managers[0].check_rank_state(
-            ranks=[rank], valid_states=["adminexcluded"], max_checks=1)
-        if failed_ranks:
-            state = self.get_rank_state(rank)
-            self.log.error("Rank %s (%s) unexpectedly restarted", rank, state)
-            return (True, state)
-        return (False, "adminexcluded")
+        state = self.get_rank_state(rank)
+        self.log.info("Rank %s (%s) did not restart within %ss", rank, state, timeout)
+        return (False, state)
 
     def get_rank_incarnation(self, rank):
         """Get the incarnation number of a rank.

--- a/src/tests/ftest/util/control_test_base.py
+++ b/src/tests/ftest/util/control_test_base.py
@@ -145,3 +145,51 @@ class ControlTestBase(TestWithServers):
             self.log.error("Rank %s (%s) unexpectedly restarted", rank, state)
             return (True, state)
         return (False, "adminexcluded")
+
+    def get_rank_incarnation(self, rank):
+        """Get the incarnation number of a rank.
+
+        The incarnation number increments each time a rank restarts, allowing
+        verification that a rank has actually restarted rather than just
+        remaining in the same state.
+
+        Args:
+            rank (int): Rank number
+
+        Returns:
+            int: Current incarnation number of the rank, or None if not found
+
+        Raises:
+            None - logs error and returns None on failure
+        """
+        try:
+            data = self.dmg.system_query(ranks=f"{rank}")
+            if data.get("status") != 0:
+                self.log.error("dmg system query failed for rank %s", rank)
+                return None
+
+            if "response" not in data or "members" not in data["response"]:
+                self.log.error("Invalid response from dmg system query for rank %s", rank)
+                return None
+
+            members = data["response"]["members"]
+            if not members:
+                self.log.error("No members returned from dmg system query for rank %s", rank)
+                return None
+
+            for member in members:
+                if member.get("rank") == rank:
+                    incarnation = member.get("incarnation")
+                    if incarnation is not None:
+                        self.log.debug("Rank %s incarnation: %s", rank, incarnation)
+                        return incarnation
+                    self.log.error("No incarnation field for rank %s", rank)
+                    return None
+
+            self.log.error("Rank %s not found in system query response", rank)
+            return None
+
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            # Catch all exceptions to prevent test framework crashes during rank queries
+            self.log.error("Exception getting incarnation for rank %s: %s", rank, error)
+            return None

--- a/src/tests/ftest/util/control_test_base.py
+++ b/src/tests/ftest/util/control_test_base.py
@@ -1,8 +1,10 @@
 """
   (C) Copyright 2020-2022 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import time
 
 from apricot import TestWithServers
 from ClusterShell.NodeSet import NodeSet
@@ -46,3 +48,94 @@ class ControlTestBase(TestWithServers):
 
         if errors:
             self.fail("\n--- Errors found! ---\n{}".format("\n".join(errors)))
+
+    def get_all_ranks(self):
+        """Get list of all ranks in the system.
+
+        Returns:
+            list: List of all rank numbers
+        """
+        return list(self.server_managers[0].ranks.keys())
+
+    def get_rank_state(self, rank):
+        """Get the state of a rank.
+
+        Args:
+            rank (int): Rank number
+
+        Returns:
+            str: Current state of the rank
+        """
+        data = self.dmg.system_query(ranks="%s" % rank)
+        if data["status"] != 0:
+            self.fail("Cmd dmg system query failed")
+        if "response" in data and "members" in data["response"]:
+            if data["response"]["members"] is None:
+                self.fail("No members returned from dmg system query")
+            for member in data["response"]["members"]:
+                return member["state"].lower()
+        self.fail("No member state returned from dmg system query")
+        return None
+
+    def exclude_rank_and_wait_restart(self, rank, expect_restart=True, timeout=30):
+        """Exclude a rank and wait for it to self-terminate and potentially restart.
+
+        Args:
+            rank (int): Rank to exclude
+            expect_restart (bool): Whether automatic restart is expected
+            timeout (int): Maximum seconds to wait for restart
+
+        Returns:
+            tuple: (restarted, final_state) - whether rank restarted and its final state
+        """
+        self.log_step("Excluding rank %s", rank)
+        self.dmg.system_exclude(ranks=[rank], rank_hosts=None)
+
+        # Wait for rank to self-terminate (should go to AdminExcluded state)
+        self.log_step("Waiting for rank %s to self-terminate", rank)
+        time.sleep(2)
+
+        # Check if rank is adminexcluded
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[rank], valid_states=["adminexcluded"], max_checks=10)
+        if failed_ranks:
+            self.fail("Rank %s did not reach AdminExcluded state after exclusion" % rank)
+
+        if expect_restart:
+            # After triggering rank exclusion with dmg system exclude, clear
+            # AdminExcluded state so rank can join on auto-restart. This enables
+            # mimic of rank exclusion via SWIM inactivity detection.
+            self.log_step("Clearing exclusion for rank %s", rank)
+            self.dmg.system_clear_exclude(ranks=[rank], rank_hosts=None)
+
+            # Wait for automatic restart (rank should go to Joined state)
+            self.log_step("Waiting for rank %s to automatically restart", rank)
+            start_time = time.time()
+            restarted = False
+
+            while time.time() - start_time < timeout:
+                time.sleep(2)
+                # Check if rank has rejoined
+                failed_ranks = self.server_managers[0].check_rank_state(
+                    ranks=[rank], valid_states=["joined"], max_checks=1)
+                if not failed_ranks:
+                    restarted = True
+                    break
+
+            if restarted:
+                self.log.info("Rank %s automatically restarted and rejoined", rank)
+                return (True, "joined")
+            state = self.get_rank_state(rank)
+            self.log.error("Rank %s (%s) did not restart within %ss", rank, state, timeout)
+            return (False, state)
+        # Verify rank stays AdminExcluded (no automatic restart)
+        self.log_step("Verifying rank %s does not automatically restart", rank)
+        time.sleep(timeout)
+
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[rank], valid_states=["adminexcluded"], max_checks=1)
+        if failed_ranks:
+            state = self.get_rank_state(rank)
+            self.log.error("Rank %s (%s) unexpectedly restarted", rank, state)
+            return (True, state)
+        return (False, "adminexcluded")

--- a/src/tests/ftest/util/control_test_base.py
+++ b/src/tests/ftest/util/control_test_base.py
@@ -101,13 +101,19 @@ class ControlTestBase(TestWithServers):
         if failed_ranks:
             self.fail("Rank %s did not reach AdminExcluded state after exclusion" % rank)
 
-        if expect_restart:
-            # After triggering rank exclusion with dmg system exclude, clear
-            # AdminExcluded state so rank can join on auto-restart. This enables
-            # mimic of rank exclusion via SWIM inactivity detection.
-            self.log_step("Clearing exclusion for rank %s", rank)
-            self.dmg.system_clear_exclude(ranks=[rank], rank_hosts=None)
+        # After triggering rank exclusion with dmg system exclude, clear
+        # AdminExcluded state so rank can join on auto-restart. This enables
+        # mimic of rank exclusion via SWIM inactivity detection.
+        self.log_step("Clearing exclusion for rank %s", rank)
+        self.dmg.system_clear_exclude(ranks=[rank], rank_hosts=None)
 
+        # Check if rank is excluded
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[rank], valid_states=["excluded"], max_checks=10)
+        if failed_ranks:
+            self.fail("Rank %s did not reach Excluded state after clear-excluded" % rank)
+
+        if expect_restart:
             # Wait for automatic restart (rank should go to Joined state)
             self.log_step("Waiting for rank %s to automatically restart", rank)
             start_time = time.time()

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -1212,7 +1212,11 @@ class DmgCommand(DmgCommandBase):
         #         "uuid": "e7f2cb06-a111-4d55-a6a5-b494b70d62ab",
         #         "fabric_uri": "ofi+sockets://192.168.100.11:31416",
         #         "fabric_contexts": 17,
-        #         "info": ""
+        #         "secondary_fabric_uri": "",
+        #         "secondary_fabric_contexts": 0,
+        #         "info": "",
+        #         "last_update": "",
+        #         "incarnation": 10
         #     },
         #     {
         #         "addr": "10.8.1.74:10001",
@@ -1222,7 +1226,11 @@ class DmgCommand(DmgCommandBase):
         #         "uuid": "db36ab28-fdb0-4822-97e6-89547393ed03",
         #         "fabric_uri": "ofi+sockets://192.168.100.74:31416",
         #         "fabric_contexts": 17,
-        #         "info": ""
+        #         "secondary_fabric_uri": "",
+        #         "secondary_fabric_contexts": 0,
+        #         "info": "",
+        #         "last_update": "",
+        #         "incarnation": 12
         #     }
         #     ]
         # },

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -176,6 +176,10 @@ class DaosServerYamlParameters(YamlParameters):
         self.fault_path = BasicParameter(None)
         self.fault_cb = BasicParameter(None)
 
+        # Engine auto-restart parameters
+        self.disable_engine_auto_restart = BasicParameter(None)
+        self.engine_auto_restart_min_delay = BasicParameter(None)
+
     def get_params(self, test):
         """Get values for all of the command params from the yaml file.
 


### PR DESCRIPTION
Functional tests for the automatic engine restart feature introduced
in the control plane. These tests verify that engines automatically
restart after self-termination when excluded from the system, with
cases to verify disabling, rate-limiting and configuration support.

Test-tag: hw,medium,dmg,control,engine_auto_restart

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
