### PR TITLE
DAOS-18794 cq: update clang-format to fedora 43 (#17976)

### DIFF
--- a/.github/actions/clang-format/Dockerfile
+++ b/.github/actions/clang-format/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM fedora:43@sha256:781b7642e8bf256e9cf75d2aa58d86f5cc695fd2df113517614e181a5eee9138
 
 RUN dnf -y install clang-tools-extra git-clang-format
 


### PR DESCRIPTION
Update clang-format GHA docker fedora 38 -> 43
so we get the latest clang-format tools.

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
