### PR TITLE
DAOS-18690 vos: reserve buffer for space emergency - b28

### DIFF
--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -116,7 +116,12 @@ struct vos_gc_bkt_df {
 /** 2.8 features */
 #define VOS_POOL_FEAT_2_8			(VOS_POOL_FEAT_GANG_SV)
 
-#define VOS_POOL_EXT_DF_PADDING_SIZE            53
+#define VOS_POOL_EXT_DF_PADDING_SIZE            52
+
+/* Preallocate 512KB buffer for backend transaction snapshots under space pressure.
+ * NB: workload of GC/DTX is deterministic (tree operations), 512K should be sufficient.
+ */
+#define VOS_SNAPBUF_EMERG_SIZE                  (1 << 19)
 
 /* VOS pool durable format extension */
 struct vos_pool_ext_df {
@@ -124,6 +129,8 @@ struct vos_pool_ext_df {
 	struct vos_gc_bkt_df	ped_gc_bkt;
 	/* Memory file size for md-on-ssd phase2 pool */
 	uint64_t                ped_mem_sz;
+	/* emergency buffer for TX snapshots under space pressure */
+	umem_off_t              ped_emerg_buf;
 	/* Paddings for other potential new feature */
 	uint64_t                ped_paddings[VOS_POOL_EXT_DF_PADDING_SIZE];
 	/* Reserved for future extension */

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -1442,8 +1442,14 @@ vos_pool_create_ex(const char *path, uuid_t uuid, daos_size_t scm_sz, daos_size_
 		pool_df->pd_version = version;
 
 	/* pd_ext is newly allocated, no need to call tx_add_ptr() */
-	pd_ext_df             = umem_off2ptr(&umem, pool_df->pd_ext);
-	pd_ext_df->ped_mem_sz = scm_sz;
+	pd_ext_df                = umem_off2ptr(&umem, pool_df->pd_ext);
+	pd_ext_df->ped_mem_sz    = scm_sz;
+	pd_ext_df->ped_emerg_buf = umem_zalloc(&umem, VOS_SNAPBUF_EMERG_SIZE);
+	if (UMOFF_IS_NULL(pd_ext_df->ped_emerg_buf)) {
+		D_ERROR("Failed to allocate pool emergency buffer.\n");
+		rc = -DER_NOSPACE;
+	}
+
 end:
 	/**
 	 * The transaction can in reality be aborted


### PR DESCRIPTION
Preallocate 512KB buffer in pool durable format extension for backend transaction snapshots under space pressure.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
