### PR TITLE
DAOS-18613 pool: Retry handle fetching upon errors

### DIFF
--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -142,6 +143,24 @@ struct pool_iv_entry {
 	};
 };
 
+static inline size_t
+pool_iv_conn_size(size_t cred_size)
+{
+	return sizeof(struct pool_iv_conn) + cred_size;
+}
+
+static inline struct pool_iv_conn *
+pool_iv_conn_next(struct pool_iv_conn *conn)
+{
+	return (struct pool_iv_conn *)((char *)conn + pool_iv_conn_size(conn->pic_cred_size));
+}
+
+static inline size_t
+pool_iv_conn_ent_size(size_t cred_size)
+{
+	return sizeof(struct pool_iv_entry) + pool_iv_conn_size(cred_size);
+}
+
 struct pool_map_refresh_ult_arg {
 	uint32_t	iua_pool_version;
 	uuid_t		iua_pool_uuid;
@@ -265,6 +284,9 @@ void ds_pool_map_refresh_ult(void *arg);
 int ds_pool_iv_conn_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid,
 			       uint64_t flags, uint64_t capas, d_iov_t *cred,
 			       uint32_t global_ver, uint32_t obj_layout_ver);
+
+int
+      ds_pool_iv_conn_hdls_update(struct ds_pool *pool, struct pool_iv_conns *conns);
 
 int ds_pool_iv_srv_hdl_update(struct ds_pool *pool, uuid_t pool_hdl_uuid,
 			      uuid_t cont_hdl_uuid);

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -1,7 +1,7 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2026 Google LLC
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -1,7 +1,7 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
- * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2026 Google LLC
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -73,26 +74,6 @@ free:
 		d_sgl_fini(sgl, true);
 
 	return rc;
-}
-
-static inline size_t
-pool_iv_conn_size(size_t cred_size)
-{
-	return sizeof(struct pool_iv_conn) + cred_size;
-}
-
-static inline struct pool_iv_conn*
-pool_iv_conn_next(struct pool_iv_conn *conn)
-{
-	return (struct pool_iv_conn *)((char *)conn +
-		pool_iv_conn_size(conn->pic_cred_size));
-}
-
-static inline size_t
-pool_iv_conn_ent_size(size_t cred_size)
-{
-	return sizeof(struct pool_iv_entry) +
-	       pool_iv_conn_size(cred_size);
 }
 
 /* FIXME: Need better handling here, for example retry if the size is not
@@ -515,14 +496,13 @@ pool_iv_conns_ent_fetch(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 }
 
 static int
-pool_iv_conns_resize(d_sg_list_t *sgl, unsigned int old_size,
-		     unsigned int new_size)
+pool_iv_conns_resize(d_sg_list_t *sgl, unsigned int new_size)
 {
 	struct pool_iv_entry *old_ent = sgl->sg_iovs[0].iov_buf;
 	struct pool_iv_entry *new_ent;
 	struct pool_iv_conns *new_conns;
 
-	D_REALLOC(new_ent, old_ent, old_size, new_size);
+	D_REALLOC(new_ent, old_ent, sgl->sg_iovs[0].iov_buf_len, new_size);
 	if (new_ent == NULL)
 		return -DER_NOMEM;
 
@@ -571,12 +551,10 @@ pool_iv_conns_ent_update(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 	dst_conns_size = dst_conns->pic_size + src_conns->pic_size;
 	if (dst_conns_size > dst_conns->pic_buf_size ||
 	    dst_conns->pic_buf_size > dst_sgl->sg_iovs[0].iov_buf_len) {
-		unsigned int old_size;
 		unsigned int new_size;
 
 		new_size = sizeof(*dst_conns) + dst_conns_size;
-		old_size = dst_sgl->sg_iovs[0].iov_buf_len;
-		rc = pool_iv_conns_resize(dst_sgl, old_size, new_size);
+		rc       = pool_iv_conns_resize(dst_sgl, new_size);
 		if (rc)
 			return rc;
 
@@ -795,9 +773,6 @@ pool_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	int			rc;
 
 	if (dss_self_rank() == entry->ns->iv_master_rank) {
-		/* The PS leader might still in initialization phase, the IV entry may
-		 * not be fully initialized yet.
-		 */
 		if (!entry->iv_valid) {
 			rc = -DER_NOTLEADER;
 			DL_INFO(rc, DF_UUID " iv class id %d, master %u is still stepping up.",
@@ -1272,6 +1247,30 @@ ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf, uint32_t map_v
 }
 
 int
+ds_pool_iv_conn_hdls_update(struct ds_pool *pool, struct pool_iv_conns *iv_conns)
+{
+	struct pool_iv_entry *iv_entry;
+	daos_size_t           iv_entry_size;
+	int                   rc;
+
+	iv_entry_size = sizeof(*iv_entry) + iv_conns->pic_size;
+	D_ALLOC(iv_entry, iv_entry_size);
+	if (iv_entry == NULL)
+		return -DER_NOMEM;
+
+	iv_entry->piv_conn_hdls.pic_size     = iv_conns->pic_size;
+	iv_entry->piv_conn_hdls.pic_buf_size = iv_conns->pic_size;
+	memcpy(&iv_entry->piv_conn_hdls.pic_conns, iv_conns->pic_conns, iv_conns->pic_size);
+
+	rc = pool_iv_update(pool->sp_iv_ns, IV_POOL_CONN, pool->sp_uuid, iv_entry, iv_entry_size,
+			    CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_LAZY, false);
+	D_DEBUG(DB_MD, DF_UUID " distribute hdls %d\n", DP_UUID(pool->sp_uuid), rc);
+
+	D_FREE(iv_entry);
+	return rc;
+}
+
+int
 ds_pool_iv_conn_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid,
 			   uint64_t flags, uint64_t sec_capas,
 			   d_iov_t *cred, uint32_t global_ver, uint32_t layout_ver)
