### PR TITLE
DAOS-18910 cart: preserve UCX provider across re-init

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -103,15 +103,38 @@ crt_prov_str_to_prov(const char *prov_str)
 {
 	int i = 0;
 
+	if (prov_str == NULL)
+		return CRT_PROV_UNKNOWN;
+
 	while (crt_na_dict[i].nad_str) {
 		if (strcmp(prov_str, crt_na_dict[i].nad_str) == 0 ||
 		    (crt_na_dict[i].nad_alt_str &&
 		     strcmp(prov_str, crt_na_dict[i].nad_alt_str) == 0))
 			return crt_na_dict[i].nad_type;
+		if (crt_na_dict[i].nad_type == CRT_PROV_UCX && crt_provider_str_is_ucx(prov_str))
+			return crt_na_dict[i].nad_type;
 		i++;
 	}
 
 	return CRT_PROV_UNKNOWN;
+}
+
+static char *
+crt_provider_configured_name_get(crt_provider_t provider)
+{
+	int i;
+
+	if (crt_gdata.cg_primary_prov == provider &&
+	    crt_gdata.cg_prov_gdata_primary.cpg_na_config.noc_provider != NULL)
+		return crt_gdata.cg_prov_gdata_primary.cpg_na_config.noc_provider;
+
+	for (i = 0; i < crt_gdata.cg_num_secondary_provs; i++) {
+		if (crt_gdata.cg_secondary_provs[i] == provider &&
+		    crt_gdata.cg_prov_gdata_secondary[i].cpg_na_config.noc_provider != NULL)
+			return crt_gdata.cg_prov_gdata_secondary[i].cpg_na_config.noc_provider;
+	}
+
+	return NULL;
 }
 
 /**
@@ -461,7 +484,11 @@ crt_get_na_dict_entry(crt_provider_t provider)
 char *
 crt_provider_name_get(crt_provider_t provider)
 {
+	char               *provider_name = crt_provider_configured_name_get(provider);
 	struct crt_na_dict *entry = crt_get_na_dict_entry(provider);
+
+	if (provider_name != NULL)
+		return provider_name;
 
 	return entry ? entry->nad_str : NULL;
 }

--- a/src/cart/crt_hg.h
+++ b/src/cart/crt_hg.h
@@ -1,7 +1,7 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
  * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -65,6 +65,15 @@ crt_prov_str_to_prov(const char *prov_str);
 
 int
 crt_hg_parse_uri(const char *uri, crt_provider_t *prov, char *addr);
+
+static inline bool
+crt_provider_str_is_ucx(const char *prov_str)
+{
+	size_t prefix_len = strlen(CRT_UCX_STR);
+
+	return prov_str != NULL && !strncmp(prov_str, CRT_UCX_STR, prefix_len) &&
+	       (prov_str[prefix_len] == '\0' || prov_str[prefix_len] == '+');
+}
 
 static inline bool
 crt_provider_is_ucx(crt_provider_t prov)

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -95,9 +95,8 @@ dump_opt(crt_init_options_t *opt)
 }
 
 static int
-crt_na_config_init(bool primary, crt_provider_t provider,
-		   char *interface, char *domain, char *port,
-		   char *auth_key, bool port_auto_adjust);
+crt_na_config_init(bool primary, crt_provider_t provider, char *provider_name, char *interface,
+		   char *domain, char *port, char *auth_key, bool port_auto_adjust);
 
 /* Workaround for CART-890 */
 static void
