### PR TITLE
SRE-3764 build: leap15.5 downgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,8 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value='pipeline-lib@your_branch') _
+@Library(value='pipeline-lib@grom72/SRE-3764') _
+
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]
@@ -642,13 +644,13 @@ pipeline {
                                                 ' --build-arg DAOS_PACKAGES_BUILD=no ' +
                                                 ' --build-arg DAOS_KEEP_SRC=yes ' +
                                                 " -t ${sanitized_JOB_NAME()}-leap15" +
-                                                ' --build-arg POINT_RELEASE=.6 '
+                                                ' --build-arg POINT_RELEASE=.5 '
                         }
                     }
                     steps {
                         script {
                             sh label: 'Install RPMs',
-                                script: './ci/rpm/install_deps.sh suse.lp156 "' + env.DAOS_RELVAL + '"'
+                                script: './ci/rpm/install_deps.sh suse.lp155 "' + env.DAOS_RELVAL + '"'
                             sh label: 'Build deps',
                                 script: './ci/rpm/build_deps.sh'
                             job_step_update(
@@ -657,7 +659,7 @@ pipeline {
                                 ' PREFIX=/opt/daos TARGET_TYPE=release',
                                 build_deps: 'yes'))
                             sh label: 'Generate RPMs',
-                                script: './ci/rpm/gen_rpms.sh suse.lp156 "' + env.DAOS_RELVAL + '"'
+                                script: './ci/rpm/gen_rpms.sh suse.lp155 "' + env.DAOS_RELVAL + '"'
                         }
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value='pipeline-lib@your_branch') _
-@Library(value='pipeline-lib@grom72/SRE-3764') _
+//@Library(value='pipeline-lib@grom72/SRE-3764') _
 
 
 /* groovylint-disable-next-line CompileStatic */
@@ -644,6 +644,56 @@ pipeline {
                                                 ' --build-arg DAOS_PACKAGES_BUILD=no ' +
                                                 ' --build-arg DAOS_KEEP_SRC=yes ' +
                                                 " -t ${sanitized_JOB_NAME()}-leap15" +
+                                                ' --build-arg POINT_RELEASE=.6 '
+                        }
+                    }
+                    steps {
+                        script {
+                            sh label: 'Install RPMs',
+                                script: './ci/rpm/install_deps.sh suse.lp156 "' + env.DAOS_RELVAL + '"'
+                            sh label: 'Build deps',
+                                script: './ci/rpm/build_deps.sh'
+                            job_step_update(
+                                sconsBuild(parallel_build: true,
+                                scons_args: sconsFaultsArgs() +
+                                ' PREFIX=/opt/daos TARGET_TYPE=release',
+                                build_deps: 'yes'))
+                            sh label: 'Generate RPMs',
+                                script: './ci/rpm/gen_rpms.sh suse.lp156 "' + env.DAOS_RELVAL + '"'
+                        }
+                    }
+                    post {
+                        success {
+                            uploadNewRPMs('leap15', 'success')
+                        }
+                        unsuccessful {
+                            sh '''if [ -f config.log ]; then
+                                      mv config.log config.log-leap15-gcc
+                                  fi'''
+                            archiveArtifacts artifacts: 'config.log-leap15-gcc',
+                                             allowEmptyArchive: true
+                        }
+                        cleanup {
+                            uploadNewRPMs('leap15', 'cleanup')
+                            job_status_update()
+                        }
+                    }
+                }
+                stage('Build on Leap 15.5') {
+                    when {
+                        beforeAgent true
+                        expression { !skip_build_stage('leap15') }
+                    }
+                    agent {
+                        dockerfile {
+                            filename 'utils/docker/Dockerfile.leap.15'
+                            label 'docker_runner'
+                            additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
+                                                                parallel_build: true,
+                                                                deps_build: false) +
+                                                ' --build-arg DAOS_PACKAGES_BUILD=no ' +
+                                                ' --build-arg DAOS_KEEP_SRC=yes ' +
+                                                " -t ${sanitized_JOB_NAME()}-leap15.5" +
                                                 ' --build-arg POINT_RELEASE=.5 '
                         }
                     }

--- a/ci/parse_ci_envs.sh
+++ b/ci/parse_ci_envs.sh
@@ -23,8 +23,8 @@ if [ -n "${STAGE_NAME:?}" ]; then
       : "${REPO_SPEC:=el-9}"
       ;;
     *Leap\ 15.6*|*leap15.6*|*opensuse15.6*|*sles15.6*)
-      : "${CHROOT_NAME:=opensuse-leap-15.5-x86_64}"
-      : "${TARGET:=leap15.5}"
+      : "${CHROOT_NAME:=opensuse-leap-15.6-x86_64}"
+      : "${TARGET:=leap15.6}"
       ;;
     *Leap\ 15.5*|*leap15.5*|*opensuse15.5*|*sles15.5*)
       : "${CHROOT_NAME:=opensuse-leap-15.5-x86_64}"
@@ -39,7 +39,7 @@ if [ -n "${STAGE_NAME:?}" ]; then
       : "${TARGET:=leap15.3}"
       ;;
     *Leap\ 15*|*leap15*|*opensuse15*|*sles15*)
-      : "${CHROOT_NAME:=opensuse-leap-15.5-x86_64}"
+      : "${CHROOT_NAME:=opensuse-leap-15.6-x86_64}"
       : "${TARGET:=leap15}"
       : "${REPO_SPEC:=sl-15}"
       ;;

--- a/ci/parse_ci_envs.sh
+++ b/ci/parse_ci_envs.sh
@@ -24,7 +24,7 @@ if [ -n "${STAGE_NAME:?}" ]; then
       ;;
     *Leap\ 15.6*|*leap15.6*|*opensuse15.6*|*sles15.6*)
       : "${CHROOT_NAME:=opensuse-leap-15.5-x86_64}"
-      : "${TARGET:=leap15.6}"
+      : "${TARGET:=leap15.5}"
       ;;
     *Leap\ 15.5*|*leap15.5*|*opensuse15.5*|*sles15.5*)
       : "${CHROOT_NAME:=opensuse-leap-15.5-x86_64}"

--- a/utils/scripts/helpers/repo-helper-leap15.sh
+++ b/utils/scripts/helpers/repo-helper-leap15.sh
@@ -13,7 +13,7 @@ set -uex
 # for custom packages if present.
 
 : "${REPO_FILE_URL:=}"
-: "${BASE_DISTRO:=opensuse/leap:15.6}"
+: "${BASE_DISTRO:=opensuse/leap:15.5}"
 : "${JENKINS_URL:=}"
 : "${REPOS:=}"
 : "${REPOSITORY_NAME:=artifactory}"

--- a/utils/scripts/helpers/repo-helper-leap15.sh
+++ b/utils/scripts/helpers/repo-helper-leap15.sh
@@ -13,7 +13,7 @@ set -uex
 # for custom packages if present.
 
 : "${REPO_FILE_URL:=}"
-: "${BASE_DISTRO:=opensuse/leap:15.5}"
+: "${BASE_DISTRO:=opensuse/leap:15.6}"
 : "${JENKINS_URL:=}"
 : "${REPOS:=}"
 : "${REPOSITORY_NAME:=artifactory}"


### PR DESCRIPTION
DAOS release 2.6 requires dependency packages in version leap 15.5.

These packages can only be build on master branch after switching to FPM-based RPM build process.

The `Build on Leap 15.5` stage must be maintained as long as RPMs for leap 15.5 are needed.
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
