### PR TITLE
SRE-3737 ci: allows custom source for gem install (#18024)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,6 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value='pipeline-lib@your_branch') _
-@Library(value='pipeline-lib@grom72/SRE-3737-no-proxy-for-Fault-Injection-testing') _
 
 // The trusted-pipeline-lib daosLatestVersion() method will convert this into a number
 /* groovylint-disable-next-line CompileStatic, VariableName */

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value='pipeline-lib@your_branch') _
+@Library(value='pipeline-lib@grom72/SRE-3737') _
 
 // The trusted-pipeline-lib daosLatestVersion() method will convert this into a number
 /* groovylint-disable-next-line CompileStatic, VariableName */

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value='pipeline-lib@your_branch') _
+@Library(value='pipeline-lib@grom72/SRE-3737-no-proxy-for-Fault-Injection-testing') _
 
 // The trusted-pipeline-lib daosLatestVersion() method will convert this into a number
 /* groovylint-disable-next-line CompileStatic, VariableName */

--- a/utils/scripts/helpers/repo-helper-el8.sh
+++ b/utils/scripts/helpers/repo-helper-el8.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+#
+#  Copyright 2022-2023 Intel Corporation.
+#  Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
 set -uex
 
 # This script is used by dockerfiles to optionally use
@@ -126,10 +133,11 @@ done
 
 disable_repos /etc/yum.repos.d/ "${save_repos[@]}"
 
-# Setup the PyPi to use the artifactory as the installation packages source
 if [ -n "$REPO_FILE_URL" ]; then
     trusted_host="${REPO_FILE_URL##*//}"
     trusted_host="${trusted_host%%/*}"; \
+
+# Setup the PyPi to use the artifactory as the installation packages source
     cat <<EOF > /etc/pip.conf
 [global]
     trusted-host = ${trusted_host}
@@ -137,5 +145,11 @@ if [ -n "$REPO_FILE_URL" ]; then
     progress_bar = off
     no_color = true
     quiet = 1
+EOF
+
+# Setup RubyGems to use artifactory as the installation source.
+    cat <<EOF > /etc/gemrc
+:sources:
+- https://${trusted_host}/artifactory/api/gems/rubygems-proxy/
 EOF
 fi

--- a/utils/scripts/helpers/repo-helper-el8.sh
+++ b/utils/scripts/helpers/repo-helper-el8.sh
@@ -5,7 +5,6 @@
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
-
 set -uex
 
 # This script is used by dockerfiles to optionally use

--- a/utils/scripts/helpers/repo-helper-el9.sh
+++ b/utils/scripts/helpers/repo-helper-el9.sh
@@ -5,7 +5,6 @@
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
-
 set -uex
 
 # This script is used by dockerfiles to optionally use

--- a/utils/scripts/helpers/repo-helper-el9.sh
+++ b/utils/scripts/helpers/repo-helper-el9.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+#
+#  Copyright 2023 Intel Corporation.
+#  Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
 set -uex
 
 # This script is used by dockerfiles to optionally use
@@ -122,10 +129,11 @@ done
 
 disable_repos /etc/yum.repos.d/ "${save_repos[@]}"
 
-# Setup the PyPi to use the artifactory as the installation packages source
 if [ -n "$REPO_FILE_URL" ]; then
     trusted_host="${REPO_FILE_URL##*//}"
     trusted_host="${trusted_host%%/*}"; \
+
+# Setup the PyPi to use the artifactory as the installation packages source
     cat <<EOF > /etc/pip.conf
 [global]
     trusted-host = ${trusted_host}
@@ -133,5 +141,11 @@ if [ -n "$REPO_FILE_URL" ]; then
     progress_bar = off
     no_color = true
     quiet = 1
+EOF
+
+# Setup RubyGems to use artifactory as the installation source.
+    cat <<EOF > /etc/gemrc
+:sources:
+- https://${trusted_host}/artifactory/api/gems/rubygems-proxy/
 EOF
 fi

--- a/utils/scripts/helpers/repo-helper-leap15.sh
+++ b/utils/scripts/helpers/repo-helper-leap15.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#
 #  Copyright 2022-2023 Intel Corporation.
 #  Copyright 2024-2026 Hewlett Packard Enterprise Development LP
 #

--- a/utils/scripts/helpers/repo-helper-leap15.sh
+++ b/utils/scripts/helpers/repo-helper-leap15.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#  Copyright 2022-2023 Intel Corporation.
+#  Copyright 2024-2026 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
 set -uex
 
 # This script is used by dockerfiles to optionally use
@@ -170,10 +175,11 @@ fi
 # run here.  Running this command just makes sure things work.
 update-ca-certificates
 
-# Setup the PyPi to use the artifactory as the installation packages source
 if [ -n "$REPO_FILE_URL" ]; then
     trusted_host="${REPO_FILE_URL##*//}"
     trusted_host="${trusted_host%%/*}"; \
+
+# Setup the PyPi to use the artifactory as the installation packages source
     cat <<EOF > /etc/pip.conf
 [global]
     trusted-host = ${trusted_host}
@@ -182,4 +188,18 @@ if [ -n "$REPO_FILE_URL" ]; then
     no_color = true
     quiet = 1
 EOF
+
+# Setup RubyGems to use artifactory as the primary installation source.
+# Prior to setup, it is essential to ensure that Ruby-Dev is installed.
+# Failure to comply with this procedure will result
+# in the manual /etc/gemrc file being overridden.
+    dnf --nodocs install ruby-devel
+    if [ ! -f /etc/gemrc ]; then
+        echo ":sources:" > /etc/gemrc
+    elif ! grep -q '^:sources:$' /etc/gemrc; then
+        echo ":sources:" >> /etc/gemrc
+    fi
+    sed -i "/^:sources:$/a- https://${trusted_host}/artifactory/api/gems/rubygems-proxy/" \
+    /etc/gemrc
+    gem env
 fi

--- a/utils/scripts/helpers/repo-helper-ubuntu.sh
+++ b/utils/scripts/helpers/repo-helper-ubuntu.sh
@@ -107,10 +107,11 @@ if [ -e /tmp/install.sh ]; then
 fi
 apt-get clean all
 
-# Setup the PyPi to use the artifactory as the installation packages source
 if [ -n "$REPO_FILE_URL" ]; then
     trusted_host="${REPO_FILE_URL##*//}"
     trusted_host="${trusted_host%%/*}"; \
+
+# Setup the PyPi to use the artifactory as the installation packages source
     cat <<EOF > /etc/pip.conf
 [global]
     trusted-host = ${trusted_host}
@@ -118,5 +119,11 @@ if [ -n "$REPO_FILE_URL" ]; then
     progress_bar = off
     no_color = true
     quiet = 1
+EOF
+
+# Setup RubyGems to use artifactory as the installation source.
+    cat <<EOF > /etc/gemrc
+:sources:
+- https://${trusted_host}/artifactory/api/gems/rubygems-proxy/
 EOF
 fi

--- a/utils/scripts/helpers/repo-helper-ubuntu.sh
+++ b/utils/scripts/helpers/repo-helper-ubuntu.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+#  Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
 set -uex
 
 # This script is used by dockerfiles to optionally use


### PR DESCRIPTION
Allows custom source for gem install.
This change is necessary to fully disable HTTPS_PROXY usage in build dockers in CI.

It is also use to validate https://github.com/daos-stack/pipeline-lib/pull/508.
Backport of (https://github.com/daos-stack/daos/pull/18024)

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
