### PR TITLE
DAOS-18767 build: Prevent config file overwrite (#17964)

### DIFF
--- a/ci/rpm/test_daos_node.sh
+++ b/ci/rpm/test_daos_node.sh
@@ -20,6 +20,10 @@ case "$ID_LIKE" in
         ;;
 esac
 
+SERVER_CONFIG="/etc/daos/daos_server.yml"
+AGENT_CONFIG="/etc/daos/daos_agent.yml"
+CONTROL_CONFIG="/etc/daos/daos_control.yml"
+
 if [ -n "$DAOS_PKG_VERSION" ]; then
     DAOS_PKG_VERSION="-${DAOS_PKG_VERSION}"
 fi
@@ -30,6 +34,7 @@ if rpm -q daos-server; then
   echo "daos-server RPM should not be installed as a dependency of daos-client"
   exit 1
 fi
+
 if ! sudo $YUM -y history undo last; then
     echo "Error trying to undo previous dnf transaction"
     $YUM history
@@ -82,13 +87,38 @@ if ! sudo $YUM -y history undo last; then
     $YUM history
     exit 1
 fi
+
+# Verify config files my creating an existing config file before installing the RPM
+if [ -f "${SERVER_CONFIG}" ]; then
+  echo "A ${SERVER_CONFIG} config file should not exist before the daos-server install"
+  ls -al /etc/daos/daos*
+  exit 1
+fi
+if [ -f "${AGENT_CONFIG}" ]; then
+  echo "A ${AGENT_CONFIG} config file should not exist before the daos-client-tests-openmpi install"
+  ls -al /etc/daos/daos*
+  exit 1
+fi
+sudo touch "${SERVER_CONFIG}"
+sudo touch "${AGENT_CONFIG}"
+
 sudo $YUM -y install daos-server"$DAOS_PKG_VERSION"
 if rpm -q daos-client; then
   echo "daos-client RPM should not be installed as a dependency of daos-server"
   exit 1
 fi
+if [ ! -f "${SERVER_CONFIG}.rpmnew" ]; then
+  echo "A ${SERVER_CONFIG}.rpmnew file should exist after the daos-server install"
+  ls -al /etc/daos/daos*
+  exit 1
+fi
 
 sudo $YUM -y install --exclude ompi daos-client-tests-openmpi"$DAOS_PKG_VERSION"
+if [ ! -f "${AGENT_CONFIG}.rpmnew" ]; then
+  echo "A ${AGENT_CONFIG}.rpmnew file should exist after the daos-client-tests-openmpi install"
+  ls -al /etc/daos/daos*
+  exit 1
+fi
 
 me=$(whoami)
 for dir in server agent; do
@@ -118,14 +148,14 @@ pip install -r $FTEST/requirements-ftest.txt
 
 sudo PYTHONPATH="$FTEST/util"                        \
      "${VIRTUAL_ENV}"/bin/python $FTEST/config_file_gen.py -n "$HOSTNAME" \
-        -a /etc/daos/daos_agent.yml -s /etc/daos/daos_server.yml
-sudo bash -c 'echo "system_ram_reserved: 4" >> /etc/daos/daos_server.yml'
+     -a "$AGENT_CONFIG" -s "$SERVER_CONFIG"
+sudo bash -c 'echo "system_ram_reserved: 4" >> '"$SERVER_CONFIG"
 sudo PYTHONPATH="$FTEST/util"                        \
      "${VIRTUAL_ENV}"/bin/python $FTEST/config_file_gen.py \
-     -n "$HOSTNAME" -d /etc/daos/daos_control.yml
-cat /etc/daos/daos_server.yml
-cat /etc/daos/daos_agent.yml
-cat /etc/daos/daos_control.yml
+     -n "$HOSTNAME" -d "$CONTROL_CONFIG"
+cat "$SERVER_CONFIG"
+cat "$AGENT_CONFIG"
+cat "$CONTROL_CONFIG"
 
 # python3.6 does not like deactivate with -u set, later versions are OK with it however.
 set +u

--- a/utils/rpms/daos.sh
+++ b/utils/rpms/daos.sh
@@ -6,6 +6,7 @@
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 set -eEuo pipefail
+set -x
 root="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 . "${root}/fpm_common.sh"
 
@@ -43,6 +44,7 @@ files=()
 TARGET_PATH="${sysconfdir}/daos"
 list_files files "${SL_PREFIX}/etc/memcheck*.supp"
 append_install_list "${files[@]}"
+CONFIG_FILES+=("${TARGET_PATH}/memcheck-cart.supp")
 
 TARGET_PATH="${sysconfdir}/bash_completion.d"
 list_files files "${SL_PREFIX}/etc/bash_completion.d/daos.bash"
@@ -129,6 +131,8 @@ if [ -f "${SL_PREFIX}/bin/daos_server" ]; then
   list_files files "${SL_PREFIX}/etc/daos_server.yml" \
   "${SL_PREFIX}/etc/vos_size_input.yaml"
   append_install_list "${files[@]}"
+  CONFIG_FILES+=("${TARGET_PATH}/daos_server.yml")
+  CONFIG_FILES+=("${TARGET_PATH}/vos_size_input.yaml")
 
   TARGET_PATH="${datadir}/daos/control"
   list_files files "${SL_PREFIX}/share/daos/control/*"
@@ -224,6 +228,7 @@ append_install_list "${files[@]}"
 TARGET_PATH="${sysconfdir}/daos"
 list_files files "${SL_PREFIX}/etc/daos_control.yml"
 append_install_list "${files[@]}"
+CONFIG_FILES+=("${TARGET_PATH}/daos_control.yml")
 
 DEPENDS=( "daos = ${VERSION}-${RELEASE}" )
 build_package "daos-admin"
@@ -268,6 +273,7 @@ append_install_list "${files[@]}"
 TARGET_PATH="${sysconfdir}/daos"
 list_files files "${SL_PREFIX}/etc/daos_agent.yml"
 append_install_list "${files[@]}"
+CONFIG_FILES+=("${TARGET_PATH}/daos_agent.yml")
 
 mkdir -p "${tmp}/${unitdir}"
 install -m 644 "utils/systemd/${agent_svc_name}" "${tmp}/${unitdir}"
@@ -353,6 +359,7 @@ append_install_list "${files[@]}"
 TARGET_PATH="${sysconfdir}/daos"
 list_files files "${SL_PREFIX}/etc/fault-inject-cart.yaml"
 append_install_list "${files[@]}"
+CONFIG_FILES+=("${TARGET_PATH}/fault-inject-cart.yaml")
 
 #todo add external depends
 EXTERNAL_DEPENDS=("${protobufc_lib}")

--- a/utils/rpms/fpm_common.sh
+++ b/utils/rpms/fpm_common.sh
@@ -10,6 +10,7 @@ export install_list=()
 export PACKAGE_TYPE="dir"
 export dbg_list=()
 export CONFLICTS=()
+export CONFIG_FILES=()
 export DEPENDS=()
 export EXTERNAL_DEPENDS=()
 export EXTRA_OPTS=()
@@ -167,6 +168,8 @@ build_package() {
   create_opts "--depends" depends "${DEPENDS[@]}" "${EXTERNAL_DEPENDS[@]}"
   conflicts=()
   create_opts "--conflicts" conflicts "${CONFLICTS[@]}"
+  config_files=()
+  create_opts "--config-files" config_files "${CONFIG_FILES[@]}"
   pkgname="${name}-${VERSION}-${RELEASE}.${ARCH}.${output_type}"
   rm -f "${pkgname}"
   # shellcheck disable=SC2068
@@ -184,6 +187,7 @@ build_package() {
   --prefix "" \
   "${depends[@]}" \
   "${conflicts[@]}" \
+  "${config_files[@]}" \
   "${EXTRA_OPTS[@]}" \
   "${install_list[@]}"
 
@@ -191,6 +195,7 @@ build_package() {
   install_list=()
 
   CONFLICTS=()
+  CONFIG_FILES=()
   DEPENDS=()
   EXTERNAL_DEPENDS=()
   if [[ ! "${name}" =~ debuginfo ]]; then


### PR DESCRIPTION
Keep modified config files installed by the DAOS RPMs when uninstalling or updating the RPMs.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test: true
Skip-func-test-el8: false
Skip-func-test-leap15: false
Skip-test-leap-15-rpms: false
Test-tag: test_setup_vm

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
