### PR TITLE
DAOS-18843 control: Add --rank opt to dmg storage format --replace

### DIFF
--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2023 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -15,6 +15,7 @@ import (
 	"github.com/daos-stack/daos/src/control/cmd/dmg/pretty"
 	"github.com/daos-stack/daos/src/control/common/cmdutil"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 )
 
 // storageCmd is the struct representing the top-level storage subcommand.
@@ -97,9 +98,10 @@ type storageFormatCmd struct {
 	ctlInvokerCmd
 	hostListCmd
 	cmdutil.JSONOutputCmd
-	Verbose bool `short:"v" long:"verbose" description:"Show results of each SCM & NVMe device format operation"`
-	Force   bool `long:"force" description:"Force storage format on a host, stopping any running engines (CAUTION: destructive operation)"`
-	Replace bool `long:"replace" description:"Replace an excluded rank. Allows a DAOS engine instance to reclaim its old rank number after metadata is lost due to PMem or other storage media failure (CAUTION: experimental operation)"`
+	Verbose bool    `short:"v" long:"verbose" description:"Show results of each SCM & NVMe device format operation"`
+	Force   bool    `long:"force" description:"Force storage format on a host, stopping any running engines (CAUTION: destructive operation)"`
+	Replace bool    `long:"replace" description:"Replace an excluded rank. Allows a DAOS engine instance to reclaim its old rank number after metadata is lost due to PMem or other storage media failure"`
+	Rank    *uint32 `long:"rank" description:"Specific rank to replace (only valid with --replace)"`
 }
 
 // Execute is run when storageFormatCmd activates.
@@ -116,7 +118,16 @@ func (cmd *storageFormatCmd) Execute(args []string) (err error) {
 		return errors.New("command expects a single host in hostlist if replace option used")
 	}
 
-	req := &control.StorageFormatReq{Reformat: cmd.Force, Replace: cmd.Replace}
+	// Default to NilRank if no rank specified
+	rank := uint32(ranklist.NilRank)
+	if cmd.Rank != nil {
+		if !cmd.Replace {
+			return errors.New("--rank option is only valid when used with --replace")
+		}
+		rank = *cmd.Rank
+	}
+
+	req := &control.StorageFormatReq{Reformat: cmd.Force, Replace: cmd.Replace, Rank: rank}
 	req.SetHostList(cmd.getHostList())
 
 	resp, err := control.StorageFormat(ctx, cmd.ctlInvoker, req)

