### PR TITLE
DAOS-18607 aggregation: reduce EC sluggish warning

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -2000,7 +2000,7 @@ static void
 cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 {
 	bool                warn_sluggish;
-	int                 warn_slug_ranks = 8; /* 8 ranks at most */
+	int                 warn_slug_ranks = 0;
 	d_rank_list_t       fail_ranks = {0};
 	struct cont_ec_agg *ec_agg;
 	struct cont_ec_agg *tmp;
@@ -2056,16 +2056,10 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 				continue;
 			}
 
-			if (!warn_sluggish) {
-				/* avoid to generate warning right after rebuild */
-				ec_agg->ea_server_ephs[i].ee_warn_slug_ts = cur_ts;
-
-			} else if (warn_slug_ranks > 0 &&
-				   (cur_ts - ec_agg->ea_server_ephs[i].ee_update_ts) >= 600 &&
-				   (cur_ts - ec_agg->ea_server_ephs[i].ee_warn_slug_ts) >= 600) {
-				ec_agg->ea_server_ephs[i].ee_warn_slug_ts = cur_ts;
-				warn_slug_ranks--;
-
+			if (warn_sluggish && warn_slug_ranks < 8 && /* warnings for <= 8 ranks */
+			    (cur_ts - ec_agg->ea_warn_slug_ts) >= 600 &&
+			    (cur_ts - ec_agg->ea_server_ephs[i].ee_update_ts) >= 600) {
+				warn_slug_ranks++;
 				D_WARN(DF_CONT ": Sluggish EC boundary report from rank %d, " DF_U64
 					       " Seconds.",
 				       DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid), rank,
@@ -2094,6 +2088,7 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 
 		cur_eph = d_hlc2sec(ec_agg->ea_current_eph);
 		new_eph = d_hlc2sec(min_eph);
+
 		if (!warn_sluggish) {
 			/* avoid to generate warning right after rebuild */
 			ec_agg->ea_warn_slug_ts = cur_ts;
@@ -2105,6 +2100,9 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 				       "cur:" DF_U64 " new:" DF_U64 " gap:" DF_U64 "\n",
 			       DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid), cur_eph, new_eph,
 			       new_eph - cur_eph);
+
+		} else if (warn_slug_ranks != 0) {
+			ec_agg->ea_warn_slug_ts = cur_ts;
 		}
 
 		if (min_eph > ec_agg->ea_rdb_eph) {

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1999,6 +1999,7 @@ out_lock:
 static void
 cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 {
+	static uint64_t     warn_sluggish_ts;
 	d_rank_list_t       fail_ranks = {0};
 	struct cont_ec_agg *ec_agg;
 	struct cont_ec_agg *tmp;
@@ -2049,11 +2050,14 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 			}
 
 			if (pool->sp_reclaim != DAOS_RECLAIM_DISABLED &&
-			    cur_ts > ec_agg->ea_server_ephs[i].ee_update_ts + 600)
+			    !ds_pool_is_rebuilding(pool) && (cur_ts - warn_sluggish_ts) >= 600 &&
+			    (cur_ts - ec_agg->ea_server_ephs[i].ee_update_ts) >= 600) {
+				warn_sluggish_ts = cur_ts;
 				D_WARN(DF_CONT ": Sluggish EC boundary report from rank %d, " DF_U64
 					       " Seconds.",
 				       DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid), rank,
 				       cur_ts - ec_agg->ea_server_ephs[i].ee_update_ts);
+			}
 
 			if (ec_agg->ea_server_ephs[i].eph < min_eph)
 				min_eph = ec_agg->ea_server_ephs[i].eph;
@@ -2077,11 +2081,14 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 
 		cur_eph = d_hlc2sec(ec_agg->ea_current_eph);
 		new_eph = d_hlc2sec(min_eph);
-		if (cur_eph && new_eph > cur_eph && (new_eph - cur_eph) >= 600)
+		if (!ds_pool_is_rebuilding(pool) && cur_eph && new_eph > cur_eph &&
+		    (new_eph - cur_eph) >= 600 && (cur_ts - warn_sluggish_ts) >= 600) {
+			warn_sluggish_ts = cur_ts;
 			D_WARN(DF_CONT ": Sluggish EC boundary reporting. "
 				       "cur:" DF_U64 " new:" DF_U64 " gap:" DF_U64 "\n",
 			       DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid), cur_eph, new_eph,
 			       new_eph - cur_eph);
