### PR TITLE
SRE-3742 ci: no_proxy for direct artifactory access in the Python Bandit check stage

### DIFF
--- a/utils/docker/Dockerfile.code_scanning
+++ b/utils/docker/Dockerfile.code_scanning
@@ -16,6 +16,16 @@ ARG CB0
 # Use local repo server if present
 ARG REPO_FILE_URL
 ARG DAOS_LAB_CA_FILE_URL
+
+# Accept DAOS_NO_PROXY at build time
+ARG DAOS_NO_PROXY
+# Propagate into the build environment
+ENV no_proxy=${DAOS_NO_PROXY}
+ENV NO_PROXY=${DAOS_NO_PROXY}
+# Persist into /etc/environment for use by shells and services
+RUN echo "no_proxy=${DAOS_NO_PROXY}" >> /etc/environment && \
+    echo "NO_PROXY=${DAOS_NO_PROXY}" >> /etc/environment
+
 # script to install OS updates basic tools and daos dependencies
 # COPY ./utils/scripts/install-fedora.sh /tmp/install.sh
 # script to setup local repo if available


### PR DESCRIPTION
In the Python Bandit check stage:
add no_proxy to access artifactory directly as an access via proxy does not work.

Signed-off-by: Tomasz Gromadzki <tomasz.gromadzki@hpe.com>


### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
