### PR TITLE
SRE-3764 build: Run Leap 15.6 stage with 15.5 RPMs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -317,7 +317,7 @@ pipeline {
                             pragma_suffix: '-vm',
                             distro: 'leap15',
                             image_version: 'leap15.6',
-                            rpm_version: 'leap15.5',
+                            rpm_version: '15.5',
                             base_branch: params.BaseBranch,
                             label: vm9_label('Leap15'),
                             next_version: params.BaseBranch,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -316,6 +316,7 @@ pipeline {
                             pragma_suffix: '-vm',
                             distro: 'leap15',
                             image_version: 'leap15.6',
+                            rpm_version: 'leap15.5',
                             base_branch: params.BaseBranch,
                             label: vm9_label('Leap15'),
                             next_version: params.BaseBranch,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,6 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value='pipeline-lib@your_branch') _
-@Library(value='pipeline-lib@hendersp/SRE-3764') _
 
 // Name of branch to be tested
 test_branch = 'release/2.6'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value='pipeline-lib@your_branch') _
+@Library(value='pipeline-lib@hendersp/SRE-3764') _
 
 // Name of branch to be tested
 test_branch = 'release/2.6'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -317,7 +317,7 @@ pipeline {
                             pragma_suffix: '-vm',
                             distro: 'leap15',
                             image_version: 'leap15.6',
-                            rpm_version: '15.5',
+                            rpm_distro: '.suse.lp155',
                             base_branch: params.BaseBranch,
                             label: vm9_label('Leap15'),
                             next_version: params.BaseBranch,


### PR DESCRIPTION
Use the override to install DAOS Leap 15.5 RPMs on hosts provisioned with Leap 15.6.

Skip-func-hw-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
