### PR TITLE
DAOS-623 build: downgrade leap to 15.5 for 2.6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value='pipeline-lib@your_branch') _
+@Library(value='pipeline-lib@grom72/SRE-leap15.5-2.6') _
 
 // The trusted-pipeline-lib daosLatestVersion() method will convert this into a number
 /* groovylint-disable-next-line CompileStatic, VariableName */

--- a/ci/parse_ci_envs.sh
+++ b/ci/parse_ci_envs.sh
@@ -23,7 +23,7 @@ if [ -n "${STAGE_NAME:?}" ]; then
       : "${REPO_SPEC:=el-9}"
       ;;
     *Leap\ 15.6*|*leap15.6*|*opensuse15.6*|*sles15.6*)
-      : "${CHROOT_NAME:=opensuse-leap-15.6-x86_64}"
+      : "${CHROOT_NAME:=opensuse-leap-15.5-x86_64}"
       : "${TARGET:=leap15.6}"
       ;;
     *Leap\ 15.5*|*leap15.5*|*opensuse15.5*|*sles15.5*)
@@ -39,7 +39,7 @@ if [ -n "${STAGE_NAME:?}" ]; then
       : "${TARGET:=leap15.3}"
       ;;
     *Leap\ 15*|*leap15*|*opensuse15*|*sles15*)
-      : "${CHROOT_NAME:=opensuse-leap-15.6-x86_64}"
+      : "${CHROOT_NAME:=opensuse-leap-15.5-x86_64}"
       : "${TARGET:=leap15}"
       : "${REPO_SPEC:=sl-15}"
       ;;


### PR DESCRIPTION
Signed-off-by: Tomasz Gromadzki <tomasz.gromadzki@hpe.com>

Priority: 2

Skip-build-el8-gcc: true

Skip-unit-tests:true
Skip-unit-test: true
Skip-NLT: true
Skip-unit-test-memcheck: true

Allow-unstable-test: true

Skip-func-test-el8: true
Skip-func-test-el9: true
Skip-func-test-leap15: false
Skip-fault-injection-test: true
Skip-test-el-9.6-rpms: true

Skip-func-hw-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
