### PR TITLE
SRE-3774 ci: Disable maldet on CI nodes

### DIFF
--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -321,6 +321,12 @@ post_provision_config_nodes() {
         dnf -y erase fuse3\*
     fi
 
+    # maldet might bring additional load on CPU during tests
+    if command -v maldet &>/dev/null; then
+        systemctl stop maldet 2>/dev/null || true
+        systemctl disable maldet 2>/dev/null || true
+    fi
+
     if [ -n "$CONFIG_POWER_ONLY" ]; then
         rm -f "$REPOS_DIR"/*_job_daos-stack_job_*_job_*.repo
         time dnf -y erase fio fuse ior-hpc mpich-autoload          \


### PR DESCRIPTION
Disable maldet service on CI node to reduce CPU load.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
