### PR TITLE
Fix test_corpc_exclusive to now follow the logic of:

### DIFF
--- a/src/tests/ftest/cart/test_corpc_exclusive.c
+++ b/src/tests/ftest/cart/test_corpc_exclusive.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -9,15 +10,15 @@
  * CORPC with 'shutdown' is sent to 3 ranks, 1,2 and 4.
  * Ranks0 and 3 are expected to not receive this call.
  */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <assert.h>
 #include <sys/stat.h>
+#include <semaphore.h>
 #include "crt_utils.h"
 
-static d_rank_t my_rank;
+static bool corpc_hdlr_called = false;
 
 static int
 corpc_aggregate(crt_rpc_t *src, crt_rpc_t *result, void *priv)
@@ -30,29 +31,31 @@ struct crt_corpc_ops corpc_set_ivns_ops = {
 };
 
 static void
-test_basic_corpc_hdlr(crt_rpc_t *rpc)
+corpc_hdlr(crt_rpc_t *rpc)
 {
 	int rc;
 
-	DBG_PRINT("Handler called\n");
+	DBG_PRINT("corpc handler called\n");
+	corpc_hdlr_called = true;
 
 	rc = crt_reply_send(rpc);
-	assert(rc == 0);
-
-	crtu_progress_stop();
-
-	/* CORPC is not sent to those ranks */
-	if (my_rank == 3 || my_rank == 0) {
-		D_ERROR("CORPC was sent to wrong rank=%d\n", my_rank);
-		assert(0);
-	}
-
+	D_ASSERT(rc == 0);
 }
 
-#define TEST_BASIC_CORPC 0xC1
+static void
+shutdown_hdlr(crt_rpc_t *rpc)
+{
+	int rc;
 
-#define TEST_CORPC_PREFWD_BASE 0x010000000
-#define TEST_CORPC_PREFWD_VER  0
+	DBG_PRINT("shutdown handler called\n");
+
+	rc = crt_reply_send(rpc);
+	D_ASSERT(rc == 0);
+
+	crtu_progress_stop();
+}
+
+#define TEST_OPC_BASE           0x010000000
 
 #define CRT_ISEQ_BASIC_CORPC	/* input fields */		 \
 	((uint32_t)		(unused)		CRT_VAR)
@@ -63,33 +66,62 @@ test_basic_corpc_hdlr(crt_rpc_t *rpc)
 CRT_RPC_DECLARE(basic_corpc, CRT_ISEQ_BASIC_CORPC, CRT_OSEQ_BASIC_CORPC)
 CRT_RPC_DEFINE(basic_corpc, CRT_ISEQ_BASIC_CORPC, CRT_OSEQ_BASIC_CORPC)
 
+#define TEST_OPC_CORPC_PING CRT_PROTO_OPC(TEST_OPC_BASE, 0, 0)
+#define TEST_OPC_SHUTDOWN   CRT_PROTO_OPC(TEST_OPC_BASE, 0, 1)
+
+/* Handle CORPC response */
 static void
 corpc_response_hdlr(const struct crt_cb_info *info)
 {
-	crtu_progress_stop();
+	sem_t *sem;
+
+	D_ASSERTF(info != NULL, "cb_info is null\n");
+	D_ASSERTF(info->cci_rc == 0, "CORPC completed with an error\n");
+
+	sem = (sem_t *)info->cci_arg;
+	sem_post(sem);
 }
 