--- a/src/control/cmd/dmg/storage_test.go
+++ b/src/control/cmd/dmg/storage_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 )
 
 func TestStorageCommands(t *testing.T) {
@@ -36,7 +37,7 @@ func TestStorageCommands(t *testing.T) {
 			"storage format",
 			strings.Join([]string{
 				printRequest(t, systemQueryReq),
-				printRequest(t, &control.StorageFormatReq{}),
+				printRequest(t, &control.StorageFormatReq{Rank: uint32(ranklist.NilRank)}),
 			}, " "),
 			nil,
 		},
@@ -51,7 +52,7 @@ func TestStorageCommands(t *testing.T) {
 			"storage format --force",
 			strings.Join([]string{
 				printRequest(t, systemQueryReq),
-				printRequest(t, &control.StorageFormatReq{Reformat: true}),
+				printRequest(t, &control.StorageFormatReq{Reformat: true, Rank: uint32(ranklist.NilRank)}),
 			}, " "),
 			nil,
 		},
@@ -172,6 +173,69 @@ func TestStorageCommands(t *testing.T) {
 			"storage format --replace --force",
 			"",
 			errors.New("may not be mixed with --force"),
+		},
+		{
+			"Format with replace and single host",
+			"storage format --replace -l foo1.com",
+			strings.Join([]string{
+				printRequest(t, func() *control.SystemQueryReq {
+					req := &control.SystemQueryReq{FailOnUnavailable: true}
+					req.SetHostList([]string{"foo1.com:10001"})
+					return req
+				}()),
+				printRequest(t, func() *control.StorageFormatReq {
+					req := &control.StorageFormatReq{
+						Replace: true, Rank: uint32(ranklist.NilRank),
+					}
+					req.SetHostList([]string{"foo1.com"})
+					return req
+				}()),
+			}, " "),
+			nil,
+		},
+		{
+			"Format with replace and rank",
+			"storage format --replace --rank 5 -l foo1.com",
+			strings.Join([]string{
+				printRequest(t, func() *control.SystemQueryReq {
+					req := &control.SystemQueryReq{FailOnUnavailable: true}
+					req.SetHostList([]string{"foo1.com:10001"})
+					return req
+				}()),
+				printRequest(t, func() *control.StorageFormatReq {
+					req := &control.StorageFormatReq{
+						Replace: true, Rank: 5,
+					}
+					req.SetHostList([]string{"foo1.com"})
+					return req
+				}()),
+			}, " "),
+			nil,
+		},
+		{
+			"Format with rank but no replace",
+			"storage format --rank 5 -l foo1.com",
+			"",
+			errors.New("--rank option is only valid when used with --replace"),
+		},
+		{
+			"Format with rank 0 and replace",
+			"storage format --replace --rank 0 -l foo1.com",
+			strings.Join([]string{
+				printRequest(t, func() *control.SystemQueryReq {
+					req := &control.SystemQueryReq{FailOnUnavailable: true}
+					req.SetHostList([]string{"foo1.com:10001"})
+					return req
+				}()),
+				printRequest(t, func() *control.StorageFormatReq {
+					req := &control.StorageFormatReq{
+						Replace: true, Rank: 0,
+					}
+					req.SetHostList([]string{"foo1.com"})
+					return req
+				}()),
+			}, " "),
+			nil,
 		},
 		{
 			"Nonexistent subcommand",

--- a/src/control/common/proto/ctl/storage.pb.go
+++ b/src/control/common/proto/ctl/storage.pb.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2022 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -346,6 +346,7 @@ type StorageFormatReq struct {
 	Scm           *FormatScmReq          `protobuf:"bytes,2,opt,name=scm,proto3" json:"scm,omitempty"`
 	Reformat      bool                   `protobuf:"varint,3,opt,name=reformat,proto3" json:"reformat,omitempty"`
 	Replace       bool                   `protobuf:"varint,4,opt,name=replace,proto3" json:"replace,omitempty"`
+	Rank          uint32                 `protobuf:"varint,5,opt,name=rank,proto3" json:"rank,omitempty"` // Specific rank to replace (only valid with replace=true)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -406,6 +407,13 @@ func (x *StorageFormatReq) GetReplace() bool {
 		return x.Replace
 	}
 	return false
+}
+
+func (x *StorageFormatReq) GetRank() uint32 {
+	if x != nil {
+		return x.Rank
+	}
+	return 0
 }
 
 type StorageFormatResp struct {
@@ -686,12 +694,13 @@ const file_ctl_storage_proto_rawDesc = "" +
 	"\x04nvme\x18\x01 \x01(\v2\x11.ctl.ScanNvmeRespR\x04nvme\x12\"\n" +
 	"\x03scm\x18\x02 \x01(\v2\x10.ctl.ScanScmRespR\x03scm\x121\n" +
 	"\fsys_mem_info\x18\x03 \x01(\v2\x0f.ctl.SysMemInfoR\n" +
-	"sysMemInfo\"\x95\x01\n" +
+	"sysMemInfo\"\xa9\x01\n" +
 	"\x10StorageFormatReq\x12&\n" +
 	"\x04nvme\x18\x01 \x01(\v2\x12.ctl.FormatNvmeReqR\x04nvme\x12#\n" +
 	"\x03scm\x18\x02 \x01(\v2\x11.ctl.FormatScmReqR\x03scm\x12\x1a\n" +
 	"\breformat\x18\x03 \x01(\bR\breformat\x12\x18\n" +
-	"\areplace\x18\x04 \x01(\bR\areplace\"o\n" +
+	"\areplace\x18\x04 \x01(\bR\areplace\x12\x12\n" +
+	"\x04rank\x18\x05 \x01(\rR\x04rank\"o\n" +
 	"\x11StorageFormatResp\x12/\n" +
 	"\x05crets\x18\x01 \x03(\v2\x19.ctl.NvmeControllerResultR\x05crets\x12)\n" +
 	"\x05mrets\x18\x02 \x03(\v2\x13.ctl.ScmMountResultR\x05mrets\"*\n" +

--- a/src/control/lib/control/storage.go
+++ b/src/control/lib/control/storage.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -310,8 +310,9 @@ type (
 	// StorageFormatReq contains the parameters for a storage format request.
 	StorageFormatReq struct {
 		unaryRequest
-		Reformat bool `json:"reformat"`
-		Replace  bool `json:"replace"`
+		Reformat bool   `json:"reformat"`
+		Replace  bool   `json:"replace"`
+		Rank     uint32 `json:"rank"` // Specific rank to replace (only valid with replace=true)
 	}
 
 	// StorageFormatResp contains the response from a storage format request.

--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -9,6 +9,7 @@ package server
 
 import (
 	"context"
+	"os"
 	"syscall"
 	"time"
 
@@ -253,6 +254,7 @@ func (svc *ControlService) ResetFormatRanks(ctx context.Context, req *ctlpb.Rank
 	}
 
 	savedRanks := make(map[uint32]ranklist.Rank) // instance idx to system rank
+
 	for _, ei := range instances {
 		rank, err := ei.GetRank()
 		if err != nil {
@@ -263,9 +265,31 @@ func (svc *ControlService) ResetFormatRanks(ctx context.Context, req *ctlpb.Rank
 		if ei.IsStarted() {
 			return nil, FaultInstancesNotStopped("reset format", rank)
 		}
-		if err := ei.RemoveSuperblock(); err != nil {
-			return nil, err
+	}
+
+	// In MD-on-SSD mode, remove the entire control metadata directory once
+	// (not per-engine). Ignore failures as multiple ranks on same host may
+	// attempt this operation, causing "directory not found" errors on subsequent
+	// attempts.
+	if svc.storage.ControlMetadataPathConfigured() {
+		mdPath := svc.storage.ControlMetadataPath()
+		svc.log.Debugf("Removing entire control metadata directory: %s", mdPath)
+		if err := os.RemoveAll(mdPath); err != nil {
+			return nil, errors.Wrap(err, "removing control metadata directory")
 		}
+
+		svc.log.Debugf("Control metadata directory removed successfully")
+	}
+
+	for _, ei := range instances {
+		if !svc.storage.ControlMetadataPathConfigured() {
+			// In PMem mode just remove superblock and rely on format flow to clear
+			// metadata.
+			if err := ei.RemoveSuperblock(); err != nil {
+				return nil, err
+			}
+		}
+
 		ei.requestStart(ctx)
 	}
 

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -1113,7 +1113,7 @@ func (cs *ControlService) StorageFormat(ctx context.Context, req *ctlpb.StorageF
 			cs.log.Errorf("instance %d: %s", idx, msg)
 			continue
 		}
-		engine.NotifyStorageReady(req.Replace)
+		engine.NotifyStorageReady(req.Replace, req.Rank)
 	}
 
 	return resp, nil

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -1033,6 +1033,21 @@ func formatNvme(ctx context.Context, req formatNvmeReq, resp *ctlpb.StorageForma
 	return nil
 }
 
+func notifyStorageReady(log logging.Logger, req *ctlpb.StorageFormatReq, engine Engine) {
+	if !engine.isAwaitingFormat() {
+		log.Debugf("instance %d not awaiting format", engine.Index())
+		return
+	}
+
+	// Prepare the replace rank pointer based on the request
+	var replaceRank *ranklist.Rank
+	if req.Replace {
+		r := ranklist.Rank(req.Rank)
+		replaceRank = &r
+	}
+	engine.NotifyStorageReady(replaceRank)
+}
+
 // StorageFormat delegates to Storage implementation's Format methods to prepare
 // storage for use by DAOS data plane.
 //
@@ -1113,7 +1128,8 @@ func (cs *ControlService) StorageFormat(ctx context.Context, req *ctlpb.StorageF
 			cs.log.Errorf("instance %d: %s", idx, msg)
 			continue
 		}
-		engine.NotifyStorageReady(req.Replace, req.Rank)
+
+		notifyStorageReady(cs.log, req, engine)
 	}
 
 	return resp, nil

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -2783,6 +2783,144 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 	}
 }
 
+func Test_notifyStorageReady(t *testing.T) {
+	for name, tc := range map[string]struct {
+		awaitingFormat bool
+		replace        bool
+		rank           uint32
+		expNotifyCalls int
+		expReplaceRank *ranklist.Rank
+	}{
+		"not awaiting format - no notification": {
+			awaitingFormat: false,
+			replace:        false,
+			expNotifyCalls: 0,
+		},
+		"awaiting format - standard join": {
+			awaitingFormat: true,
+			replace:        false,
+			expNotifyCalls: 1,
+			expReplaceRank: nil,
+		},
+		"awaiting format - replace with NilRank (auto-detect)": {
+			awaitingFormat: true,
+			replace:        true,
+			rank:           uint32(ranklist.NilRank),
+			expNotifyCalls: 1,
+			expReplaceRank: func() *ranklist.Rank { r := ranklist.NilRank; return &r }(),
+		},
+		"awaiting format - replace with explicit rank 5": {
+			awaitingFormat: true,
+			replace:        true,
+			rank:           5,
+			expNotifyCalls: 1,
+			expReplaceRank: func() *ranklist.Rank { r := ranklist.Rank(5); return &r }(),
+		},
+		"awaiting format - replace with explicit rank 0": {
+			awaitingFormat: true,
+			replace:        true,
+			rank:           0,
+			expNotifyCalls: 1,
+			expReplaceRank: func() *ranklist.Rank { r := ranklist.Rank(0); return &r }(),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			// Track NotifyStorageReady calls and parameters
+			notifyCalls := 0
+			var capturedRank *ranklist.Rank
+
+			// Create a mock engine that tracks NotifyStorageReady calls
+			mockEngine := &struct {
+				MockInstance
+				awaitingFormat bool
+			}{
+				MockInstance: MockInstance{
+					cfg: MockInstanceConfig{
+						Index: 0,
+					},
+				},
+				awaitingFormat: tc.awaitingFormat,
+			}
+
+			// Override the isAwaitingFormat method
+			isAwaitingFormat := func() bool {
+				return mockEngine.awaitingFormat
+			}
+			_ = isAwaitingFormat
+
+			// Override NotifyStorageReady to capture calls
+			notifyStorageReady := func(rank *ranklist.Rank) {
+				notifyCalls++
+				capturedRank = rank
+			}
+			_ = notifyStorageReady
+
+			// Create a custom engine interface with overridden methods
+			engine := &testNotifyEngine{
+				MockInstance:         mockEngine.MockInstance,
+				isAwaitingFormatFn:   isAwaitingFormat,
+				notifyStorageReadyFn: notifyStorageReady,
+			}
+
+			req := &ctlpb.StorageFormatReq{
+				Replace: tc.replace,
+				Rank:    tc.rank,
+			}
+
+			// Call the function under test
+			notifyStorageReady_helper(log, req, engine)
+
+			// Verify number of NotifyStorageReady calls
+			test.AssertEqual(t, tc.expNotifyCalls, notifyCalls,
+				"unexpected number of NotifyStorageReady calls")
+
+			if tc.expNotifyCalls == 0 {
+				return
+			}
+
+			// Verify the rank parameter passed to NotifyStorageReady
+			if tc.expReplaceRank == nil {
+				test.AssertTrue(t, capturedRank == nil,
+					"expected nil rank for standard join")
+			} else {
+				test.AssertTrue(t, capturedRank != nil,
+					"expected non-nil rank for replace mode")
+				test.AssertEqual(t, *tc.expReplaceRank, *capturedRank,
+					"rank mismatch in NotifyStorageReady call")
+			}
+		})
+	}
+}
+
+// testNotifyEngine is a test helper that allows overriding specific methods
+type testNotifyEngine struct {
+	MockInstance
+	isAwaitingFormatFn   func() bool
+	notifyStorageReadyFn func(*ranklist.Rank)
+}
+
+func (e *testNotifyEngine) isAwaitingFormat() bool {
+	if e.isAwaitingFormatFn != nil {
+		return e.isAwaitingFormatFn()
+	}
+	return e.MockInstance.isAwaitingFormat()
+}
+
+func (e *testNotifyEngine) NotifyStorageReady(rank *ranklist.Rank) {
+	if e.notifyStorageReadyFn != nil {
+		e.notifyStorageReadyFn(rank)
+	} else {
+		e.MockInstance.NotifyStorageReady(rank)
+	}
+}
+
+func notifyStorageReady_helper(log logging.Logger, req *ctlpb.StorageFormatReq, engine Engine) {
+	notifyStorageReady(log, req, engine)
+}
+
 func TestServer_CtlSvc_StorageNvmeRebind(t *testing.T) {
 	usrCurrent, _ := user.Current()
 	username := usrCurrent.Username

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -2846,23 +2846,23 @@ func Test_notifyStorageReady(t *testing.T) {
 			}
 
 			// Override the isAwaitingFormat method
-			isAwaitingFormat := func() bool {
+			mockIsAwaitingFormat := func() bool {
 				return mockEngine.awaitingFormat
 			}
-			_ = isAwaitingFormat
+			_ = mockIsAwaitingFormat
 
 			// Override NotifyStorageReady to capture calls
-			notifyStorageReady := func(rank *ranklist.Rank) {
+			mockNotifyStorageReady := func(rank *ranklist.Rank) {
 				notifyCalls++
 				capturedRank = rank
 			}
-			_ = notifyStorageReady
+			_ = mockNotifyStorageReady
 
 			// Create a custom engine interface with overridden methods
 			engine := &testNotifyEngine{
 				MockInstance:         mockEngine.MockInstance,
-				isAwaitingFormatFn:   isAwaitingFormat,
-				notifyStorageReadyFn: notifyStorageReady,
+				isAwaitingFormatFn:   mockIsAwaitingFormat,
+				notifyStorageReadyFn: mockNotifyStorageReady,
 			}
 
 			req := &ctlpb.StorageFormatReq{
@@ -2871,7 +2871,7 @@ func Test_notifyStorageReady(t *testing.T) {
 			}
 
 			// Call the function under test
-			notifyStorageReady_helper(log, req, engine)
+			notifyStorageReady(log, req, engine)
 
 			// Verify number of NotifyStorageReady calls
 			test.AssertEqual(t, tc.expNotifyCalls, notifyCalls,
@@ -2915,10 +2915,6 @@ func (e *testNotifyEngine) NotifyStorageReady(rank *ranklist.Rank) {
 	} else {
 		e.MockInstance.NotifyStorageReady(rank)
 	}
-}
-
-func notifyStorageReady_helper(log logging.Logger, req *ctlpb.StorageFormatReq, engine Engine) {
-	notifyStorageReady(log, req, engine)
 }
 
 func TestServer_CtlSvc_StorageNvmeRebind(t *testing.T) {

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -44,7 +44,7 @@ type Engine interface {
 
 	// These methods should probably be replaced by callbacks.
 	NotifyDrpcReady(*srvpb.NotifyReadyReq)
-	NotifyStorageReady(bool)
+	NotifyStorageReady(bool, uint32)
 
 	// These methods should probably be refactored out into functions that
 	// accept the engine instance as a parameter.

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -44,7 +44,7 @@ type Engine interface {
 
 	// These methods should probably be replaced by callbacks.
 	NotifyDrpcReady(*srvpb.NotifyReadyReq)
-	NotifyStorageReady(bool, uint32)
+	NotifyStorageReady(*ranklist.Rank)
 
 	// These methods should probably be refactored out into functions that
 	// accept the engine instance as a parameter.

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -248,7 +248,10 @@ func TestServer_Harness_Start(t *testing.T) {
 				}
 				runner := engine.NewTestRunner(tc.trc, engineCfg)
 
-				msc := &sysprov.MockSysConfig{IsMountedBool: true}
+				msc := &sysprov.MockSysConfig{
+					IsMountedBool: true,
+					RealReadFile:  true,
+				}
 				sysp := sysprov.NewMockSysProvider(log, msc)
 				provider := storage.MockProvider(
 					log, 0, &engineCfg.Storage,
@@ -289,6 +292,13 @@ func TestServer_Harness_Start(t *testing.T) {
 				ei.setSuperblock(&Superblock{
 					UUID: uuid, Rank: rank, ValidRank: isValid,
 				})
+
+				// Write superblock to disk if rank is preset so it can be read back
+				if tc.rankInSuperblock {
+					if err := ei.WriteSuperblock(); err != nil {
+						t.Fatal(err)
+					}
+				}
 
 				if err := harness.AddInstance(ei); err != nil {
 					t.Fatal(err)

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -39,6 +39,11 @@ type (
 	onInstanceExitFn func(context.Context, uint32, ranklist.Rank, uint64, error, int) error
 )
 
+func errReplaceSuperblockHasRank(r ranklist.Rank) error {
+	return errors.Errorf("cannot replace: superblock already has valid rank %d (reformat "+
+		"required)", r)
+}
+
 // EngineInstance encapsulates control-plane specific configuration
 // and functionality for managed I/O Engine instances. The distinction
 // between this structure and what's in the engine package is that the
@@ -207,6 +212,11 @@ func (ei *EngineInstance) determineRank(ctx context.Context, ready *srvpb.Notify
 	replaceRank := ei.replaceRank.Load()
 	isReplace := replaceRank != nil
 	if isReplace {
+		// During replace operations, fail if superblock already has a valid rank
+		// Prior checks in replace flow should prevent this failsafe from being reached
+		if superblock.ValidRank {
+			return ranklist.NilRank, false, 0, errReplaceSuperblockHasRank(r)
+		}
 		// Explicit rank specified for replacement if not NilRank
 		r = *replaceRank
 	}

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"sync/atomic"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
@@ -53,7 +54,7 @@ type EngineInstance struct {
 	incarnation     uint64
 	storage         *storage.Provider
 	waitFormat      atm.Bool
-	storageReady    chan bool
+	storageReady    chan storageReadyInfo
 	waitDrpc        atm.Bool
 	drpcReady       chan *srvpb.NotifyReadyReq
 	ready           atm.Bool
@@ -62,6 +63,7 @@ type EngineInstance struct {
 	hostFaultDomain *system.FaultDomain
 	joinSystem      systemJoinFn
 	replaceRank     atm.Bool
+	targetRank      uint32
 	onAwaitFormat   []onAwaitFormatFn
 	onStorageReady  []onStorageReadyFn
 	onReady         []onReadyFn
@@ -86,7 +88,7 @@ func NewEngineInstance(l logging.Logger, p *storage.Provider, jf systemJoinFn, r
 		storage:          p,
 		joinSystem:       jf,
 		drpcReady:        make(chan *srvpb.NotifyReadyReq),
-		storageReady:     make(chan bool),
+		storageReady:     make(chan storageReadyInfo),
 		startRequested:   make(chan bool),
 		Publisher:        ps,
 		_lastHealthStats: make(map[string]*ctlpb.BioHealthResp),
@@ -200,6 +202,12 @@ func (ei *EngineInstance) determineRank(ctx context.Context, ready *srvpb.Notify
 	r := ranklist.NilRank
 	if superblock.Rank != nil {
 		r = *superblock.Rank
+	}
+
+	// If replacing a rank and a target rank was specified, use that rank.
+	targetRank := atomic.LoadUint32(&ei.targetRank)
+	if ei.replaceRank.Load() && targetRank != uint32(ranklist.NilRank) {
+		r = ranklist.Rank(targetRank)
 	}
 
 	joinReq := &control.SystemJoinReq{

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -54,7 +54,7 @@ type EngineInstance struct {
 	incarnation     uint64
 	storage         *storage.Provider
 	waitFormat      atm.Bool
-	storageReady    chan storageReadyInfo
+	storageReady    chan struct{}
 	waitDrpc        atm.Bool
 	drpcReady       chan *srvpb.NotifyReadyReq
 	ready           atm.Bool
@@ -62,8 +62,7 @@ type EngineInstance struct {
 	fsRoot          string
 	hostFaultDomain *system.FaultDomain
 	joinSystem      systemJoinFn
-	replaceRank     atm.Bool
-	targetRank      uint32
+	replaceRank     atomic.Pointer[ranklist.Rank]
 	onAwaitFormat   []onAwaitFormatFn
 	onStorageReady  []onStorageReadyFn
 	onReady         []onReadyFn
@@ -88,7 +87,7 @@ func NewEngineInstance(l logging.Logger, p *storage.Provider, jf systemJoinFn, r
 		storage:          p,
 		joinSystem:       jf,
 		drpcReady:        make(chan *srvpb.NotifyReadyReq),
-		storageReady:     make(chan storageReadyInfo),
+		storageReady:     make(chan struct{}),
 		startRequested:   make(chan bool),
 		Publisher:        ps,
 		_lastHealthStats: make(map[string]*ctlpb.BioHealthResp),
@@ -204,10 +203,12 @@ func (ei *EngineInstance) determineRank(ctx context.Context, ready *srvpb.Notify
 		r = *superblock.Rank
 	}
 
-	// If replacing a rank and a target rank was specified, use that rank.
-	targetRank := atomic.LoadUint32(&ei.targetRank)
-	if ei.replaceRank.Load() && targetRank != uint32(ranklist.NilRank) {
-		r = ranklist.Rank(targetRank)
+	// Check if we're in replace mode and if a specific rank was provided
+	replaceRank := ei.replaceRank.Load()
+	isReplace := replaceRank != nil
+	if isReplace {
+		// Explicit rank specified for replacement if not NilRank
+		r = *replaceRank
 	}
 
 	joinReq := &control.SystemJoinReq{
@@ -221,11 +222,11 @@ func (ei *EngineInstance) determineRank(ctx context.Context, ready *srvpb.Notify
 		InstanceIdx:          ei.Index(),
 		Incarnation:          ready.GetIncarnation(),
 		CheckMode:            ready.GetCheckMode(),
-		Replace:              ei.replaceRank.Load(),
+		Replace:              isReplace,
 	}
 
 	// Reset replaceRank state for instance after joinSystem() has been attempted.
-	defer ei.replaceRank.SetFalse()
+	defer ei.replaceRank.Store(nil)
 
 	resp, err := ei.joinSystem(ctx, joinReq)
 	if err != nil {
@@ -234,7 +235,7 @@ func (ei *EngineInstance) determineRank(ctx context.Context, ready *srvpb.Notify
 		// If this is a replace operation and join failed, clean up the formatted storage to
 		// prevent leaving the rank in a formatted state. This prevents the engine
 		// inadvertently being joined later with a new rank.
-		if ei.replaceRank.Load() {
+		if isReplace {
 			ei.log.Infof("cleaning up after join failure during replace")
 			if cleanupErr := ei.cleanupFailedJoinReplace(ctx); cleanupErr != nil {
 				ei.log.Errorf("failed to cleanup after join failure: %v", cleanupErr)

--- a/src/control/server/instance_exec.go
+++ b/src/control/server/instance_exec.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2020-2023 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -189,6 +189,12 @@ func (ei *EngineInstance) startRunner(parent context.Context) (_ chan *engine.Ru
 			cancel()
 		}
 	}()
+
+	// Reinitialize the storageReady channel for this engine start attempt.
+	// The channel may have been closed by a previous format operation, and
+	// reading from a closed channel returns immediately, which would bypass
+	// the format wait in awaitStorageReady().
+	ei.storageReady = make(chan struct{})
 
 	if err = ei.format(ctx); err != nil {
 		return

--- a/src/control/server/instance_exec.go
+++ b/src/control/server/instance_exec.go
@@ -194,7 +194,7 @@ func (ei *EngineInstance) startRunner(parent context.Context) (_ chan *engine.Ru
 	// The channel may have been closed by a previous format operation, and
 	// reading from a closed channel returns immediately, which would bypass
 	// the format wait in awaitStorageReady().
-	ei.storageReady = make(chan struct{})
+	ei.storageReady = make(chan bool)
 
 	if err = ei.format(ctx); err != nil {
 		return

--- a/src/control/server/instance_storage.go
+++ b/src/control/server/instance_storage.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/dustin/go-humanize"
@@ -20,8 +21,16 @@ import (
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
+
+// storageReadyInfo contains information about storage readiness including whether a subsequent join
+// should be made to an existing rank.
+type storageReadyInfo struct {
+	replaceRank bool   // Try to assign an existing rank to the formatted engine
+	targetRank  uint32 // If replacing, try to use a specific rank
+}
 
 // GetStorage retrieve the storage provider for an engine instance.
 func (ei *EngineInstance) GetStorage() *storage.Provider {
@@ -71,9 +80,12 @@ func (ei *EngineInstance) MountScm() error {
 }
 
 // NotifyStorageReady releases any blocks on awaitStorageReady().
-func (ei *EngineInstance) NotifyStorageReady(replaceRank bool) {
+func (ei *EngineInstance) NotifyStorageReady(replaceRank bool, targetRank uint32) {
 	go func() {
-		ei.storageReady <- replaceRank
+		ei.storageReady <- storageReadyInfo{
+			replaceRank: replaceRank,
+			targetRank:  targetRank,
+		}
 	}()
 }
 
@@ -232,12 +244,17 @@ func (ei *EngineInstance) awaitStorageReady(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		ei.log.Infof("%s %s storage not ready: %s", build.DataPlaneName, msgIdx, ctx.Err())
-	case replaceRank := <-ei.storageReady:
+	case readyInfo := <-ei.storageReady:
 		// Set replaceRank instance state to be used later in join request.
-		ei.replaceRank.Store(replaceRank)
+		ei.replaceRank.Store(readyInfo.replaceRank)
+		atomic.StoreUint32(&ei.targetRank, readyInfo.targetRank)
 		msg := fmt.Sprintf("%s %s storage ready", build.DataPlaneName, msgIdx)
-		if replaceRank {
-			msg += ", attempting to replace rank..."
+		if readyInfo.replaceRank {
+			if readyInfo.targetRank != uint32(ranklist.NilRank) {
+				msg += fmt.Sprintf(", attempting to replace rank %d...", readyInfo.targetRank)
+			} else {
+				msg += ", attempting to replace rank..."
+			}
 		}
 		ei.log.Info(msg)
 	}

--- a/src/control/server/instance_storage.go
+++ b/src/control/server/instance_storage.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sync/atomic"
 	"syscall"
 
 	"github.com/dustin/go-humanize"
@@ -24,13 +23,6 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
-
-// storageReadyInfo contains information about storage readiness including whether a subsequent join
-// should be made to an existing rank.
-type storageReadyInfo struct {
-	replaceRank bool   // Try to assign an existing rank to the formatted engine
-	targetRank  uint32 // If replacing, try to use a specific rank
-}
 
 // GetStorage retrieve the storage provider for an engine instance.
 func (ei *EngineInstance) GetStorage() *storage.Provider {
@@ -80,13 +72,12 @@ func (ei *EngineInstance) MountScm() error {
 }
 
 // NotifyStorageReady releases any blocks on awaitStorageReady().
-func (ei *EngineInstance) NotifyStorageReady(replaceRank bool, targetRank uint32) {
-	go func() {
-		ei.storageReady <- storageReadyInfo{
-			replaceRank: replaceRank,
-			targetRank:  targetRank,
-		}
-	}()
+// If rank is nil, indicates standard join behavior.
+// If rank is non-nil and points to NilRank, indicates replace mode with auto-detection.
+// If rank is non-nil and points to a valid rank, indicates replace mode with explicit rank.
+func (ei *EngineInstance) NotifyStorageReady(rank *ranklist.Rank) {
+	ei.replaceRank.Store(rank)
+	close(ei.storageReady)
 }
 
 func (ei *EngineInstance) clearFormat(ctx context.Context, stopEngineFn func(context.Context, *EngineInstance) error) error {
@@ -244,16 +235,16 @@ func (ei *EngineInstance) awaitStorageReady(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		ei.log.Infof("%s %s storage not ready: %s", build.DataPlaneName, msgIdx, ctx.Err())
-	case readyInfo := <-ei.storageReady:
-		// Set replaceRank instance state to be used later in join request.
-		ei.replaceRank.Store(readyInfo.replaceRank)
-		atomic.StoreUint32(&ei.targetRank, readyInfo.targetRank)
+	case <-ei.storageReady:
 		msg := fmt.Sprintf("%s %s storage ready", build.DataPlaneName, msgIdx)
-		if readyInfo.replaceRank {
-			if readyInfo.targetRank != uint32(ranklist.NilRank) {
-				msg += fmt.Sprintf(", attempting to replace rank %d...", readyInfo.targetRank)
-			} else {
+
+		// Check if we're in replace mode
+		replaceRank := ei.replaceRank.Load()
+		if replaceRank != nil {
+			if replaceRank.Equals(ranklist.NilRank) {
 				msg += ", attempting to replace rank..."
+			} else {
+				msg += fmt.Sprintf(", attempting to replace rank %d...", *replaceRank)
 			}
 		}
 		ei.log.Info(msg)

--- a/src/control/server/instance_storage_test.go
+++ b/src/control/server/instance_storage_test.go
@@ -340,11 +340,11 @@ func TestEngineInstance_NeedsScmFormat(t *testing.T) {
 type tally struct {
 	sync.Mutex
 	evtDesc      string
-	storageReady chan bool
+	storageReady chan storageReadyInfo
 	finished     chan struct{}
 }
 
-func newTally(sr chan bool) *tally {
+func newTally(sr chan storageReadyInfo) *tally {
 	return &tally{
 		storageReady: sr,
 		finished:     make(chan struct{}),

--- a/src/control/server/instance_storage_test.go
+++ b/src/control/server/instance_storage_test.go
@@ -340,11 +340,11 @@ func TestEngineInstance_NeedsScmFormat(t *testing.T) {
 type tally struct {
 	sync.Mutex
 	evtDesc      string
-	storageReady chan storageReadyInfo
+	storageReady chan struct{}
 	finished     chan struct{}
 }
 
-func newTally(sr chan storageReadyInfo) *tally {
+func newTally(sr chan struct{}) *tally {
 	return &tally{
 		storageReady: sr,
 		finished:     make(chan struct{}),

--- a/src/control/server/instance_superblock.go
+++ b/src/control/server/instance_superblock.go
@@ -93,11 +93,9 @@ func (ei *EngineInstance) hasSuperblock() bool {
 //
 // Should not be called if SCM format is required.
 func (ei *EngineInstance) needsSuperblock() (bool, error) {
-	if ei.hasSuperblock() {
-		ei.log.Debugf("instance %d has no superblock set", ei.Index())
-		return false, nil
-	}
-
+	// Always read superblock from disk to avoid stale in-memory state preventing format.
+	// The in-memory superblock may exist from a previous operation, but the on-disk
+	// superblock may have been deleted.
 	err := ei.ReadSuperblock()
 	if os.IsNotExist(errors.Cause(err)) {
 		ei.log.Debugf("instance %d: superblock not found", ei.Index())

--- a/src/control/server/instance_test.go
+++ b/src/control/server/instance_test.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -377,7 +377,7 @@ func (mi *MockInstance) isAwaitingFormat() bool {
 }
 
 func (mi *MockInstance) NotifyDrpcReady(_ *srvpb.NotifyReadyReq) {}
-func (mi *MockInstance) NotifyStorageReady(_ bool)               {}
+func (mi *MockInstance) NotifyStorageReady(_ bool, _ uint32)     {}
 
 func (mi *MockInstance) GetBioHealth(context.Context, *ctlpb.BioHealthReq) (*ctlpb.BioHealthResp, error) {
 	return nil, nil

--- a/src/control/server/instance_test.go
+++ b/src/control/server/instance_test.go
@@ -513,19 +513,17 @@ func TestEngineInstance_determineRank(t *testing.T) {
 			expRank:           0,
 			expLocalJoin:      false,
 		},
-		"replace overrides superblock rank": {
-			setupRank:   func() *ranklist.Rank { r := ranklist.Rank(5); return &r }(),
-			replaceRank: func() *ranklist.Rank { r := ranklist.Rank(10); return &r }(),
-			joinResp: &control.SystemJoinResp{
-				Rank:       10,
-				State:      system.MemberStateJoined,
-				LocalJoin:  false,
-				MapVersion: 2,
-			},
-			expJoinReqRank:    10,
+		"replace fails if superblock has valid rank": {
+			setupRank:         func() *ranklist.Rank { r := ranklist.Rank(5); return &r }(),
+			replaceRank:       func() *ranklist.Rank { r := ranklist.Rank(10); return &r }(),
 			expJoinReqReplace: true,
-			expRank:           10,
-			expLocalJoin:      false,
+			expErr:            errors.New("cannot replace: superblock already has valid rank"),
+		},
+		"replace with auto-detect fails if superblock has valid rank": {
+			setupRank:         func() *ranklist.Rank { r := ranklist.Rank(5); return &r }(),
+			replaceRank:       func() *ranklist.Rank { r := ranklist.NilRank; return &r }(),
+			expJoinReqReplace: true,
+			expErr:            errors.New("cannot replace: superblock already has valid rank"),
 		},
 		"excluded rank": {
 			setupRank: func() *ranklist.Rank { r := ranklist.Rank(3); return &r }(),
@@ -615,21 +613,12 @@ func TestEngineInstance_determineRank(t *testing.T) {
 				MapVersion: 1,
 			},
 		},
-		"NotifyStorageReady: replace overrides superblock rank": {
-			useNotifyAPI:        true,
-			replaceRank:         func() *ranklist.Rank { r := ranklist.Rank(10); return &r }(),
-			setupRank:           func() *ranklist.Rank { r := ranklist.Rank(5); return &r }(),
-			expJoinReqRank:      10,
-			expJoinReqReplace:   true,
-			expRank:             10,
-			expLocalJoin:        false,
-			validateFullJoinReq: true,
-			joinResp: &control.SystemJoinResp{
-				Rank:       10,
-				State:      system.MemberStateJoined,
-				LocalJoin:  false,
-				MapVersion: 1,
-			},
+		"NotifyStorageReady: replace fails if superblock has valid rank": {
+			useNotifyAPI:      true,
+			replaceRank:       func() *ranklist.Rank { r := ranklist.Rank(10); return &r }(),
+			setupRank:         func() *ranklist.Rank { r := ranklist.Rank(5); return &r }(),
+			expJoinReqReplace: true,
+			expErr:            errors.New("cannot replace: superblock already has valid rank"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/server/instance_test.go
+++ b/src/control/server/instance_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	uuid "github.com/google/uuid"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/lib/atm"
+	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	sysprov "github.com/daos-stack/daos/src/control/provider/system"
@@ -377,7 +379,7 @@ func (mi *MockInstance) isAwaitingFormat() bool {
 }
 
 func (mi *MockInstance) NotifyDrpcReady(_ *srvpb.NotifyReadyReq) {}
-func (mi *MockInstance) NotifyStorageReady(_ bool, _ uint32)     {}
+func (mi *MockInstance) NotifyStorageReady(_ *ranklist.Rank)     {}
 
 func (mi *MockInstance) GetBioHealth(context.Context, *ctlpb.BioHealthReq) (*ctlpb.BioHealthResp, error) {
 	return nil, nil
@@ -417,4 +419,314 @@ func (mi *MockInstance) GetLastHealthStats(pciAddr string) *ctlpb.BioHealthResp 
 
 func (mi *MockInstance) SetLastHealthStats(pciAddr string, bhr *ctlpb.BioHealthResp) {
 	mi.cfg.LastHealthStats[pciAddr] = bhr
+}
+
+func TestEngineInstance_determineRank(t *testing.T) {
+	defaultUUID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	defaultReq := &srvpb.NotifyReadyReq{
+		Uri:            "test-uri",
+		SecondaryUris:  []string{"secondary-uri"},
+		Nctxs:          8,
+		SecondaryNctxs: []uint32{4},
+		Incarnation:    1,
+	}
+
+	for name, tc := range map[string]struct {
+		setupRank           *ranklist.Rank // Initial rank in superblock
+		replaceRank         *ranklist.Rank // Replace rank pointer (nil = not replacing)
+		useNotifyAPI        bool           // If true, use NotifyStorageReady() instead of direct Store()
+		joinResp            *control.SystemJoinResp
+		joinErr             error
+		noSB                bool
+		expJoinReqRank      ranklist.Rank
+		expJoinReqReplace   bool
+		expRank             ranklist.Rank
+		expLocalJoin        bool
+		expErr              error
+		validateFullJoinReq bool // If true, validate all SystemJoinReq fields
+	}{
+		"nil superblock": {
+			noSB:   true,
+			expErr: errors.New("nil superblock"),
+		},
+		"standard join - no rank": {
+			joinResp: &control.SystemJoinResp{
+				Rank:       5,
+				State:      system.MemberStateJoined,
+				LocalJoin:  false,
+				MapVersion: 1,
+			},
+			expJoinReqRank:    ranklist.NilRank,
+			expJoinReqReplace: false,
+			expRank:           5,
+			expLocalJoin:      false,
+		},
+		"standard join - existing rank": {
+			setupRank: func() *ranklist.Rank { r := ranklist.Rank(3); return &r }(),
+			joinResp: &control.SystemJoinResp{
+				Rank:       3,
+				State:      system.MemberStateJoined,
+				LocalJoin:  true,
+				MapVersion: 1,
+			},
+			expJoinReqRank:    3,
+			expJoinReqReplace: false,
+			expRank:           3,
+			expLocalJoin:      true,
+		},
+		"replace with auto-detect": {
+			replaceRank: func() *ranklist.Rank { r := ranklist.NilRank; return &r }(),
+			joinResp: &control.SystemJoinResp{
+				Rank:       7,
+				State:      system.MemberStateJoined,
+				LocalJoin:  false,
+				MapVersion: 2,
+			},
+			expJoinReqRank:    ranklist.NilRank,
+			expJoinReqReplace: true,
+			expRank:           7,
+			expLocalJoin:      false,
+		},
+		"replace with explicit rank": {
+			replaceRank: func() *ranklist.Rank { r := ranklist.Rank(10); return &r }(),
+			joinResp: &control.SystemJoinResp{
+				Rank:       10,
+				State:      system.MemberStateJoined,
+				LocalJoin:  false,
+				MapVersion: 2,
+			},
+			expJoinReqRank:    10,
+			expJoinReqReplace: true,
+			expRank:           10,
+			expLocalJoin:      false,
+		},
+		"replace with explicit rank 0": {
+			replaceRank: func() *ranklist.Rank { r := ranklist.Rank(0); return &r }(),
+			joinResp: &control.SystemJoinResp{
+				Rank:       0,
+				State:      system.MemberStateJoined,
+				LocalJoin:  false,
+				MapVersion: 2,
+			},
+			expJoinReqRank:    0,
+			expJoinReqReplace: true,
+			expRank:           0,
+			expLocalJoin:      false,
+		},
+		"replace overrides superblock rank": {
+			setupRank:   func() *ranklist.Rank { r := ranklist.Rank(5); return &r }(),
+			replaceRank: func() *ranklist.Rank { r := ranklist.Rank(10); return &r }(),
+			joinResp: &control.SystemJoinResp{
+				Rank:       10,
+				State:      system.MemberStateJoined,
+				LocalJoin:  false,
+				MapVersion: 2,
+			},
+			expJoinReqRank:    10,
+			expJoinReqReplace: true,
+			expRank:           10,
+			expLocalJoin:      false,
+		},
+		"excluded rank": {
+			setupRank: func() *ranklist.Rank { r := ranklist.Rank(3); return &r }(),
+			joinResp: &control.SystemJoinResp{
+				Rank:  3,
+				State: system.MemberStateExcluded,
+			},
+			expJoinReqRank:    3,
+			expJoinReqReplace: false,
+			expErr:            errors.New("excluded"),
+		},
+		"admin excluded rank": {
+			setupRank: func() *ranklist.Rank { r := ranklist.Rank(3); return &r }(),
+			joinResp: &control.SystemJoinResp{
+				Rank:  3,
+				State: system.MemberStateAdminExcluded,
+			},
+			expJoinReqRank:    3,
+			expJoinReqReplace: false,
+			expErr:            errors.New("excluded"),
+		},
+		"join failure": {
+			joinErr: errors.New("join failed"),
+			expErr:  errors.New("join failed"),
+		},
+		"NotifyStorageReady: standard join - no replace": {
+			useNotifyAPI:        true,
+			replaceRank:         nil, // NotifyStorageReady(nil) = standard join
+			setupRank:           nil,
+			expJoinReqRank:      ranklist.NilRank,
+			expJoinReqReplace:   false,
+			expRank:             5,
+			expLocalJoin:        false,
+			validateFullJoinReq: true,
+			joinResp: &control.SystemJoinResp{
+				Rank:       5,
+				State:      system.MemberStateJoined,
+				LocalJoin:  false,
+				MapVersion: 1,
+			},
+		},
+		"NotifyStorageReady: standard join - existing rank in superblock": {
+			useNotifyAPI:        true,
+			replaceRank:         nil, // NotifyStorageReady(nil) = standard join
+			setupRank:           func() *ranklist.Rank { r := ranklist.Rank(5); return &r }(),
+			expJoinReqRank:      5,
+			expJoinReqReplace:   false,
+			expRank:             5,
+			expLocalJoin:        true,
+			validateFullJoinReq: true,
+			joinResp: &control.SystemJoinResp{
+				Rank:       5,
+				State:      system.MemberStateJoined,
+				LocalJoin:  true,
+				MapVersion: 1,
+			},
+		},
+		"NotifyStorageReady: replace with auto-detect": {
+			useNotifyAPI:        true,
+			replaceRank:         func() *ranklist.Rank { r := ranklist.NilRank; return &r }(),
+			setupRank:           nil,
+			expJoinReqRank:      ranklist.NilRank,
+			expJoinReqReplace:   true,
+			expRank:             7,
+			expLocalJoin:        false,
+			validateFullJoinReq: true,
+			joinResp: &control.SystemJoinResp{
+				Rank:       7,
+				State:      system.MemberStateJoined,
+				LocalJoin:  false,
+				MapVersion: 1,
+			},
+		},
+		"NotifyStorageReady: replace with explicit rank 7": {
+			useNotifyAPI:        true,
+			replaceRank:         func() *ranklist.Rank { r := ranklist.Rank(7); return &r }(),
+			setupRank:           nil,
+			expJoinReqRank:      7,
+			expJoinReqReplace:   true,
+			expRank:             7,
+			expLocalJoin:        false,
+			validateFullJoinReq: true,
+			joinResp: &control.SystemJoinResp{
+				Rank:       7,
+				State:      system.MemberStateJoined,
+				LocalJoin:  false,
+				MapVersion: 1,
+			},
+		},
+		"NotifyStorageReady: replace overrides superblock rank": {
+			useNotifyAPI:        true,
+			replaceRank:         func() *ranklist.Rank { r := ranklist.Rank(10); return &r }(),
+			setupRank:           func() *ranklist.Rank { r := ranklist.Rank(5); return &r }(),
+			expJoinReqRank:      10,
+			expJoinReqReplace:   true,
+			expRank:             10,
+			expLocalJoin:        false,
+			validateFullJoinReq: true,
+			joinResp: &control.SystemJoinResp{
+				Rank:       10,
+				State:      system.MemberStateJoined,
+				LocalJoin:  false,
+				MapVersion: 1,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			var capturedJoinReq *control.SystemJoinReq
+
+			mockJoin := func(_ context.Context, req *control.SystemJoinReq) (*control.SystemJoinResp, error) {
+				capturedJoinReq = req
+
+				if tc.joinErr != nil {
+					return nil, tc.joinErr
+				}
+
+				// Verify the replace flag is set correctly
+				test.AssertEqual(t, tc.expJoinReqReplace, req.Replace, "Replace flag mismatch")
+
+				// Verify rank in join request
+				test.AssertEqual(t, tc.expJoinReqRank, req.Rank, "unexpected rank in join request")
+
+				// Verify additional join request fields if requested
+				if tc.validateFullJoinReq {
+					test.AssertEqual(t, defaultUUID.String(), req.UUID, "UUID mismatch")
+					test.AssertEqual(t, defaultReq.Uri, req.URI, "URI mismatch")
+					test.AssertEqual(t, defaultReq.SecondaryUris, req.SecondaryURIs, "SecondaryURIs mismatch")
+					test.AssertEqual(t, defaultReq.Nctxs, req.NumContexts, "NumContexts mismatch")
+					test.AssertEqual(t, defaultReq.SecondaryNctxs, req.NumSecondaryContexts, "NumSecondaryContexts mismatch")
+				}
+
+				return tc.joinResp, nil
+			}
+
+			testEngineIdx := 0
+			baseDir, cleanup := test.CreateTestDir(t)
+			defer cleanup()
+			mdDir := filepath.Join(baseDir, "daos_control", fmt.Sprintf("engine%d", testEngineIdx))
+			if err := os.MkdirAll(mdDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg := engine.MockConfig().
+				WithStorageControlMetadataPath(baseDir).
+				WithStorage(
+					storage.NewTierConfig().
+						WithStorageClass("ram").
+						WithScmMountPoint("/mnt/daos"),
+				)
+			runner := engine.NewRunner(log, cfg)
+			storage := storage.MockProvider(log, 0, &cfg.Storage, nil, nil, nil, nil)
+			engine := NewEngineInstance(log, storage, mockJoin, runner, nil)
+			sb := &Superblock{
+				UUID:      defaultUUID.String(),
+				ValidRank: tc.setupRank != nil,
+			}
+			if tc.setupRank != nil {
+				sb.Rank = tc.setupRank
+			}
+			if !tc.noSB {
+				engine.setSuperblock(sb)
+			}
+
+			// Set replace rank via NotifyStorageReady() API or direct Store()
+			if tc.useNotifyAPI {
+				engine.NotifyStorageReady(tc.replaceRank)
+				// Verify replaceRank was stored correctly by NotifyStorageReady()
+				storedRank := engine.replaceRank.Load()
+				if tc.replaceRank == nil {
+					test.AssertTrue(t, storedRank == nil, "replaceRank should be nil for standard join")
+				} else {
+					test.AssertTrue(t, storedRank != nil, "replaceRank should be set")
+					test.AssertEqual(t, *tc.replaceRank, *storedRank, "stored replaceRank mismatch")
+				}
+			} else if tc.replaceRank != nil {
+				engine.replaceRank.Store(tc.replaceRank)
+			}
+
+			rank, localJoin, mapVersion, err := engine.determineRank(test.Context(t), defaultReq)
+
+			test.CmpErr(t, tc.expErr, err)
+			if tc.expErr != nil {
+				return
+			}
+
+			test.AssertEqual(t, tc.expRank, rank, "rank mismatch")
+			test.AssertEqual(t, tc.expLocalJoin, localJoin, "localJoin mismatch")
+			if tc.joinResp != nil {
+				test.AssertEqual(t, tc.joinResp.MapVersion, mapVersion, "mapVersion mismatch")
+			}
+
+			// Verify replaceRank is cleared after join
+			test.AssertTrue(t, engine.replaceRank.Load() == nil, "replaceRank should be cleared")
+
+			// Additional validation for captured join request
+			if tc.validateFullJoinReq && capturedJoinReq == nil {
+				t.Fatal("join request was not captured")
+			}
+		})
+	}
 }

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -1649,9 +1649,19 @@ func (svc *mgmtSvc) eraseAndRestart(pause bool) error {
 	if err := svc.sysdb.Stop(); err != nil {
 		return errors.Wrap(err, "failed to stop system database")
 	}
+
 	if err := svc.sysdb.RemoveFiles(); err != nil {
 		return errors.Wrap(err, "failed to remove system database")
 	}
+
+	// Sync filesystem to ensure all deletions are committed to disk before restart.
+	// In MD-on-SSD mode, this ensures the control metadata device has all changes
+	// committed so they persist across the server restart and remount.
+	unix.Sync()
+
+	// Give the kernel time to complete pending I/O operations to the control metadata
+	// device before restarting. This is especially important for MD-on-SSD mode.
+	time.Sleep(100 * time.Millisecond)
 
 	myPath, err := os.Readlink("/proc/self/exe")
 	if err != nil {
@@ -1670,48 +1680,287 @@ func (svc *mgmtSvc) eraseAndRestart(pause bool) error {
 	return nil
 }
 
+// waitForLeaderElection polls MS replicas after an erase operation to ensure that
+// raft leader election has completed. This is critical because after erasing the raft
+// databases, the cluster needs time to bootstrap and elect a new leader before engines
+// can successfully join.
+func (svc *mgmtSvc) waitForLeaderElection(ctx context.Context, hostAddrs []string) error {
+	if len(hostAddrs) == 0 {
+		svc.log.Debug("waitForLeaderElection: no peers to check, skipping")
+		return nil
+	}
+
+	svc.log.Tracef("waitForLeaderElection: polling %d replica(s) for leader election", len(hostAddrs))
+
+	maxWait := 30 * time.Second
+	pollInterval := 500 * time.Millisecond
+	deadline := time.Now().Add(maxWait)
+	attempts := 0
+
+	for {
+		attempts++
+		if time.Now().After(deadline) {
+			return errors.Errorf("timeout waiting for raft leader election after erase (%d attempts)", attempts)
+		}
+
+		// Query each replica for leader information
+		leaderReq := &control.LeaderQueryReq{}
+		leaderReq.SetHostList(hostAddrs)
+
+		resp, err := control.LeaderQuery(ctx, svc.rpcClient, leaderReq)
+		if err == nil && resp != nil && resp.Leader != "" {
+			// Leader elected successfully
+			svc.log.Tracef("waitForLeaderElection: SUCCESS - raft leader elected: %s (after %d attempts)", resp.Leader, attempts)
+			return nil
+		}
+
+		// Log the status and retry
+		if err != nil {
+			svc.log.Debugf("waitForLeaderElection: attempt %d - error: %s", attempts, err)
+		} else if resp != nil && resp.Leader == "" {
+			svc.log.Debugf("waitForLeaderElection: attempt %d - no leader yet (replicas=%v)", attempts, resp.Replicas)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+			// Continue polling
+		}
+	}
+}
+
+// waitForReplicasReady polls MS replicas to ensure they have restarted and are ready
+// to accept join requests after an erase operation. This prevents engines from trying
+// to join before replicas have finished restarting with clean databases.
+func (svc *mgmtSvc) waitForReplicasReady(ctx context.Context, peers []*net.TCPAddr) error {
+	if len(peers) == 0 {
+		svc.log.Debug("waitForReplicasReady: no peers to check, skipping")
+		return nil
+	}
+
+	svc.log.Tracef("waitForReplicasReady: polling %d MS replica(s) to confirm restart", len(peers))
+
+	// Build hostlist from peer addresses
+	var hostAddrs []string
+	for _, peer := range peers {
+		hostAddrs = append(hostAddrs, peer.String())
+	}
+
+	maxWait := 30 * time.Second
+	pollInterval := 500 * time.Millisecond
+	deadline := time.Now().Add(maxWait)
+	attempts := 0
+
+	for {
+		attempts++
+		if time.Now().After(deadline) {
+			return errors.Errorf("timeout waiting for MS replicas to become ready after erase (%d attempts)", attempts)
+		}
+
+		// Try to query each replica - if successful, it's restarted and ready
+		queryReq := &control.SystemQueryReq{
+			FailOnUnavailable: true,
+		}
+		queryReq.SetHostList(hostAddrs)
+
+		resp, err := control.SystemQuery(ctx, svc.rpcClient, queryReq)
+		if err == nil && resp != nil {
+			// All replicas responded successfully
+			svc.log.Tracef("waitForReplicasReady: SUCCESS - all MS replicas ready (after %d attempts)", attempts)
+			return nil
+		}
+
+		// Log the error and retry
+		if err != nil {
+			svc.log.Debugf("waitForReplicasReady: attempt %d - error: %s", attempts, err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+			// Continue polling
+		}
+	}
+}
+
 // SystemErase implements the gRPC handler for erasing system metadata.
+//
+// SAFETY WARNINGS:
+//  1. This operation is DESTRUCTIVE and IRREVERSIBLE
+//  2. All ranks must be stopped before calling (enforced by checkSystemErase)
+//  3. On the leader, raft DB is stopped early in the operation, creating a window
+//     where leadership changes cannot be safely handled
+//  4. If the leader crashes after stopping raft but before completing, manual
+//     recovery will be required (replicas/engines may be in inconsistent states)
+//  5. The operation should complete in under 1 minute under normal conditions
+//
+// Operation sequence:
+// - Non-leader replicas: erase local engines + DB, restart immediately
+// - Leader: erase its own DB first, coordinate replica/engine erase, restart last
 func (svc *mgmtSvc) SystemErase(ctx context.Context, pbReq *mgmtpb.SystemEraseReq) (*mgmtpb.SystemEraseResp, error) {
 	// At a minimum, ensure that this only runs on MS replicas.
 	if err := svc.checkReplicaRequest(pbReq); err != nil {
 		return nil, err
 	}
 
-	svc.log.Debug("Received SystemErase RPC")
+	isLeader := svc.sysdb.IsLeader()
+	svc.log.Tracef("SystemErase: START [role=%s]", func() string {
+		if isLeader {
+			return "LEADER"
+		}
+		return "REPLICA"
+	}())
 
-	// If this is called on a non-leader replica, nuke the local
-	// instance of the database and any superblocks, then restart.
-	//
-	// TODO (DAOS-7080): Rework this to remove redundancy and thoroughly
-	// wipe SCM rather than removing things piecemeal.
-	if !svc.sysdb.IsLeader() {
+	// If this is called on a non-leader replica, stop engines, remove superblocks,
+	// erase the raft DB, and restart the control plane. When the control plane
+	// restarts, engines will automatically start but enter AwaitFormat state (no
+	// superblock). They will remain in AwaitFormat until the leader calls
+	// ResetFormatRanks (which is idempotent for already-started engines) followed
+	// by StorageFormat to complete the format process.
+	if !isLeader {
+		svc.log.Trace("SystemErase: REPLICA - Step 1: Stopping local engines")
+
 		for _, engine := range svc.harness.Instances() {
+			svc.log.Tracef("SystemErase: REPLICA - Stopping engine instance %d", engine.Index())
 			if err := engine.Stop(unix.SIGKILL); err != nil {
 				svc.log.Errorf("instance %d failed to stop: %s", engine.Index(), err)
 			}
+			svc.log.Tracef("SystemErase: REPLICA - Removing superblock for instance %d", engine.Index())
 			if err := engine.RemoveSuperblock(); err != nil {
 				svc.log.Errorf("instance %d failed to remove superblock: %s", engine.Index(), err)
 			}
 		}
+
+		// Sync filesystem to commit superblock deletions before proceeding
+		svc.log.Trace("SystemErase: REPLICA - Step 2: Syncing filesystem")
+
+		unix.Sync()
+		// Give the kernel time to complete pending I/O operations
+		time.Sleep(100 * time.Millisecond)
+
+		// Erase and restart control plane. Engines will be restarted later by
+		// ResetFormatRanks after all MS replicas are ready.
+		svc.log.Trace("SystemErase: REPLICA - Step 3: Erasing raft DB and restarting control plane")
 		if err := svc.eraseAndRestart(false); err != nil {
 			return nil, errors.Wrap(err, "erasing and restarting non-leader")
 		}
+		// Never reaches here - process is exec'd
 	}
 
-	// On the leader, we should first tell all servers to prepare for
-	// reformat by wiping out their engine superblocks, etc.
+	svc.log.Trace("SystemErase: LEADER - Step 1: Gathering MS replica peer addresses")
+
+	// On the leader, we need to coordinate the erase operation across replicas and engines.
+	// CRITICAL: Get peer addresses and prepare fanout request BEFORE stopping the database,
+	// as these operations require access to the membership/raft data.
+
+	// Get MS replica peer addresses before stopping the database
+	peers, err := svc.sysdb.PeerAddrs()
+	if err != nil {
+		return nil, err
+	}
+	svc.log.Tracef("SystemErase: LEADER - Found %d MS replica peer(s): %v", len(peers), peers)
+
+	svc.log.Trace("SystemErase: LEADER - Step 2: Preparing fanout request for ResetFormatRanks")
+
+	// Prepare fanout request for ResetFormatRanks before stopping the database
 	fanReq, fanResp, err := svc.getFanout(&mgmtpb.SystemQueryReq{})
 	if err != nil {
 		return nil, err
 	}
 	fanReq.Method = control.ResetFormatRanks
+	svc.log.Tracef("SystemErase: LEADER - Fanout request prepared for ranks: %s", fanReq.Ranks)
+
+	svc.log.Trace("SystemErase: LEADER - Step 3: Erasing leader's raft DB (POINT OF NO RETURN)")
+
+	// NOW erase the leader's database. This must happen before telling replicas to erase,
+	// to prevent a race where replicas restart with clean DBs, rejoin the cluster,
+	// and sync the leader's OLD database entries before the leader erases itself.
+	// We erase the leader's DB but DON'T restart yet - the leader needs to stay
+	// up to coordinate the erase operation on replicas and engines.
+	//
+	// SAFETY WARNING: After stopping raft, the leader cannot handle leadership changes.
+	// If the leader crashes or becomes unavailable after this point, manual intervention
+	// will be required. The operation should complete quickly to minimize this window.
+
+	// Stop the database and remove files
+	svc.log.Infof("%s pid %d: erasing system db on leader", build.ControlPlaneName, os.Getpid())
+	if err := svc.sysdb.Stop(); err != nil {
+		// In test scenarios, the mock DB may not have a shutdown callback.
+		// Log but continue - RemoveFiles is the critical operation.
+		svc.log.Debugf("stop system database: %s (continuing with erase)", err)
+	}
+	svc.log.Debug("SystemErase: LEADER - Raft database stopped")
+	if err := svc.sysdb.RemoveFiles(); err != nil {
+		// Critical: DB is stopped but files not removed. Try to log and continue.
+		svc.log.Errorf("CRITICAL: failed to remove leader DB files, continuing: %s", err)
+	}
+	svc.log.Debug("SystemErase: LEADER - Raft database files removed")
+
+	unix.Sync()
+	time.Sleep(100 * time.Millisecond)
+
+	svc.log.Trace("SystemErase: LEADER - Step 4: Sending erase request to MS replica peers")
+
+	// Now tell MS replica peers to erase their databases and restart.
+	// When they restart and try to rejoin, they'll find the leader's DB is also clean.
+	for _, peer := range peers {
+		svc.log.Tracef("SystemErase: LEADER - Sending erase RPC to peer %s", peer.String())
+		peerReq := new(control.SystemEraseReq)
+		peerReq.AddHost(peer.String())
+
+		if _, err := control.SystemErase(ctx, svc.rpcClient, peerReq); err != nil {
+			if control.IsRetryableConnErr(err) {
+				svc.log.Tracef("SystemErase: LEADER - Retryable connection error for peer %s: %s",
+					peer.String(), err)
+				continue
+			}
+			return nil, err
+		}
+		svc.log.Tracef("SystemErase: LEADER - Peer %s acknowledged erase request", peer.String())
+	}
+
+	svc.log.Trace("SystemErase: LEADER - Step 5: Waiting for MS replicas to restart")
+
+	// Wait for MS replicas to restart and become ready to accept join requests.
+	// This polls the replicas with SystemQuery until they respond successfully.
+	// If this fails, the system is in an inconsistent state (leader DB erased,
+	// replica state unknown) and requires manual recovery.
+	if err := svc.waitForReplicasReady(ctx, peers); err != nil {
+		return nil, errors.Wrap(err, "waiting for MS replicas to restart (system in inconsistent state)")
+	}
+
+	svc.log.Trace("SystemErase: LEADER - Step 6: Waiting for raft leader election")
+
+	// Build host address list from peer addresses for leader election check
+	var hostAddrs []string
+	for _, peer := range peers {
+		hostAddrs = append(hostAddrs, peer.String())
+	}
+
+	// CRITICAL: After replicas restart with clean databases, wait for raft leader election
+	// to complete before allowing engines to join. Without a raft leader, join requests
+	// will fail with "not the DAOS Management Service leader" errors.
+	if err := svc.waitForLeaderElection(ctx, hostAddrs); err != nil {
+		svc.log.Errorf("CRITICAL: Replicas ready but leader not elected: %s", err)
+		return nil, errors.Wrap(err, "waiting for raft leader election after erase")
+	}
+
+	svc.log.Trace("SystemErase: LEADER - Step 7: Calling ResetFormatRanks on all engines")
+
+	// Next, tell all servers to prepare for reformat by wiping out their engine
+	// superblocks. This will restart engines into AwaitFormat state.
+	// By doing this after erasing MS replicas, the replicas have clean databases
+	// when engines attempt to format and join.
+	// Note: fanReq was prepared before stopping the database.
 	fanResp, _, err = svc.rpcFanout(ctx, fanReq, fanResp, false)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, mr := range fanResp.Results {
-		svc.log.Debugf("member response: %#v", mr)
+		svc.log.Tracef("SystemErase: LEADER - ResetFormatRanks result: %#v", mr)
 	}
 
 	pbResp := new(mgmtpb.SystemEraseResp)
@@ -1723,28 +1972,29 @@ func (svc *mgmtSvc) SystemErase(ctx context.Context, pbReq *mgmtpb.SystemEraseRe
 	}
 
 	if fanResp.Results.Errors() != nil {
+		svc.log.Errorf("SystemErase: LEADER - ResetFormatRanks encountered errors")
 		return pbResp, nil
 	}
+	svc.log.Info("System Erase complete, engines ready for manual 'dmg storage format'")
 
-	// Next, tell all of the replicas to lobotomize themselves and restart.
-	peers, err := svc.sysdb.PeerAddrs()
+	svc.log.Trace("SystemErase: LEADER - Step 8: Restarting leader control plane")
+
+	// Finally, restart the leader to complete the erase.
+	// The leader's DB was already erased at the start of SystemErase.
+	myPath, err := os.Readlink("/proc/self/exe")
 	if err != nil {
-		return nil, err
+		return pbResp, errors.Wrap(err, "unable to determine path to self")
 	}
-	for _, peer := range peers {
-		peerReq := new(control.SystemEraseReq)
-		peerReq.AddHost(peer.String())
 
-		if _, err := control.SystemErase(ctx, svc.rpcClient, peerReq); err != nil {
-			if control.IsRetryableConnErr(err) {
-				continue
-			}
-			return nil, err
+	svc.log.Infof("System Erase Exec'ing %s to restart control plane", myPath)
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		if err := unix.Exec(myPath, append([]string{myPath}, os.Args[1:]...), os.Environ()); err != nil {
+			svc.log.Error(errors.Wrap(err, "Exec() failed").Error())
 		}
-	}
+	}()
 
-	// Finally, take care of the leader on the way out.
-	return pbResp, errors.Wrap(svc.eraseAndRestart(true), "erasing and restarting leader")
+	return pbResp, nil
 }
 
 // SystemCleanup implements the method defined for the Management Service.

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -1988,7 +1988,10 @@ func (svc *mgmtSvc) SystemErase(ctx context.Context, pbReq *mgmtpb.SystemEraseRe
 
 	svc.log.Infof("System Erase Exec'ing %s to restart control plane", myPath)
 	go func() {
-		time.Sleep(50 * time.Millisecond)
+		// Allow sufficient time for the gRPC response to be sent to the client
+		// before restarting the process. 50ms was insufficient and caused EOF errors
+		// when the process restarted before the client finished reading the response.
+		time.Sleep(500 * time.Millisecond)
 		if err := unix.Exec(myPath, append([]string{myPath}, os.Args[1:]...), os.Environ()); err != nil {
 			svc.log.Error(errors.Wrap(err, "Exec() failed").Error())
 		}

--- a/src/control/system/errors.go
+++ b/src/control/system/errors.go
@@ -155,7 +155,7 @@ func (err *ErrJoinFailure) Error() string {
 	case err.rankChanged:
 		return fmt.Sprintf("can't rejoin member with uuid %s: rank changed from %d -> %d", *err.curUUID, *err.curRank, *err.newRank)
 	case err.uuidChanged:
-		return fmt.Sprintf("can't rejoin member with rank %d: uuid changed from %s -> %s", *err.curRank, *err.curUUID, *err.newUUID)
+		return fmt.Sprintf("can't rejoin member with rank %d: uuid changed from %s -> %s (use 'dmg storage format --replace --rank %d' to update UUID)", *err.curRank, *err.curUUID, *err.newUUID, *err.curRank)
 	case err.isExcluded:
 		return fmt.Sprintf("member %s (rank %d) has been administratively excluded", err.curUUID, *err.curRank)
 	case err.addrChanged:

--- a/src/control/system/faults.go
+++ b/src/control/system/faults.go
@@ -56,9 +56,24 @@ func FaultJoinReplaceRankNotFound(nrFieldsNotMatching int) *fault.Fault {
 func FaultJoinMemberExists(newUUID, dbUUID uuid.UUID) *fault.Fault {
 	return systemFault(
 		code.SystemJoinMemberExists,
-		fmt.Sprintf("system member with matching control address, fabric URIs, and fault domain already exists with UUID %s (join request UUID: %s)", dbUUID, newUUID),
-		"format the rank with 'dmg storage format --replace' to update the UUID and rejoin the system",
+		fmt.Sprintf("system member with matching control address, fabric URIs, and fault "+
+			"domain already exists with UUID %s (join request UUID: %s)", dbUUID,
+			newUUID),
+		"format the rank with 'dmg storage format --replace' to update the UUID and "+
+			"rejoin the system",
 	)
+}
+
+// FaultJoinMemberExistsAdminExcluded is similar to FaultJoinMemberExists but the existing rank
+// entry is in an AdminExcluded state. The resolution includes clearing this state before retry.
+func FaultJoinMemberExistsAdminExcluded(newUUID, dbUUID uuid.UUID) *fault.Fault {
+	f := FaultJoinMemberExists(newUUID, dbUUID)
+	f.Description = fmt.Sprintf("%s, rank database entry is in an AdminExcluded state",
+		f.Description)
+	f.Resolution = fmt.Sprintf("clear manual exclusion first with 'dmg system clear-exclude "+
+		"-r <rank>' then %s", f.Resolution)
+
+	return f
 }
 
 func systemFault(code code.Code, desc, res string) *fault.Fault {

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -127,7 +127,21 @@ func (m *Membership) Count() (int, error) {
 // match.
 func (m *Membership) FindRankFromJoinRequest(req *JoinRequest) (Rank, error) {
 	if !req.Rank.Equals(NilRank) {
-		return NilRank, errors.New("unexpected rank in replace-rank request")
+		m.log.Debugf("rank %d provided in request", req.Rank)
+
+		cm, err := m.db.FindMemberByRank(req.Rank)
+		if err != nil {
+			return NilRank, errors.Wrapf(err,
+				"failed to find system member with rank %d", req.Rank)
+		}
+
+		if matched, missing := memberFieldsMatch(cm, req); !matched {
+			m.log.Errorf("replace-rank join request for rank %d failed, "+
+				"fields %v didn't match", cm.Rank, missing)
+			return NilRank, FaultJoinReplaceRankNotFound(len(missing))
+		}
+
+		return cm.Rank, nil
 	}
 
 	currentMembers, err := m.db.AllMembers()

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -123,27 +123,35 @@ func (m *Membership) Count() (int, error) {
 	return m.db.MemberCount()
 }
 
-// FindRankFromJoinRequest finds the first rank that matches join request parameters. UUID shouldn't
-// match.
-func (m *Membership) FindRankFromJoinRequest(req *JoinRequest) (Rank, error) {
-	if !req.Rank.Equals(NilRank) {
-		m.log.Debugf("rank %d provided in request", req.Rank)
-
-		cm, err := m.db.FindMemberByRank(req.Rank)
-		if err != nil {
-			return NilRank, errors.Wrapf(err,
-				"failed to find system member with rank %d", req.Rank)
-		}
-
-		if matched, missing := memberFieldsMatch(cm, req); !matched {
-			m.log.Errorf("replace-rank join request for rank %d failed, "+
-				"fields %v didn't match", cm.Rank, missing)
-			return NilRank, FaultJoinReplaceRankNotFound(len(missing))
-		}
-
-		return cm.Rank, nil
+// findRankByExplicitRequest validates and returns the rank when an explicit rank is provided
+// in the replace request.
+func (m *Membership) findRankByExplicitRequest(req *JoinRequest) (Rank, error) {
+	cm, err := m.db.FindMemberByRank(req.Rank)
+	if err != nil {
+		return NilRank, errors.Wrapf(err,
+			"failed to find system member with rank %d", req.Rank)
 	}
 
+	// Verify fields match
+	if matched, missing := memberFieldsMatch(cm, req); !matched {
+		m.log.Errorf("replace-rank join request for rank %d failed, "+
+			"fields %v didn't match", cm.Rank, missing)
+		return NilRank, FaultJoinReplaceRankNotFound(len(missing))
+	}
+
+	// Verify UUID is different (indicating this is actually a replacement)
+	if cm.UUID == req.UUID {
+		m.log.Errorf("uuid %q already exists for rank %d; not a replacement",
+			req.UUID, cm.Rank)
+		return NilRank, ErrUuidExists(req.UUID)
+	}
+
+	return cm.Rank, nil
+}
+
+// findRankByAutoDetection finds a rank to replace by searching for a member with matching
+// attributes but different UUID.
+func (m *Membership) findRankByAutoDetection(req *JoinRequest) (Rank, error) {
 	currentMembers, err := m.db.AllMembers()
 	if err != nil {
 		return NilRank, errors.Wrap(err, "failed to get all system members")
@@ -180,6 +188,19 @@ func (m *Membership) FindRankFromJoinRequest(req *JoinRequest) (Rank, error) {
 	}
 
 	return rank, nil
+}
+
+// FindRankFromJoinRequest finds the rank to replace based on the join request.
+// If req.Rank is not NilRank, validates that the specified rank matches the request.
+// Otherwise, auto-detects the rank by finding a member with matching attributes but different UUID.
+func (m *Membership) FindRankFromJoinRequest(req *JoinRequest) (Rank, error) {
+	if !req.Rank.Equals(NilRank) {
+		m.log.Debugf("explicit rank %d provided in request", req.Rank)
+		return m.findRankByExplicitRequest(req)
+	}
+
+	m.log.Debug("auto-detecting rank to replace")
+	return m.findRankByAutoDetection(req)
 }
 
 // JoinRequest contains information needed for join membership update.
@@ -273,6 +294,9 @@ func (m *Membership) checkForMatchingMember(req *JoinRequest) error {
 		}
 
 		// All fields match except UUID - this rank needs to use --replace
+		if cm.State == MemberStateAdminExcluded {
+			return FaultJoinMemberExistsAdminExcluded(req.UUID, cm.UUID)
+		}
 		return FaultJoinMemberExists(req.UUID, cm.UUID)
 	}
 

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -35,6 +35,10 @@ var (
 		cmpopts.IgnoreUnexported(Member{}),
 		cmpopts.EquateApproxTime(time.Second),
 	}
+	memberCmpOptsNoTimestamp = []cmp.Option{
+		cmpopts.IgnoreUnexported(Member{}),
+		cmpopts.IgnoreFields(Member{}, "LastUpdate"),
+	}
 )
 
 func mockEvtEngineDied(t *testing.T, r uint32, inc uint64) *events.RASEvent {
@@ -1216,7 +1220,7 @@ func TestSystem_Membership_OnEvent(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(tc.expMembers, members, memberCmpOpts...); diff != "" {
+			if diff := cmp.Diff(tc.expMembers, members, memberCmpOptsNoTimestamp...); diff != "" {
 				t.Errorf("unexpected membership (-want, +got):\n%s\n", diff)
 			}
 		})

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -977,7 +977,7 @@ func TestSystem_Membership_Join(t *testing.T) {
 	newUUID := uuid.New()
 	newMember := MockMember(t, 2, MemberStateJoined).WithFaultDomain(fd2)
 	newMemberShallowFD := MockMember(t, 3, MemberStateJoined).WithFaultDomain(shallowFD)
-	adminExcludedMember := MockMember(t, 3, MemberStateAdminExcluded)
+	adminExcludedMember := MockMember(t, 3, MemberStateAdminExcluded).WithFaultDomain(fd2)
 
 	expMapVer := uint32(len(defaultCurMembers) + 1)
 
@@ -1145,6 +1145,22 @@ func TestSystem_Membership_Join(t *testing.T) {
 				FaultDomain:             curMember.FaultDomain,
 			},
 			expErr: FaultJoinMemberExists(newUUID, curMember.UUID),
+		},
+		"join with all fields matching except UUID; needs --replace; admin-excluded": {
+			curMembers: []*Member{
+				adminExcludedMember,
+			},
+			req: &JoinRequest{
+				Rank:                    NilRank,
+				UUID:                    newUUID,
+				ControlAddr:             adminExcludedMember.Addr,
+				PrimaryFabricURI:        adminExcludedMember.PrimaryFabricURI,
+				SecondaryFabricURIs:     adminExcludedMember.SecondaryFabricURIs,
+				FabricContexts:          adminExcludedMember.PrimaryFabricContexts,
+				SecondaryFabricContexts: adminExcludedMember.SecondaryFabricContexts,
+				FaultDomain:             adminExcludedMember.FaultDomain,
+			},
+			expErr: FaultJoinMemberExistsAdminExcluded(newUUID, adminExcludedMember.UUID),
 		},
 		"new member with bad fault domain depth": {
 			req: &JoinRequest{

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -752,15 +752,90 @@ func TestSystem_Membership_FindRankFromJoinRequest(t *testing.T) {
 		expRank    Rank
 		expErr     error
 	}{
-		"non-nil rank in request": {
+		"non-nil rank with matching member fields": {
+			req: &JoinRequest{
+				Rank:                    curMember.Rank,
+				UUID:                    newUUID,
+				ControlAddr:             curMember.Addr,
+				PrimaryFabricURI:        curMember.PrimaryFabricURI,
+				SecondaryFabricURIs:     curMember.SecondaryFabricURIs,
+				FabricContexts:          curMember.PrimaryFabricContexts,
+				SecondaryFabricContexts: curMember.SecondaryFabricContexts,
+				FaultDomain:             curMember.FaultDomain,
+			},
+			expRank: curMember.Rank,
+		},
+		"non-nil rank with non-matching control address": {
 			req: &JoinRequest{
 				Rank:             curMember.Rank,
-				UUID:             curMember.UUID,
-				ControlAddr:      curMember.Addr,
-				PrimaryFabricURI: curMember.Addr.String(),
+				UUID:             newUUID,
+				ControlAddr:      newMember.Addr,
+				PrimaryFabricURI: curMember.PrimaryFabricURI,
 				FabricContexts:   curMember.PrimaryFabricContexts,
+				FaultDomain:      curMember.FaultDomain,
 			},
-			expErr: errors.New("unexpected rank"),
+			expErr: FaultJoinReplaceRankNotFound(1),
+		},
+		"non-nil rank with non-matching fabric URI": {
+			req: &JoinRequest{
+				Rank:             curMember.Rank,
+				UUID:             newUUID,
+				ControlAddr:      curMember.Addr,
+				PrimaryFabricURI: newMember.PrimaryFabricURI,
+				FabricContexts:   curMember.PrimaryFabricContexts,
+				FaultDomain:      curMember.FaultDomain,
+			},
+			expErr: FaultJoinReplaceRankNotFound(1),
+		},
+		"non-nil rank with non-matching fault domain": {
+			req: &JoinRequest{
+				Rank:             curMember.Rank,
+				UUID:             newUUID,
+				ControlAddr:      curMember.Addr,
+				PrimaryFabricURI: curMember.PrimaryFabricURI,
+				FabricContexts:   curMember.PrimaryFabricContexts,
+				FaultDomain:      fd2,
+			},
+			expErr: FaultJoinReplaceRankNotFound(1),
+		},
+		"non-nil rank with multiple non-matching fields": {
+			req: &JoinRequest{
+				Rank:             curMember.Rank,
+				UUID:             newUUID,
+				ControlAddr:      newMember.Addr,
+				PrimaryFabricURI: newMember.PrimaryFabricURI,
+				FabricContexts:   newMember.PrimaryFabricContexts,
+				FaultDomain:      fd2,
+			},
+			expErr: FaultJoinReplaceRankNotFound(4),
+		},
+		"non-nil rank not found in membership": {
+			req: &JoinRequest{
+				Rank:             Rank(999),
+				UUID:             newUUID,
+				ControlAddr:      curMember.Addr,
+				PrimaryFabricURI: curMember.PrimaryFabricURI,
+				FabricContexts:   curMember.PrimaryFabricContexts,
+				FaultDomain:      curMember.FaultDomain,
+			},
+			expErr: errors.New("failed to find system member"),
+		},
+		"valid rank zero with matching fields": {
+			curMembers: []*Member{
+				MockMember(t, 0, MemberStateJoined).WithFaultDomain(fd1),
+				MockMember(t, 1, MemberStateJoined).WithFaultDomain(fd1),
+			},
+			req: &JoinRequest{
+				Rank:                    Rank(0),
+				UUID:                    newUUID,
+				ControlAddr:             defaultCurMembers[0].Addr,
+				PrimaryFabricURI:        defaultCurMembers[0].PrimaryFabricURI,
+				SecondaryFabricURIs:     defaultCurMembers[0].SecondaryFabricURIs,
+				FabricContexts:          defaultCurMembers[0].PrimaryFabricContexts,
+				SecondaryFabricContexts: defaultCurMembers[0].SecondaryFabricContexts,
+				FaultDomain:             defaultCurMembers[0].FaultDomain,
+			},
+			expRank: Rank(0),
 		},
 		"empty membership": {
 			curMembers: []*Member{},

--- a/src/proto/ctl/storage.proto
+++ b/src/proto/ctl/storage.proto
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2022 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -56,6 +56,7 @@ message StorageFormatReq {
 	FormatScmReq scm = 2;
 	bool reformat = 3;
 	bool          replace  = 4;
+	uint32        rank     = 5; // Specific rank to replace (only valid with replace=true)
 }
 
 message StorageFormatResp {


### PR DESCRIPTION
This commit adds support for explicit rank specification during
storage format replace operations and improves test coverage:

1. Feature: --rank option for dmg storage format --replace
   - Allows explicit rank assignment (e.g., --replace --rank 5)
   - Supports auto-detection with NilRank (--replace without --rank)
   - Updates StorageFormatReq protobuf with rank field
   - Implements rank validation and membership checks

2. Code improvements and refactoring:
   - Extracted notifyStorageReady() helper for cleaner separation
   - Enhanced error handling with specific fault types
   - Improved logging for replace operations

3. Comprehensive test coverage:
   - Better test maintainability with reduced duplication
   - Add missing test coverage for determineRank()

Features: control
Signed-off-by: Tom Nabarro <thomas.nabarro@hpe.com>

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