@@ -1297,9 +1296,8 @@ ds_pool_iv_conn_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid,
 	pic->pic_obj_ver = layout_ver;
 	memcpy(&pic->pic_creds[0], cred->iov_buf, cred->iov_len);
 
-	rc = pool_iv_update(pool->sp_iv_ns, IV_POOL_CONN, hdl_uuid,
-			    iv_entry, iv_entry_size, CRT_IV_SHORTCUT_NONE,
-			    CRT_IV_SYNC_EAGER, false);
+	rc = pool_iv_update(pool->sp_iv_ns, IV_POOL_CONN, pool->sp_uuid, iv_entry, iv_entry_size,
+			    CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_EAGER, false);
 	D_DEBUG(DB_MD, DF_UUID" distribute hdl "DF_UUID" capas "DF_U64" %d\n",
 		DP_UUID(pool->sp_uuid), DP_UUID(hdl_uuid), sec_capas, rc);
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1951,18 +1951,83 @@ out:
 	return rc;
 }
 
+struct add_conn_arg {
+	uint32_t              obj_ver;
+	uint32_t              global_ver;
+	struct pool_iv_conns *iv_hdls;
+};
+
+static int
+add_conn_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
+{
+	struct add_conn_arg  *arg      = varg;
+	struct pool_iv_conns *iv_conns = arg->iv_hdls;
+	struct pool_hdl      *hdl      = val->iov_buf;
+	struct pool_iv_conn  *conn;
+
+	if (key->iov_len != sizeof(uuid_t)) {
+		D_WARN("skip invalid key size: " DF_U64 "\n", key->iov_len);
+		return 0;
+	}
+
+	if (val->iov_len != sizeof(struct pool_hdl) + hdl->ph_cred_len) {
+		D_INFO("skip value size: " DF_U64 " for old pool version or invalid handle\n",
+		       val->iov_len);
+		return 0;
+	}
+
+	if (iv_conns == NULL ||
+	    iv_conns->pic_buf_size < iv_conns->pic_size + pool_iv_conn_size(hdl->ph_cred_len)) {
+		unsigned int          new_size;
+		unsigned int          curr_size;
+		struct pool_iv_conns *new_conns;
+
+		curr_size =
+		    iv_conns ? iv_conns->pic_buf_size + sizeof(*iv_conns) : sizeof(*iv_conns);
+		new_size = curr_size + 32 * pool_iv_conn_size(hdl->ph_cred_len);
+
+		if (iv_conns != NULL)
+			D_REALLOC(new_conns, iv_conns, curr_size, new_size);
+		else
+			D_ALLOC(new_conns, new_size);
+
+		if (new_conns == NULL)
+			return -DER_NOMEM;
+
+		arg->iv_hdls           = new_conns;
+		iv_conns               = new_conns;
+		iv_conns->pic_buf_size = new_size - sizeof(*iv_conns);
+	}
+
+	conn = (struct pool_iv_conn *)((char *)iv_conns->pic_conns + iv_conns->pic_size);
+
+	uuid_copy(conn->pic_hdl, key->iov_buf);
+	conn->pic_flags     = hdl->ph_flags;
+	conn->pic_capas     = hdl->ph_sec_capas;
+	conn->pic_cred_size = hdl->ph_cred_len;
+	memcpy(&conn->pic_creds[0], &hdl->ph_cred[0], hdl->ph_cred_len);
+	conn->pic_global_ver = arg->global_ver;
+	conn->pic_obj_ver    = arg->obj_ver;
+	iv_conns->pic_size += pool_iv_conn_size(hdl->ph_cred_len);
+
+	D_INFO("load handle " DF_UUID "\n", DP_UUID(conn->pic_hdl));
+	return 0;
+}
+
 /*
- * Read the DB for map_buf, map_version, and prop. If the return value is 0,
- * the caller is responsible for freeing *map_buf_out and *prop_out eventually.
+ * Read the DB for map_buf, map_version, prop and pool iv hdls. If the return value is 0,
+ * the caller is responsible for freeing *map_buf_out, *prop_out and pool iv_hdls eventually.
  */
 static int
 read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
