### PR TITLE
DAOS-18799 pool: Fix handle loading

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2069,21 +2069,15 @@ add_conn_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		return 0;
 	}
 
-	if (iv_conns == NULL ||
-	    iv_conns->pic_buf_size < iv_conns->pic_size + pool_iv_conn_size(hdl->ph_cred_len)) {
+	if (iv_conns->pic_buf_size < iv_conns->pic_size + pool_iv_conn_size(hdl->ph_cred_len)) {
 		unsigned int          new_size;
 		unsigned int          curr_size;
 		struct pool_iv_conns *new_conns;
 
-		curr_size =
-		    iv_conns ? iv_conns->pic_buf_size + sizeof(*iv_conns) : sizeof(*iv_conns);
+		curr_size = iv_conns->pic_buf_size + sizeof(*iv_conns);
 		new_size = curr_size + 32 * pool_iv_conn_size(hdl->ph_cred_len);
 
-		if (iv_conns != NULL)
-			D_REALLOC(new_conns, iv_conns, curr_size, new_size);
-		else
-			D_ALLOC(new_conns, new_size);
-
+		D_REALLOC(new_conns, iv_conns, curr_size, new_size);
 		if (new_conns == NULL)
 			return -DER_NOMEM;
 
@@ -2108,8 +2102,9 @@ add_conn_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 }
 
 /*
- * Read the DB for map_buf, map_version, prop and pool iv hdls. If the return value is 0,
- * the caller is responsible for freeing *map_buf_out, *prop_out and pool iv_hdls eventually.
+ * Read the DB for map_buf, map_version, prop, etc. If the return value is 0,
+ * the caller is responsible for freeing *map_buf_out, *prop_out and *iv_hdls
+ * eventually.
  */
 static int
 read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
@@ -2204,7 +2199,11 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 	D_ASSERT(prop_entry != NULL);
 	arg.obj_ver    = prop_entry->dpe_val;
 	arg.global_ver = svc->ps_global_version;
-	arg.iv_hdls    = NULL;
+	D_ALLOC_PTR(arg.iv_hdls);
+	if (arg.iv_hdls == NULL) {
+		rc = -DER_NOMEM;
+		goto out_free;
+	}
 	rc = rdb_tx_iterate(&tx, &svc->ps_handles, false /* backward */, add_conn_cb, &arg);
 	if (rc != 0) {
 		DL_ERROR(rc, "Failed to find hdls for evict pool " DF_UUIDF " connections.",
@@ -2614,14 +2613,10 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 		goto out;
 	}
 
-	if (iv_hdls != NULL) {
-		rc = ds_pool_iv_conn_hdls_update(svc->ps_pool, iv_hdls);
-		if (rc != 0) {
-			DL_ERROR(rc, DF_UUID ": ds_pool_iv_conn_hdls_update failed",
-				 DP_UUID(svc->ps_uuid));
-			goto out;
-		}
-		D_INFO(DF_UUID ": distribute existing hdls\n", DP_UUID(svc->ps_uuid));
+	rc = ds_pool_iv_conn_hdls_update(svc->ps_pool, iv_hdls);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_UUID ": ds_pool_iv_conn_hdls_update failed", DP_UUID(svc->ps_uuid));
+		goto out;
 	}
 
 	/* resume pool upgrade if needed */
@@ -2661,7 +2656,6 @@ out:
 		daos_prop_free(prop);
 	if (iv_hdls != NULL)
 		D_FREE(iv_hdls);
-
 	if (svc->ps_error != 0) {
 		/*
 		 * Step up with the error anyway, so that RPCs to the PS


### PR DESCRIPTION
It appears that if the PS leader skips the ds_pool_iv_conn_hdls_update call during pool_svc_step_up_cb because there's no pool handle in the DB, IV fetches for pool handles will create invalid IV entries and return unexpected -DER_NOTLEADERs. To prevent that, this patch changes pool_svc_step_up_cb to call ds_pool_iv_conn_hdls_update even if there's no pool handle in the DB.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
