### PR TITLE
DAOS-18880 cq: specify min python version in lint requirements

### DIFF
--- a/utils/cq/requirements.txt
+++ b/utils/cq/requirements.txt
@@ -2,11 +2,11 @@
 pyenchant
 ## flake8 6 removed --diff option which breaks flake precommit hook.
 ## https://github.com/pycqa/flake8/issues/1389 https://github.com/PyCQA/flake8/pull/1720
-flake8==7.3.0
-isort==8.0.1
-pylint==4.0.5
-yamllint==1.38.0
-codespell==2.4.2
+flake8==7.3.0;python_version>="3.9"
+isort==8.0.1;python_version>="3.10"
+pylint==4.0.5;python_version>="3.10"
+yamllint==1.38.0;python_version>="3.10"
+codespell==2.4.2;python_version>="3.9"
 # Used by ci/jira_query.py which pip installs it standalone.
 jira
-torch>=2.2.0
+torch>=2.2.0;python_version>="3.8"

--- a/utils/githooks/README.md
+++ b/utils/githooks/README.md
@@ -14,7 +14,7 @@ Installing is a two-step process:
 
 ### 1. Install the hooks
 
-Recommended: Configure your `core.hookspath`.  
+Configure your `core.hookspath`.  
 Any new githooks added to the repository will automatically run,
 but possibly require additional software to produce the desired effect.
 Additionally, as the branch changes, the githooks change with it.
@@ -23,7 +23,8 @@ Additionally, as the branch changes, the githooks change with it.
 git config core.hookspath utils/githooks
 ```
 
-Additionally, one can copy the files into an already configured path.
+Alternatively, one can copy the files into an already configured path.
+This is not recommended as the hooks will have to be manually copied whenever there are updates.
 
 ### 2. Install the tools
 
@@ -32,13 +33,24 @@ However, some hooks will simply check for required software and are
 effectively a noop if such is not installed.
 
 Requirements come from a combination of `pip` and system packages and can usually be installed through standard means.  
-To install `pip` packages specified in [utils/cq/requirements.txt](../../utils/cq/requirements.txt) it is recommended to setup a virtual environment and install with pip.  
-If you already have a [virtual environment for building](../../docs/QSG/build_from_scratch.md#python-packages) you can simply install the requirements:
 
+#### Install pip packages
+To install `pip` packages specified in [utils/cq/requirements.txt](../../utils/cq/requirements.txt) it is recommended to setup a virtual environment and install with pip.  
+It is recommended to use python 3.11, but you need at least 3.10 to get the latest version of each package.  
+You can setup a virtual environment with:
+```sh
+python3.11 -m venv /path/to/my_env
+```
+Then, to use it:
+```sh
+source /path/to/my_env/bin/activate
+```
+Then, to install the requirements:
 ```sh
 python3 -m pip install -r utils/cq/requirements.txt
 ```
 
+#### Install System Packages
 Install system packages with your package manager - for example:
 
 ```sh


### PR DESCRIPTION
Specify the minimum python version in the linting requirements file. This will produce a warning instead of a generic error when installing.

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