-			uint32_t *map_version_out, daos_prop_t **prop_out)
+			uint32_t *map_version_out, daos_prop_t **prop_out,
+			struct pool_iv_conns **iv_hdls)
 {
-	struct rdb_tx		tx;
-	d_iov_t			value;
-	struct pool_buf	       *map_buf;
-	struct daos_prop_entry *svc_rf_entry;
+	struct rdb_tx           tx;
+	d_iov_t                 value;
+	struct pool_buf        *map_buf = NULL;
+	struct daos_prop_entry *prop_entry;
+	struct add_conn_arg     arg  = {0};
 	daos_prop_t	       *prop = NULL;
 	uint32_t                map_version;
 	int                     rc;
@@ -1984,14 +2049,13 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to read pool properties: "DF_RC"\n",
 			DP_UUID(svc->ps_uuid), DP_RC(rc));
-		daos_prop_free(prop);
-		goto out_map_buf;
+		goto out_free;
 	}
 
-	svc_rf_entry = daos_prop_entry_get(prop, DAOS_PROP_PO_SVC_REDUN_FAC);
-	D_ASSERT(svc_rf_entry != NULL);
-	if (daos_prop_is_set(svc_rf_entry))
-		svc->ps_svc_rf = svc_rf_entry->dpe_val;
+	prop_entry = daos_prop_entry_get(prop, DAOS_PROP_PO_SVC_REDUN_FAC);
+	D_ASSERT(prop_entry != NULL);
+	if (daos_prop_is_set(prop_entry))
+		svc->ps_svc_rf = prop_entry->dpe_val;
 	else
 		svc->ps_svc_rf = -1;
 
@@ -2002,7 +2066,7 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 		/* Check if duplicate operations detection is enabled, for informative debug log */
 		rc = rdb_get_size(svc->ps_rsvc.s_db, &rdb_size);
 		if (rc != 0)
-			goto out_lock;
+			goto out_free;
 		rdb_size_ok = (rdb_size >= DUP_OP_MIN_RDB_SIZE);
 
 		d_iov_set(&value, &svc->ps_ops_enabled, sizeof(svc->ps_ops_enabled));
@@ -2010,7 +2074,7 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 		if (rc != 0) {
 			D_ERROR(DF_UUID ": failed to lookup svc_ops_enabled: " DF_RC "\n",
 				DP_UUID(svc->ps_uuid), DP_RC(rc));
-			goto out_lock;
+			goto out_free;
 		}
 
 		d_iov_set(&value, &svc->ps_ops_age, sizeof(svc->ps_ops_age));
@@ -2018,7 +2082,7 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 		if (rc != 0) {
 			DL_ERROR(rc, DF_UUID ": failed to lookup svc_ops_age",
 				 DP_UUID(svc->ps_uuid));
-			goto out_lock;
+			goto out_free;
 		}
 
 		d_iov_set(&value, &svc->ps_ops_max, sizeof(svc->ps_ops_max));
@@ -2026,7 +2090,7 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 		if (rc != 0) {
 			DL_ERROR(rc, DF_UUID ": failed to lookup svc_ops_max",
 				 DP_UUID(svc->ps_uuid));
-			goto out_lock;
+			goto out_free;
 		}
 
 		D_DEBUG(DB_MD,
@@ -2043,14 +2107,33 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 			DP_UUID(svc->ps_uuid));
 	}
 
+	prop_entry = daos_prop_entry_get(prop, DAOS_PROP_PO_OBJ_VERSION);
+	D_ASSERT(prop_entry != NULL);
+	arg.obj_ver    = prop_entry->dpe_val;
+	arg.global_ver = svc->ps_global_version;
+	arg.iv_hdls    = NULL;
+	rc = rdb_tx_iterate(&tx, &svc->ps_handles, false /* backward */, add_conn_cb, &arg);
+	if (rc != 0) {
+		DL_ERROR(rc, "Failed to find hdls for evict pool " DF_UUIDF " connections.",
+			 DP_UUID(svc->ps_uuid));
+		D_GOTO(out_free, rc);
+	}
+
 	D_ASSERTF(rc == 0, DF_RC"\n", DP_RC(rc));
