### PR TITLE
DAOS-18793 cq: fix commit pragma stop_on_match

### DIFF
--- a/ci/gen_commit_pragmas.py
+++ b/ci/gen_commit_pragmas.py
@@ -108,13 +108,6 @@ def read_commit_pragma_mapping():
                     raise ValueError(
                         f'Invalid handler: {config[path_match][pragma_key]["handler"]}')
 
-                # Set default stop_on_match and check for invalid values
-                if 'stop_on_match' not in config[path_match][pragma_key]:
-                    config[path_match][pragma_key]['stop_on_match'] = False
-                elif not isinstance(config[path_match][pragma_key]['stop_on_match'], bool):
-                    raise ValueError(
-                        f'Invalid stop_on_match: {config[path_match][pragma_key]["stop_on_match"]}')
-
                 # Check for missing or invalid tags
                 if 'tags' not in config[path_match][pragma_key]:
                     raise ValueError(f'Missing tags for {path_match}')
@@ -135,13 +128,6 @@ def read_commit_pragma_mapping():
                     set(['val', 'stop_on_match'])
                 if extra_keys:
                     raise ValueError(f'Unsupported keys in config: {", ".join(extra_keys)}')
-
-                # Set default stop_on_match and check for invalid values
-                if 'stop_on_match' not in config[path_match][pragma_key]:
-                    config[path_match][pragma_key]['stop_on_match'] = False
-                elif not isinstance(config[path_match][pragma_key]['stop_on_match'], bool):
-                    raise ValueError(
-                        f'Invalid stop_on_match: {config[path_match][pragma_key]["stop_on_match"]}')
 
                 # Check for missing or invalid val
                 if 'val' not in config[path_match][pragma_key]:


### PR DESCRIPTION
Do not default stop_on_match to False since the nested default will always override the higher-level value.

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
