### PR TITLE
DAOS-18929 cart: add refcounting of crt bulks

### DIFF
--- a/src/cart/crt_bulk.c
+++ b/src/cart/crt_bulk.c
@@ -183,7 +183,7 @@ int
 crt_bulk_addref(crt_bulk_t crt_bulk)
 {
 	struct crt_bulk *bulk = crt_bulk;
-	int              rc   = -DER_SUCCESS;
+	int              rc   = DER_SUCCESS;
 
 	if (bulk == NULL) {
 		D_ERROR("invalid parameter, NULL bulk\n");
@@ -220,7 +220,6 @@ crt_bulk_free_common(struct crt_bulk *bulk)
 
 	D_ASSERT(bulk != NULL);
 
-	/* Decrement refcount on bulk handle itself */
 	if (bulk->hg_bulk_hdl != HG_BULK_NULL) {
 		hg_ret = HG_Bulk_free(bulk->hg_bulk_hdl);
 		if (hg_ret != HG_SUCCESS) {
@@ -233,8 +232,7 @@ crt_bulk_free_common(struct crt_bulk *bulk)
 	if (!bulk->deferred && bulk->crt_ctx != NULL)
 		put_quota_resource(bulk->crt_ctx, CRT_QUOTA_BULKS);
 
-	if (bulk->iovs != NULL)
-		D_FREE(bulk->iovs);
+	D_FREE(bulk->iovs);
 	D_FREE(bulk);
 }
 

--- a/src/cart/crt_bulk.c
+++ b/src/cart/crt_bulk.c
@@ -184,17 +184,10 @@ crt_bulk_addref(crt_bulk_t crt_bulk)
 {
 	struct crt_bulk *bulk = crt_bulk;
 	int              rc   = -DER_SUCCESS;
-	hg_return_t      hg_ret;
 
 	if (bulk == NULL) {
 		D_ERROR("invalid parameter, NULL bulk\n");
 		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	hg_ret = HG_Bulk_ref_incr(bulk->hg_bulk_hdl);
-	if (hg_ret != HG_SUCCESS) {
-		D_ERROR("HG_Bulk_ref_incr failed, hg_ret: %d.\n", hg_ret);
-		rc = crt_hgret_2_der(hg_ret);
 	}
 
 	atomic_fetch_add(&bulk->refcount, 1);
@@ -206,43 +199,43 @@ int
 crt_bulk_free(crt_bulk_t crt_bulk)
 {
 	struct crt_bulk *bulk = crt_bulk;
-	int              rc   = -DER_SUCCESS;
-	hg_return_t      hg_ret;
 
 	if (bulk == NULL) {
 		D_ERROR("invalid parameter, NULL bulk\n");
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	/* This can happen if D_QUOTA_BULKS is enabled on a client */
-	if (bulk->hg_bulk_hdl == HG_BULK_NULL) {
-		if (bulk->deferred) {
-			/* Treat as success */
-			D_GOTO(out, rc = DER_SUCCESS);
-		} else {
-			D_ASSERTF(0, "Bulk handle should not be NULL\n");
-		}
-	}
-
-	hg_ret = HG_Bulk_free(bulk->hg_bulk_hdl);
-	if (hg_ret != HG_SUCCESS) {
-		D_ERROR("HG_Bulk_free failed, hg_ret: %d.\n", hg_ret);
-		rc = crt_hgret_2_der(hg_ret);
+		return -DER_INVAL;
 	}
 
 	if (atomic_fetch_sub(&bulk->refcount, 1) > 1)
 		return DER_SUCCESS;
 
-	/* decoded bulks are not counted towards quota; such bulks have crt_ctx set to NULL */
-	if (bulk->crt_ctx)
-		put_quota_resource(bulk->crt_ctx, CRT_QUOTA_BULKS);
-out:
-	if (bulk != NULL) {
-		if (bulk->iovs)
-			D_FREE(bulk->iovs);
-		D_FREE(bulk);
+	crt_bulk_free_common(bulk);
+
+	return DER_SUCCESS;
+}
+
+void
+crt_bulk_free_common(struct crt_bulk *bulk)
+{
+	hg_return_t hg_ret;
+
+	D_ASSERT(bulk != NULL);
+
+	/* Decrement refcount on bulk handle itself */
+	if (bulk->hg_bulk_hdl != HG_BULK_NULL) {
+		hg_ret = HG_Bulk_free(bulk->hg_bulk_hdl);
+		if (hg_ret != HG_SUCCESS) {
+			D_ERROR("HG_Bulk_free() failed (%s)\n", HG_Error_to_string(hg_ret));
+			/* Ignore the error, as we are already in a cleanup path */
+		}
 	}
-	return rc;
+
+	/* decoded bulks are not counted towards quota; such bulks have crt_ctx set to NULL */
+	if (!bulk->deferred && bulk->crt_ctx != NULL)
+		put_quota_resource(bulk->crt_ctx, CRT_QUOTA_BULKS);
+
+	if (bulk->iovs != NULL)
+		D_FREE(bulk->iovs);
+	D_FREE(bulk);
 }
 
 /* Helper function to check for bulk expiration */

--- a/src/cart/crt_bulk.c
+++ b/src/cart/crt_bulk.c
@@ -1,7 +1,7 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
  * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -106,6 +106,7 @@ crt_bulk_create(crt_context_t crt_ctx, d_sg_list_t *sgl,
 	D_ALLOC_PTR(ret_hdl);
 	if (ret_hdl == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
+	ret_hdl->refcount = 1;
 
 	quota_rc = get_quota_resource(crt_ctx, CRT_QUOTA_BULKS);
 	if (quota_rc == -DER_QUOTA_LIMIT) {
@@ -196,6 +197,7 @@ crt_bulk_addref(crt_bulk_t crt_bulk)
 		rc = crt_hgret_2_der(hg_ret);
 	}
 
+	atomic_fetch_add(&bulk->refcount, 1);
 out:
 	return rc;
 }
@@ -227,6 +229,9 @@ crt_bulk_free(crt_bulk_t crt_bulk)
 		D_ERROR("HG_Bulk_free failed, hg_ret: %d.\n", hg_ret);
 		rc = crt_hgret_2_der(hg_ret);
 	}
+
+	if (atomic_fetch_sub(&bulk->refcount, 1) > 1)
+		return DER_SUCCESS;
 
 	/* decoded bulks are not counted towards quota; such bulks have crt_ctx set to NULL */
 	if (bulk->crt_ctx)

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -134,12 +134,13 @@ crt_proc_crt_bulk_t_deffered(struct crt_bulk *bulk)
 	if (bulk->bound) {
 		rc = crt_hg_bulk_bind(bulk->hg_bulk_hdl, &ctx->cc_hg_ctx);
 		if (rc != 0) {
-			D_ERROR("Failed to bind bulk during proc\n");
+			DL_ERROR(rc, "Failed to bind bulk during proc");
 			/* free will return quota resource */
 			crt_bulk_free(bulk->hg_bulk_hdl);
 			return rc;
 		}
 	}
+	/* Mark as no longer deferred once allocation is complete */
 	bulk->deferred = false;
 
 	return 0;
@@ -165,7 +166,7 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op, crt_bulk_t *pcrt_bul
 		/* Deferred allocation as a result of D_QUOTA_BULKS limit */
 		if (bulk != CRT_BULK_NULL) {
 			if (bulk->deferred && (rc = crt_proc_crt_bulk_t_deffered(bulk)) != 0) {
-				D_ERROR("Failed to do deferred bulk allocation during proc\n");
+				DL_ERROR(rc, "Failed to do deferred bulk allocation during proc");
 				return rc;
 			}
 			hg_bulk = bulk->hg_bulk_hdl;
@@ -192,12 +193,10 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op, crt_bulk_t *pcrt_bul
 
 		/* Allocate space for a wrapper struct */
 		D_ALLOC_PTR(bulk);
-		if (!bulk)
+		if (bulk == NULL)
 			return -DER_NOMEM;
 
 		bulk->hg_bulk_hdl = hg_bulk;
-		bulk->deferred    = false;
-		bulk->crt_ctx     = NULL;
 		bulk->refcount    = 1;
 
 		*pcrt_bulk = bulk;
@@ -209,21 +208,25 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op, crt_bulk_t *pcrt_bul
 		if (bulk == NULL)
 			return 0;
 
-		/* Prevent HG proc from assigning NULL if recount is not zero */
+		/**
+		 * Prevent HG proc from assigning NULL if refcount is not zero and keep reference on
+		 * HG bulk, we'll free it ourselves. hg_proc_hg_bulk_t() will decrement refcount on
+		 * the HG bulk.
+		 */
 		hg_bulk = bulk->hg_bulk_hdl;
-		hg_ret  = hg_proc_hg_bulk_t(proc, &hg_bulk);
+		HG_Bulk_ref_incr(hg_bulk);
+		hg_ret = hg_proc_hg_bulk_t(proc, &hg_bulk);
 		if (hg_ret != HG_SUCCESS) {
-			D_ERROR("Failed to free bulk during proc\n");
+			D_ERROR("Failed to free bulk during proc (%s)\n",
+				HG_Error_to_string(hg_ret));
 			return -DER_HG;
 		}
 
 		if (atomic_fetch_sub(&bulk->refcount, 1) > 1)
 			return 0;
 
-		/* Free the wrapper struct */
-		if (bulk->iovs)
-			D_FREE(bulk->iovs);
-		D_FREE(bulk);
+		/* This is the real free */
+		crt_bulk_free_common(bulk);
 		*pcrt_bulk = NULL;
 		return 0;
 	}

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -116,7 +116,7 @@ CRT_PROC_TYPE_FUNC(uint64_t)
 CRT_PROC_TYPE_FUNC(bool)
 
 static int
-crt_proc_crt_bulk_t_deffered(struct crt_bulk *bulk)
+crt_proc_crt_bulk_t_deferred(struct crt_bulk *bulk)
 {
 	struct crt_context *ctx;
 	int                 rc;
@@ -135,8 +135,9 @@ crt_proc_crt_bulk_t_deffered(struct crt_bulk *bulk)
 		rc = crt_hg_bulk_bind(bulk->hg_bulk_hdl, &ctx->cc_hg_ctx);
 		if (rc != 0) {
 			DL_ERROR(rc, "Failed to bind bulk during proc");
-			/* free will return quota resource */
-			crt_bulk_free(bulk->hg_bulk_hdl);
+			put_quota_resource(ctx, CRT_QUOTA_BULKS);
+			(void)HG_Bulk_free(bulk->hg_bulk_hdl);
+			bulk->hg_bulk_hdl = HG_BULK_NULL;
 			return rc;
 		}
 	}
@@ -165,7 +166,7 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op, crt_bulk_t *pcrt_bul
 
 		/* Deferred allocation as a result of D_QUOTA_BULKS limit */
 		if (bulk != CRT_BULK_NULL) {
-			if (bulk->deferred && (rc = crt_proc_crt_bulk_t_deffered(bulk)) != 0) {
+			if (bulk->deferred && (rc = crt_proc_crt_bulk_t_deferred(bulk)) != 0) {
 				DL_ERROR(rc, "Failed to do deferred bulk allocation during proc");
 				return rc;
 			}
@@ -196,8 +197,14 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op, crt_bulk_t *pcrt_bul
 		if (bulk == NULL)
 			return -DER_NOMEM;
 
-		bulk->hg_bulk_hdl = hg_bulk;
-		bulk->refcount    = 1;
+		*bulk = (struct crt_bulk){.hg_bulk_hdl = hg_bulk,
+					  .crt_ctx     = NULL,
+					  .iovs        = NULL,
+					  .sgl         = {0},
+					  .bulk_perm   = 0, /* unused */
+					  .refcount    = 1,
+					  .bound       = false,
+					  .deferred    = false};
 
 		*pcrt_bulk = bulk;
 		return 0;
@@ -214,12 +221,14 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op, crt_bulk_t *pcrt_bul
 		 * the HG bulk.
 		 */
 		hg_bulk = bulk->hg_bulk_hdl;
-		HG_Bulk_ref_incr(hg_bulk);
+		(void)HG_Bulk_ref_incr(hg_bulk);
 		hg_ret = hg_proc_hg_bulk_t(proc, &hg_bulk);
 		if (hg_ret != HG_SUCCESS) {
+			/* For correctness, call HG_Bulk_free() here but this is theoretically not
+			 * needed as hg_proc_hg_bulk_t() cannot fail in this context */
+			(void)HG_Bulk_free(hg_bulk);
 			D_ERROR("Failed to free bulk during proc (%s)\n",
 				HG_Error_to_string(hg_ret));
-			return -DER_HG;
 		}
 
 		if (atomic_fetch_sub(&bulk->refcount, 1) > 1)

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -1,7 +1,7 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
  * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -115,12 +115,43 @@ CRT_PROC_TYPE_FUNC(int64_t)
 CRT_PROC_TYPE_FUNC(uint64_t)
 CRT_PROC_TYPE_FUNC(bool)
 
+static int
+crt_proc_crt_bulk_t_deffered(struct crt_bulk *bulk)
+{
+	struct crt_context *ctx;
+	int                 rc;
+
+	/* Create mercury handle based on saved params */
+	ctx = bulk->crt_ctx;
+	D_ASSERT(ctx != NULL);
+
+	rc = crt_hg_bulk_create(&ctx->cc_hg_ctx, &bulk->sgl, bulk->bulk_perm, &bulk->hg_bulk_hdl);
+	if (rc != DER_SUCCESS)
+		return rc;
+
+	record_quota_resource(ctx, CRT_QUOTA_BULKS);
+
+	if (bulk->bound) {
+		rc = crt_hg_bulk_bind(bulk->hg_bulk_hdl, &ctx->cc_hg_ctx);
+		if (rc != 0) {
+			D_ERROR("Failed to bind bulk during proc\n");
+			/* free will return quota resource */
+			crt_bulk_free(bulk->hg_bulk_hdl);
+			return rc;
+		}
+	}
+	bulk->deferred = false;
+
+	return 0;
+}
+
 int
 crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op, crt_bulk_t *pcrt_bulk)
 {
 	struct crt_bulk *bulk = NULL;
+	hg_bulk_t        hg_bulk;
 	hg_return_t      hg_ret;
-	hg_bulk_t        tmp_hg_bulk;
+	int              rc;
 
 	/*
 	 * We only send 'hg_bulk_t' over the wire. During encoding stage we
@@ -131,54 +162,30 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op, crt_bulk_t *pcrt_bul
 	case CRT_PROC_ENCODE:
 		bulk = *pcrt_bulk;
 
-		/* RPC can have a NULL bulk. if so, encode a NULL value */
-		if (!bulk) {
-			tmp_hg_bulk = HG_BULK_NULL;
-			hg_ret      = hg_proc_hg_bulk_t(proc, (hg_bulk_t *)&tmp_hg_bulk);
-			return (hg_ret == HG_SUCCESS) ? 0 : -DER_HG;
-		}
-
 		/* Deferred allocation as a result of D_QUOTA_BULKS limit */
-		if (bulk->deferred) {
-			struct crt_context *ctx;
-			int                 rc;
-
-			/* Create mercury handle based on saved params */
-			ctx = bulk->crt_ctx;
-			D_ASSERT(ctx != NULL);
-
-			rc = crt_hg_bulk_create(&ctx->cc_hg_ctx, &bulk->sgl, bulk->bulk_perm,
-						&bulk->hg_bulk_hdl);
-			if (rc != DER_SUCCESS)
+		if (bulk != CRT_BULK_NULL) {
+			if (bulk->deferred && (rc = crt_proc_crt_bulk_t_deffered(bulk)) != 0) {
+				D_ERROR("Failed to do deferred bulk allocation during proc\n");
 				return rc;
-
-			record_quota_resource(ctx, CRT_QUOTA_BULKS);
-
-			if (bulk->bound) {
-				rc = crt_hg_bulk_bind(bulk->hg_bulk_hdl, &ctx->cc_hg_ctx);
-				if (rc != 0) {
-					D_ERROR("Failed to bind bulk during proc\n");
-					/* free will return quota resource */
-					crt_bulk_free(bulk->hg_bulk_hdl);
-					return rc;
-				}
 			}
-			bulk->deferred = false;
+			hg_bulk = bulk->hg_bulk_hdl;
+		} else {
+			/* RPC can have a NULL bulk. if so, encode a NULL value */
+			hg_bulk = HG_BULK_NULL;
 		}
 
 		/* Pack mercury bulk handle to send over the wire */
-		hg_ret = hg_proc_hg_bulk_t(proc, (hg_bulk_t *)&bulk->hg_bulk_hdl);
+		hg_ret = hg_proc_hg_bulk_t(proc, &hg_bulk);
 		return (hg_ret == HG_SUCCESS) ? 0 : -DER_HG;
-		break;
 
 	case CRT_PROC_DECODE:
 		/* unpack mercury handle and wrap it around crt_bulk_t struct */
-		hg_ret = hg_proc_hg_bulk_t(proc, &tmp_hg_bulk);
+		hg_ret = hg_proc_hg_bulk_t(proc, &hg_bulk);
 		if (hg_ret != HG_SUCCESS)
 			return -DER_HG;
 
 		/* don't create a bulk wrapper if null bulk was transmitted */
-		if (tmp_hg_bulk == HG_BULK_NULL) {
+		if (hg_bulk == HG_BULK_NULL) {
 			*pcrt_bulk = NULL;
 			return 0;
 		}
@@ -188,13 +195,13 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op, crt_bulk_t *pcrt_bul
 		if (!bulk)
 			return -DER_NOMEM;
 
-		bulk->hg_bulk_hdl = tmp_hg_bulk;
+		bulk->hg_bulk_hdl = hg_bulk;
 		bulk->deferred    = false;
 		bulk->crt_ctx     = NULL;
+		bulk->refcount    = 1;
 
 		*pcrt_bulk = bulk;
 		return 0;
-		break;
 
 	case CRT_PROC_FREE:
 		bulk = *pcrt_bulk;
@@ -202,15 +209,23 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op, crt_bulk_t *pcrt_bul
 		if (bulk == NULL)
 			return 0;
 
-		hg_ret = hg_proc_hg_bulk_t(proc, &bulk->hg_bulk_hdl);
+		/* Prevent HG proc from assigning NULL if recount is not zero */
+		hg_bulk = bulk->hg_bulk_hdl;
+		hg_ret  = hg_proc_hg_bulk_t(proc, &hg_bulk);
+		if (hg_ret != HG_SUCCESS) {
+			D_ERROR("Failed to free bulk during proc\n");
+			return -DER_HG;
+		}
+
+		if (atomic_fetch_sub(&bulk->refcount, 1) > 1)
+			return 0;
 
 		/* Free the wrapper struct */
 		if (bulk->iovs)
 			D_FREE(bulk->iovs);
 		D_FREE(bulk);
 		*pcrt_bulk = NULL;
-		return (hg_ret == HG_SUCCESS) ? 0 : -DER_HG;
-		break;
+		return 0;
 	}
 
 	/* Should not get here */

--- a/src/cart/crt_internal_fns.h
+++ b/src/cart/crt_internal_fns.h
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -61,6 +61,9 @@ crt_bulk_desc_dup(struct crt_bulk_desc *bulk_desc_new,
 	D_ASSERT(bulk_desc_new != NULL && bulk_desc != NULL);
 	*bulk_desc_new = *bulk_desc;
 }
+
+void
+crt_bulk_free_common(struct crt_bulk *bulk);
 
 void
 crt_hdlr_proto_query(crt_rpc_t *rpc_req);

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -422,14 +422,14 @@ struct crt_quotas {
  * Deferred allocation is only supported on clients through D_QUOTA_BULKS env
  */
 struct crt_bulk {
-	hg_bulk_t       hg_bulk_hdl; /** mercury bulk handle */
-	bool            deferred;    /** whether handle allocation was deferred */
-	crt_context_t   crt_ctx;     /** context on which bulk is to be created  */
-	bool            bound;       /** whether crt_bulk_bind() was used on it */
-	d_iov_t        *iovs;        /** original iovs */
 	d_sg_list_t     sgl;         /** original sgl */
+	d_iov_t        *iovs;        /** original iovs */
+	hg_bulk_t       hg_bulk_hdl; /** mercury bulk handle */
+	crt_context_t   crt_ctx;     /** context on which bulk is to be created  */
 	crt_bulk_perm_t bulk_perm;   /** bulk permissions */
 	ATOMIC uint32_t refcount;    /** reference count for this struct */
+	bool            bound;       /** whether crt_bulk_bind() was used on it */
+	bool            deferred;    /** whether handle allocation was deferred */
 };
 
 /* crt_context */

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -429,6 +429,7 @@ struct crt_bulk {
 	d_iov_t        *iovs;        /** original iovs */
 	d_sg_list_t     sgl;         /** original sgl */
 	crt_bulk_perm_t bulk_perm;   /** bulk permissions */
+	ATOMIC uint32_t refcount;    /** reference count for this struct */
 };
 
 /* crt_context */


### PR DESCRIPTION
This allows for caching decoded bulk handles on server

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
