### PR TITLE
DAOS-18262 common: make sure DAOS file permissions are always 0XXY (#17680)

### DIFF
--- a/src/control/common/file_utils.go
+++ b/src/control/common/file_utils.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -20,9 +20,11 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-// UtilLogDepth signifies stack depth, set calldepth on calls to logger so
-// log message context refers to caller not callee.
-const UtilLogDepth = 4
+const (
+	// UtilLogDepth signifies stack depth, set calldepth on calls to logger so
+	// log message context refers to caller not callee.
+	UtilLogDepth = 4
+)
 
 // GetFilenames returns names of files in a directory.
 func GetFilenames(dir string) ([]string, error) {
@@ -138,6 +140,13 @@ func writeFile(path string, data []byte, perm os.FileMode) (err error) {
 			os.Remove(path)
 		}
 	}()
+
+	// The requested permissions may have been reduced by the umask.
+	// Using chmod ensures the requested permissions are applied.
+	err = os.Chmod(path, perm)
+	if err != nil {
+		return
+	}
 
 	n, err := f.Write(data)
 	if err != nil {
@@ -369,4 +378,15 @@ func HasPrefixPath(base, sub string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// MkdirForcePerm creates a new directory with the specified name and permission bits (umask ignored).
+func MkdirForcePerm(path string, perm os.FileMode) error {
+	err := os.Mkdir(path, perm)
+	if err != nil {
+		return err
+	}
+	// The requested permissions may have been reduced by the umask.
+	// Using Chmod ensures the requested permissions are applied.
+	return os.Chmod(path, perm)
 }

--- a/src/control/common/file_utils_test.go
+++ b/src/control/common/file_utils_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -176,5 +177,27 @@ func TestUtils_HasPrefixPath(t *testing.T) {
 	if hp {
 		t.Fatalf("%q is not a prefix of %q", testDir, testPath)
 	}
+}
 
+func TestUtils_MkdirForcePerm(t *testing.T) {
+	expPerm := 0777
+
+	testDir, clean := CreateTestDir(t)
+	defer clean()
+
+	testPath := path.Join(testDir, "foo")
+	err := MkdirForcePerm(testPath, os.FileMode(expPerm))
+	if err != nil {
+		t.Fatalf("Unexpected error: %q", err)
+	}
+
+	info, err := os.Stat(testPath)
+	if err != nil {
+		t.Fatalf("Unexpected error: %q", err)
+	}
+
+	perm := int(info.Mode().Perm())
+	if perm != expPerm {
+		t.Fatalf("Created directory has unexpected permissions: %04o instead of %04o", perm, expPerm)
+	}
 }

--- a/src/control/lib/daos/constants.go
+++ b/src/control/lib/daos/constants.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2022 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -8,6 +9,7 @@ package daos
 
 /*
 #include <daos_types.h>
+#include <daos_srv/control.h>
 */
 import "C"
 
@@ -19,4 +21,9 @@ const (
 
 	// MaxAttributeNameLength defines the maximum length of an attribute name.
 	MaxAttributeNameLength = C.DAOS_ATTR_NAME_MAX
+)
+
+const (
+	DefaultFilePerm = C.DEFAULT_FILE_PERM
+	DefaultDirPerm  = C.DEFAULT_DIR_PERM
 )

--- a/src/control/provider/system/mocks.go
+++ b/src/control/provider/system/mocks.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2022-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
@@ -238,11 +239,10 @@ func (msp *MockSysProvider) Getegid() int {
 	return msp.cfg.GetegidRes
 }
 
-// Mkdir creates a new directory with the specified name and permission
-// bits (before umask).
+// Mkdir creates a new directory with the specified name and permission bits (umask ignored).
 func (msp *MockSysProvider) Mkdir(path string, flags os.FileMode) error {
 	if msp.cfg.RealMkdir {
-		return os.Mkdir(path, flags)
+		return common.MkdirForcePerm(path, flags)
 	}
 	return msp.cfg.MkdirErr
 }

--- a/src/control/provider/system/system_linux.go
+++ b/src/control/provider/system/system_linux.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/daos-stack/daos/src/control/common"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -391,10 +392,9 @@ func (s LinuxProvider) Getegid() int {
 	return os.Getegid()
 }
 
-// Mkdir creates a new directory with the specified name and permission
-// bits (before umask).
-func (s LinuxProvider) Mkdir(name string, perm os.FileMode) error {
-	return os.Mkdir(name, perm)
+// Mkdir creates a new directory with the specified name and permission bits (umask ignored).
+func (s LinuxProvider) Mkdir(path string, perm os.FileMode) error {
+	return common.MkdirForcePerm(path, perm)
 }
 
 // RemoveAll removes path and any children it contains.

--- a/src/control/server/instance_superblock.go
+++ b/src/control/server/instance_superblock.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
 )
 
@@ -205,6 +206,6 @@ func WriteSuperblock(sbPath string, sb *Superblock) error {
 		return err
 	}
 
-	return errors.Wrapf(common.WriteFileAtomic(sbPath, data, 0600),
+	return errors.Wrapf(common.WriteFileAtomic(sbPath, data, daos.DefaultFilePerm),
 		"Failed to write Superblock to %s", sbPath)
 }

--- a/src/control/server/storage/bdev/backend_class.go
+++ b/src/control/server/storage/bdev/backend_class.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 // (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -19,13 +20,14 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
 const (
-	aioBlockSize       = humanize.KiByte * 4 // device block size hardcoded to 4096 bytes
-	defaultAioFileMode = 0600                // AIO file permissions set to owner +rw
+	aioBlockSize       = humanize.KiByte * 4  // device block size hardcoded to 4096 bytes
+	defaultAioFileMode = daos.DefaultFilePerm // AIO file permissions
 )
 
 func createEmptyFile(log logging.Logger, path string, size uint64) error {
@@ -100,6 +102,14 @@ func writeConfigFile(log logging.Logger, buf *bytes.Buffer, req *storage.BdevWri
 	f, err := os.Create(req.ConfigOutputPath)
 	if err != nil {
 		return errors.Wrap(err, "create")
+	}
+
+	// os.Create() above creates a file with 0666 permissions (before umask).
+	// Typical umask is 022 so the effective permissions of the created file is 0644.
+	// The os.Chmod ensures the final permissions for both the user and their group are the same.
+	err = os.Chmod(req.ConfigOutputPath, 0664)
+	if err != nil {
+		return errors.Wrap(err, "chmod")
 	}
 
 	defer func() {

--- a/src/control/server/storage/metadata/provider.go
+++ b/src/control/server/storage/metadata/provider.go
@@ -196,11 +196,13 @@ func (p *Provider) isUsableFS(fs *system.FsType, path string) bool {
 }
 
 func (p *Provider) setupDataDir(req storage.MetadataFormatRequest) error {
+	perms := os.FileMode(0775)
+
 	if err := p.sys.RemoveAll(req.DataPath); err != nil {
 		return errors.Wrap(err, "removing old control metadata subdirectory")
 	}
 
-	if err := p.sys.Mkdir(req.DataPath, 0755); err != nil {
+	if err := p.sys.Mkdir(req.DataPath, perms); err != nil {
 		return errors.Wrap(err, "creating control metadata subdirectory")
 	}
 
@@ -210,7 +212,7 @@ func (p *Provider) setupDataDir(req storage.MetadataFormatRequest) error {
 
 	for _, idx := range req.EngineIdxs {
 		engPath := storage.ControlMetadataEngineDir(req.DataPath, idx)
-		if err := p.sys.Mkdir(engPath, 0755); err != nil {
+		if err := p.sys.Mkdir(engPath, perms); err != nil {
 			return errors.Wrapf(err, "creating control metadata engine %d subdirectory", idx)
 		}
 

--- a/src/control/server/storage/mount/provider.go
+++ b/src/control/server/storage/mount/provider.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2022-2024 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -19,7 +20,7 @@ import (
 )
 
 const (
-	defaultMountPointPerms = 0755
+	defaultMountPointPerms = 0775
 	defaultUnmountFlags    = 0
 )
 

--- a/src/control/system/raft/raft.go
+++ b/src/control/system/raft/raft.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 	"github.com/daos-stack/daos/src/control/system/checker"
@@ -265,6 +266,13 @@ func ConfigureComponents(log logging.Logger, dbCfg *DatabaseConfig) (*RaftCompon
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to init boltdb at %s", dbCfg.DBFilePath())
+	}
+
+	// Boltdb file permissions on create are set to 0600.
+	// The os.Chmod ensures the final permissions for both the user and their group are the same.
+	err = os.Chmod(dbCfg.DBFilePath(), daos.DefaultFilePerm)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to set permissions for boltdb at %s", dbCfg.DBFilePath())
 	}
 
 	return &RaftComponents{

--- a/src/control/system/raft/raft_recovery.go
+++ b/src/control/system/raft/raft_recovery.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2022-2024 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -21,6 +22,8 @@ import (
 	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
 
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
@@ -86,7 +89,7 @@ func RecoverLocalReplica(log logging.Logger, cfg *DatabaseConfig) error {
 }
 
 func createRaftDir(dbPath string) error {
-	if err := os.Mkdir(dbPath, 0700); err != nil && !os.IsExist(err) {
+	if err := common.MkdirForcePerm(dbPath, daos.DefaultDirPerm); err != nil && !os.IsExist(err) {
 		return errors.Wrap(err, "failed to create raft directory")
 	}
 	return nil

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -670,6 +670,13 @@ server_init(int argc, char *argv[])
 	int			rc;
 	struct engine_metrics	*metrics;
 
+	/**
+	 * The typical umask is 022. The group portion is cleared, which allows the group
+	 * permissions to be set freely. This setting is intended to remain in effect for the entire
+	 * lifetime of the process.
+	 */
+	(void)umask(002);
+
 	/*
 	 * Begin the HLC recovery as early as possible. Do not read the HLC
 	 * before the hlc_recovery_end call below.

--- a/src/include/daos_srv/control.h
+++ b/src/include/daos_srv/control.h
@@ -16,7 +16,11 @@
 #include <stdbool.h>
 #include <assert.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <daos/common.h>
+
+#define DEFAULT_FILE_PERM               (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP)
+#define DEFAULT_DIR_PERM                (S_IRWXU | S_IRWXG)
 
 #define NVME_PCI_DEV_TYPE_VMD           "vmd"
 #define NVME_DETAIL_BUFLEN              1024

--- a/src/mgmt/mgmt_common.c
+++ b/src/mgmt/mgmt_common.c
@@ -12,7 +12,6 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/types.h>
-#include <sys/stat.h>
 
 #include <daos_errno.h>
 #include <daos_types.h>
@@ -124,7 +123,7 @@ ds_mgmt_tgt_recreate(uuid_t pool_uuid, daos_size_t scm_size, int tgt_nr, int *tg
 			DP_RC(rc));
 		goto out;
 	}
-	rc = mkdir(pool_newborns_path, 0700);
+	rc = mkdir(pool_newborns_path, DEFAULT_DIR_PERM);
 	if (rc < 0 && errno != EEXIST) {
 		rc = daos_errno2der(errno);
 		D_ERROR("failed to created pool directory: " DF_RC "\n", DP_RC(rc));

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -449,7 +449,7 @@ ds_mgmt_tgt_setup(void)
 
 	stored_mode = umask(0);
 	/** create NEWBORNS directory if it does not exist already */
-	rc = mkdir(newborns_path, S_IRWXU);
+	rc = mkdir(newborns_path, DEFAULT_DIR_PERM);
 	if (rc < 0 && errno != EEXIST) {
 		D_ERROR("failed to create NEWBORNS dir: %d\n", errno);
 		umask(stored_mode);
@@ -457,7 +457,7 @@ ds_mgmt_tgt_setup(void)
 	}
 
 	/** create ZOMBIES directory if it does not exist already */
-	rc = mkdir(zombies_path, S_IRWXU);
+	rc = mkdir(zombies_path, DEFAULT_DIR_PERM);
 	if (rc < 0 && errno != EEXIST) {
 		D_ERROR("failed to create ZOMBIES dir: %d\n", errno);
 		umask(stored_mode);
@@ -648,7 +648,7 @@ struct tgt_create_args {
 static void *
 tgt_create_preallocate(void *arg)
 {
-	struct tgt_create_args	*tca = arg;
+	struct tgt_create_args  *tca = arg;
 	int			 rc;
 
 	(void)dss_xstream_set_affinity(tca->tca_dx);
@@ -677,7 +677,7 @@ tgt_create_preallocate(void *arg)
 		if (rc)
 			goto out;
 
-		rc = mkdir(tca->tca_newborn, 0700);
+		rc = mkdir(tca->tca_newborn, DEFAULT_DIR_PERM);
 		if (rc < 0 && errno != EEXIST) {
 			rc = daos_errno2der(errno);
 			D_ERROR("failed to created pool directory: "DF_RC"\n",
@@ -712,6 +712,7 @@ tgt_create_preallocate(void *arg)
 	}
 out:
 	tca->tca_rc = rc;
+
 	return NULL;
 }
 

--- a/src/utils/ddb/ddb_mgmt.c
+++ b/src/utils/ddb/ddb_mgmt.c
@@ -229,11 +229,11 @@ ddb_dirs_prepare(const char *path)
 	if (unlikely(rc >= sizeof(zombies_path)))
 		return -DER_EXCEEDS_PATH_LEN;
 
-	rc = ddb_mkdir(newborns_path, S_IRWXU);
+	rc = ddb_mkdir(newborns_path, DEFAULT_DIR_PERM);
 	if (rc)
 		return rc;
 
-	rc = ddb_mkdir(zombies_path, S_IRWXU);
+	rc = ddb_mkdir(zombies_path, DEFAULT_DIR_PERM);
 	if (rc)
 		return rc;
 


### PR DESCRIPTION
Ref: #17680

At least:

- 0660 for files
- 0770 for directories.

So daos_server group can access DAOS files.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
