### PR TITLE
DAOS-18901 vos: Cap merged extent size

### DIFF
--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1813,8 +1814,9 @@ trigger_flush(struct agg_merge_window *mw, struct evt_extent *lgc_ext)
 	D_AGG_ASSERTF(mw, w_ext->ex_hi < lgc_ext->ex_lo, "win:" DF_EXT ", lgc_ent:" DF_EXT "\n",
 		      DP_EXT(w_ext), DP_EXT(lgc_ext));
 
-	/* Window is large enough */
-	if (merge_window_size(mw) >= mw->mw_flush_thresh)
+	/* Cap the merged extent at the defined threshold */
+	if ((merge_window_size(mw) + (evt_extent_width(lgc_ext) * mw->mw_rsize)) >
+	    mw->mw_flush_thresh)
 		return true;
 
 	/* Trigger flush when entry is disjoint with window */


### PR DESCRIPTION
Cap the merged extent size at the defined threshold.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
