### PR TITLE
DAOS-18784 test: use the same pool in ftest/dfuse/fio_small (#17950)

### DIFF
--- a/src/tests/ftest/dfuse/fio_pil4dfs_small.py
+++ b/src/tests/ftest/dfuse/fio_pil4dfs_small.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2019-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -20,19 +21,7 @@ class FioPil4dfsSmall(FioBase):
         """Jira ID: DAOS-12142.
 
         Test Description:
-            Test Fio in small config with libpil4dfs.so.
-
-        Use Cases:
-            Aim of this test is to test different combinations
-            of following fio configs:
-            1 Client
-            thread: 1
-            verify: 'crc64'
-            iodepth: 16
-            blocksize: 256B|1M
-            size: 1M|1G
-            read_write: rw|randrw
-            numjobs: 1
+            Verify Fio in various small configs with libpil4dfs.so.
 
         :avocado: tags=all,daily_regression
         :avocado: tags=hw,medium
@@ -40,10 +29,32 @@ class FioPil4dfsSmall(FioBase):
         :avocado: tags=FioPil4dfsSmall,test_fio_pil4dfs_small
         """
         self.fio_cmd.env['LD_PRELOAD'] = os.path.join(self.prefix, 'lib64', 'libpil4dfs.so')
+
+        self.log_step('Create a pool')
         pool = self.get_pool(connect=False)
-        container = self.get_container(pool)
-        container.set_attr(attrs={'dfuse-direct-io-disable': 'on'})
-        dfuse = get_dfuse(self, self.hostlist_clients)
-        start_dfuse(self, dfuse, pool, container)
-        self.fio_cmd.update_directory(dfuse.mount_dir.value)
-        self.execute_fio()
+
+        # Run with various container properties
+        for properties in self.params.get("properties_variants", '/run/container/*'):
+            self.log_step('Create a container with properties: %s', properties)
+            container = self.get_container(pool, properties=properties)
+            container.set_attr(attrs={'dfuse-direct-io-disable': 'on'})
+
+            self.log_step('Start dfuse')
+            dfuse = get_dfuse(self, self.hostlist_clients)
+            start_dfuse(self, dfuse, pool, container)
+            self.fio_cmd.update_directory(dfuse.mount_dir.value)
+
+            # Run with various fio parameters
+            for variant in self.params.get("variants", '/run/fio/global/*'):
+                self.log_step(
+                    f'Run fio with direct={variant[0]}, blocksize={variant[1]}, '
+                    f'size={variant[2]}, rw={variant[3]}')
+                self.fio_cmd.update('global', 'direct', variant[0], 'global.direct')
+                self.fio_cmd.update('global', 'blocksize', variant[1], 'global.blocksize')
+                self.fio_cmd.update('global', 'size', variant[2], 'global.size')
+                self.fio_cmd.update('global', 'rw', variant[3], 'global.rw')
+                self.execute_fio()
+
+            self.log_step('Stop dfuse and destroy container')
+            dfuse.stop()
+            container.destroy()

--- a/src/tests/ftest/dfuse/fio_pil4dfs_small.yaml
+++ b/src/tests/ftest/dfuse/fio_pil4dfs_small.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 2
   test_clients: 1
 
-timeout: 360
+timeout: 420
 
 server_config:
   name: daos_server

--- a/src/tests/ftest/dfuse/fio_pil4dfs_small.yaml
+++ b/src/tests/ftest/dfuse/fio_pil4dfs_small.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 2
   test_clients: 1
 
-timeout: 1000
+timeout: 360
 
 server_config:
   name: daos_server
@@ -18,31 +18,18 @@ server_config:
       nr_xs_helpers: 1
       log_file: daos_server1.log
       storage: auto
-  transport_config:
-    allow_insecure: true
-
-agent_config:
-  transport_config:
-    allow_insecure: true
-
-dmg:
-  transport_config:
-    allow_insecure: true
 
 pool:
-  scm_size: 1600000000
-  nvme_size: 20000000000
+  scm_size: 2G
+  nvme_size: 20G
 
 container:
   type: POSIX
   control_method: daos
-  rf_properties: !mux
-    rf0:
-      properties: cksum:crc16,cksum_size:16384,srv_cksum:on
-    rf1:
-      properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
-    rf2:
-      properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:2
+  properties_variants:
+    - cksum:crc16,cksum_size:16384,srv_cksum:on
+    - cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
+    - cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:2
 
 fio:
   names:
@@ -53,24 +40,18 @@ fio:
     ioengine: 'sync'
     thread: 1
     group_reporting: 1
-    direct_io: !mux
-      on:
-        direct: 1
-      off:
     verify: 'crc64'
     iodepth: 16
-    bs: !mux
-      bs_256B:
-        blocksize: '256B'
-        size: '1M'
-      bs_1M:
-        blocksize: '1M'
-        size: '2G'
-    read_write: !mux
-      sequential:
-        rw: 'rw'
-      random:
-        rw: 'randrw'
+    variants:
+      # [direct, blocksize, size, rw]
+      - [0, 256B, 1M, rw]
+      - [0, 256B, 1M, randrw]
+      - [0, 1M,   2G, rw]
+      - [0, 1M,   2G, randrw]
+      - [1, 256B, 1M, rw]
+      - [1, 256B, 1M, randrw]
+      - [1, 1M,   2G, rw]
+      - [1, 1M,   2G, randrw]
   test:
     numjobs: 1
 

--- a/src/tests/ftest/dfuse/fio_small.py
+++ b/src/tests/ftest/dfuse/fio_small.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2019-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -18,30 +19,38 @@ class FioSmall(FioBase):
         """Jira ID: DAOS-2493.
 
         Test Description:
-            Test Fio in small config.
-
-        Use Cases:
-            Aim of this test is to test different combinations
-            of following fio configs:
-            1 Client
-            ioengine: 'libaio'
-            thread: 1
-            verify: 'crc64'
-            iodepth: 16
-            blocksize: 256B|1M
-            size: 1M|1G
-            read_write: rw|randrw
-            numjobs: 1
+            Verify Fio in various small configs.
 
         :avocado: tags=all,daily_regression
         :avocado: tags=hw,medium
         :avocado: tags=dfuse,fio,checksum,tx
         :avocado: tags=FioSmall,test_fio_small
         """
+        self.log_step('Create a pool')
         pool = self.get_pool(connect=False)
-        container = self.get_container(pool)
-        container.set_attr(attrs={'dfuse-direct-io-disable': 'on'})
-        dfuse = get_dfuse(self, self.hostlist_clients)
-        start_dfuse(self, dfuse, pool, container)
-        self.fio_cmd.update_directory(dfuse.mount_dir.value)
-        self.execute_fio()
+
+        # Run with various container properties
+        for properties in self.params.get("properties_variants", '/run/container/*'):
+            self.log_step('Create a container with properties: %s', properties)
+            container = self.get_container(pool, properties=properties)
+            container.set_attr(attrs={'dfuse-direct-io-disable': 'on'})
+
+            self.log_step('Start dfuse')
+            dfuse = get_dfuse(self, self.hostlist_clients)
+            start_dfuse(self, dfuse, pool, container)
+            self.fio_cmd.update_directory(dfuse.mount_dir.value)
+
+            # Run with various fio parameters
+            for variant in self.params.get("variants", '/run/fio/global/*'):
+                self.log_step(
+                    f'Run fio with direct={variant[0]}, blocksize={variant[1]}, '
+                    f'size={variant[2]}, rw={variant[3]}')
+                self.fio_cmd.update('global', 'direct', variant[0], 'global.direct')
+                self.fio_cmd.update('global', 'blocksize', variant[1], 'global.blocksize')
+                self.fio_cmd.update('global', 'size', variant[2], 'global.size')
+                self.fio_cmd.update('global', 'rw', variant[3], 'global.rw')
+                self.execute_fio()
+
+            self.log_step('Stop dfuse and destroy container')
+            dfuse.stop()
+            container.destroy()

--- a/src/tests/ftest/dfuse/fio_small.yaml
+++ b/src/tests/ftest/dfuse/fio_small.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 2
   test_clients: 1
 
-timeout: 360
+timeout: 420
 
 server_config:
   name: daos_server

--- a/src/tests/ftest/dfuse/fio_small.yaml
+++ b/src/tests/ftest/dfuse/fio_small.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 2
   test_clients: 1
 
-timeout: 1000
+timeout: 360
 
 server_config:
   name: daos_server
@@ -18,32 +18,18 @@ server_config:
       nr_xs_helpers: 1
       log_file: daos_server1.log
       storage: auto
-  transport_config:
-    allow_insecure: true
-
-agent_config:
-  transport_config:
-    allow_insecure: true
-
-dmg:
-  transport_config:
-    allow_insecure: true
 
 pool:
-  scm_size: 1600000000
-  nvme_size: 20000000000
-  control_method: dmg
+  scm_size: 2G
+  nvme_size: 20G
 
 container:
   type: POSIX
   control_method: daos
-  rf_properties: !mux
-    rf0:
-      properties: cksum:crc16,cksum_size:16384,srv_cksum:on
-    rf1:
-      properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
-    rf2:
-      properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:2
+  properties_variants:
+    - cksum:crc16,cksum_size:16384,srv_cksum:on
+    - cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
+    - cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:2
 
 fio:
   names:
@@ -54,24 +40,18 @@ fio:
     ioengine: 'libaio'
     thread: 1
     group_reporting: 1
-    direct_io: !mux
-      on:
-        direct: 1
-      off:
     verify: 'crc64'
     iodepth: 16
-    bs: !mux
-      bs_256B:
-        blocksize: '256B'
-        size: '1M'
-      bs_1M:
-        blocksize: '1M'
-        size: '2G'
-    read_write: !mux
-      sequential:
-        rw: 'rw'
-      random:
-        rw: 'randrw'
+    variants:
+      # [direct, blocksize, size, rw]
+      - [0, 256B, 1M, rw]
+      - [0, 256B, 1M, randrw]
+      - [0, 1M,   2G, rw]
+      - [0, 1M,   2G, randrw]
+      - [1, 256B, 1M, rw]
+      - [1, 256B, 1M, randrw]
+      - [1, 1M,   2G, rw]
+      - [1, 1M,   2G, randrw]
   test:
     numjobs: 1
 


### PR DESCRIPTION
Run each variant in ftest/dfuse/fio_small with the same pool. Do the same for ftest/dfuse/fio_pil4dfs_small.
This is more like production and speeds up the test.

Test-tag: FioSmall FioPil4dfsSmall
Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