-static struct crt_proto_rpc_format my_proto_rpc_fmt_basic_corpc[] = {
-	{
-		.prf_flags	= 0,
-		.prf_req_fmt	= &CQF_basic_corpc,
-		.prf_hdlr	= test_basic_corpc_hdlr,
-		.prf_co_ops	= &corpc_set_ivns_ops,
-	}
-};
+/* Handle shutdown response*/
+static void
+shutdown_resp_hdlr(const struct crt_cb_info *info)
+{
+	sem_t *sem;
 
-static struct crt_proto_format my_proto_fmt_basic_corpc = {
-	.cpf_name = "my-proto-basic_corpc",
-	.cpf_ver = TEST_CORPC_PREFWD_VER,
-	.cpf_count = ARRAY_SIZE(my_proto_rpc_fmt_basic_corpc),
-	.cpf_prf = &my_proto_rpc_fmt_basic_corpc[0],
-	.cpf_base = TEST_CORPC_PREFWD_BASE,
+	D_ASSERTF(info != NULL, "cb_info is null\n");
+	D_ASSERTF(info->cci_rc == 0, "Shutdown RPC completed with an error\n");
+
+	DBG_PRINT("Shutdown response handler called\n");
+
+	sem = (sem_t *)info->cci_arg;
+	sem_post(sem);
+}
+
+static struct crt_proto_rpc_format proto_rpc_fmt[] = {{
+							  .prf_flags   = 0,
+							  .prf_req_fmt = &CQF_basic_corpc,
+							  .prf_hdlr    = corpc_hdlr,
+							  .prf_co_ops  = &corpc_set_ivns_ops,
+						      },
+						      {
+							  .prf_flags   = 0,
+							  .prf_req_fmt = NULL,
+							  .prf_hdlr    = shutdown_hdlr,
+							  .prf_co_ops  = NULL,
+						      }};
+
+static struct crt_proto_format     my_proto = {
+	.cpf_name  = "my-proto-basic_corpc",
+	.cpf_ver   = 0,
+	.cpf_count = ARRAY_SIZE(proto_rpc_fmt),
+	.cpf_prf   = &proto_rpc_fmt[0],
+	.cpf_base  = TEST_OPC_BASE,
 };
 
 int main(void)
 {
 	int		rc;
-	crt_context_t	g_main_ctx;
+	crt_context_t    ctx;
 	d_rank_list_t	*rank_list;
 	d_rank_list_t	membs;
 	d_rank_t	memb_ranks[] = {1, 2, 4};
@@ -99,109 +131,120 @@ int main(void)
 	char		*env_self_rank;
 	char		*grp_cfg_file;
 	pthread_t	progress_thread;
+	sem_t            sem;
+	crt_endpoint_t   server_ep;
+	int              i;
+	static d_rank_t  my_rank;
 
 	membs.rl_nr = 3;
 	membs.rl_ranks = memb_ranks;
 
+	/* get self rank from the env that crt_launch prepares */
 	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
 	d_freeenv_str(&env_self_rank);
 
-	/* rank, num_attach_retries, is_server, assert_on_error */
+	rc = sem_init(&sem, 0, 0);
+	D_ASSERTF(rc == 0, "sem_init() failed.\n");
+
+	/* rank, num_attach_retries, is_server, D_ASSERT_on_error */
 	crtu_test_init(my_rank, 20, true, true);
+	crtu_set_shutdown_delay(0);
 
 	rc = d_log_init();
-	assert(rc == 0);
+	D_ASSERT(rc == 0);
 
 	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
-	assert(rc == 0);
+	D_ASSERTF(rc == 0, "crt_init() failed\n");
 
-	rc = crt_proto_register(&my_proto_fmt_basic_corpc);
-	assert(rc == 0);
+	rc = crt_proto_register(&my_proto);
+	D_ASSERTF(rc == 0, "crt_proto_register() failed\n");
 
-	rc = crt_context_create(&g_main_ctx);
-	assert(rc == 0);
+	rc = crt_context_create(&ctx);
+	D_ASSERTF(rc == 0, "crt_context_create() failed\n");
 
-	rc = pthread_create(&progress_thread, 0,
-			    crtu_progress_fn, &g_main_ctx);
-	if (rc != 0) {
-		D_ERROR("pthread_create() failed; rc=%d\n", rc);
-		assert(0);
-	}
+	rc = pthread_create(&progress_thread, 0, crtu_progress_fn, &ctx);
+	D_ASSERTF(rc == 0, "pthread_create() failed; rc=%d\n", rc);
 
 	d_agetenv_str(&grp_cfg_file, "CRT_L_GRP_CFG");
 
 	rc = crt_rank_self_set(my_rank, 1 /* group_version_min */);
-	if (rc != 0) {
-		D_ERROR("crt_rank_self_set(%d) failed; rc=%d\n",
-			my_rank, rc);
-		assert(0);
-	}
+	D_ASSERTF(rc == 0, "crt_rank_self_set(%d) failed\n", my_rank);
 
 	grp = crt_group_lookup(NULL);
-	if (!grp) {
-		D_ERROR("Failed to lookup group\n");
-		assert(0);
-	}
+	D_ASSERTF(grp != NULL, "Failed to lookup group\n");
 
 	/* load group info from a config file and delete file upon return */
-	rc = crtu_load_group_from_file(grp_cfg_file, g_main_ctx, grp, my_rank,
-				       true);
+	rc = crtu_load_group_from_file(grp_cfg_file, ctx, grp, my_rank, true);
 	d_freeenv_str(&grp_cfg_file);
-	if (rc != 0) {
-		D_ERROR("crtu_load_group_from_file() failed; rc=%d\n", rc);
-		assert(0);
-	}
+	D_ASSERTF(rc == 0, "crtu_load_group_from_file() failed; rc=%d\n", rc);
 
+	/* test requires 5 ranks */
 	rc = crt_group_size(grp, &grp_size);
-	assert(rc == 0);
-
-	if (grp_size != 5) {
-		D_ERROR("This test assumes 5 ranks\n");
-		assert(0);
-	}
+	D_ASSERTF(rc == 0, "crt_group_size() failed\n");
+	D_ASSERTF(grp_size == 5, "This test requires 5 ranks\n");
 
 	rc = crt_group_ranks_get(grp, &rank_list);
-	if (rc != 0) {
-		D_ERROR("crt_group_ranks_get() failed; rc=%d\n", rc);
-		assert(0);
-	}
+	D_ASSERTF(rc == 0, "crt_group_ranks_get() failed; rc=%d\n", rc);
 
-	rc = crtu_wait_for_ranks(g_main_ctx, grp, rank_list, 0,
-				 1, 50, 100.0);
-	if (rc != 0) {
-		D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
-		assert(0);
-	}
+	/* rank=0 is initiator of the test, the rest of ranks wait for rpcs */
+	if (my_rank != 0)
+		D_GOTO(wait_for_rpcs, 0);
+
+	/* Wait for all ranks to come up, 5 seconds per ping, 100 seconds max */
+	rc = crtu_wait_for_ranks(ctx, grp, rank_list, 0, 1, 5, 100.0);
+	D_ASSERTF(rc == 0, "wait_for_ranks() failed; rc=%d\n", rc);
 
 	d_rank_list_free(rank_list);
 	rank_list = NULL;
 
-	if (my_rank == 0) {
-		DBG_PRINT("Rank 0 sending CORPC call\n");
-		rc = crt_corpc_req_create(g_main_ctx, NULL, &membs,
-			CRT_PROTO_OPC(TEST_CORPC_PREFWD_BASE,
-				TEST_CORPC_PREFWD_VER, 0), NULL, 0,
-			CRT_RPC_FLAG_FILTER_INVERT,
-			crt_tree_topo(CRT_TREE_KNOMIAL, 4), &rpc);
-		assert(rc == 0);
+	/* Send test CORPC with rank=3 excluded in membership list */
+	DBG_PRINT("Rank 0 sending CORPC call\n");
+	rc = crt_corpc_req_create(ctx, NULL, &membs, TEST_OPC_CORPC_PING, NULL, 0,
+				  CRT_RPC_FLAG_FILTER_INVERT, crt_tree_topo(CRT_TREE_KNOMIAL, 4),
+				  &rpc);
+	D_ASSERT(rc == 0);
 
-		rc = crt_req_send(rpc, corpc_response_hdlr, NULL);
-		assert(rc == 0);
+	rc = crt_req_send(rpc, corpc_response_hdlr, &sem);
+	D_ASSERT(rc == 0);
+
+	/* wait for corpc completion */
+	crtu_sem_timedwait(&sem, 61, __LINE__);
+
+	/* Send shutdown rpc to ranks 1 through 5 */
+	server_ep.ep_grp = NULL;
+	for (i = 1; i < grp_size; i++) {
+		server_ep.ep_rank = i;
+		server_ep.ep_tag  = 0;
+
+		rc = crt_req_create(ctx, &server_ep, TEST_OPC_SHUTDOWN, &rpc);
+		D_ASSERTF(rc == 0, "crt_req_create() TEST_OPC_SHUTDOWN failed\n");
+
+		rc = crt_req_send(rpc, shutdown_resp_hdlr, &sem);
+		crtu_sem_timedwait(&sem, 61, __LINE__);
 	}
 
-	sleep(10);
-	/* rank=3 is not sent shutdown sequence */
-	if (my_rank == 3)
-		crtu_progress_stop();
+	/* rank0 issues a local progress stop */
+	crtu_progress_stop();
 
+wait_for_rpcs:
+	/* Wait until progress thread exits */
 	pthread_join(progress_thread, NULL);
+
+	/* CORPC handler should have been called on ranks 1,2,4 and not any other */
+	if (my_rank == 1 || my_rank == 2 || my_rank == 4)
+		D_ASSERTF(corpc_hdlr_called == true, "corpc_handler was not called\n");
+	else
+		D_ASSERTF(corpc_hdlr_called == false, "corpc_handler was called\n");
+
 	DBG_PRINT("All tests done\n");
 
+	rc = sem_destroy(&sem);
+	D_ASSERTF(rc == 0, "sem_destroy() failed\n");
+
 	rc = crt_finalize();
-	assert(rc == 0);
+	D_ASSERTF(rc == 0, "crt_finalize() failed\n");
 
 	d_log_fini();
-
 	return 0;
 }


### PR DESCRIPTION
- 5 ranks start up
- rank0: waits for other ranks initiates CORPC ping to 3 ranks: 1, 2 and 4 waits for CORPC to complete initiates SHUTDOWN rpc to 4 ranks: 1, 2, 3, 4 stops local progress thread
- all other ranks: wait for incoming rpcs upon SHUTDOWN rpc, stop local progress thread
- ranks 1,2,4 verify corpc handler was called
- ranks 0,3 verify corpc handler was not called

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