+	*iv_hdls         = arg.iv_hdls;
 	*map_buf_out = map_buf;
 	*map_version_out = map_version;
 	*prop_out = prop;
 
-out_map_buf:
-	if (rc != 0)
-		D_FREE(map_buf);
+out_free:
+	if (rc != 0) {
+		if (map_buf != NULL)
+			D_FREE(map_buf);
+		if (prop != NULL)
+			daos_prop_free(prop);
+		if (arg.iv_hdls != NULL)
+			D_FREE(arg.iv_hdls);
+	}
 out_lock:
 	ABT_rwlock_unlock(svc->ps_lock);
 	rdb_tx_end(&tx);
@@ -2285,6 +2368,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	uuid_t			pool_hdl_uuid;
 	uuid_t			cont_hdl_uuid;
 	daos_prop_t	       *prop = NULL;
+	struct pool_iv_conns   *iv_hdls            = NULL;
 	bool			cont_svc_up = false;
 	bool			events_initialized = false;
 	d_rank_t                rank               = dss_self_rank();
@@ -2306,7 +2390,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	if (!primary_group_initialized())
 		return -DER_GRPVER;
 
-	rc = read_db_for_stepping_up(svc, &map_buf, &map_version, &prop);
+	rc = read_db_for_stepping_up(svc, &map_buf, &map_version, &prop, &iv_hdls);
 	if (rc != 0)
 		goto out;
 
@@ -2381,6 +2465,16 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 		goto out;
 	}
 
+	if (iv_hdls != NULL) {
+		rc = ds_pool_iv_conn_hdls_update(svc->ps_pool, iv_hdls);
+		if (rc != 0) {
+			DL_ERROR(rc, DF_UUID ": ds_pool_iv_conn_hdls_update failed",
+				 DP_UUID(svc->ps_uuid));
+			goto out;
+		}
+		D_INFO(DF_UUID ": distribute existing hdls\n", DP_UUID(svc->ps_uuid));
+	}
+
 	/* resume pool upgrade if needed */
 	rc = ds_pool_upgrade_if_needed(svc->ps_uuid, NULL, svc, NULL);
 	if (rc != 0)
@@ -2414,6 +2508,9 @@ out:
 		D_FREE(map_buf);
 	if (prop != NULL)
 		daos_prop_free(prop);
+	if (iv_hdls != NULL)
+		D_FREE(iv_hdls);
+
 	if (svc->ps_error != 0) {
 		/*
 		 * Step up with the error anyway, so that RPCs to the PS

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2026-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1976,21 +1976,15 @@ add_conn_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		return 0;
 	}
 
-	if (iv_conns == NULL ||
-	    iv_conns->pic_buf_size < iv_conns->pic_size + pool_iv_conn_size(hdl->ph_cred_len)) {
+	if (iv_conns->pic_buf_size < iv_conns->pic_size + pool_iv_conn_size(hdl->ph_cred_len)) {
 		unsigned int          new_size;
 		unsigned int          curr_size;
 		struct pool_iv_conns *new_conns;
 
-		curr_size =
-		    iv_conns ? iv_conns->pic_buf_size + sizeof(*iv_conns) : sizeof(*iv_conns);
+		curr_size = iv_conns->pic_buf_size + sizeof(*iv_conns);
 		new_size = curr_size + 32 * pool_iv_conn_size(hdl->ph_cred_len);
 
-		if (iv_conns != NULL)
-			D_REALLOC(new_conns, iv_conns, curr_size, new_size);
-		else
-			D_ALLOC(new_conns, new_size);
-
+		D_REALLOC(new_conns, iv_conns, curr_size, new_size);
 		if (new_conns == NULL)
 			return -DER_NOMEM;
 
@@ -2111,7 +2105,11 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 	D_ASSERT(prop_entry != NULL);
 	arg.obj_ver    = prop_entry->dpe_val;
 	arg.global_ver = svc->ps_global_version;
-	arg.iv_hdls    = NULL;
+	D_ALLOC_PTR(arg.iv_hdls);
+	if (arg.iv_hdls == NULL) {
+		rc = -DER_NOMEM;
+		goto out_free;
+	}
 	rc = rdb_tx_iterate(&tx, &svc->ps_handles, false /* backward */, add_conn_cb, &arg);
 	if (rc != 0) {
 		DL_ERROR(rc, "Failed to find hdls for evict pool " DF_UUIDF " connections.",
@@ -2465,14 +2463,10 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 		goto out;
 	}
 
-	if (iv_hdls != NULL) {
-		rc = ds_pool_iv_conn_hdls_update(svc->ps_pool, iv_hdls);
-		if (rc != 0) {
-			DL_ERROR(rc, DF_UUID ": ds_pool_iv_conn_hdls_update failed",
-				 DP_UUID(svc->ps_uuid));
-			goto out;
-		}
-		D_INFO(DF_UUID ": distribute existing hdls\n", DP_UUID(svc->ps_uuid));
+	rc = ds_pool_iv_conn_hdls_update(svc->ps_pool, iv_hdls);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_UUID ": ds_pool_iv_conn_hdls_update failed", DP_UUID(svc->ps_uuid));
+		goto out;
 	}
 
 	/* resume pool upgrade if needed */
