### PR TITLE
DAOS-18758 test: telemetry_pool_metrics.py - bump pool size to 5G (#1…

### DIFF
--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
@@ -15,7 +15,7 @@ server_config:
           scm_mount: /mnt/daos
   system_ram_reserved: 1
 pool:
-  scm_size: 1G
+  scm_size: 5G
 container:
   type: POSIX
   control_method: daos


### PR DESCRIPTION
…7904)

Bump the pool size to 5G so there is enough space to generate data.

Skip-unit-tests: true
Skip-fault-injection-test: true
Required-githooks: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