+		}
 
 		if (min_eph > ec_agg->ea_rdb_eph) {
 			rc = cont_agg_eph_store(svc, ec_agg->ea_cont_uuid, min_eph,

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1999,7 +1999,8 @@ out_lock:
 static void
 cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 {
-	static uint64_t     warn_sluggish_ts;
+	bool                warn_sluggish;
+	int                 warn_slug_ranks = 8; /* 8 ranks at most */
 	d_rank_list_t       fail_ranks = {0};
 	struct cont_ec_agg *ec_agg;
 	struct cont_ec_agg *tmp;
@@ -2040,6 +2041,12 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 
 		min_eph = DAOS_EPOCH_MAX;
 		cur_ts  = daos_gettime_coarse();
+
+		if (!ds_pool_is_rebuilding(pool) && pool->sp_reclaim != DAOS_RECLAIM_DISABLED)
+			warn_sluggish = true;
+		else
+			warn_sluggish = false;
+
 		for (i = 0; i < ec_agg->ea_servers_num; i++) {
 			rank = ec_agg->ea_server_ephs[i].rank;
 
@@ -2049,10 +2056,16 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 				continue;
 			}
 
-			if (pool->sp_reclaim != DAOS_RECLAIM_DISABLED &&
-			    !ds_pool_is_rebuilding(pool) && (cur_ts - warn_sluggish_ts) >= 600 &&
-			    (cur_ts - ec_agg->ea_server_ephs[i].ee_update_ts) >= 600) {
-				warn_sluggish_ts = cur_ts;
+			if (!warn_sluggish) {
+				/* avoid to generate warning right after rebuild */
+				ec_agg->ea_server_ephs[i].ee_warn_slug_ts = cur_ts;
+
+			} else if (warn_slug_ranks > 0 &&
+				   (cur_ts - ec_agg->ea_server_ephs[i].ee_update_ts) >= 600 &&
+				   (cur_ts - ec_agg->ea_server_ephs[i].ee_warn_slug_ts) >= 600) {
+				ec_agg->ea_server_ephs[i].ee_warn_slug_ts = cur_ts;
+				warn_slug_ranks--;
+
 				D_WARN(DF_CONT ": Sluggish EC boundary report from rank %d, " DF_U64
 					       " Seconds.",
 				       DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid), rank,
@@ -2081,9 +2094,13 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 
 		cur_eph = d_hlc2sec(ec_agg->ea_current_eph);
 		new_eph = d_hlc2sec(min_eph);
-		if (!ds_pool_is_rebuilding(pool) && cur_eph && new_eph > cur_eph &&
-		    (new_eph - cur_eph) >= 600 && (cur_ts - warn_sluggish_ts) >= 600) {
-			warn_sluggish_ts = cur_ts;
+		if (!warn_sluggish) {
+			/* avoid to generate warning right after rebuild */
+			ec_agg->ea_warn_slug_ts = cur_ts;
+
+		} else if (cur_eph && new_eph > cur_eph && (new_eph - cur_eph) >= 600 &&
+			   (cur_ts - ec_agg->ea_warn_slug_ts) >= 600) {
+			ec_agg->ea_warn_slug_ts = cur_ts;
 			D_WARN(DF_CONT ": Sluggish EC boundary reporting. "
 				       "cur:" DF_U64 " new:" DF_U64 " gap:" DF_U64 "\n",
 			       DP_CONT(svc->cs_pool_uuid, ec_agg->ea_cont_uuid), cur_eph, new_eph,

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -62,7 +62,6 @@ struct ec_eph {
 	d_rank_t	rank;
 	daos_epoch_t	eph;
 	uint64_t        ee_update_ts; /* update timestamp */
-	uint64_t        ee_warn_slug_ts;
 };
 
 /* container EC aggregation epoch control descriptor, which is only on leader */

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -62,6 +62,7 @@ struct ec_eph {
 	d_rank_t	rank;
 	daos_epoch_t	eph;
 	uint64_t        ee_update_ts; /* update timestamp */
+	uint64_t        ee_warn_slug_ts;
 };
 
 /* container EC aggregation epoch control descriptor, which is only on leader */
@@ -69,6 +70,7 @@ struct cont_ec_agg {
 	uuid_t			ea_cont_uuid;
 	daos_epoch_t		ea_current_eph;
 	daos_epoch_t             ea_rdb_eph;
+	uint64_t                 ea_warn_slug_ts;
 	struct ec_eph		*ea_server_ephs;
 	d_list_t		ea_list;
 	int			ea_servers_num;


### PR DESCRIPTION
- disable the sluggish warning when rebuild is running
- in other cases, log it every 10 minutes

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