@@ -2510,7 +2504,6 @@ out:
 		daos_prop_free(prop);
 	if (iv_hdls != NULL)
 		D_FREE(iv_hdls);
-
 	if (svc->ps_error != 0) {
 		/*
 		 * Step up with the error anyway, so that RPCs to the PS

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1048,8 +1048,7 @@ ds_pool_put(struct ds_pool *pool)
 void
 pool_fetch_hdls_ult(void *data)
 {
-	struct ds_pool	*pool = data;
-	int		rc = 0;
+	struct ds_pool *pool = data;
 
 	D_INFO(DF_UUID": begin: fetch_hdls=%u stopping=%u\n", DP_UUID(pool->sp_uuid),
 	       pool->sp_fetch_hdls, pool->sp_stopping);
@@ -1065,19 +1064,18 @@ pool_fetch_hdls_ult(void *data)
 	}
 	ABT_mutex_unlock(pool->sp_mutex);
 
-	if (pool->sp_stopping) {
-		D_DEBUG(DB_MD, DF_UUID": skip fetching hdl due to stop\n",
-			DP_UUID(pool->sp_uuid));
-		D_GOTO(out, rc);
-	}
-	D_INFO(DF_UUID": fetching handles\n", DP_UUID(pool->sp_uuid));
-	rc = ds_pool_iv_conn_hdl_fetch(pool);
-	if (rc) {
-		D_INFO(DF_UUID" iv conn fetch %d\n", DP_UUID(pool->sp_uuid), rc);
-		D_GOTO(out, rc);
+	while (!pool->sp_stopping) {
+		int rc;
+
+		D_DEBUG(DB_MD, DF_UUID ": fetching handles: begin\n", DP_UUID(pool->sp_uuid));
+		rc = ds_pool_iv_conn_hdl_fetch(pool);
+		D_DEBUG(DB_MD, DF_UUID ": fetching handles: end: " DF_RC "\n",
+			DP_UUID(pool->sp_uuid), DP_RC(rc));
+		if (rc == 0)
+			break;
+		dss_sleep(1000 /* ms */);
 	}
 
-out:
 	D_INFO(DF_UUID": signaling done\n", DP_UUID(pool->sp_uuid));
 	ABT_mutex_lock(pool->sp_mutex);
 	ABT_cond_signal(pool->sp_fetch_hdls_done_cond);

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1713,8 +1713,8 @@ out:
 	if (rc != 0)
 		D_FREE(hdl);
 
-	D_DEBUG(DB_MD, DF_UUID": connect "DF_RC"\n",
-		DP_UUID(pool->sp_uuid), DP_RC(rc));
+	D_DEBUG(DB_MD, DF_UUID ": connect " DF_UUID " " DF_RC "\n", DP_UUID(pool->sp_uuid),
+		DP_UUID(pic->pic_hdl), DP_RC(rc));
 	return rc;
 }
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1,7 +1,7 @@
 /*
  * (C) Copyright 2016-2025 Intel Corporation.
- * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2026 Google LLC
+ * (C) Copyright 2026-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */


### PR DESCRIPTION
DAOS-18613 pool: Retry handle fetching upon errors (#17910)
Backporting the similar behavior from the master branch.

DAOS-18799 pool: Fix handle loading (#18016)
It appears that if the PS leader skips the ds_pool_iv_conn_hdls_update
call during pool_svc_step_up_cb because there's no pool handle in the
DB, IV fetches for pool handles will create invalid IV entries and
return unexpected -DER_NOTLEADERs. To prevent that, this patch changes
pool_svc_step_up_cb to call ds_pool_iv_conn_hdls_update even if there's
no pool handle in the DB.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
