### PR TITLE
SRE-3755 ci: Add NFS mount retry to handle transient server readiness

### DIFF
--- a/ci/functional/test_main_prep_node.sh
+++ b/ci/functional/test_main_prep_node.sh
@@ -339,9 +339,28 @@ if [ "$result" -ne 0 ]; then
 fi
 
 set -x
-if [ -n "$FIRST_NODE" ] && ! grep /mnt/share /proc/mounts; then
+if [ -n "$FIRST_NODE" ] && ! grep -qs ' /mnt/share ' /proc/mounts; then
     mkdir -p /mnt/share
-    mount "$FIRST_NODE":/export/share /mnt/share
+    # Retry the NFS mount to handle the case where the NFS server on
+    # FIRST_NODE has not fully registered its exports yet.
+    nfs_mounted=false
+    for attempt in $(seq 1 3); do
+        if mount "$FIRST_NODE":/export/share /mnt/share; then
+            nfs_mounted=true
+            break
+        fi
+        echo "NFS mount attempt $attempt failed, retrying in 5s..."
+        sleep 5
+    done
+    if ! "$nfs_mounted"; then
+        echo "ERROR: NFS mount failed after $attempt attempts:"
+        echo "  $FIRST_NODE:/export/share -> /mnt/share"
+        echo "Exports advertised by $FIRST_NODE:"
+        showmount -e "$FIRST_NODE" || true
+        echo "DNS/hosts resolution for $FIRST_NODE:"
+        getent hosts "$FIRST_NODE" || true
+        exit 32
+    fi
 fi
 
 # The package name defaults to "(root)" unless there is a dot in the


### PR DESCRIPTION
The NFS mount in test_main_prep_node.sh can fail with "access denied" when the NFS server on FIRST_NODE hasn't fully registered its exports before client nodes attempt to mount. This is a race between setup_nfs.sh completing on the server and clush launching test_main_prep_node.sh on all nodes simultaneously.

Add a retry loop (3 attempts, 5s apart) around the mount call, and on final failure print showmount/getent diagnostics to aid debugging. Also tighten the /proc/mounts grep to avoid false substring matches.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
