### PR TITLE
DAOS-18849 vos: re-check in vos_cont_destroy()

### DIFF
--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -654,8 +654,23 @@ vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 		D_GOTO(exit, rc);
 	}
 
-	d_iov_set(&iov, &key, sizeof(struct d_uuid));
-	rc = dbtree_delete(pool->vp_cont_th, BTR_PROBE_EQ, &iov, NULL);
+	/*
+	 * Temporary workaround: Re-check if the container is re-opened by rebuild
+	 * when this function yield on flushing header or starting local tx.
+	 *
+	 * This additional check should be removed once rebuild no longer do on-demand
+	 * container open/create.
+	 */
+	rc = cont_lookup(&key, &pkey, &cont, pool->vp_sysdb);
+	if (rc == 0) {
+		D_ERROR(DF_CONT " Container is re-opened (%d)!\n", DP_CONT(pool->vp_id, co_uuid),
+			cont->vc_open_count);
+		cont_decref(cont);
+		rc = -DER_BUSY;
+	} else {
+		d_iov_set(&iov, &key, sizeof(struct d_uuid));
+		rc = dbtree_delete(pool->vp_cont_th, BTR_PROBE_EQ, &iov, NULL);
+	}
 
 	rc = umem_tx_end(vos_pool2umm(pool), rc);
 	if (rc) {


### PR DESCRIPTION
In md-on-ssd mode, vos_cont_destroy() chould yield on flushing WAL or starting local tx, so should re-check if the container is re-opened by rebuild after tx started.

This additional check could be removed once rebuild no longer do on-demand container open/create.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
