### PR TITLE
DAOS-18871 object: log real res_used in migr_res_watchdog (#18088)

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -4547,8 +4547,9 @@ migr_res_watchdog(void)
 
 			ABT_mutex_lock(res->res_mutex);
 			if (d_list_empty(&res->res_waitq)) {
-				D_WARN(" bucket=%d: limit=%lu, used=0, waiter=<NULL>\n", j,
-				       res->res_limit);
+				D_WARN(" bucket=%d: limit=" DF_U64 ", used=" DF_U64
+				       ", waiter=<NULL>\n",
+				       j, res->res_limit, res->res_used);
 				ABT_mutex_unlock(res->res_mutex);
 				continue;
 			}


### PR DESCRIPTION
Empty waitq does not imply zero resource usage.
Report actual res_used when waitq is empty in
migr_res_watchdog() to avoid misleading watchdog diagnostics

Skip-test: true
Skip-unit-tests: true
Skip-nlt: true
Skip-unit-test-memcheck: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
