### PR TITLE
DAOS-18953 test: Update installed packages detection list

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
   (C) Copyright 2018-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -43,6 +43,9 @@ class LaunchError(Exception):
 class Launch():
     """Class to launch avocado tests."""
 
+    FIND_PACKAGES = ("daos", "argobots", "libabt", "dpdk", "fuse", "libfabric", "libisa-l",
+                     "libisal", "isa-l", "libpmem", "pmempool", "mercury", "spdk", "mpifileutils",
+                     "mlnx-ofed-basic", "doca-ofed", "openmpi", "mpich", "ior", "mpich", "bullseye")
     RESULTS_DIRS = (
         "daos_configs", "daos_logs", "cart_logs", "daos_dumps", "valgrind_logs", "stacktraces")
 
@@ -273,8 +276,7 @@ class Launch():
         # pylint: disable=unsupported-binary-operation
         all_hosts = args.test_servers | args.test_clients | self.local_host
         self.details["installed packages"] = find_packages(
-            logger, all_hosts,
-            "'^(daos|libfabric|mercury|ior|openmpi|mpich|mpifileutils|mlnx-ofed-basic)-'")
+            logger, all_hosts, f"'^({'|'.join(self.FIND_PACKAGES)})-'")
 
         # Setup the test environment
         test_env = TestEnvironment()


### PR DESCRIPTION
Update the list of installed packages reported in the launch.py details.json file.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test: true
Skip-func-test-el8: false
Skip-func-test-el9: false
Skip-func-test-leap15: false
Test-tag: test_always_passes

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
