### PR TITLE
DAOS-18921 tests: avoid MS broken during CR test

### DIFF
--- a/src/tests/ftest/recovery/cat_recov_core.yaml
+++ b/src/tests/ftest/recovery/cat_recov_core.yaml
@@ -51,3 +51,5 @@ daos_tests:
     test_daos_cat_recov_core: DAOS_Cat_Recov_Core
   daos_test:
     test_daos_cat_recov_core: F
+  args:
+    test_daos_cat_recov_core: -s3


### PR DESCRIPTION
During CR tests, some rank maybe excluded intentionally. Set enough MS replicas in the configuration file to avoid MS broken during the eviction related CR test cases.

Test-tag: test_daos_cat_recov_core
Skip-nlt: true
Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