@@ -477,40 +476,7 @@ __split_arg(char *s_arg_to_split, const char *delim, char **first_arg, char **se
 crt_provider_t
 crt_str_to_provider(const char *str_provider)
 {
-	crt_provider_t prov = CRT_PROV_UNKNOWN;
-	int            i, len;
-	char          *p = NULL;
-
-	if (str_provider == NULL)
-		return prov;
-
-	for (i = 0; crt_na_dict[i].nad_str != NULL; i++) {
-		if (!strncmp(str_provider, crt_na_dict[i].nad_str,
-			     strlen(crt_na_dict[i].nad_str) + 1) ||
-		    (crt_na_dict[i].nad_alt_str &&
-		     !strncmp(str_provider, crt_na_dict[i].nad_alt_str,
-			      strlen(crt_na_dict[i].nad_alt_str) + 1))) {
-			prov = crt_na_dict[i].nad_type;
-			break;
-		}
-		if (crt_na_dict[i].nad_type == CRT_PROV_UCX &&
-		    !strncmp(str_provider, CRT_UCX_STR, strlen(CRT_UCX_STR))) {
-			len = strlen(str_provider);
-			if (len > strlen(CRT_UCX_STR) && strchr(str_provider, '+')) {
-				D_STRNDUP(p, str_provider, len);
-				if (!p) {
-					return prov;
-				} else {
-					crt_na_dict[i].nad_str       = p;
-					crt_na_dict[i].nad_str_alloc = true;
-				}
-			}
-			prov = crt_na_dict[i].nad_type;
-			break;
-		}
-	}
-
-	return prov;
+	return crt_prov_str_to_prov(str_provider);
 }
 
 static int
@@ -864,7 +830,7 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 		prov_settings_apply(true, primary_provider, opt);
 		crt_gdata.cg_primary_prov = primary_provider;
 
-		rc = crt_na_config_init(true, primary_provider, iface0, domain0,
+		rc = crt_na_config_init(true, primary_provider, provider_str0, iface0, domain0,
 					port0, auth_key0, port_auto_adjust);
 		if (rc != 0) {
 			D_ERROR("crt_na_config_init() failed, "DF_RC"\n", DP_RC(rc));
@@ -900,7 +866,7 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 
 			prov_settings_apply(false, tmp_prov, opt);
 
-			rc = crt_na_config_init(false, tmp_prov, iface1, domain1,
+			rc = crt_na_config_init(false, tmp_prov, provider_str1, iface1, domain1,
 						port1, auth_key1, port_auto_adjust);
 			if (rc != 0) {
 				D_ERROR("crt_na_config_init() failed, "DF_RC"\n", DP_RC(rc));
@@ -1070,10 +1036,6 @@ crt_finalize(void)
 				crt_na_config_fini(false, crt_gdata.cg_secondary_provs[i]);
 		}
 
-		for (i = 0; crt_na_dict[i].nad_str != NULL; i++)
-			if (crt_na_dict[i].nad_str_alloc)
-				D_FREE(crt_na_dict[i].nad_str);
-
 		D_FREE(crt_gdata.cg_secondary_provs);
 		D_FREE(crt_gdata.cg_prov_gdata_secondary);
 	} else {
@@ -1189,11 +1151,9 @@ crt_port_range_verify(int port)
 	}
 }
 
-
 static int
-crt_na_config_init(bool primary, crt_provider_t provider,
-		   char *interface, char *domain, char *port_str,
-		   char *auth_key, bool port_auto_adjust)
+crt_na_config_init(bool primary, crt_provider_t provider, char *provider_name, char *interface,
+		   char *domain, char *port_str, char *auth_key, bool port_auto_adjust)
 {
 	struct crt_na_config		*na_cfg;
 	int				rc = 0;
@@ -1209,6 +1169,12 @@ crt_na_config_init(bool primary, crt_provider_t provider,
 	if (provider == CRT_PROV_OFI_CXI && !domain) {
 		D_ERROR("Domain must be set for CXI provider\n");
 		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (provider_name) {
+		D_STRNDUP(na_cfg->noc_provider, provider_name, 255);
+		if (!na_cfg->noc_provider)
+			D_GOTO(out, rc = -DER_NOMEM);
 	}
 
 	if (interface) {
@@ -1334,6 +1300,7 @@ crt_na_config_init(bool primary, crt_provider_t provider,
 
 out:
 	if (rc != -DER_SUCCESS) {
+		D_FREE(na_cfg->noc_provider);
 		D_FREE(na_cfg->noc_interface);
 		D_FREE(na_cfg->noc_domain);
 		D_FREE(na_cfg->noc_auth_key);
@@ -1348,6 +1315,7 @@ void crt_na_config_fini(bool primary, crt_provider_t provider)
 	struct crt_na_config *na_cfg;
 
 	na_cfg = crt_provider_get_na_config(primary, provider);
+	D_FREE(na_cfg->noc_provider);
 	D_FREE(na_cfg->noc_interface);
 	D_FREE(na_cfg->noc_domain);
 	D_FREE(na_cfg->noc_auth_key);

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -37,6 +37,7 @@ struct crt_na_config {
 	int32_t		 noc_port;
 	int		 noc_iface_total;
 	int               noc_domain_total;
+	char             *noc_provider;
 	char		*noc_interface;
 	char		*noc_domain;
 	char		*noc_auth_key;
@@ -167,7 +168,7 @@ struct crt_gdata {
 	struct d_tm_node_t	*cg_uri_other;
 	/** Number of cores on a system */
 	long			 cg_num_cores;
-	/** Inflight rpc quota limit */
+	/** In-flight rpc quota limit */
 	uint32_t                 cg_rpc_quota;
 	/** bulk quota limit */
 	uint32_t                 cg_bulk_quota;


### PR DESCRIPTION
Client re-initialization could fail when the attach info used a UCX provider such as ucx+dc_x. The first daos_init() succeeded, but after daos_fini() a second daos_init() could return DER_NONEXIST because CaRT no longer recognized the UCX provider string.

The problem was that UCX provider handling depended on mutating the global provider dictionary at init time and restoring it at finalize time. That made re-init fragile and also left provider parsing inconsistent between init and URI parsing paths.

Fix this by treating ucx+* strings as CRT_PROV_UCX without rewriting the global provider table, and by storing the concrete provider string in per-provider runtime config so later URI generation and logging keep the original UCX transport name.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
