### PR TITLE
DAOS-18776 test: move test_create_no_space_loop to daily (#18005)

### DIFF
--- a/src/tests/ftest/pool/create.py
+++ b/src/tests/ftest/pool/create.py
@@ -1,6 +1,6 @@
 """
 (C) Copyright 2021-2023 Intel Corporation.
-(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+(C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -55,7 +55,7 @@ class PoolCreateTests(TestWithServers):
         :avocado: tags=pool
         :avocado: tags=PoolCreateTests,test_create_max_pool
         """
-        # Create 1 pool using 90% of the available capacity
+        # Create 1 pool using almost all of the available capacity
         pool = add_pool(self, namespace="/run/pool_2/*", create=False)
         check_pool_creation(self, [pool], 120)
 
@@ -67,19 +67,19 @@ class PoolCreateTests(TestWithServers):
             server.  Verify that attempting to create  a pool of the same size
             across all of the servers fails due to no space.  Now verify that
             creating a pool of the same size on across all but the first server
-            succeeds.  Repeat the last two steps 100 times with the addition of
+            succeeds.  Repeat the last two steps 20 times with the addition of
             deleting the successfully created pool to verify that there is not
             any subtle/low capacity space being lost with each failed create.
 
-        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=all,daily_regression
         :avocado: tags=hw,medium
         :avocado: tags=pool
         :avocado: tags=PoolCreateTests,test_create_no_space_loop
         """
         # Define three pools to create:
-        #   - one pool using 90% of the available capacity of one server
-        #   - one pool using 90% of the available capacity of all servers
-        #   - one pool using 90% of the available capacity of the other server
+        #   - one pool using almost all of the available capacity of one server
+        #   - one pool using almost all of the available capacity of all servers
+        #   - one pool using almost all of the available capacity of the other server
         ranks = sorted(self.server_managers[0].ranks.keys())
         params = (
             {"target_list": ranks[:1]},
@@ -106,7 +106,7 @@ class PoolCreateTests(TestWithServers):
             pools.append(
                 add_pool(self, namespace="/run/pool_2/*", create=False, **params[index]))
 
-        for index in range(100):
+        for index in range(20):
             # Create the second of three pools which should fail due to not enough space.
             self.log.info("Loop %s", index)
             pools[1].create()

--- a/src/tests/ftest/pool/create.yaml
+++ b/src/tests/ftest/pool/create.yaml
@@ -6,7 +6,7 @@ timeouts:
   test_create_max_pool_scm_only: 180
   test_create_max_pool: 300
   test_create_no_space: 300
-  test_create_no_space_loop: 4100
+  test_create_no_space_loop: 900
 
 server_config:
   name: daos_server
@@ -25,10 +25,6 @@ server_config:
 
 pool_1:
   scm_size: 1
-  svcn: 1
-  quantity: 1
 
 pool_2:
-  size: 90%
-  svcn: 1
-  quantity: 1
+  size: 95%


### PR DESCRIPTION
Move test_create_no_space_loop to daily and reduce loops from 100 to 20. Also increase pool percent from 90 to 95% to further stress.

Test-tag: PoolCreateTests
Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
