### PR TITLE
DAOS-18607 object: misc fixes to improve server side congestion

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -748,8 +748,11 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 		else
 			dca->dca_steps = length;
 
-		/* Use helper ULT to handle DTX RPC if there are enough helper XS. */
-		if (dss_has_enough_helper()) {
+		/*
+		 * Direct use current ULT instead of dss_chore to send DTX RPC to avoid being
+		 * blocked by some slow dss_chore users. DAOS-18607.
+		 */
+		if (0 && dss_has_enough_helper()) {
 			rc = ABT_eventual_create(0, &dca->dca_chore_eventual);
 			if (rc != ABT_SUCCESS) {
 				D_ERROR("failed to create eventual: %d\n", rc);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1725,7 +1725,7 @@ dc_obj_retry_delay(tse_task_t *task, uint32_t opc, int err, uint32_t *retry_cnt,
 	/* Randomly delay [1,  max_delay - 5] for DER_OVERLOAD_RETRY case. */
 	if (err == -DER_OVERLOAD_RETRY) {
 		delay = daos_rpc_rand_delay(timeout_sec) << 20;
-	} else if (++(*retry_cnt) > 1) {
+	} else if (++(*retry_cnt) > 1 || obj_is_modification_opc(opc)) {
 		/* Randomly delay [31 ~ 1023] us if it is not the first retried object RPC. */
 		delay = (d_rand() | ((1 << 5) - 1)) & ((1 << 10) - 1);
 		/* Rebuild is being established on the server side, wait a bit longer */
@@ -1739,16 +1739,18 @@ dc_obj_retry_delay(tse_task_t *task, uint32_t opc, int err, uint32_t *retry_cnt,
 				delay <<= 8;
 				break;
 			case DAOS_OBJ_RPC_CPD:
-				/* 8 times of the delay for compounded RPC. */
-				delay <<= 3;
+				delay <<= (*retry_cnt + 3);
 				break;
 			default:
+				if (obj_is_modification_opc(opc))
+					delay <<= (*retry_cnt + 1);
+				else
+					delay <<= (*retry_cnt - 1);
 				break;
 			}
 
-			/* Increase delay after multiple times retry. */
-			if (*retry_cnt >= 5)
-				delay <<= 1;
+			if (*retry_cnt > 10 || delay > 3000000)
+				delay = 3000000 + ((d_rand() | ((1 << 5) - 1)) & ((1 << 10) - 1));
 		}
 	}
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2884,7 +2884,8 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 			 (orw->orw_api_flags & (DAOS_COND_DKEY_INSERT | DAOS_COND_AKEY_INSERT))) ||
 			(rc == -DER_NONEXIST &&
 			 (orw->orw_api_flags & (DAOS_COND_DKEY_UPDATE | DAOS_COND_AKEY_UPDATE))),
-		    DB_IO, DLOG_ERR, rc, DF_UOID, DP_UOID(orw->orw_oid));
+		    DB_IO, DLOG_ERR, rc, "tgt_update " DF_UOID " with TX " DF_DTI,
+		    DP_UOID(orw->orw_oid), DP_DTI(&orw->orw_dti));
 
 out:
 	if (dth != NULL)


### PR DESCRIPTION
Include the following improvements:

1. Increase RPC retry latency to reduce server load that is caused by resent IO requests.

2. Use current ULT to send DTX RPC instead of via helper::dss_chore to avoid being blocked
   when helper xstream is too busy.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
