### PR TITLE
DAOS-18607 container: reduce EC agg sluggish warn msg

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1834,6 +1834,7 @@ cont_track_eph_leader_alloc(struct cont_svc *cont_svc, uuid_t cont_uuid,
 		eph_ldr->cte_server_ephs[i].re_ec_agg_eph_update_ts = daos_gettime_coarse();
 	}
 	d_list_add(&eph_ldr->cte_list, &cont_svc->cs_cont_ephs_leader_list);
+	eph_ldr->cte_ec_agg_warn_slug_ts = daos_gettime_coarse();
 	*leader_p = eph_ldr;
 out:
 	if (rc) {
@@ -2159,6 +2160,7 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 	daos_epoch_t			 min_stable_eph;
 	uint64_t                         cur_ts;
 	int				 i;
+	int                              warn_slug_ranks = 8; /* 8 ranks at most */
 	int				 rc = 0;
 
 	rc = map_ranks_failed(pool->sp_map, &fail_ranks);
@@ -2193,6 +2195,8 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 		min_ec_agg_eph = DAOS_EPOCH_MAX;
 		min_stable_eph = DAOS_EPOCH_MAX;
 		cur_ts         = daos_gettime_coarse();
+		if (ds_pool_is_rebuilding(pool) || pool->sp_reclaim == DAOS_RECLAIM_DISABLED)
+			eph_ldr->cte_ec_agg_warn_slug_ts = cur_ts;
 		for (i = 0; i < eph_ldr->cte_servers_num; i++) {
 			d_rank_t rank = eph_ldr->cte_server_ephs[i].re_rank;
 
@@ -2202,13 +2206,16 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 				continue;
 			}
 
-			if (pool->sp_reclaim != DAOS_RECLAIM_DISABLED &&
-			    cur_ts > eph_ldr->cte_server_ephs[i].re_ec_agg_eph_update_ts + 600)
+			if (cur_ts > eph_ldr->cte_ec_agg_warn_slug_ts + 600 &&
+			    cur_ts > eph_ldr->cte_server_ephs[i].re_ec_agg_eph_update_ts + 600 &&
+			    warn_slug_ranks > 0) {
+				warn_slug_ranks--;
 				D_WARN(DF_CONT ": Sluggish EC boundary report from rank %d, " DF_U64
 					       " Seconds.",
 				       DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid), rank,
 				       cur_ts -
 					   eph_ldr->cte_server_ephs[i].re_ec_agg_eph_update_ts);
+			}
 
 			if (eph_ldr->cte_server_ephs[i].re_ec_agg_eph < min_ec_agg_eph)
 				min_ec_agg_eph = eph_ldr->cte_server_ephs[i].re_ec_agg_eph;
@@ -2239,7 +2246,8 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 
 		cur_eph = d_hlc2sec(eph_ldr->cte_current_ec_agg_eph);
 		new_eph = d_hlc2sec(min_ec_agg_eph);
-		if (cur_eph && new_eph > cur_eph && (new_eph - cur_eph) >= 600)
+		if ((cur_ts > eph_ldr->cte_ec_agg_warn_slug_ts + 600) && cur_eph &&
+		    (new_eph > cur_eph) && (new_eph - cur_eph) >= 600)
 			D_WARN(DF_CONT ": Sluggish EC boundary reporting. "
 				       "cur:" DF_U64 " new:" DF_U64 " gap:" DF_U64 "\n",
 			       DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid), cur_eph, new_eph,
@@ -2295,8 +2303,6 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 		}
 		eph_ldr->cte_current_ec_agg_eph = min_ec_agg_eph;
 		eph_ldr->cte_current_stable_eph = min_stable_eph;
-		if (atomic_load(&pool->sp_rebuilding))
-			break;
 	}
 	ABT_mutex_unlock(svc->cs_cont_ephs_mutex);
 

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -72,9 +72,11 @@ struct cont_track_eph_leader {
 	daos_epoch_t		cte_current_stable_eph;
 	daos_epoch_t             cte_rdb_ec_agg_eph; /* EC agg epoch in RDB */
 	struct rank_eph		*cte_server_ephs;
-	d_list_t		cte_list;
-	int			cte_servers_num;
-	uint32_t		cte_deleted:1;
+	d_list_t                 cte_list;
+	int                      cte_servers_num;
+	uint32_t                 cte_deleted : 1;
+	/* TS to check for ec_agg_eph sluggish warning */
+	uint64_t                 cte_ec_agg_warn_slug_ts;
 };
 
 /*


### PR DESCRIPTION
And refine cont_agg_eph_sync() a little bit to avoid stable epoch cannot be updated in rebuilding.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
