### PR TITLE
DAOS-18086 control: Fix data race in drpc unit test (#17979)

### DIFF
--- a/src/control/drpc/drpc_server.go
+++ b/src/control/drpc/drpc_server.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2018-2023 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -30,6 +30,13 @@ type DomainSocketServer struct {
 	service       *ModuleService
 	sessions      map[net.Conn]*Session
 	sessionsMutex sync.Mutex
+}
+
+// GetNumSessions gets the number of current sessions in the server.
+func (d *DomainSocketServer) GetNumSessions() int {
+	d.sessionsMutex.Lock()
+	defer d.sessionsMutex.Unlock()
+	return len(d.sessions)
 }
 
 // closeSession cleans up the session and removes it from the list of active

--- a/src/control/drpc/drpc_server_test.go
+++ b/src/control/drpc/drpc_server_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -283,38 +284,51 @@ func TestServer_RegisterModule(t *testing.T) {
 	}
 }
 
-func TestServer_Listen_AcceptError(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer test.ShowBufferOnFailure(t, buf)
+func TestDrpc_DomainSocketServer_Listen(t *testing.T) {
+	for name, tc := range map[string]struct {
+		newMockListener    func(t *testing.T) *mockListener
+		expAcceptCallCount int
+		expNumSessions     int
+	}{
+		"accept error": {
+			newMockListener: func(t *testing.T) *mockListener {
+				lis := newMockListener(t)
+				lis.acceptErr = errors.New("mock accept error")
+				return lis
+			},
+			expAcceptCallCount: 1, // return after first error
+		},
+		"accept multiple": {
+			newMockListener: func(t *testing.T) *mockListener {
+				lis := newMockListener(t)
+				lis.setNumConnsToAccept(3)
+				return lis
+			},
+			expAcceptCallCount: 4, // accepted connections + final error to exit listener
+			expNumSessions:     3,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := test.MustLogContext(t)
+			log := logging.FromContext(ctx)
 
-	lis := newMockListener()
-	lis.acceptErr = errors.New("mock accept error")
-	dss, _ := NewDomainSocketServer(log, "dontcare.sock", testFileMode)
-	dss.listener = lis
+			dss, err := NewDomainSocketServer(log, "dontcare.sock", testFileMode)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lis := tc.newMockListener(t)
+			dss.listener = lis
 
-	dss.Listen(test.Context(t)) // should return instantly
+			dss.Listen(ctx)
 
-	test.AssertEqual(t, lis.acceptCallCount, 1, "should have returned after first error")
-}
+			// Time for session goroutines to settle
+			time.Sleep(500 * time.Microsecond)
 
-func TestServer_Listen_AcceptConnection(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer test.ShowBufferOnFailure(t, buf)
-
-	lis := newMockListener()
-	lis.setNumConnsToAccept(3)
-	dss, err := NewDomainSocketServer(log, "dontcare.sock", testFileMode)
-	if err != nil {
-		t.Fatal(err)
+			test.AssertEqual(t, tc.expAcceptCallCount, lis.acceptCallCount, "")
+			test.AssertEqual(t, tc.expNumSessions, dss.GetNumSessions(),
+				"server should have made connections into sessions")
+		})
 	}
-	dss.listener = lis
-
-	dss.Listen(test.Context(t)) // will return when error is sent
-
-	test.AssertEqual(t, lis.acceptCallCount, lis.acceptNumConns+1,
-		"should have returned after listener errored")
-	test.AssertEqual(t, dss.GetNumSessions(), lis.acceptNumConns,
-		"server should have made connections into sessions")
 }
 
 func TestServer_ListenSession_Error(t *testing.T) {

--- a/src/control/drpc/drpc_server_test.go
+++ b/src/control/drpc/drpc_server_test.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2023 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -303,14 +303,17 @@ func TestServer_Listen_AcceptConnection(t *testing.T) {
 
 	lis := newMockListener()
 	lis.setNumConnsToAccept(3)
-	dss, _ := NewDomainSocketServer(log, "dontcare.sock", testFileMode)
+	dss, err := NewDomainSocketServer(log, "dontcare.sock", testFileMode)
+	if err != nil {
+		t.Fatal(err)
+	}
 	dss.listener = lis
 
 	dss.Listen(test.Context(t)) // will return when error is sent
 
 	test.AssertEqual(t, lis.acceptCallCount, lis.acceptNumConns+1,
 		"should have returned after listener errored")
-	test.AssertEqual(t, len(dss.sessions), lis.acceptNumConns,
+	test.AssertEqual(t, dss.GetNumSessions(), lis.acceptNumConns,
 		"server should have made connections into sessions")
 }
 

--- a/src/control/drpc/mocks_test.go
+++ b/src/control/drpc/mocks_test.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2022 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -167,6 +167,7 @@ func (m *mockConn) SetReadOutputBytesToResponse(t *testing.T, resp *Response) {
 
 // mockListener is a mock of the net.Listener interface
 type mockListener struct {
+	t               *testing.T
 	acceptNumConns  int // accept a certain number of connections before failing
 	acceptErr       error
 	acceptCallCount int
@@ -179,7 +180,9 @@ func (l *mockListener) Accept() (net.Conn, error) {
 	if l.acceptCallCount > l.acceptNumConns {
 		return nil, l.acceptErr
 	}
-	return newMockConn(), nil
+	c := newMockConn()
+	c.SetReadOutputBytesToResponse(l.t, &Response{})
+	return c, nil
 }
 
 func (l *mockListener) Close() error {
@@ -197,10 +200,8 @@ func (l *mockListener) setNumConnsToAccept(n int) {
 	l.acceptErr = errors.New("mock done accepting connections")
 }
 
-func newMockListener() *mockListener {
-	return &mockListener{
-		acceptNumConns: -1,
-	}
+func newMockListener(t *testing.T) *mockListener {
+	return &mockListener{t: t}
 }
 
 // ctxMockListener is a mock of the net.Listener interface that blocks


### PR DESCRIPTION
This issue was only affecting unit tests.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
