### PR TITLE
DAOS-18613 container: Add pool UUID to cont_op_in (#17921)

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -296,7 +296,7 @@ crt_opc_decode(crt_opcode_t crt_opc, char **module_name, char **opc_name)
 			break;
 		case DAOS_CONT_MODULE:
 			switch (op_id) {
-				CONT_PROTO_CLI_RPC_LIST(8, ds_cont_op_handler_v8)
+				CONT_PROTO_CLI_RPC_LIST(9)
 				CONT_PROTO_SRV_RPC_LIST
 			}
 			break;

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -36,15 +36,15 @@ dc_cont_init(void)
 	uint32_t        ver_array[2] = {DAOS_CONT_VERSION - 1, DAOS_CONT_VERSION};
 
 	dc_cont_proto_version = 0;
-	rc = daos_rpc_proto_query(cont_proto_fmt_v7.cpf_base, ver_array, 2, &dc_cont_proto_version);
+	rc = daos_rpc_proto_query(cont_proto_fmt_v9.cpf_base, ver_array, 2, &dc_cont_proto_version);
 	if (rc)
 		return rc;
 
 	if (dc_cont_proto_version == DAOS_CONT_VERSION - 1) {
-		rc = daos_rpc_register(&cont_proto_fmt_v7, CONT_PROTO_CLI_COUNT, NULL,
+		rc = daos_rpc_register(&cont_proto_fmt_v8, CONT_PROTO_CLI_COUNT, NULL,
 				       DAOS_CONT_MODULE);
 	} else if (dc_cont_proto_version == DAOS_CONT_VERSION) {
-		rc = daos_rpc_register(&cont_proto_fmt_v8, CONT_PROTO_CLI_COUNT, NULL,
+		rc = daos_rpc_register(&cont_proto_fmt_v9, CONT_PROTO_CLI_COUNT, NULL,
 				       DAOS_CONT_MODULE);
 	} else {
 		D_ERROR("%d version cont RPC not supported.\n", dc_cont_proto_version);
@@ -66,9 +66,9 @@ dc_cont_fini(void)
 	int rc;
 
 	if (dc_cont_proto_version == DAOS_CONT_VERSION - 1)
-		rc = daos_rpc_unregister(&cont_proto_fmt_v7);
-	else
 		rc = daos_rpc_unregister(&cont_proto_fmt_v8);
+	else
+		rc = daos_rpc_unregister(&cont_proto_fmt_v9);
 	if (rc != 0)
 		D_ERROR("failed to unregister %d version cont RPCs: "DF_RC"\n",
 			dc_cont_proto_version, DP_RC(rc));
@@ -152,12 +152,12 @@ cont_task_reinit(tse_task_t *task)
 static int
 cont_create_complete(tse_task_t *task, void *data)
 {
-	struct cont_args       *arg = (struct cont_args *)data;
-	daos_cont_create_t     *args;
-	struct dc_pool	       *pool = arg->pool;
-	struct cont_create_out *out = crt_reply_get(arg->rpc);
-	bool                    reinit = false;
-	int			rc = task->dt_result;
+	struct cont_args          *arg = (struct cont_args *)data;
+	daos_cont_create_t        *args;
+	struct dc_pool            *pool   = arg->pool;
+	struct cont_create_v8_out *out    = crt_reply_get(arg->rpc);
+	bool                       reinit = false;
+	int                        rc     = task->dt_result;
 
 	rc = cont_rsvc_client_complete_rpc(pool, &arg->rpc->cr_ep, rc,
 					   &out->cco_op, task);
@@ -414,14 +414,15 @@ dc_cont_create(tse_task_t *task)
 		goto err_prop;
 	}
 	uuid_clear(null_hdl_uuid);
-	rc = dc_cont_req_create(daos_task2ctx(task), &ep, CONT_CREATE, pool->dp_pool_hdl,
-				args->uuid, null_hdl_uuid, &tpriv->rq_time, &rpc);
+	rc =
+	    dc_cont_req_create(daos_task2ctx(task), &ep, CONT_CREATE, pool->dp_pool,
+			       pool->dp_pool_hdl, args->uuid, null_hdl_uuid, &tpriv->rq_time, &rpc);
 	if (rc != 0) {
 		D_ERROR("failed to create rpc: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_prop, rc);
 	}
 
-	cont_create_in_set_data(rpc, CONT_CREATE, dc_cont_proto_version, rpc_prop);
+	cont_create_in_set_data(rpc, rpc_prop);
 
 	arg.pool = pool;
 	arg.rpc = rpc;
@@ -452,11 +453,11 @@ err_task:
 static int
 cont_destroy_complete(tse_task_t *task, void *data)
 {
-	struct cont_args        *arg    = (struct cont_args *)data;
-	struct dc_pool		*pool = arg->pool;
-	struct cont_destroy_out	*out = crt_reply_get(arg->rpc);
-	bool                     reinit = false;
-	int			 rc = task->dt_result;
+	struct cont_args           *arg    = (struct cont_args *)data;
+	struct dc_pool             *pool   = arg->pool;
+	struct cont_destroy_v8_out *out    = crt_reply_get(arg->rpc);
+	bool                        reinit = false;
+	int                         rc     = task->dt_result;
 
 	rc = cont_rsvc_client_complete_rpc(pool, &arg->rpc->cr_ep, rc,
 					   &out->cdo_op, task);
@@ -553,14 +554,14 @@ dc_cont_destroy(tse_task_t *task)
 	}
 	opc = label ? CONT_DESTROY_BYLABEL : CONT_DESTROY;
 	uuid_clear(null_hdl_uuid);
-	rc = dc_cont_req_create(daos_task2ctx(task), &ep, opc, pool->dp_pool_hdl, uuid,
-				null_hdl_uuid, &tpriv->rq_time, &rpc);
+	rc = dc_cont_req_create(daos_task2ctx(task), &ep, opc, pool->dp_pool, pool->dp_pool_hdl,
+				uuid, null_hdl_uuid, &tpriv->rq_time, &rpc);
 	if (rc != 0) {
 		D_ERROR("failed to create rpc: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_pool, rc);
 	}
 
-	cont_destroy_in_set_data(rpc, opc, dc_cont_proto_version, args->force, label);
+	cont_destroy_in_set_data(rpc, args->force, label);
 
 	arg.pool = pool;
 	arg.rpc = rpc;
@@ -790,7 +791,7 @@ static int
 cont_open_complete(tse_task_t *task, void *data)
 {
 	struct cont_open_args	*arg = (struct cont_open_args *)data;
-	struct cont_open_out    *out   = crt_reply_get(arg->rpc);
+	struct cont_open_v8_out *out   = crt_reply_get(arg->rpc);
 	struct dc_pool		*pool = arg->coa_pool;
 	struct cont_task_priv   *tpriv = dc_task_get_priv(task);
 	struct dc_cont          *cont  = tpriv->cont;
@@ -825,7 +826,7 @@ cont_open_complete(tse_task_t *task, void *data)
 
 	/* If open by label, copy the returned UUID into dc_cont structure */
 	if (arg->coa_label) {
-		struct cont_open_bylabel_out *lbl_out = crt_reply_get(arg->rpc);
+		struct cont_open_bylabel_v8_out *lbl_out = crt_reply_get(arg->rpc);
 
 		uuid_copy(cont->dc_uuid, lbl_out->colo_uuid);
 	}
@@ -883,7 +884,7 @@ cont_open_complete(tse_task_t *task, void *data)
 	arg->coa_info->ci_nsnapshots = out->coo_snap_count;
 	arg->coa_info->ci_lsnapshot = out->coo_lsnapshot;
 	if (arg->coa_label) {
-		struct cont_open_bylabel_out *lbl_out = crt_reply_get(arg->rpc);
+		struct cont_open_bylabel_v8_out *lbl_out = crt_reply_get(arg->rpc);
 
 		arg->coa_info->ci_md_otime = lbl_out->coo_md_otime;
 		arg->coa_info->ci_md_mtime = lbl_out->coo_md_mtime;
@@ -953,7 +954,7 @@ dc_cont_open_internal(tse_task_t *task, const char *label, struct dc_pool *pool)
 				DP_CONT(pool->dp_pool, tpriv->cont->dc_uuid), DP_RC(rc));
 		goto err;
 	}
-	rc = dc_cont_req_create(daos_task2ctx(task), &ep, cont_op, pool->dp_pool_hdl,
+	rc = dc_cont_req_create(daos_task2ctx(task), &ep, cont_op, pool->dp_pool, pool->dp_pool_hdl,
 				tpriv->cont->dc_uuid, tpriv->cont->dc_cont_hdl, &tpriv->rq_time,
 				&rpc);
 	if (rc != 0) {
@@ -968,8 +969,7 @@ dc_cont_open_internal(tse_task_t *task, const char *label, struct dc_pool *pool)
 		    DAOS_CO_QUERY_PROP_EC_CELL_SZ | DAOS_CO_QUERY_PROP_EC_PDA |
 		    DAOS_CO_QUERY_PROP_RP_PDA | DAOS_CO_QUERY_PROP_GLOBAL_VERSION |
 		    DAOS_CO_QUERY_PROP_OBJ_VERSION | DAOS_CO_QUERY_PROP_PERF_DOMAIN;
-	cont_open_in_set_data(rpc, cont_op, dc_cont_proto_version, tpriv->cont->dc_capas, prop_bits,
-			      label);
+	cont_open_in_set_data(rpc, tpriv->cont->dc_capas, prop_bits, label);
 
 	arg.coa_pool	= pool;
 	arg.coa_info	= args->info;
@@ -1076,12 +1076,12 @@ struct cont_close_args {
 static int
 cont_close_complete(tse_task_t *task, void *data)
 {
-	struct cont_close_args	*arg = (struct cont_close_args *)data;
-	struct cont_close_out	*out = crt_reply_get(arg->rpc);
-	struct dc_pool          *pool   = arg->cca_pool;
-	struct dc_cont		*cont = arg->cca_cont;
-	bool                     reinit = false;
-	int			 rc = task->dt_result;
+	struct cont_close_args   *arg    = (struct cont_close_args *)data;
+	struct cont_close_v8_out *out    = crt_reply_get(arg->rpc);
+	struct dc_pool           *pool   = arg->cca_pool;
+	struct dc_cont           *cont   = arg->cca_cont;
+	bool                      reinit = false;
+	int                       rc     = task->dt_result;
 
 	rc = cont_rsvc_client_complete_rpc(pool, &arg->rpc->cr_ep, rc,
 					   &out->cco_op, task);
@@ -1217,8 +1217,9 @@ dc_cont_close(tse_task_t *task)
 			DP_CONT(pool->dp_pool, cont->dc_uuid), DP_RC(rc));
 		goto err_pool;
 	}
-	rc = dc_cont_req_create(daos_task2ctx(task), &ep, CONT_CLOSE, pool->dp_pool_hdl,
-				cont->dc_uuid, cont->dc_cont_hdl, &tpriv->rq_time, &rpc);
+	rc = dc_cont_req_create(daos_task2ctx(task), &ep, CONT_CLOSE, pool->dp_pool,
+				pool->dp_pool_hdl, cont->dc_uuid, cont->dc_cont_hdl,
+				&tpriv->rq_time, &rpc);
 	if (rc != 0) {
 		D_ERROR("failed to create rpc: "DF_RC"\n", DP_RC(rc));
 		goto err_pool;
@@ -1267,7 +1268,7 @@ static int
 cont_query_complete(tse_task_t *task, void *data)
 {
 	struct cont_query_args		*arg = (struct cont_query_args *)data;
-	struct cont_query_out           *out   = crt_reply_get(arg->rpc);
+	struct cont_query_v8_out        *out   = crt_reply_get(arg->rpc);
 	struct dc_pool			*pool = arg->cqa_pool;
 	struct dc_cont                  *cont  = arg->cqa_cont;
 	time_t				 otime_sec, mtime_sec;
@@ -1486,14 +1487,15 @@ dc_cont_query(tse_task_t *task)
 			DP_CONT(pool->dp_pool, cont->dc_uuid), DP_RC(rc));
 		goto err_cont;
 	}
-	rc = dc_cont_req_create(daos_task2ctx(task), &ep, CONT_QUERY, pool->dp_pool_hdl,
-				cont->dc_uuid, cont->dc_cont_hdl, &tpriv->rq_time, &rpc);
+	rc = dc_cont_req_create(daos_task2ctx(task), &ep, CONT_QUERY, pool->dp_pool,
+				pool->dp_pool_hdl, cont->dc_uuid, cont->dc_cont_hdl,
+				&tpriv->rq_time, &rpc);
 	if (rc != 0) {
 		D_ERROR("failed to create rpc: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_cont, rc);
 	}
 
-	cont_query_in_set_data(rpc, CONT_QUERY, dc_cont_proto_version, cont_query_bits(args->prop));
+	cont_query_in_set_data(rpc, cont_query_bits(args->prop));
 
 	arg.cqa_pool = pool;
 	arg.cqa_cont = cont;
@@ -1534,7 +1536,7 @@ static int
 cont_set_prop_complete(tse_task_t *task, void *data)
 {
 	struct cont_set_prop_args       *arg    = (struct cont_set_prop_args *)data;
-	struct cont_prop_set_out	*out = crt_reply_get(arg->rpc);
+	struct cont_prop_set_v8_out     *out    = crt_reply_get(arg->rpc);
 	struct dc_pool			*pool = arg->cqa_pool;
 	struct dc_cont			*cont = arg->cqa_cont;
 	bool                             reinit = false;
@@ -1667,15 +1669,15 @@ dc_cont_set_prop(tse_task_t *task)
 			DP_CONT(pool->dp_pool, cont->dc_uuid), DP_RC(rc));
 		goto err_cont;
 	}
-	rc = dc_cont_req_create(daos_task2ctx(task), &ep, CONT_PROP_SET, pool->dp_pool_hdl,
-				cont->dc_uuid, cont->dc_cont_hdl, &tpriv->rq_time, &rpc);
+	rc = dc_cont_req_create(daos_task2ctx(task), &ep, CONT_PROP_SET, pool->dp_pool,
+				pool->dp_pool_hdl, cont->dc_uuid, cont->dc_cont_hdl,
+				&tpriv->rq_time, &rpc);
 	if (rc != 0) {
 		D_ERROR("failed to create rpc: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_cont, rc);
 	}
 
-	cont_prop_set_in_set_data(rpc, CONT_PROP_SET, dc_cont_proto_version, args->prop,
-				  pool->dp_pool);
+	cont_prop_set_in_set_data(rpc, args->prop, pool->dp_pool);
 
 	arg.cqa_pool = pool;
 	arg.cqa_cont = cont;
@@ -1716,7 +1718,7 @@ static int
 cont_update_acl_complete(tse_task_t *task, void *data)
 {
 	struct cont_update_acl_args     *arg    = (struct cont_update_acl_args *)data;
-	struct cont_acl_update_out	*out = crt_reply_get(arg->rpc);
+	struct cont_acl_update_v8_out   *out    = crt_reply_get(arg->rpc);
 	struct dc_pool			*pool = arg->cua_pool;
 	struct dc_cont			*cont = arg->cua_cont;
 	bool                             reinit = false;
@@ -1805,14 +1807,15 @@ dc_cont_update_acl(tse_task_t *task)
 			DP_CONT(pool->dp_pool, cont->dc_uuid), DP_RC(rc));
 		goto err_cont;
 	}
-	rc = dc_cont_req_create(daos_task2ctx(task), &ep, CONT_ACL_UPDATE, pool->dp_pool_hdl,
-				cont->dc_uuid, cont->dc_cont_hdl, &tpriv->rq_time, &rpc);
+	rc = dc_cont_req_create(daos_task2ctx(task), &ep, CONT_ACL_UPDATE, pool->dp_pool,
+				pool->dp_pool_hdl, cont->dc_uuid, cont->dc_cont_hdl,
+				&tpriv->rq_time, &rpc);
 	if (rc != 0) {
 		D_ERROR("failed to create rpc: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_cont, rc);
 	}
 
-	cont_acl_update_in_set_data(rpc, CONT_ACL_UPDATE, dc_cont_proto_version, args->acl);
+	cont_acl_update_in_set_data(rpc, args->acl);
 
 	arg.cua_pool = pool;
 	arg.cua_cont = cont;
@@ -1853,7 +1856,7 @@ static int
 cont_delete_acl_complete(tse_task_t *task, void *data)
 {
 	struct cont_delete_acl_args     *arg    = (struct cont_delete_acl_args *)data;
-	struct cont_acl_delete_out	*out = crt_reply_get(arg->rpc);
+	struct cont_acl_delete_v8_out   *out    = crt_reply_get(arg->rpc);
 	struct dc_pool			*pool = arg->cda_pool;
 	struct dc_cont			*cont = arg->cda_cont;
 	bool                             reinit = false;
@@ -1942,15 +1945,15 @@ dc_cont_delete_acl(tse_task_t *task)
 			DP_CONT(pool->dp_pool, cont->dc_uuid), DP_RC(rc));
 		goto err_cont;
 	}
-	rc = dc_cont_req_create(daos_task2ctx(task), &ep, CONT_ACL_DELETE, pool->dp_pool_hdl,
-				cont->dc_uuid, cont->dc_cont_hdl, &tpriv->rq_time, &rpc);
+	rc = dc_cont_req_create(daos_task2ctx(task), &ep, CONT_ACL_DELETE, pool->dp_pool,
+				pool->dp_pool_hdl, cont->dc_uuid, cont->dc_cont_hdl,
+				&tpriv->rq_time, &rpc);
 	if (rc != 0) {
 		D_ERROR("failed to create rpc: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_cont, rc);
 	}
 
-	cont_acl_delete_in_set_data(rpc, CONT_ACL_DELETE, dc_cont_proto_version, args->name,
-				    args->type);
+	cont_acl_delete_in_set_data(rpc, args->name, args->type);
 
 	arg.cda_pool = pool;
 	arg.cda_cont = cont;
@@ -2076,8 +2079,7 @@ get_tgt_rank(struct dc_pool *pool, unsigned int *rank)
 int
 dc_cont_alloc_oids(tse_task_t *task)
 {
-	daos_cont_alloc_oids_t		*args;
-	struct cont_oid_alloc_in	*in;
+	daos_cont_alloc_oids_t          *args;
 	struct dc_pool			*pool;
 	struct dc_cont			*cont;
 	crt_endpoint_t                   ep;
@@ -2109,15 +2111,15 @@ dc_cont_alloc_oids(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(err_cont, rc);
 
-	rc = dc_cont_req_create(daos_task2ctx(task), &ep, CONT_OID_ALLOC, pool->dp_pool_hdl,
-				cont->dc_uuid, cont->dc_cont_hdl, NULL /* req_timep */, &rpc);
+	rc = dc_cont_req_create(daos_task2ctx(task), &ep, CONT_OID_ALLOC, pool->dp_pool,
+				pool->dp_pool_hdl, cont->dc_uuid, cont->dc_cont_hdl,
+				NULL /* req_timep */, &rpc);
 	if (rc != 0) {
 		D_ERROR("failed to create rpc: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_cont, rc);
 	}
 
-	in           = crt_req_get(rpc);
-	in->num_oids = args->num_oids;
+	cont_oid_alloc_in_set_data(rpc, args->num_oids);
 
 	arg.coaa_pool	= pool;
 	arg.coaa_cont	= cont;
@@ -2557,9 +2559,9 @@ cont_req_prepare(daos_handle_t coh, enum cont_operation opcode, crt_context_t *c
 		goto out;
 	}
 
-	rc = dc_cont_req_create(ctx, &ep, opcode, args->cra_pool->dp_pool_hdl,
-				args->cra_cont->dc_uuid, args->cra_cont->dc_cont_hdl,
-				&tpriv->rq_time, &args->cra_rpc);
+	rc = dc_cont_req_create(ctx, &ep, opcode, args->cra_pool->dp_pool,
+				args->cra_pool->dp_pool_hdl, args->cra_cont->dc_uuid,
+				args->cra_cont->dc_cont_hdl, &tpriv->rq_time, &args->cra_rpc);
 	if (rc != 0) {
 		D_ERROR("failed to create rpc: "DF_RC"\n", DP_RC(rc));
 		cont_req_cleanup(CLEANUP_TASK_PRIV, task, true /* free_tpriv */, args);
@@ -2573,9 +2575,9 @@ out:
 static int
 attr_list_req_complete(tse_task_t *task, void *data)
 {
-	struct cont_req_arg	  *args = data;
-	daos_cont_list_attr_t	  *task_args = dc_task_get_args(task);
-	struct cont_attr_list_out *out = crt_reply_get(args->cra_rpc);
+	struct cont_req_arg          *args      = data;
+	daos_cont_list_attr_t        *task_args = dc_task_get_args(task);
+	struct cont_attr_list_v8_out *out       = crt_reply_get(args->cra_rpc);
 
 	*task_args->size = out->calo_size;
 	return 0;
@@ -2625,7 +2627,7 @@ dc_cont_list_attr(tse_task_t *task)
 		}
 	}
 
-	cont_attr_list_in_set_data(cb_args.cra_rpc, CONT_ATTR_LIST, dc_cont_proto_version, bulk);
+	cont_attr_list_in_set_data(cb_args.cra_rpc, bulk);
 
 	cb_args.cra_bulk     = bulk;
 	cb_args.cra_callback = attr_list_req_complete;
@@ -2822,8 +2824,7 @@ dc_cont_get_attr(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(out_rpc, rc);
 
-	cont_attr_get_in_set_data(cb_args.cra_rpc, CONT_ATTR_GET, dc_cont_proto_version, args->n,
-				  key_length, bulk);
+	cont_attr_get_in_set_data(cb_args.cra_rpc, args->n, key_length, bulk);
 
 	cb_args.cra_bulk = bulk;
 	rc = tse_task_register_comp_cb(task, cont_req_complete,
@@ -2932,8 +2933,7 @@ dc_cont_set_attr(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(out_rpc, rc);
 
-	cont_attr_set_in_set_data(cb_args.cra_rpc, CONT_ATTR_SET, dc_cont_proto_version, count,
-				  bulk);
+	cont_attr_set_in_set_data(cb_args.cra_rpc, count, bulk);
 
 	cb_args.cra_bulk = bulk;
 	rc = tse_task_register_comp_cb(task, cont_req_complete,
@@ -3014,8 +3014,7 @@ dc_cont_del_attr(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(out_rpc, rc);
 
-	cont_attr_del_in_set_data(cb_args.cra_rpc, CONT_ATTR_DEL, dc_cont_proto_version, count,
-				  bulk);
+	cont_attr_del_in_set_data(cb_args.cra_rpc, count, bulk);
 
 	cb_args.cra_bulk = bulk;
 	rc = tse_task_register_comp_cb(task, cont_req_complete,
@@ -3055,7 +3054,7 @@ cont_epoch_op_req_complete(tse_task_t *task, void *data)
 
 	/* Only assign epoch if the task is really done (i.e., cont_req_complete did not reinit) */
 	if (arg->eoa_req.cra_tpriv == NULL) {
-		struct cont_epoch_op_out *op_out = crt_reply_get(arg->eoa_req.cra_rpc);
+		struct cont_epoch_op_v8_out *op_out = crt_reply_get(arg->eoa_req.cra_rpc);
 
 		*arg->eoa_epoch = op_out->ceo_epoch;
 	}
@@ -3088,7 +3087,7 @@ dc_epoch_op(daos_handle_t coh, crt_opcode_t opc, daos_epoch_t *epoch, unsigned i
 
 	if (opc != CONT_SNAP_CREATE)
 		epc = *epoch;
-	cont_epoch_op_in_set_data(arg.eoa_req.cra_rpc, opc, dc_cont_proto_version, epc, opts);
+	cont_epoch_op_in_set_data(arg.eoa_req.cra_rpc, epc, opts);
 
 	arg.eoa_epoch = epoch;
 
@@ -3218,7 +3217,7 @@ cont_get_oit_oid_req_complete(tse_task_t *task, void *data)
 		return rc;
 
 	if (arg->goo_req.cra_tpriv == NULL) {
-		struct cont_snap_oit_oid_get_out *oit_out = crt_reply_get(arg->goo_req.cra_rpc);
+		struct cont_snap_oit_oid_get_v8_out *oit_out = crt_reply_get(arg->goo_req.cra_rpc);
 
 		*arg->goo_oid = oit_out->ogo_oid;
 	}
@@ -3248,8 +3247,7 @@ int dc_cont_snap_oit_oid_get(tse_task_t *task)
 
 	epoch       = dc_args->epoch;
 	arg.goo_oid = dc_args->oid;
-	cont_snap_oit_oid_get_in_set_data(arg.goo_req.cra_rpc, CONT_SNAP_OIT_OID_GET,
-					  dc_cont_proto_version, epoch);
+	cont_snap_oit_oid_get_in_set_data(arg.goo_req.cra_rpc, epoch);
 
 	rc = tse_task_register_comp_cb(task, cont_get_oit_oid_req_complete,
 				       &arg, sizeof(arg));
@@ -3296,9 +3294,9 @@ err:
 static int
 snap_list_req_complete(tse_task_t *task, void *data)
 {
-	struct cont_req_arg	  *args = data;
-	daos_cont_list_snap_t	  *task_args = dc_task_get_args(task);
-	struct cont_snap_list_out *out = crt_reply_get(args->cra_rpc);
+	struct cont_req_arg          *args      = data;
+	daos_cont_list_snap_t        *task_args = dc_task_get_args(task);
+	struct cont_snap_list_v8_out *out       = crt_reply_get(args->cra_rpc);
 
 	*task_args->nr = out->slo_count;
 	task_args->anchor->da_type = DAOS_ANCHOR_TYPE_EOF;
@@ -3353,7 +3351,7 @@ dc_cont_list_snap(tse_task_t *task)
 		}
 	}
 
-	cont_snap_list_in_set_data(cb_args.cra_rpc, CONT_SNAP_LIST, dc_cont_proto_version, bulk);
+	cont_snap_list_in_set_data(cb_args.cra_rpc, bulk);
 
 	cb_args.cra_bulk     = bulk;
 	cb_args.cra_callback = snap_list_req_complete;

--- a/src/container/rpc.c
+++ b/src/container/rpc.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -68,6 +69,7 @@ crt_proc_daos_obj_id_t(crt_proc_t proc, crt_proc_op_t proc_op,
 
 CRT_RPC_DEFINE(cont_op, DAOS_ISEQ_CONT_OP, DAOS_OSEQ_CONT_OP)
 CRT_RPC_DEFINE(cont_op_v8, DAOS_ISEQ_CONT_OP_V8, DAOS_OSEQ_CONT_OP)
+CRT_RPC_DEFINE(cont_op_v9, DAOS_ISEQ_CONT_OP_V9, DAOS_OSEQ_CONT_OP)
 
 static int
 crt_proc_struct_cont_op_in(crt_proc_t proc, crt_proc_op_t proc_op,
@@ -89,56 +91,63 @@ crt_proc_struct_cont_op_v8_in(crt_proc_t proc, crt_proc_op_t proc_op, struct con
 	return crt_proc_cont_op_v8_in(proc, data);
 }
 
-CRT_RPC_DEFINE(cont_create, DAOS_ISEQ_CONT_CREATE, DAOS_OSEQ_CONT_CREATE)
+static int
+crt_proc_struct_cont_op_v9_in(crt_proc_t proc, crt_proc_op_t proc_op, struct cont_op_v9_in *data)
+{
+	return crt_proc_cont_op_v9_in(proc, data);
+}
+
 CRT_RPC_DEFINE(cont_create_v8, DAOS_ISEQ_CONT_CREATE_V8, DAOS_OSEQ_CONT_CREATE)
-CRT_RPC_DEFINE(cont_destroy, DAOS_ISEQ_CONT_DESTROY, DAOS_OSEQ_CONT_DESTROY)
+CRT_RPC_DEFINE(cont_create_v9, DAOS_ISEQ_CONT_CREATE_V9, DAOS_OSEQ_CONT_CREATE)
 CRT_RPC_DEFINE(cont_destroy_v8, DAOS_ISEQ_CONT_DESTROY_V8, DAOS_OSEQ_CONT_DESTROY)
-CRT_RPC_DEFINE(cont_destroy_bylabel, DAOS_ISEQ_CONT_DESTROY_BYLABEL, DAOS_OSEQ_CONT_DESTROY)
+CRT_RPC_DEFINE(cont_destroy_v9, DAOS_ISEQ_CONT_DESTROY_V9, DAOS_OSEQ_CONT_DESTROY)
 CRT_RPC_DEFINE(cont_destroy_bylabel_v8, DAOS_ISEQ_CONT_DESTROY_BYLABEL_V8, DAOS_OSEQ_CONT_DESTROY)
-CRT_RPC_DEFINE(cont_open, DAOS_ISEQ_CONT_OPEN, DAOS_OSEQ_CONT_OPEN)
+CRT_RPC_DEFINE(cont_destroy_bylabel_v9, DAOS_ISEQ_CONT_DESTROY_BYLABEL_V9, DAOS_OSEQ_CONT_DESTROY)
 CRT_RPC_DEFINE(cont_open_v8, DAOS_ISEQ_CONT_OPEN_V8, DAOS_OSEQ_CONT_OPEN)
-CRT_RPC_DEFINE(cont_open_bylabel, DAOS_ISEQ_CONT_OPEN_BYLABEL, DAOS_OSEQ_CONT_OPEN_BYLABEL)
+CRT_RPC_DEFINE(cont_open_v9, DAOS_ISEQ_CONT_OPEN_V9, DAOS_OSEQ_CONT_OPEN)
 CRT_RPC_DEFINE(cont_open_bylabel_v8, DAOS_ISEQ_CONT_OPEN_BYLABEL_V8, DAOS_OSEQ_CONT_OPEN_BYLABEL)
-CRT_RPC_DEFINE(cont_close, DAOS_ISEQ_CONT_CLOSE, DAOS_OSEQ_CONT_CLOSE)
+CRT_RPC_DEFINE(cont_open_bylabel_v9, DAOS_ISEQ_CONT_OPEN_BYLABEL_V9, DAOS_OSEQ_CONT_OPEN_BYLABEL)
 CRT_RPC_DEFINE(cont_close_v8, DAOS_ISEQ_CONT_CLOSE_V8, DAOS_OSEQ_CONT_CLOSE)
-CRT_RPC_DEFINE(cont_query, DAOS_ISEQ_CONT_QUERY, DAOS_OSEQ_CONT_QUERY)
+CRT_RPC_DEFINE(cont_close_v9, DAOS_ISEQ_CONT_CLOSE_V9, DAOS_OSEQ_CONT_CLOSE)
 CRT_RPC_DEFINE(cont_query_v8, DAOS_ISEQ_CONT_QUERY_V8, DAOS_OSEQ_CONT_QUERY)
+CRT_RPC_DEFINE(cont_query_v9, DAOS_ISEQ_CONT_QUERY_V9, DAOS_OSEQ_CONT_QUERY)
 CRT_RPC_DEFINE(cont_oid_alloc, DAOS_ISEQ_CONT_OID_ALLOC, DAOS_OSEQ_CONT_OID_ALLOC)
-CRT_RPC_DEFINE(cont_attr_list, DAOS_ISEQ_CONT_ATTR_LIST, DAOS_OSEQ_CONT_ATTR_LIST)
+CRT_RPC_DEFINE(cont_oid_alloc_v9, DAOS_ISEQ_CONT_OID_ALLOC_V9, DAOS_OSEQ_CONT_OID_ALLOC)
 CRT_RPC_DEFINE(cont_attr_list_v8, DAOS_ISEQ_CONT_ATTR_LIST_V8, DAOS_OSEQ_CONT_ATTR_LIST)
-CRT_RPC_DEFINE(cont_attr_get, DAOS_ISEQ_CONT_ATTR_GET, DAOS_OSEQ_CONT_ATTR_GET)
+CRT_RPC_DEFINE(cont_attr_list_v9, DAOS_ISEQ_CONT_ATTR_LIST_V9, DAOS_OSEQ_CONT_ATTR_LIST)
 CRT_RPC_DEFINE(cont_attr_get_v8, DAOS_ISEQ_CONT_ATTR_GET_V8, DAOS_OSEQ_CONT_ATTR_GET)
-CRT_RPC_DEFINE(cont_attr_set, DAOS_ISEQ_CONT_ATTR_SET, DAOS_OSEQ_CONT_ATTR_SET)
+CRT_RPC_DEFINE(cont_attr_get_v9, DAOS_ISEQ_CONT_ATTR_GET_V9, DAOS_OSEQ_CONT_ATTR_GET)
 CRT_RPC_DEFINE(cont_attr_set_v8, DAOS_ISEQ_CONT_ATTR_SET_V8, DAOS_OSEQ_CONT_ATTR_SET)
-CRT_RPC_DEFINE(cont_attr_del, DAOS_ISEQ_CONT_ATTR_DEL, DAOS_OSEQ_CONT_ATTR_DEL)
+CRT_RPC_DEFINE(cont_attr_set_v9, DAOS_ISEQ_CONT_ATTR_SET_V9, DAOS_OSEQ_CONT_ATTR_SET)
 CRT_RPC_DEFINE(cont_attr_del_v8, DAOS_ISEQ_CONT_ATTR_DEL_V8, DAOS_OSEQ_CONT_ATTR_DEL)
-CRT_RPC_DEFINE(cont_epoch_op, DAOS_ISEQ_CONT_EPOCH_OP, DAOS_OSEQ_CONT_EPOCH_OP)
+CRT_RPC_DEFINE(cont_attr_del_v9, DAOS_ISEQ_CONT_ATTR_DEL_V9, DAOS_OSEQ_CONT_ATTR_DEL)
 CRT_RPC_DEFINE(cont_epoch_op_v8, DAOS_ISEQ_CONT_EPOCH_OP_V8, DAOS_OSEQ_CONT_EPOCH_OP)
-CRT_RPC_DEFINE(cont_snap_list, DAOS_ISEQ_CONT_SNAP_LIST, DAOS_OSEQ_CONT_SNAP_LIST)
+CRT_RPC_DEFINE(cont_epoch_op_v9, DAOS_ISEQ_CONT_EPOCH_OP_V9, DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DEFINE(cont_snap_list_v8, DAOS_ISEQ_CONT_SNAP_LIST_V8, DAOS_OSEQ_CONT_SNAP_LIST)
-CRT_RPC_DEFINE(cont_snap_create, DAOS_ISEQ_CONT_EPOCH_OP, DAOS_OSEQ_CONT_EPOCH_OP)
+CRT_RPC_DEFINE(cont_snap_list_v9, DAOS_ISEQ_CONT_SNAP_LIST_V9, DAOS_OSEQ_CONT_SNAP_LIST)
 CRT_RPC_DEFINE(cont_snap_create_v8, DAOS_ISEQ_CONT_EPOCH_OP_V8, DAOS_OSEQ_CONT_EPOCH_OP)
-CRT_RPC_DEFINE(cont_snap_destroy, DAOS_ISEQ_CONT_EPOCH_OP, DAOS_OSEQ_CONT_EPOCH_OP)
+CRT_RPC_DEFINE(cont_snap_create_v9, DAOS_ISEQ_CONT_EPOCH_OP_V9, DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DEFINE(cont_snap_destroy_v8, DAOS_ISEQ_CONT_EPOCH_OP_V8, DAOS_OSEQ_CONT_EPOCH_OP)
-CRT_RPC_DEFINE(cont_snap_oit_oid_get, DAOS_ISEQ_CONT_SNAP_OIT_OID_GET,
-		DAOS_OSEQ_CONT_SNAP_OIT_OID_GET)
+CRT_RPC_DEFINE(cont_snap_destroy_v9, DAOS_ISEQ_CONT_EPOCH_OP_V9, DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DEFINE(cont_snap_oit_oid_get_v8, DAOS_ISEQ_CONT_SNAP_OIT_OID_GET_V8,
 	       DAOS_OSEQ_CONT_SNAP_OIT_OID_GET)
-CRT_RPC_DEFINE(cont_snap_oit_destroy, DAOS_ISEQ_CONT_EPOCH_OP, DAOS_OSEQ_CONT_EPOCH_OP)
+CRT_RPC_DEFINE(cont_snap_oit_oid_get_v9, DAOS_ISEQ_CONT_SNAP_OIT_OID_GET_V9,
+	       DAOS_OSEQ_CONT_SNAP_OIT_OID_GET)
 CRT_RPC_DEFINE(cont_snap_oit_destroy_v8, DAOS_ISEQ_CONT_EPOCH_OP_V8, DAOS_OSEQ_CONT_EPOCH_OP)
+CRT_RPC_DEFINE(cont_snap_oit_destroy_v9, DAOS_ISEQ_CONT_EPOCH_OP_V9, DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DEFINE(cont_tgt_destroy, DAOS_ISEQ_TGT_DESTROY, DAOS_OSEQ_TGT_DESTROY)
 CRT_RPC_DEFINE(cont_tgt_query, DAOS_ISEQ_TGT_QUERY, DAOS_OSEQ_TGT_QUERY)
 CRT_RPC_DEFINE(cont_tgt_epoch_aggregate, DAOS_ISEQ_CONT_TGT_EPOCH_AGGREGATE,
 		DAOS_OSEQ_CONT_TGT_EPOCH_AGGREGATE)
 CRT_RPC_DEFINE(cont_tgt_snapshot_notify, DAOS_ISEQ_CONT_TGT_SNAPSHOT_NOTIFY,
-		DAOS_OSEQ_CONT_TGT_SNAPSHOT_NOTIFY)
-CRT_RPC_DEFINE(cont_prop_set, DAOS_ISEQ_CONT_PROP_SET, DAOS_OSEQ_CONT_PROP_SET)
+	       DAOS_OSEQ_CONT_TGT_SNAPSHOT_NOTIFY)
 CRT_RPC_DEFINE(cont_prop_set_v8, DAOS_ISEQ_CONT_PROP_SET_V8, DAOS_OSEQ_CONT_PROP_SET)
+CRT_RPC_DEFINE(cont_prop_set_v9, DAOS_ISEQ_CONT_PROP_SET_V9, DAOS_OSEQ_CONT_PROP_SET)
 CRT_RPC_DEFINE(cont_prop_set_bylabel, DAOS_ISEQ_CONT_PROP_SET_BYLABEL, DAOS_OSEQ_CONT_PROP_SET)
-CRT_RPC_DEFINE(cont_acl_update, DAOS_ISEQ_CONT_ACL_UPDATE, DAOS_OSEQ_CONT_ACL_UPDATE)
 CRT_RPC_DEFINE(cont_acl_update_v8, DAOS_ISEQ_CONT_ACL_UPDATE_V8, DAOS_OSEQ_CONT_ACL_UPDATE)
-CRT_RPC_DEFINE(cont_acl_delete, DAOS_ISEQ_CONT_ACL_DELETE, DAOS_OSEQ_CONT_ACL_DELETE)
+CRT_RPC_DEFINE(cont_acl_update_v9, DAOS_ISEQ_CONT_ACL_UPDATE_V9, DAOS_OSEQ_CONT_ACL_UPDATE)
 CRT_RPC_DEFINE(cont_acl_delete_v8, DAOS_ISEQ_CONT_ACL_DELETE_V8, DAOS_OSEQ_CONT_ACL_DELETE)
+CRT_RPC_DEFINE(cont_acl_delete_v9, DAOS_ISEQ_CONT_ACL_DELETE_V9, DAOS_OSEQ_CONT_ACL_DELETE)
 
 /* Define for cont_rpcs[] array population below.
  * See CONT_PROTO_*_RPC_LIST macro definition
@@ -151,22 +160,22 @@ CRT_RPC_DEFINE(cont_acl_delete_v8, DAOS_ISEQ_CONT_ACL_DELETE_V8, DAOS_OSEQ_CONT_
 	    .prf_co_ops  = NULL,                                                                   \
 	},
 
-static struct crt_proto_rpc_format cont_proto_rpc_fmt_v8[] = {
-    CONT_PROTO_CLI_RPC_LIST(8, ds_cont_op_handler_v8) CONT_PROTO_SRV_RPC_LIST};
+static struct crt_proto_rpc_format cont_proto_rpc_fmt_v9[] = {CONT_PROTO_CLI_RPC_LIST(9)
+								  CONT_PROTO_SRV_RPC_LIST};
 
-static struct crt_proto_rpc_format cont_proto_rpc_fmt_v7[] = {
-    CONT_PROTO_CLI_RPC_LIST(7, ds_cont_op_handler_v7) CONT_PROTO_SRV_RPC_LIST};
+static struct crt_proto_rpc_format cont_proto_rpc_fmt_v8[] = {CONT_PROTO_CLI_RPC_LIST(8)
+								  CONT_PROTO_SRV_RPC_LIST};
 
 #undef X
+
+struct crt_proto_format cont_proto_fmt_v9 = {.cpf_name  = "cont",
+					     .cpf_ver   = 9,
+					     .cpf_count = ARRAY_SIZE(cont_proto_rpc_fmt_v9),
+					     .cpf_prf   = cont_proto_rpc_fmt_v9,
+					     .cpf_base  = DAOS_RPC_OPCODE(0, DAOS_CONT_MODULE, 0)};
 
 struct crt_proto_format cont_proto_fmt_v8 = {.cpf_name  = "cont",
 					     .cpf_ver   = 8,
 					     .cpf_count = ARRAY_SIZE(cont_proto_rpc_fmt_v8),
 					     .cpf_prf   = cont_proto_rpc_fmt_v8,
-					     .cpf_base  = DAOS_RPC_OPCODE(0, DAOS_CONT_MODULE, 0)};
-
-struct crt_proto_format cont_proto_fmt_v7 = {.cpf_name  = "cont",
-					     .cpf_ver   = 7,
-					     .cpf_count = ARRAY_SIZE(cont_proto_rpc_fmt_v7),
-					     .cpf_prf   = cont_proto_rpc_fmt_v7,
 					     .cpf_base  = DAOS_RPC_OPCODE(0, DAOS_CONT_MODULE, 0)};

--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -31,41 +31,59 @@
 #define CONT_PROTO_VER_WITH_NHANDLES   7
 /* version in which cont_op_in includes a client operation key */
 #define CONT_PROTO_VER_WITH_SVC_OP_KEY 8
+/* version in which cont_op_in includes the pool UUID */
+#define CONT_PROTO_VER_WITH_POOL_UUID  9
 
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */
-#define CONT_PROTO_CLI_RPC_LIST(ver, hdlr)                                                         \
-	X(CONT_CREATE, 0, ver >= 8 ? &CQF_cont_create_v8 : &CQF_cont_create, hdlr, NULL)           \
-	X(CONT_DESTROY, 0, ver >= 8 ? &CQF_cont_destroy_v8 : &CQF_cont_destroy, hdlr, NULL)        \
-	X(CONT_OPEN, 0, ver >= 8 ? &CQF_cont_open_v8 : &CQF_cont_open, hdlr, NULL)                 \
-	X(CONT_CLOSE, 0, ver >= 8 ? &CQF_cont_close_v8 : &CQF_cont_close, hdlr, NULL)              \
-	X(CONT_QUERY, 0, ver >= 8 ? &CQF_cont_query_v8 : &CQF_cont_query, hdlr, NULL)              \
-	X(CONT_OID_ALLOC, 0, &CQF_cont_oid_alloc, ds_cont_oid_alloc_handler, NULL)                 \
-	X(CONT_ATTR_LIST, 0, ver >= 8 ? &CQF_cont_attr_list_v8 : &CQF_cont_attr_list, hdlr, NULL)  \
-	X(CONT_ATTR_GET, 0, ver >= 8 ? &CQF_cont_attr_get_v8 : &CQF_cont_attr_get, hdlr, NULL)     \
-	X(CONT_ATTR_SET, 0, ver >= 8 ? &CQF_cont_attr_set_v8 : &CQF_cont_attr_set, hdlr, NULL)     \
-	X(CONT_ATTR_DEL, 0, ver >= 8 ? &CQF_cont_attr_del_v8 : &CQF_cont_attr_del, hdlr, NULL)     \
-	X(CONT_EPOCH_AGGREGATE, 0, ver >= 8 ? &CQF_cont_epoch_op_v8 : &CQF_cont_epoch_op, hdlr,    \
+#define CONT_PROTO_CLI_RPC_LIST(ver)                                                               \
+	X(CONT_CREATE, 0, ver >= 9 ? &CQF_cont_create_v9 : &CQF_cont_create_v8,                    \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_DESTROY, 0, ver >= 9 ? &CQF_cont_destroy_v9 : &CQF_cont_destroy_v8,                 \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_OPEN, 0, ver >= 9 ? &CQF_cont_open_v9 : &CQF_cont_open_v8, ds_cont_op_handler,      \
 	  NULL)                                                                                    \
-	X(CONT_SNAP_LIST, 0, ver >= 8 ? &CQF_cont_snap_list_v8 : &CQF_cont_snap_list, hdlr, NULL)  \
-	X(CONT_SNAP_CREATE, 0, ver >= 8 ? &CQF_cont_epoch_op_v8 : &CQF_cont_epoch_op, hdlr, NULL)  \
-	X(CONT_SNAP_DESTROY, 0, ver >= 8 ? &CQF_cont_epoch_op_v8 : &CQF_cont_epoch_op, hdlr, NULL) \
-	X(CONT_PROP_SET, 0, ver >= 8 ? &CQF_cont_prop_set_v8 : &CQF_cont_prop_set, hdlr, NULL)     \
-	X(CONT_ACL_UPDATE, 0, ver >= 8 ? &CQF_cont_acl_update_v8 : &CQF_cont_acl_update, hdlr,     \
+	X(CONT_CLOSE, 0, ver >= 9 ? &CQF_cont_close_v9 : &CQF_cont_close_v8, ds_cont_op_handler,   \
 	  NULL)                                                                                    \
-	X(CONT_ACL_DELETE, 0, ver >= 8 ? &CQF_cont_acl_delete_v8 : &CQF_cont_acl_delete, hdlr,     \
+	X(CONT_QUERY, 0, ver >= 9 ? &CQF_cont_query_v9 : &CQF_cont_query_v8, ds_cont_op_handler,   \
 	  NULL)                                                                                    \
-	X(CONT_OPEN_BYLABEL, 0, ver >= 8 ? &CQF_cont_open_bylabel_v8 : &CQF_cont_open_bylabel,     \
-	  hdlr, NULL)                                                                              \
+	X(CONT_OID_ALLOC, 0, ver >= 9 ? &CQF_cont_oid_alloc_v9 : &CQF_cont_oid_alloc,              \
+	  ds_cont_oid_alloc_handler, NULL)                                                         \
+	X(CONT_ATTR_LIST, 0, ver >= 9 ? &CQF_cont_attr_list_v9 : &CQF_cont_attr_list_v8,           \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_ATTR_GET, 0, ver >= 9 ? &CQF_cont_attr_get_v9 : &CQF_cont_attr_get_v8,              \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_ATTR_SET, 0, ver >= 9 ? &CQF_cont_attr_set_v9 : &CQF_cont_attr_set_v8,              \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_ATTR_DEL, 0, ver >= 9 ? &CQF_cont_attr_del_v9 : &CQF_cont_attr_del_v8,              \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_EPOCH_AGGREGATE, 0, ver >= 9 ? &CQF_cont_epoch_op_v9 : &CQF_cont_epoch_op_v8,       \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_SNAP_LIST, 0, ver >= 9 ? &CQF_cont_snap_list_v9 : &CQF_cont_snap_list_v8,           \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_SNAP_CREATE, 0, ver >= 9 ? &CQF_cont_epoch_op_v9 : &CQF_cont_epoch_op_v8,           \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_SNAP_DESTROY, 0, ver >= 9 ? &CQF_cont_epoch_op_v9 : &CQF_cont_epoch_op_v8,          \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_PROP_SET, 0, ver >= 9 ? &CQF_cont_prop_set_v9 : &CQF_cont_prop_set_v8,              \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_ACL_UPDATE, 0, ver >= 9 ? &CQF_cont_acl_update_v9 : &CQF_cont_acl_update_v8,        \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_ACL_DELETE, 0, ver >= 9 ? &CQF_cont_acl_delete_v9 : &CQF_cont_acl_delete_v8,        \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_OPEN_BYLABEL, 0, ver >= 9 ? &CQF_cont_open_bylabel_v9 : &CQF_cont_open_bylabel_v8,  \
+	  ds_cont_op_handler, NULL)                                                                \
 	X(CONT_DESTROY_BYLABEL, 0,                                                                 \
-	  ver >= 8 ? &CQF_cont_destroy_bylabel_v8 : &CQF_cont_destroy_bylabel, hdlr, NULL)         \
+	  ver >= 9 ? &CQF_cont_destroy_bylabel_v9 : &CQF_cont_destroy_bylabel_v8,                  \
+	  ds_cont_op_handler, NULL)                                                                \
 	X(CONT_SNAP_OIT_OID_GET, 0,                                                                \
-	  ver >= 8 ? &CQF_cont_snap_oit_oid_get_v8 : &CQF_cont_snap_oit_oid_get, hdlr, NULL)       \
-	X(CONT_SNAP_OIT_CREATE, 0, ver >= 8 ? &CQF_cont_epoch_op_v8 : &CQF_cont_epoch_op, hdlr,    \
-	  NULL)                                                                                    \
-	X(CONT_SNAP_OIT_DESTROY, 0, ver >= 8 ? &CQF_cont_epoch_op_v8 : &CQF_cont_epoch_op, hdlr,   \
-	  NULL)
+	  ver >= 9 ? &CQF_cont_snap_oit_oid_get_v9 : &CQF_cont_snap_oit_oid_get_v8,                \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_SNAP_OIT_CREATE, 0, ver >= 9 ? &CQF_cont_epoch_op_v9 : &CQF_cont_epoch_op_v8,       \
+	  ds_cont_op_handler, NULL)                                                                \
+	X(CONT_SNAP_OIT_DESTROY, 0, ver >= 9 ? &CQF_cont_epoch_op_v9 : &CQF_cont_epoch_op_v8,      \
+	  ds_cont_op_handler, NULL)
 
 #define CONT_PROTO_SRV_RPC_LIST                                                                    \
 	X(CONT_TGT_DESTROY, 0, &CQF_cont_tgt_destroy, ds_cont_tgt_destroy_handler,                 \
@@ -82,15 +100,15 @@
 #define X(a, ...) a,
 
 enum cont_operation {
-	CONT_PROTO_CLI_RPC_LIST(DAOS_CONT_VERSION, ds_cont_op_handler_v8) CONT_PROTO_CLI_COUNT,
+	CONT_PROTO_CLI_RPC_LIST(DAOS_CONT_VERSION) CONT_PROTO_CLI_COUNT,
 	CONT_PROTO_CLI_LAST = CONT_PROTO_CLI_COUNT - 1,
 	CONT_PROTO_SRV_RPC_LIST
 };
 
 #undef X
 
+extern struct crt_proto_format cont_proto_fmt_v9;
 extern struct crt_proto_format cont_proto_fmt_v8;
-extern struct crt_proto_format cont_proto_fmt_v7;
 extern int dc_cont_proto_version;
 
 /* clang-format off */
@@ -104,14 +122,14 @@ extern int dc_cont_proto_version;
 	((uuid_t)		(ci_hdl)		CRT_VAR)
 
 #define DAOS_ISEQ_CONT_OP_V8	/* input fields */		 \
-				/* pool handle UUID */		 \
-	((uuid_t)		(ci_pool_hdl)		CRT_VAR) \
-				/* container UUID */		 \
-	((uuid_t)		(ci_uuid)		CRT_VAR) \
-				/* container handle UUID */	 \
-	((uuid_t)		(ci_hdl)		CRT_VAR) \
+	DAOS_ISEQ_CONT_OP					 \
 	((uuid_t)		(ci_cli_id)		CRT_VAR) \
 	((uint64_t)		(ci_time)		CRT_VAR)
+
+#define DAOS_ISEQ_CONT_OP_V9	/* input fields */		 \
+	DAOS_ISEQ_CONT_OP_V8					 \
+				/* pool UUID */			 \
+	((uuid_t)		(ci_pool)		CRT_VAR)
 
 #define DAOS_OSEQ_CONT_OP	/* output fields */		 \
 				/* operation return code */	 \
@@ -123,94 +141,102 @@ extern int dc_cont_proto_version;
 
 CRT_RPC_DECLARE(cont_op, DAOS_ISEQ_CONT_OP, DAOS_OSEQ_CONT_OP)
 CRT_RPC_DECLARE(cont_op_v8, DAOS_ISEQ_CONT_OP_V8, DAOS_OSEQ_CONT_OP)
-
-#define DAOS_ISEQ_CONT_CREATE		/* input fields */		 \
-					/* .ci_hdl unused */		 \
-	((struct cont_op_in)		(cci_op)		CRT_VAR) \
-	((daos_prop_t)			(cci_prop)		CRT_PTR)
+CRT_RPC_DECLARE(cont_op_v9, DAOS_ISEQ_CONT_OP_V9, DAOS_OSEQ_CONT_OP)
 
 #define DAOS_ISEQ_CONT_CREATE_V8	/* input fields */		 \
 					/* .ci_hdl unused */		 \
 	((struct cont_op_v8_in)		(cci_op)		CRT_VAR) \
 	((daos_prop_t)			(cci_prop)		CRT_PTR)
 
+#define DAOS_ISEQ_CONT_CREATE_V9	/* input fields */		 \
+					/* .ci_hdl unused */		 \
+	((struct cont_op_v9_in)		(cci_op)		CRT_VAR) \
+	((daos_prop_t)			(cci_prop)		CRT_PTR)
+
 #define DAOS_OSEQ_CONT_CREATE		/* output fields */		 \
 	((struct cont_op_out)		(cco_op)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_create, DAOS_ISEQ_CONT_CREATE, DAOS_OSEQ_CONT_CREATE)
 CRT_RPC_DECLARE(cont_create_v8, DAOS_ISEQ_CONT_CREATE_V8, DAOS_OSEQ_CONT_CREATE)
+CRT_RPC_DECLARE(cont_create_v9, DAOS_ISEQ_CONT_CREATE_V9, DAOS_OSEQ_CONT_CREATE)
 
 /* clang-format on */
 
 static inline void
-cont_create_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			daos_prop_t **cci_propp)
+cont_create_in_get_data(crt_rpc_t *rpc, daos_prop_t **cci_propp)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY)
-		*cci_propp = ((struct cont_create_v8_in *)in)->cci_prop;
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		*cci_propp = ((struct cont_create_v9_in *)in)->cci_prop;
 	else
-		*cci_propp = ((struct cont_create_in *)in)->cci_prop;
+		*cci_propp = ((struct cont_create_v8_in *)in)->cci_prop;
 }
 
 static inline void
-cont_create_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, daos_prop_t *cci_prop)
+cont_create_in_set_data(crt_rpc_t *rpc, daos_prop_t *cci_prop)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY)
-		((struct cont_create_v8_in *)in)->cci_prop = cci_prop;
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		((struct cont_create_v9_in *)in)->cci_prop = cci_prop;
 	else
-		((struct cont_create_in *)in)->cci_prop = cci_prop;
+		((struct cont_create_v8_in *)in)->cci_prop = cci_prop;
 }
 
 /* clang-format off */
-#define DAOS_ISEQ_CONT_DESTROY		/* input fields */		 \
-					/* .ci_hdl unused */		 \
-	((struct cont_op_in)		(cdi_op)		CRT_VAR) \
-					/* evict all handles */		 \
-	((uint32_t)			(cdi_force)		CRT_VAR)
-
 #define DAOS_ISEQ_CONT_DESTROY_V8	/* input fields */		 \
 					/* .ci_hdl unused */		 \
 	((struct cont_op_v8_in)		(cdi_op)		CRT_VAR) \
 					/* evict all handles */		 \
 	((uint32_t)			(cdi_force)		CRT_VAR)
 
+#define DAOS_ISEQ_CONT_DESTROY_V9	/* input fields */		 \
+					/* .ci_hdl unused */		 \
+	((struct cont_op_v9_in)		(cdi_op)		CRT_VAR) \
+					/* evict all handles */		 \
+	((uint32_t)			(cdi_force)		CRT_VAR)
+
 #define DAOS_OSEQ_CONT_DESTROY		/* output fields */		 \
 	((struct cont_op_out)		(cdo_op)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_destroy, DAOS_ISEQ_CONT_DESTROY, DAOS_OSEQ_CONT_DESTROY)
 CRT_RPC_DECLARE(cont_destroy_v8, DAOS_ISEQ_CONT_DESTROY_V8, DAOS_OSEQ_CONT_DESTROY)
+CRT_RPC_DECLARE(cont_destroy_v9, DAOS_ISEQ_CONT_DESTROY_V9, DAOS_OSEQ_CONT_DESTROY)
 
 /* Container destroy bylabel input
- * Must begin with what DAOS_ISEQ_CONT_DESTROY has, for reusing cont_destroy_in
- * in the common code. cdi_op.ci_uuid is ignored.
+ * cdi_op.ci_uuid is ignored.
  */
-#define DAOS_ISEQ_CONT_DESTROY_BYLABEL		/* input fields */	 \
-	DAOS_ISEQ_CONT_DESTROY						 \
-	((uint32_t)				(cdli_pad32)	CRT_VAR) \
-	((d_const_string_t)			(cdli_label)	CRT_VAR)
-
 #define DAOS_ISEQ_CONT_DESTROY_BYLABEL_V8	/* input fields */	 \
 	DAOS_ISEQ_CONT_DESTROY_V8					 \
 	((uint32_t)				(cdli_pad32)	CRT_VAR) \
 	((d_const_string_t)			(cdli_label)	CRT_VAR)
 
+#define DAOS_ISEQ_CONT_DESTROY_BYLABEL_V9	/* input fields */	 \
+	DAOS_ISEQ_CONT_DESTROY_V9					 \
+	((uint32_t)				(cdli_pad32)	CRT_VAR) \
+	((d_const_string_t)			(cdli_label)	CRT_VAR)
+
 /* Container destroy bylabel output same as destroy by uuid. */
-CRT_RPC_DECLARE(cont_destroy_bylabel, DAOS_ISEQ_CONT_DESTROY_BYLABEL, DAOS_OSEQ_CONT_DESTROY)
 CRT_RPC_DECLARE(cont_destroy_bylabel_v8, DAOS_ISEQ_CONT_DESTROY_BYLABEL_V8, DAOS_OSEQ_CONT_DESTROY)
+CRT_RPC_DECLARE(cont_destroy_bylabel_v9, DAOS_ISEQ_CONT_DESTROY_BYLABEL_V9, DAOS_OSEQ_CONT_DESTROY)
 
 /* clang-format on */
 
 static inline void
-cont_destroy_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint32_t *cdi_forcep,
-			 const char **labelp)
+cont_destroy_in_get_data(crt_rpc_t *rpc, uint32_t *cdi_forcep, const char **labelp)
 {
-	void *in = crt_req_get(rpc);
+	void        *in  = crt_req_get(rpc);
+	crt_opcode_t opc = opc_get(rpc->cr_opc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		if (opc == CONT_DESTROY_BYLABEL) {
+			*cdi_forcep = ((struct cont_destroy_bylabel_v9_in *)in)->cdi_force;
+			if (labelp)
+				*labelp = ((struct cont_destroy_bylabel_v9_in *)in)->cdli_label;
+		} else { /* CONT_DESTROY */
+			*cdi_forcep = ((struct cont_destroy_v9_in *)in)->cdi_force;
+			/* labelp should be NULL */
+		}
+	} else {
 		if (opc == CONT_DESTROY_BYLABEL) {
 			*cdi_forcep = ((struct cont_destroy_bylabel_v8_in *)in)->cdi_force;
 			if (labelp)
@@ -219,51 +245,41 @@ cont_destroy_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, u
 			*cdi_forcep = ((struct cont_destroy_v8_in *)in)->cdi_force;
 			/* labelp should be NULL */
 		}
-	} else {
-		if (opc == CONT_DESTROY_BYLABEL) {
-			*cdi_forcep = ((struct cont_destroy_bylabel_in *)in)->cdi_force;
-			if (labelp)
-				*labelp = ((struct cont_destroy_bylabel_in *)in)->cdli_label;
-		} else { /* CONT_DESTROY*/
-			*cdi_forcep = ((struct cont_destroy_in *)in)->cdi_force;
-			/* labelp should be NULL */
-		}
 	}
 }
 
 static inline void
-cont_destroy_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint64_t cdi_force,
-			 const char *label)
+cont_destroy_in_set_data(crt_rpc_t *rpc, uint64_t cdi_force, const char *label)
 {
-	void *in = crt_req_get(rpc);
+	void        *in  = crt_req_get(rpc);
+	crt_opcode_t opc = opc_get(rpc->cr_opc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		if (opc == CONT_DESTROY_BYLABEL) {
+			((struct cont_destroy_bylabel_v9_in *)in)->cdi_force  = cdi_force;
+			((struct cont_destroy_bylabel_v9_in *)in)->cdli_label = label;
+		} else { /* CONT_DESTROY */
+			((struct cont_destroy_v9_in *)in)->cdi_force = cdi_force;
+		}
+	} else {
 		if (opc == CONT_DESTROY_BYLABEL) {
 			((struct cont_destroy_bylabel_v8_in *)in)->cdi_force  = cdi_force;
 			((struct cont_destroy_bylabel_v8_in *)in)->cdli_label = label;
 		} else { /* CONT_DESTROY */
 			((struct cont_destroy_v8_in *)in)->cdi_force = cdi_force;
 		}
-	} else {
-		if (opc == CONT_DESTROY_BYLABEL) {
-			((struct cont_destroy_bylabel_in *)in)->cdi_force  = cdi_force;
-			((struct cont_destroy_bylabel_in *)in)->cdli_label = label;
-		} else { /* CONT_DESTROY */
-			((struct cont_destroy_in *)in)->cdi_force = cdi_force;
-		}
 	}
 }
 
 /* clang-format off */
 
-#define DAOS_ISEQ_CONT_OPEN	/* input fields */		 \
-	((struct cont_op_in)	(coi_op)		CRT_VAR) \
-	((uint64_t)		(coi_flags)		CRT_VAR) \
-	((uint64_t)		(coi_sec_capas)		CRT_VAR) \
-	((uint64_t)		(coi_prop_bits)		CRT_VAR)
-
 #define DAOS_ISEQ_CONT_OPEN_V8	/* input fields */		 \
 	((struct cont_op_v8_in)	(coi_op)		CRT_VAR) \
+	((uint64_t)		(coi_flags)		CRT_VAR) \
+	((uint64_t)		(coi_prop_bits)		CRT_VAR)
+
+#define DAOS_ISEQ_CONT_OPEN_V9	/* input fields */		 \
+	((struct cont_op_v9_in)	(coi_op)		CRT_VAR) \
 	((uint64_t)		(coi_flags)		CRT_VAR) \
 	((uint64_t)		(coi_prop_bits)		CRT_VAR)
 
@@ -277,18 +293,17 @@ cont_destroy_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, u
 	((uint64_t)		(coo_md_mtime)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_open_v8, DAOS_ISEQ_CONT_OPEN_V8, DAOS_OSEQ_CONT_OPEN)
-CRT_RPC_DECLARE(cont_open, DAOS_ISEQ_CONT_OPEN, DAOS_OSEQ_CONT_OPEN)
+CRT_RPC_DECLARE(cont_open_v9, DAOS_ISEQ_CONT_OPEN_V9, DAOS_OSEQ_CONT_OPEN)
 
 /* Container open bylabel input
- * Must begin with what DAOS_ISEQ_CONT_OPEN has, for reusing cont_open_in
- * in the common code. coi_op.ci_uuid is ignored.
+ * coi_op.ci_uuid is ignored.
  */
-#define DAOS_ISEQ_CONT_OPEN_BYLABEL	/* input fields */		 \
-	DAOS_ISEQ_CONT_OPEN				 		 \
-	((d_const_string_t)		(coli_label)		CRT_VAR)
-
 #define DAOS_ISEQ_CONT_OPEN_BYLABEL_V8	/* input fields */		 \
 	DAOS_ISEQ_CONT_OPEN_V8						 \
+	((d_const_string_t)		(coli_label)		CRT_VAR)
+
+#define DAOS_ISEQ_CONT_OPEN_BYLABEL_V9	/* input fields */		 \
+	DAOS_ISEQ_CONT_OPEN_V9						 \
 	((d_const_string_t)		(coli_label)		CRT_VAR)
 
 /* Container open bylabel output */
@@ -302,18 +317,30 @@ CRT_RPC_DECLARE(cont_open, DAOS_ISEQ_CONT_OPEN, DAOS_OSEQ_CONT_OPEN)
 	((uint64_t)			(coo_md_otime)		CRT_VAR) \
 	((uint64_t)			(coo_md_mtime)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_open_bylabel, DAOS_ISEQ_CONT_OPEN_BYLABEL, DAOS_OSEQ_CONT_OPEN_BYLABEL)
 CRT_RPC_DECLARE(cont_open_bylabel_v8, DAOS_ISEQ_CONT_OPEN_BYLABEL_V8, DAOS_OSEQ_CONT_OPEN_BYLABEL)
+CRT_RPC_DECLARE(cont_open_bylabel_v9, DAOS_ISEQ_CONT_OPEN_BYLABEL_V9, DAOS_OSEQ_CONT_OPEN_BYLABEL)
 
 /* clang-format on */
 
 static inline void
-cont_open_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint64_t *coi_flagsp,
-		      uint64_t *coi_prop_bitsp, const char **labelp)
+cont_open_in_get_data(crt_rpc_t *rpc, uint64_t *coi_flagsp, uint64_t *coi_prop_bitsp,
+		      const char **labelp)
 {
-	void *in = crt_req_get(rpc);
+	void        *in  = crt_req_get(rpc);
+	crt_opcode_t opc = opc_get(rpc->cr_opc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		if (opc == CONT_OPEN_BYLABEL) {
+			*coi_flagsp     = ((struct cont_open_bylabel_v9_in *)in)->coi_flags;
+			*coi_prop_bitsp = ((struct cont_open_bylabel_v9_in *)in)->coi_prop_bits;
+			if (labelp)
+				*labelp = ((struct cont_open_bylabel_v9_in *)in)->coli_label;
+		} else { /* CONT_OPEN */
+			*coi_flagsp     = ((struct cont_open_v9_in *)in)->coi_flags;
+			*coi_prop_bitsp = ((struct cont_open_v9_in *)in)->coi_prop_bits;
+			/* labelp should be NULL */
+		}
+	} else {
 		if (opc == CONT_OPEN_BYLABEL) {
 			*coi_flagsp     = ((struct cont_open_bylabel_v8_in *)in)->coi_flags;
 			*coi_prop_bitsp = ((struct cont_open_bylabel_v8_in *)in)->coi_prop_bits;
@@ -324,27 +351,26 @@ cont_open_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint
 			*coi_prop_bitsp = ((struct cont_open_v8_in *)in)->coi_prop_bits;
 			/* labelp should be NULL */
 		}
-	} else {
-		if (opc == CONT_OPEN_BYLABEL) {
-			*coi_flagsp     = ((struct cont_open_bylabel_in *)in)->coi_flags;
-			*coi_prop_bitsp = ((struct cont_open_bylabel_in *)in)->coi_prop_bits;
-			if (labelp)
-				*labelp = ((struct cont_open_bylabel_in *)in)->coli_label;
-		} else { /* CONT_OPEN */
-			*coi_flagsp     = ((struct cont_open_in *)in)->coi_flags;
-			*coi_prop_bitsp = ((struct cont_open_in *)in)->coi_prop_bits;
-			/* labelp should be NULL */
-		}
 	}
 }
 
 static inline void
-cont_open_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint64_t coi_flags,
-		      uint64_t coi_prop_bits, const char *label)
+cont_open_in_set_data(crt_rpc_t *rpc, uint64_t coi_flags, uint64_t coi_prop_bits, const char *label)
 {
-	void *in = crt_req_get(rpc);
+	void        *in  = crt_req_get(rpc);
+	crt_opcode_t opc = opc_get(rpc->cr_opc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		if (opc == CONT_OPEN_BYLABEL) {
+			((struct cont_open_bylabel_v9_in *)in)->coi_flags     = coi_flags;
+			((struct cont_open_bylabel_v9_in *)in)->coi_prop_bits = coi_prop_bits;
+			((struct cont_open_bylabel_v9_in *)in)->coli_label    = label;
+		} else { /* CONT_OPEN */
+			((struct cont_open_v9_in *)in)->coi_flags     = coi_flags;
+			((struct cont_open_v9_in *)in)->coi_prop_bits = coi_prop_bits;
+			/* labelp should be NULL */
+		}
+	} else {
 		if (opc == CONT_OPEN_BYLABEL) {
 			((struct cont_open_bylabel_v8_in *)in)->coi_flags     = coi_flags;
 			((struct cont_open_bylabel_v8_in *)in)->coi_prop_bits = coi_prop_bits;
@@ -353,50 +379,42 @@ cont_open_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint
 			((struct cont_open_v8_in *)in)->coi_flags     = coi_flags;
 			((struct cont_open_v8_in *)in)->coi_prop_bits = coi_prop_bits;
 		}
-	} else {
-		if (opc == CONT_OPEN_BYLABEL) {
-			((struct cont_open_bylabel_in *)in)->coi_flags     = coi_flags;
-			((struct cont_open_bylabel_in *)in)->coi_prop_bits = coi_prop_bits;
-			((struct cont_open_bylabel_in *)in)->coli_label    = label;
-		} else { /* CONT_OPEN */
-			((struct cont_open_in *)in)->coi_flags     = coi_flags;
-			((struct cont_open_in *)in)->coi_prop_bits = coi_prop_bits;
-		}
 	}
 }
 
 static inline void
-cont_op_in_get_label(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, const char **clbl_out)
+cont_op_in_get_label(crt_rpc_t *rpc, const char **clbl_out)
 {
-	void *in = crt_req_get(rpc);
+	void        *in  = crt_req_get(rpc);
+	crt_opcode_t opc = opc_get(rpc->cr_opc);
 
 	D_ASSERT((opc == CONT_OPEN_BYLABEL) || (opc == CONT_DESTROY_BYLABEL));
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		if (opc == CONT_OPEN_BYLABEL)
+			*clbl_out = ((struct cont_open_bylabel_v9_in *)in)->coli_label;
+		else
+			*clbl_out = ((struct cont_destroy_bylabel_v9_in *)in)->cdli_label;
+	} else {
 		if (opc == CONT_OPEN_BYLABEL)
 			*clbl_out = ((struct cont_open_bylabel_v8_in *)in)->coli_label;
 		else
 			*clbl_out = ((struct cont_destroy_bylabel_v8_in *)in)->cdli_label;
-	} else {
-		if (opc == CONT_OPEN_BYLABEL)
-			*clbl_out = ((struct cont_open_bylabel_in *)in)->coli_label;
-		else
-			*clbl_out = ((struct cont_destroy_bylabel_in *)in)->cdli_label;
 	}
 }
 
 /* clang-format off */
 
-#define DAOS_ISEQ_CONT_CLOSE	/* input fields */		 \
-	((struct cont_op_in)	(cci_op)		CRT_VAR)
-
 #define DAOS_ISEQ_CONT_CLOSE_V8	/* input fields */		 \
 	((struct cont_op_v8_in)	(cci_op)		CRT_VAR)
+
+#define DAOS_ISEQ_CONT_CLOSE_V9	/* input fields */		 \
+	((struct cont_op_v9_in)	(cci_op)		CRT_VAR)
 
 #define DAOS_OSEQ_CONT_CLOSE	/* output fields */		 \
 	((struct cont_op_out)	(cco_op)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_close, DAOS_ISEQ_CONT_CLOSE, DAOS_OSEQ_CONT_CLOSE)
 CRT_RPC_DECLARE(cont_close_v8, DAOS_ISEQ_CONT_CLOSE_V8, DAOS_OSEQ_CONT_CLOSE)
+CRT_RPC_DECLARE(cont_close_v9, DAOS_ISEQ_CONT_CLOSE_V9, DAOS_OSEQ_CONT_CLOSE)
 
 /* clang-format on */
 
@@ -437,12 +455,12 @@ CRT_RPC_DECLARE(cont_close_v8, DAOS_ISEQ_CONT_CLOSE_V8, DAOS_OSEQ_CONT_CLOSE)
 
 /* clang-format off */
 
-#define DAOS_ISEQ_CONT_QUERY	/* input fields */		 \
-	((struct cont_op_in)	(cqi_op)		CRT_VAR) \
-	((uint64_t)		(cqi_bits)		CRT_VAR)
-
 #define DAOS_ISEQ_CONT_QUERY_V8	/* input fields */		 \
 	((struct cont_op_v8_in)	(cqi_op)		CRT_VAR) \
+	((uint64_t)		(cqi_bits)		CRT_VAR)
+
+#define DAOS_ISEQ_CONT_QUERY_V9	/* input fields */		 \
+	((struct cont_op_v9_in)	(cqi_op)		CRT_VAR) \
 	((uint64_t)		(cqi_bits)		CRT_VAR)
 
 #define DAOS_OSEQ_CONT_QUERY	/* common fields */		 \
@@ -454,31 +472,31 @@ CRT_RPC_DECLARE(cont_close_v8, DAOS_ISEQ_CONT_CLOSE_V8, DAOS_OSEQ_CONT_CLOSE)
 	((uint64_t)		(cqo_md_otime)		CRT_VAR) \
 	((uint64_t)		(cqo_md_mtime)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_query, DAOS_ISEQ_CONT_QUERY, DAOS_OSEQ_CONT_QUERY)
 CRT_RPC_DECLARE(cont_query_v8, DAOS_ISEQ_CONT_QUERY_V8, DAOS_OSEQ_CONT_QUERY)
+CRT_RPC_DECLARE(cont_query_v9, DAOS_ISEQ_CONT_QUERY_V9, DAOS_OSEQ_CONT_QUERY)
 
 /* clang-format on */
 
 static inline void
-cont_query_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint64_t *cqi_bitsp)
+cont_query_in_get_data(crt_rpc_t *rpc, uint64_t *cqi_bitsp)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY)
-		*cqi_bitsp = ((struct cont_query_v8_in *)in)->cqi_bits;
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		*cqi_bitsp = ((struct cont_query_v9_in *)in)->cqi_bits;
 	else
-		*cqi_bitsp = ((struct cont_query_in *)in)->cqi_bits;
+		*cqi_bitsp = ((struct cont_query_v8_in *)in)->cqi_bits;
 }
 
 static inline void
-cont_query_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint64_t cqi_bits)
+cont_query_in_set_data(crt_rpc_t *rpc, uint64_t cqi_bits)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY)
-		((struct cont_query_v8_in *)in)->cqi_bits = cqi_bits;
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		((struct cont_query_v9_in *)in)->cqi_bits = cqi_bits;
 	else
-		((struct cont_query_in *)in)->cqi_bits = cqi_bits;
+		((struct cont_query_v8_in *)in)->cqi_bits = cqi_bits;
 }
 
 /** Add more items to query when needed */
@@ -489,60 +507,79 @@ cont_query_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uin
 	((struct cont_op_in)	(coai_op)		CRT_VAR) \
 	((daos_size_t)		(num_oids)		CRT_VAR)
 
+#define DAOS_ISEQ_CONT_OID_ALLOC_V9 /* input fields */		 \
+	((struct cont_op_v9_in)	(coai_op)		CRT_VAR) \
+	((daos_size_t)		(num_oids)		CRT_VAR)
+
 #define DAOS_OSEQ_CONT_OID_ALLOC /* output fields */		 \
 	((struct cont_op_out)	(coao_op)		CRT_VAR) \
 	((uint64_t)		(oid)			CRT_VAR)
 
 CRT_RPC_DECLARE(cont_oid_alloc, DAOS_ISEQ_CONT_OID_ALLOC, DAOS_OSEQ_CONT_OID_ALLOC)
+CRT_RPC_DECLARE(cont_oid_alloc_v9, DAOS_ISEQ_CONT_OID_ALLOC_V9, DAOS_OSEQ_CONT_OID_ALLOC)
 
-#define DAOS_ISEQ_CONT_ATTR_LIST 	/* input fields */		 \
-	((struct cont_op_in)		(cali_op)		CRT_VAR) \
-	((crt_bulk_t)			(cali_bulk)		CRT_VAR)
+static inline void
+cont_oid_alloc_in_get_data(crt_rpc_t *rpc, daos_size_t *num_oidsp)
+{
+	void *in = crt_req_get(rpc);
+
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		*num_oidsp = ((struct cont_oid_alloc_v9_in *)in)->num_oids;
+	else
+		*num_oidsp = ((struct cont_oid_alloc_in *)in)->num_oids;
+}
+
+static inline void
+cont_oid_alloc_in_set_data(crt_rpc_t *rpc, daos_size_t num_oids)
+{
+	void *in = crt_req_get(rpc);
+
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		((struct cont_oid_alloc_v9_in *)in)->num_oids = num_oids;
+	else
+		((struct cont_oid_alloc_in *)in)->num_oids = num_oids;
+}
 
 #define DAOS_ISEQ_CONT_ATTR_LIST_V8	/* input fields */		 \
 	((struct cont_op_v8_in)		(cali_op)		CRT_VAR) \
+	((crt_bulk_t)			(cali_bulk)		CRT_VAR)
+
+#define DAOS_ISEQ_CONT_ATTR_LIST_V9	/* input fields */		 \
+	((struct cont_op_v9_in)		(cali_op)		CRT_VAR) \
 	((crt_bulk_t)			(cali_bulk)		CRT_VAR)
 
 #define DAOS_OSEQ_CONT_ATTR_LIST	/* output fields */		 \
 	((struct cont_op_out)		(calo_op)		CRT_VAR) \
 	((uint64_t)			(calo_size)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_attr_list, DAOS_ISEQ_CONT_ATTR_LIST, DAOS_OSEQ_CONT_ATTR_LIST)
 CRT_RPC_DECLARE(cont_attr_list_v8, DAOS_ISEQ_CONT_ATTR_LIST_V8, DAOS_OSEQ_CONT_ATTR_LIST)
+CRT_RPC_DECLARE(cont_attr_list_v9, DAOS_ISEQ_CONT_ATTR_LIST_V9, DAOS_OSEQ_CONT_ATTR_LIST)
 
 /* clang-format on */
 
 static inline void
-cont_attr_list_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			   crt_bulk_t *cali_bulkp)
+cont_attr_list_in_get_data(crt_rpc_t *rpc, crt_bulk_t *cali_bulkp)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY)
-		*cali_bulkp = ((struct cont_attr_list_v8_in *)in)->cali_bulk;
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		*cali_bulkp = ((struct cont_attr_list_v9_in *)in)->cali_bulk;
 	else
-		*cali_bulkp = ((struct cont_attr_list_in *)in)->cali_bulk;
+		*cali_bulkp = ((struct cont_attr_list_v8_in *)in)->cali_bulk;
 }
 
 static inline void
-cont_attr_list_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			   crt_bulk_t cali_bulk)
+cont_attr_list_in_set_data(crt_rpc_t *rpc, crt_bulk_t cali_bulk)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY)
-		((struct cont_attr_list_v8_in *)in)->cali_bulk = cali_bulk;
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		((struct cont_attr_list_v9_in *)in)->cali_bulk = cali_bulk;
 	else
-		((struct cont_attr_list_in *)in)->cali_bulk = cali_bulk;
+		((struct cont_attr_list_v8_in *)in)->cali_bulk = cali_bulk;
 }
 
 /* clang-format off */
-
-#define DAOS_ISEQ_CONT_ATTR_GET		/* input fields */		 \
-	((struct cont_op_in)		(cagi_op)		CRT_VAR) \
-	((uint64_t)			(cagi_count)		CRT_VAR) \
-	((uint64_t)			(cagi_key_length)	CRT_VAR) \
-	((crt_bulk_t)			(cagi_bulk)		CRT_VAR)
 
 #define DAOS_ISEQ_CONT_ATTR_GET_V8	/* input fields */                                              \
 	((struct cont_op_v8_in)		(cagi_op)		CRT_VAR) \
@@ -550,157 +587,159 @@ cont_attr_list_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
 	((uint64_t)			(cagi_key_length)	CRT_VAR) \
 	((crt_bulk_t)			(cagi_bulk)		CRT_VAR)
 
+#define DAOS_ISEQ_CONT_ATTR_GET_V9	/* input fields */																 \
+	((struct cont_op_v9_in)		(cagi_op)		CRT_VAR) \
+	((uint64_t)			(cagi_count)		CRT_VAR) \
+	((uint64_t)			(cagi_key_length)	CRT_VAR) \
+	((crt_bulk_t)			(cagi_bulk)		CRT_VAR)
+
 #define DAOS_OSEQ_CONT_ATTR_GET		/* output fields */		 \
 	((struct cont_op_out)		(cago_op)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_attr_get, DAOS_ISEQ_CONT_ATTR_GET, DAOS_OSEQ_CONT_ATTR_GET)
 CRT_RPC_DECLARE(cont_attr_get_v8, DAOS_ISEQ_CONT_ATTR_GET_V8, DAOS_OSEQ_CONT_ATTR_GET)
+CRT_RPC_DECLARE(cont_attr_get_v9, DAOS_ISEQ_CONT_ATTR_GET_V9, DAOS_OSEQ_CONT_ATTR_GET)
 
 /* clang-format on */
 
 static inline void
-cont_attr_get_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			  uint64_t *cagi_countp, uint64_t *cagi_key_lengthp, crt_bulk_t *cagi_bulkp)
+cont_attr_get_in_get_data(crt_rpc_t *rpc, uint64_t *cagi_countp, uint64_t *cagi_key_lengthp,
+			  crt_bulk_t *cagi_bulkp)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		*cagi_countp      = ((struct cont_attr_get_v9_in *)in)->cagi_count;
+		*cagi_key_lengthp = ((struct cont_attr_get_v9_in *)in)->cagi_key_length;
+		*cagi_bulkp       = ((struct cont_attr_get_v9_in *)in)->cagi_bulk;
+	} else {
 		*cagi_countp      = ((struct cont_attr_get_v8_in *)in)->cagi_count;
 		*cagi_key_lengthp = ((struct cont_attr_get_v8_in *)in)->cagi_key_length;
 		*cagi_bulkp       = ((struct cont_attr_get_v8_in *)in)->cagi_bulk;
-	} else {
-		*cagi_countp      = ((struct cont_attr_get_in *)in)->cagi_count;
-		*cagi_key_lengthp = ((struct cont_attr_get_in *)in)->cagi_key_length;
-		*cagi_bulkp       = ((struct cont_attr_get_in *)in)->cagi_bulk;
 	}
 }
 
 static inline void
-cont_attr_get_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint64_t cagi_count,
-			  uint64_t cagi_key_length, crt_bulk_t cagi_bulk)
+cont_attr_get_in_set_data(crt_rpc_t *rpc, uint64_t cagi_count, uint64_t cagi_key_length,
+			  crt_bulk_t cagi_bulk)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		((struct cont_attr_get_v9_in *)in)->cagi_count      = cagi_count;
+		((struct cont_attr_get_v9_in *)in)->cagi_key_length = cagi_key_length;
+		((struct cont_attr_get_v9_in *)in)->cagi_bulk       = cagi_bulk;
+	} else {
 		((struct cont_attr_get_v8_in *)in)->cagi_count      = cagi_count;
 		((struct cont_attr_get_v8_in *)in)->cagi_key_length = cagi_key_length;
 		((struct cont_attr_get_v8_in *)in)->cagi_bulk       = cagi_bulk;
-	} else {
-		((struct cont_attr_get_in *)in)->cagi_count      = cagi_count;
-		((struct cont_attr_get_in *)in)->cagi_key_length = cagi_key_length;
-		((struct cont_attr_get_in *)in)->cagi_bulk       = cagi_bulk;
 	}
 }
 
 /* clang-format off */
-
-#define DAOS_ISEQ_CONT_ATTR_SET		/* input fields */		 \
-	((struct cont_op_in)		(casi_op)		CRT_VAR) \
-	((uint64_t)			(casi_count)		CRT_VAR) \
-	((crt_bulk_t)			(casi_bulk)		CRT_VAR)
 
 #define DAOS_ISEQ_CONT_ATTR_SET_V8	/* input fields */		 \
 	((struct cont_op_v8_in)		(casi_op)		CRT_VAR) \
 	((uint64_t)			(casi_count)		CRT_VAR) \
 	((crt_bulk_t)			(casi_bulk)		CRT_VAR)
 
+#define DAOS_ISEQ_CONT_ATTR_SET_V9	/* input fields */		 \
+	((struct cont_op_v9_in)		(casi_op)		CRT_VAR) \
+	((uint64_t)			(casi_count)		CRT_VAR) \
+	((crt_bulk_t)			(casi_bulk)		CRT_VAR)
+
 #define DAOS_OSEQ_CONT_ATTR_SET		/* output fields */		 \
 	((struct cont_op_out)		(caso_op)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_attr_set, DAOS_ISEQ_CONT_ATTR_SET, DAOS_OSEQ_CONT_ATTR_SET)
 CRT_RPC_DECLARE(cont_attr_set_v8, DAOS_ISEQ_CONT_ATTR_SET_V8, DAOS_OSEQ_CONT_ATTR_SET)
+CRT_RPC_DECLARE(cont_attr_set_v9, DAOS_ISEQ_CONT_ATTR_SET_V9, DAOS_OSEQ_CONT_ATTR_SET)
 
 /* clang-format on */
 
 static inline void
-cont_attr_set_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			  uint64_t *casi_countp, crt_bulk_t *casi_bulkp)
+cont_attr_set_in_get_data(crt_rpc_t *rpc, uint64_t *casi_countp, crt_bulk_t *casi_bulkp)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		*casi_countp = ((struct cont_attr_set_v9_in *)in)->casi_count;
+		*casi_bulkp  = ((struct cont_attr_set_v9_in *)in)->casi_bulk;
+	} else {
 		*casi_countp = ((struct cont_attr_set_v8_in *)in)->casi_count;
 		*casi_bulkp  = ((struct cont_attr_set_v8_in *)in)->casi_bulk;
-	} else {
-		*casi_countp = ((struct cont_attr_set_in *)in)->casi_count;
-		*casi_bulkp  = ((struct cont_attr_set_in *)in)->casi_bulk;
 	}
 }
 
 static inline void
-cont_attr_set_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint64_t casi_count,
-			  crt_bulk_t casi_bulk)
+cont_attr_set_in_set_data(crt_rpc_t *rpc, uint64_t casi_count, crt_bulk_t casi_bulk)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		((struct cont_attr_set_v9_in *)in)->casi_count = casi_count;
+		((struct cont_attr_set_v9_in *)in)->casi_bulk  = casi_bulk;
+	} else {
 		((struct cont_attr_set_v8_in *)in)->casi_count = casi_count;
 		((struct cont_attr_set_v8_in *)in)->casi_bulk  = casi_bulk;
-	} else {
-		((struct cont_attr_set_in *)in)->casi_count = casi_count;
-		((struct cont_attr_set_in *)in)->casi_bulk  = casi_bulk;
 	}
 }
 
 /* clang-format off */
-
-#define DAOS_ISEQ_CONT_ATTR_DEL		/* input fields */		 \
-	((struct cont_op_in)		(cadi_op)		CRT_VAR) \
-	((uint64_t)			(cadi_count)		CRT_VAR) \
-	((crt_bulk_t)			(cadi_bulk)		CRT_VAR)
 
 #define DAOS_ISEQ_CONT_ATTR_DEL_V8	/* input fields */		 \
 	((struct cont_op_v8_in)		(cadi_op)		CRT_VAR) \
 	((uint64_t)			(cadi_count)		CRT_VAR) \
 	((crt_bulk_t)			(cadi_bulk)		CRT_VAR)
 
+#define DAOS_ISEQ_CONT_ATTR_DEL_V9	/* input fields */		 \
+	((struct cont_op_v9_in)		(cadi_op)		CRT_VAR) \
+	((uint64_t)			(cadi_count)		CRT_VAR) \
+	((crt_bulk_t)			(cadi_bulk)		CRT_VAR)
+
 #define DAOS_OSEQ_CONT_ATTR_DEL		/* output fields */		 \
 	((struct cont_op_out)		(cado_op)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_attr_del, DAOS_ISEQ_CONT_ATTR_DEL, DAOS_OSEQ_CONT_ATTR_DEL)
 CRT_RPC_DECLARE(cont_attr_del_v8, DAOS_ISEQ_CONT_ATTR_DEL_V8, DAOS_OSEQ_CONT_ATTR_DEL)
+CRT_RPC_DECLARE(cont_attr_del_v9, DAOS_ISEQ_CONT_ATTR_DEL_V9, DAOS_OSEQ_CONT_ATTR_DEL)
 
 /* clang-format on */
 
 static inline void
-cont_attr_del_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			  uint64_t *cadi_countp, crt_bulk_t *cadi_bulkp)
+cont_attr_del_in_get_data(crt_rpc_t *rpc, uint64_t *cadi_countp, crt_bulk_t *cadi_bulkp)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		*cadi_countp = ((struct cont_attr_del_v9_in *)in)->cadi_count;
+		*cadi_bulkp  = ((struct cont_attr_del_v9_in *)in)->cadi_bulk;
+	} else {
 		*cadi_countp = ((struct cont_attr_del_v8_in *)in)->cadi_count;
 		*cadi_bulkp  = ((struct cont_attr_del_v8_in *)in)->cadi_bulk;
-	} else {
-		*cadi_countp = ((struct cont_attr_del_in *)in)->cadi_count;
-		*cadi_bulkp  = ((struct cont_attr_del_in *)in)->cadi_bulk;
 	}
 }
 
 static inline void
-cont_attr_del_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint64_t cadi_count,
-			  crt_bulk_t cadi_bulk)
+cont_attr_del_in_set_data(crt_rpc_t *rpc, uint64_t cadi_count, crt_bulk_t cadi_bulk)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		((struct cont_attr_del_v9_in *)in)->cadi_count = cadi_count;
+		((struct cont_attr_del_v9_in *)in)->cadi_bulk  = cadi_bulk;
+	} else {
 		((struct cont_attr_del_v8_in *)in)->cadi_count = cadi_count;
 		((struct cont_attr_del_v8_in *)in)->cadi_bulk  = cadi_bulk;
-	} else {
-		((struct cont_attr_del_in *)in)->cadi_count = cadi_count;
-		((struct cont_attr_del_in *)in)->cadi_bulk  = cadi_bulk;
 	}
 }
 
 /* clang-format off */
 
-#define DAOS_ISEQ_CONT_EPOCH_OP		/* input fields */		 \
-	((struct cont_op_in)		(cei_op)		CRT_VAR) \
+#define DAOS_ISEQ_CONT_EPOCH_OP_V8	/* input fields */		 \
+	((struct cont_op_v8_in)		(cei_op)		CRT_VAR) \
 	((daos_epoch_t)			(cei_epoch)		CRT_VAR) \
 	((uint64_t)			(cei_opts)		CRT_VAR)
 
-#define DAOS_ISEQ_CONT_EPOCH_OP_V8	/* input fields */		 \
-	((struct cont_op_v8_in)		(cei_op)		CRT_VAR) \
+#define DAOS_ISEQ_CONT_EPOCH_OP_V9	/* input fields */		 \
+	((struct cont_op_v9_in)		(cei_op)		CRT_VAR) \
 	((daos_epoch_t)			(cei_epoch)		CRT_VAR) \
 	((uint64_t)			(cei_opts)		CRT_VAR)
 
@@ -708,139 +747,133 @@ cont_attr_del_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, 
 	((struct cont_op_out)		(ceo_op)		CRT_VAR) \
 	((daos_epoch_t)			(ceo_epoch)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_epoch_op, DAOS_ISEQ_CONT_EPOCH_OP, DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DECLARE(cont_epoch_op_v8, DAOS_ISEQ_CONT_EPOCH_OP_V8, DAOS_OSEQ_CONT_EPOCH_OP)
+CRT_RPC_DECLARE(cont_epoch_op_v9, DAOS_ISEQ_CONT_EPOCH_OP_V9, DAOS_OSEQ_CONT_EPOCH_OP)
 
 /* clang-format on */
 
 static inline void
-cont_epoch_op_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			  daos_epoch_t *cei_epochp, uint64_t *cei_optsp)
+cont_epoch_op_in_get_data(crt_rpc_t *rpc, daos_epoch_t *cei_epochp, uint64_t *cei_optsp)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		*cei_epochp = ((struct cont_epoch_op_v9_in *)in)->cei_epoch;
+		*cei_optsp  = ((struct cont_epoch_op_v9_in *)in)->cei_opts;
+	} else {
 		*cei_epochp = ((struct cont_epoch_op_v8_in *)in)->cei_epoch;
 		*cei_optsp  = ((struct cont_epoch_op_v8_in *)in)->cei_opts;
-	} else {
-		*cei_epochp = ((struct cont_epoch_op_in *)in)->cei_epoch;
-		*cei_optsp  = ((struct cont_epoch_op_in *)in)->cei_opts;
 	}
 }
 
 static inline void
-cont_epoch_op_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			  daos_epoch_t cei_epoch, uint64_t cei_opts)
+cont_epoch_op_in_set_data(crt_rpc_t *rpc, daos_epoch_t cei_epoch, uint64_t cei_opts)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		((struct cont_epoch_op_v9_in *)in)->cei_epoch = cei_epoch;
+		((struct cont_epoch_op_v9_in *)in)->cei_opts  = cei_opts;
+	} else {
 		((struct cont_epoch_op_v8_in *)in)->cei_epoch = cei_epoch;
 		((struct cont_epoch_op_v8_in *)in)->cei_opts  = cei_opts;
-	} else {
-		((struct cont_epoch_op_in *)in)->cei_epoch = cei_epoch;
-		((struct cont_epoch_op_in *)in)->cei_opts  = cei_opts;
 	}
 }
 
 /* clang-format off */
 
-#define DAOS_ISEQ_CONT_SNAP_LIST	/* input fields */		 \
-	((struct cont_op_in)		(sli_op)		CRT_VAR) \
-	((crt_bulk_t)			(sli_bulk)		CRT_VAR)
-
 #define DAOS_ISEQ_CONT_SNAP_LIST_V8	/* input fields */		 \
 	((struct cont_op_v8_in)		(sli_op)		CRT_VAR) \
+	((crt_bulk_t)			(sli_bulk)		CRT_VAR)
+
+#define DAOS_ISEQ_CONT_SNAP_LIST_V9	/* input fields */		 \
+	((struct cont_op_v9_in)		(sli_op)		CRT_VAR) \
 	((crt_bulk_t)			(sli_bulk)		CRT_VAR)
 
 #define DAOS_OSEQ_CONT_SNAP_LIST	/* output fields */		 \
 	((struct cont_op_out)		(slo_op)		CRT_VAR) \
 	((uint32_t)			(slo_count)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_snap_list, DAOS_ISEQ_CONT_SNAP_LIST, DAOS_OSEQ_CONT_SNAP_LIST)
 CRT_RPC_DECLARE(cont_snap_list_v8, DAOS_ISEQ_CONT_SNAP_LIST_V8, DAOS_OSEQ_CONT_SNAP_LIST)
+CRT_RPC_DECLARE(cont_snap_list_v9, DAOS_ISEQ_CONT_SNAP_LIST_V9, DAOS_OSEQ_CONT_SNAP_LIST)
 
 /* clang-format on */
 
 static inline void
-cont_snap_list_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			   crt_bulk_t *sli_bulkp)
+cont_snap_list_in_get_data(crt_rpc_t *rpc, crt_bulk_t *sli_bulkp)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY)
-		*sli_bulkp = ((struct cont_snap_list_v8_in *)in)->sli_bulk;
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		*sli_bulkp = ((struct cont_snap_list_v9_in *)in)->sli_bulk;
 	else
-		*sli_bulkp = ((struct cont_snap_list_in *)in)->sli_bulk;
+		*sli_bulkp = ((struct cont_snap_list_v8_in *)in)->sli_bulk;
 }
 
 static inline void
-cont_snap_list_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			   crt_bulk_t sli_bulk)
+cont_snap_list_in_set_data(crt_rpc_t *rpc, crt_bulk_t sli_bulk)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY)
-		((struct cont_snap_list_v8_in *)in)->sli_bulk = sli_bulk;
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		((struct cont_snap_list_v9_in *)in)->sli_bulk = sli_bulk;
 	else
-		((struct cont_snap_list_in *)in)->sli_bulk = sli_bulk;
+		((struct cont_snap_list_v8_in *)in)->sli_bulk = sli_bulk;
 }
 
 /* clang-format off */
 
-CRT_RPC_DECLARE(cont_snap_create, DAOS_ISEQ_CONT_EPOCH_OP, DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DECLARE(cont_snap_create_v8, DAOS_ISEQ_CONT_EPOCH_OP_V8, DAOS_OSEQ_CONT_EPOCH_OP)
+CRT_RPC_DECLARE(cont_snap_create_v9, DAOS_ISEQ_CONT_EPOCH_OP_V9, DAOS_OSEQ_CONT_EPOCH_OP)
 
-CRT_RPC_DECLARE(cont_snap_destroy, DAOS_ISEQ_CONT_EPOCH_OP, DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DECLARE(cont_snap_destroy_v8, DAOS_ISEQ_CONT_EPOCH_OP_V8, DAOS_OSEQ_CONT_EPOCH_OP)
+CRT_RPC_DECLARE(cont_snap_destroy_v9, DAOS_ISEQ_CONT_EPOCH_OP_V9, DAOS_OSEQ_CONT_EPOCH_OP)
 
-CRT_RPC_DECLARE(cont_snap_oit_create, DAOS_ISEQ_CONT_EPOCH_OP, DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DECLARE(cont_snap_oit_create_v8, DAOS_ISEQ_CONT_EPOCH_OP_V8, DAOS_OSEQ_CONT_EPOCH_OP)
+CRT_RPC_DECLARE(cont_snap_oit_create_v9, DAOS_ISEQ_CONT_EPOCH_OP_V9, DAOS_OSEQ_CONT_EPOCH_OP)
 
-CRT_RPC_DECLARE(cont_snap_oit_destroy, DAOS_ISEQ_CONT_EPOCH_OP, DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DECLARE(cont_snap_oit_destroy_v8, DAOS_ISEQ_CONT_EPOCH_OP_V8, DAOS_OSEQ_CONT_EPOCH_OP)
-
-#define DAOS_ISEQ_CONT_SNAP_OIT_OID_GET		/* input fields */		 \
-	((struct cont_op_in)			(ogi_op)		CRT_VAR) \
-	((daos_epoch_t)				(ogi_epoch)		CRT_VAR)
+CRT_RPC_DECLARE(cont_snap_oit_destroy_v9, DAOS_ISEQ_CONT_EPOCH_OP_V9, DAOS_OSEQ_CONT_EPOCH_OP)
 
 #define DAOS_ISEQ_CONT_SNAP_OIT_OID_GET_V8	/* input fields */		 \
 	((struct cont_op_v8_in)			(ogi_op)		CRT_VAR) \
+	((daos_epoch_t)				(ogi_epoch)		CRT_VAR)
+
+#define DAOS_ISEQ_CONT_SNAP_OIT_OID_GET_V9	/* input fields */		 \
+	((struct cont_op_v9_in)			(ogi_op)		CRT_VAR) \
 	((daos_epoch_t)				(ogi_epoch)		CRT_VAR)
 
 #define DAOS_OSEQ_CONT_SNAP_OIT_OID_GET 	/* output fields */		 \
 	((struct cont_op_out)			(ogo_op)		CRT_VAR) \
 	((daos_obj_id_t)			(ogo_oid)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_snap_oit_oid_get, DAOS_ISEQ_CONT_SNAP_OIT_OID_GET,
-		DAOS_OSEQ_CONT_SNAP_OIT_OID_GET)
 CRT_RPC_DECLARE(cont_snap_oit_oid_get_v8, DAOS_ISEQ_CONT_SNAP_OIT_OID_GET_V8,
+		DAOS_OSEQ_CONT_SNAP_OIT_OID_GET)
+CRT_RPC_DECLARE(cont_snap_oit_oid_get_v9, DAOS_ISEQ_CONT_SNAP_OIT_OID_GET_V9,
 		DAOS_OSEQ_CONT_SNAP_OIT_OID_GET)
 
 /* clang-format on */
 
 static inline void
-cont_snap_oit_oid_get_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-				  daos_epoch_t *ogi_epochp)
+cont_snap_oit_oid_get_in_get_data(crt_rpc_t *rpc, daos_epoch_t *ogi_epochp)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY)
-		*ogi_epochp = ((struct cont_snap_oit_oid_get_v8_in *)in)->ogi_epoch;
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		*ogi_epochp = ((struct cont_snap_oit_oid_get_v9_in *)in)->ogi_epoch;
 	else
-		*ogi_epochp = ((struct cont_snap_oit_oid_get_in *)in)->ogi_epoch;
+		*ogi_epochp = ((struct cont_snap_oit_oid_get_v8_in *)in)->ogi_epoch;
 }
 
 static inline void
-cont_snap_oit_oid_get_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-				  daos_epoch_t ogi_epoch)
+cont_snap_oit_oid_get_in_set_data(crt_rpc_t *rpc, daos_epoch_t ogi_epoch)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY)
-		((struct cont_snap_oit_oid_get_v8_in *)in)->ogi_epoch = ogi_epoch;
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		((struct cont_snap_oit_oid_get_v9_in *)in)->ogi_epoch = ogi_epoch;
 	else
-		((struct cont_snap_oit_oid_get_in *)in)->ogi_epoch = ogi_epoch;
+		((struct cont_snap_oit_oid_get_v8_in *)in)->ogi_epoch = ogi_epoch;
 }
 
 /* clang-format off */
@@ -904,24 +937,23 @@ CRT_RPC_DECLARE(cont_tgt_epoch_aggregate, DAOS_ISEQ_CONT_TGT_EPOCH_AGGREGATE,
 CRT_RPC_DECLARE(cont_tgt_snapshot_notify, DAOS_ISEQ_CONT_TGT_SNAPSHOT_NOTIFY,
 		DAOS_OSEQ_CONT_TGT_SNAPSHOT_NOTIFY)
 
-#define DAOS_ISEQ_CONT_PROP_SET		/* input fields */		 \
-	((struct cont_op_in)		(cpsi_op)		CRT_VAR) \
-	((daos_prop_t)			(cpsi_prop)		CRT_PTR) \
-	((uuid_t)			(cpsi_pool_uuid)	CRT_VAR)
-
 #define DAOS_ISEQ_CONT_PROP_SET_V8	/* input fields */		 \
 	((struct cont_op_v8_in)		(cpsi_op)		CRT_VAR) \
 	((daos_prop_t)			(cpsi_prop)		CRT_PTR) \
 	((uuid_t)			(cpsi_pool_uuid)	CRT_VAR)
 
+#define DAOS_ISEQ_CONT_PROP_SET_V9	/* input fields */		 \
+	((struct cont_op_v9_in)		(cpsi_op)		CRT_VAR) \
+	((daos_prop_t)			(cpsi_prop)		CRT_PTR)
+
 #define DAOS_OSEQ_CONT_PROP_SET		/* output fields */		 \
 	((struct cont_op_out)		(cpso_op)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_prop_set, DAOS_ISEQ_CONT_PROP_SET, DAOS_OSEQ_CONT_PROP_SET)
 CRT_RPC_DECLARE(cont_prop_set_v8, DAOS_ISEQ_CONT_PROP_SET_V8, DAOS_OSEQ_CONT_PROP_SET)
+CRT_RPC_DECLARE(cont_prop_set_v9, DAOS_ISEQ_CONT_PROP_SET_V9, DAOS_OSEQ_CONT_PROP_SET)
 
 #define DAOS_ISEQ_CONT_PROP_SET_BYLABEL		/* input fields */	 \
-	DAOS_ISEQ_CONT_PROP_SET_V8					 \
+	DAOS_ISEQ_CONT_PROP_SET_V9					 \
 	((d_const_string_t)		(cpsi_label)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_prop_set_bylabel, DAOS_ISEQ_CONT_PROP_SET_BYLABEL, DAOS_OSEQ_CONT_PROP_SET)
@@ -929,175 +961,184 @@ CRT_RPC_DECLARE(cont_prop_set_bylabel, DAOS_ISEQ_CONT_PROP_SET_BYLABEL, DAOS_OSE
 /* clang-format on */
 
 static inline void
-cont_prop_set_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			  daos_prop_t **cpsi_propp, uuid_t *cpsi_pool_uuidp, uuid_t *cpsi_co_uuidp,
-			  const char **cont_label)
+cont_prop_set_in_get_data(crt_rpc_t *rpc, daos_prop_t **cpsi_propp, uuid_t *cpsi_pool_uuidp,
+			  uuid_t *cpsi_co_uuidp, const char **cont_label)
 {
-	void *in = crt_req_get(rpc);
+	crt_opcode_t opc = opc_get(rpc->cr_opc);
 
 	if (opc == CONT_PROP_SET_BYLABEL) {
-		*cpsi_propp = ((struct cont_prop_set_bylabel_in *)in)->cpsi_prop;
-		if (cpsi_pool_uuidp)
-			uuid_copy(*cpsi_pool_uuidp,
-				  ((struct cont_prop_set_bylabel_in *)in)->cpsi_pool_uuid);
+		struct cont_prop_set_bylabel_in *in = crt_req_get(rpc);
+
+		*cpsi_propp = in->cpsi_prop;
+		if (cpsi_pool_uuidp != NULL)
+			uuid_copy(*cpsi_pool_uuidp, in->cpsi_op.ci_pool);
+		if (cpsi_co_uuidp != NULL)
+			uuid_copy(*cpsi_co_uuidp, in->cpsi_op.ci_uuid);
 		if (cont_label != NULL)
-			*cont_label = ((struct cont_prop_set_bylabel_in *)in)->cpsi_label;
-	} else if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
-		*cpsi_propp = ((struct cont_prop_set_v8_in *)in)->cpsi_prop;
-		if (cpsi_pool_uuidp)
-			uuid_copy(*cpsi_pool_uuidp,
-				  ((struct cont_prop_set_v8_in *)in)->cpsi_pool_uuid);
-		if (cpsi_co_uuidp)
-			uuid_copy(*cpsi_co_uuidp,
-				  ((struct cont_prop_set_v8_in *)in)->cpsi_op.ci_uuid);
+			*cont_label = in->cpsi_label;
 	} else {
-		*cpsi_propp = ((struct cont_prop_set_in *)in)->cpsi_prop;
-		if (cpsi_pool_uuidp)
-			uuid_copy(*cpsi_pool_uuidp,
-				  ((struct cont_prop_set_in *)in)->cpsi_pool_uuid);
-		if (cpsi_co_uuidp)
-			uuid_copy(*cpsi_co_uuidp, ((struct cont_prop_set_in *)in)->cpsi_op.ci_uuid);
+		if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+			struct cont_prop_set_v9_in *in = crt_req_get(rpc);
+
+			*cpsi_propp = in->cpsi_prop;
+			if (cpsi_pool_uuidp != NULL)
+				uuid_copy(*cpsi_pool_uuidp, in->cpsi_op.ci_pool);
+			if (cpsi_co_uuidp != NULL)
+				uuid_copy(*cpsi_co_uuidp, in->cpsi_op.ci_uuid);
+			if (cont_label != NULL)
+				*cont_label = NULL;
+		} else {
+			struct cont_prop_set_v8_in *in = crt_req_get(rpc);
+
+			*cpsi_propp = in->cpsi_prop;
+			if (cpsi_pool_uuidp != NULL)
+				uuid_copy(*cpsi_pool_uuidp, in->cpsi_pool_uuid);
+			if (cpsi_co_uuidp != NULL)
+				uuid_copy(*cpsi_co_uuidp, in->cpsi_op.ci_uuid);
+			if (cont_label != NULL)
+				*cont_label = NULL;
+		}
 	}
 }
 
 static inline void
-cont_prop_set_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			  daos_prop_t *cpsi_prop, uuid_t cpsi_pool_uuid)
+cont_prop_set_in_set_data(crt_rpc_t *rpc, daos_prop_t *cpsi_prop, uuid_t cpsi_pool_uuid)
 {
-	void *in = crt_req_get(rpc);
+	void        *in  = crt_req_get(rpc);
+	crt_opcode_t opc = opc_get(rpc->cr_opc);
 
 	if (opc == CONT_PROP_SET_BYLABEL) {
 		((struct cont_prop_set_bylabel_in *)in)->cpsi_prop = cpsi_prop;
-		uuid_copy(((struct cont_prop_set_bylabel_in *)in)->cpsi_pool_uuid, cpsi_pool_uuid);
-	} else if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
-		((struct cont_prop_set_v8_in *)in)->cpsi_prop = cpsi_prop;
-		uuid_copy(((struct cont_prop_set_v8_in *)in)->cpsi_pool_uuid, cpsi_pool_uuid);
+		uuid_copy(((struct cont_prop_set_bylabel_in *)in)->cpsi_op.ci_pool, cpsi_pool_uuid);
 	} else {
-		((struct cont_prop_set_in *)in)->cpsi_prop = cpsi_prop;
-		uuid_copy(((struct cont_prop_set_in *)in)->cpsi_pool_uuid, cpsi_pool_uuid);
+		if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+			((struct cont_prop_set_v9_in *)in)->cpsi_prop = cpsi_prop;
+			uuid_copy(((struct cont_prop_set_v9_in *)in)->cpsi_op.ci_pool,
+				  cpsi_pool_uuid);
+		} else {
+			((struct cont_prop_set_v8_in *)in)->cpsi_prop = cpsi_prop;
+			uuid_copy(((struct cont_prop_set_v8_in *)in)->cpsi_pool_uuid,
+				  cpsi_pool_uuid);
+		}
 	}
 }
 
 static inline void
-cont_prop_set_in_set_cont_uuid(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			       uuid_t cont_uuid)
+cont_prop_set_in_set_cont_uuid(crt_rpc_t *rpc, uuid_t cont_uuid)
 {
 	void *in = crt_req_get(rpc);
 
-	D_ASSERT(opc == CONT_PROP_SET);
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY)
-		uuid_copy(((struct cont_prop_set_v8_in *)in)->cpsi_op.ci_uuid, cont_uuid);
+	D_ASSERT(opc_get(rpc->cr_opc) == CONT_PROP_SET);
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		uuid_copy(((struct cont_prop_set_v9_in *)in)->cpsi_op.ci_uuid, cont_uuid);
 	else
-		uuid_copy(((struct cont_prop_set_in *)in)->cpsi_op.ci_uuid, cont_uuid);
+		uuid_copy(((struct cont_prop_set_v8_in *)in)->cpsi_op.ci_uuid, cont_uuid);
 }
 
 static inline void
-cont_prop_set_bylabel_in_set_label(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-				   const char *label)
+cont_prop_set_bylabel_in_set_label(crt_rpc_t *rpc, const char *label)
 {
 	void *in = crt_req_get(rpc);
 
-	D_ASSERT(opc == CONT_PROP_SET_BYLABEL);
+	D_ASSERT(opc_get(rpc->cr_opc) == CONT_PROP_SET_BYLABEL);
 	/* NB: prop set by label is on the server side only - no version variants */
 	((struct cont_prop_set_bylabel_in *)in)->cpsi_label = label;
 }
 
 /* clang-format off */
 
-#define DAOS_ISEQ_CONT_ACL_UPDATE	/* input fields */		 \
-	((struct cont_op_in)		(caui_op)		CRT_VAR) \
-	((struct daos_acl)		(caui_acl)		CRT_PTR)
-
 #define DAOS_ISEQ_CONT_ACL_UPDATE_V8 	/* input fields */		 \
 	((struct cont_op_v8_in)		(caui_op)		CRT_VAR) \
+	((struct daos_acl)		(caui_acl)		CRT_PTR)
+
+#define DAOS_ISEQ_CONT_ACL_UPDATE_V9	/* input fields */		 \
+	((struct cont_op_v9_in)		(caui_op)		CRT_VAR) \
 	((struct daos_acl)		(caui_acl)		CRT_PTR)
 
 #define DAOS_OSEQ_CONT_ACL_UPDATE	/* output fields */		 \
 	((struct cont_op_out)		(cauo_op)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_acl_update, DAOS_ISEQ_CONT_ACL_UPDATE, DAOS_OSEQ_CONT_ACL_UPDATE)
 CRT_RPC_DECLARE(cont_acl_update_v8, DAOS_ISEQ_CONT_ACL_UPDATE_V8, DAOS_OSEQ_CONT_ACL_UPDATE)
+CRT_RPC_DECLARE(cont_acl_update_v9, DAOS_ISEQ_CONT_ACL_UPDATE_V9, DAOS_OSEQ_CONT_ACL_UPDATE)
 
 /* clang-format on */
 
 static inline void
-cont_acl_update_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			    struct daos_acl **caui_aclp)
+cont_acl_update_in_get_data(crt_rpc_t *rpc, struct daos_acl **caui_aclp)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY)
-		*caui_aclp = ((struct cont_acl_update_v8_in *)in)->caui_acl;
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		*caui_aclp = ((struct cont_acl_update_v9_in *)in)->caui_acl;
 	else
-		*caui_aclp = ((struct cont_acl_update_in *)in)->caui_acl;
+		*caui_aclp = ((struct cont_acl_update_v8_in *)in)->caui_acl;
 }
 
 static inline void
-cont_acl_update_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			    struct daos_acl *caui_acl)
+cont_acl_update_in_set_data(crt_rpc_t *rpc, struct daos_acl *caui_acl)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY)
-		((struct cont_acl_update_v8_in *)in)->caui_acl = caui_acl;
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9)
+		((struct cont_acl_update_v9_in *)in)->caui_acl = caui_acl;
 	else
-		((struct cont_acl_update_in *)in)->caui_acl = caui_acl;
+		((struct cont_acl_update_v8_in *)in)->caui_acl = caui_acl;
 }
 
 /* clang-format off */
-
-#define DAOS_ISEQ_CONT_ACL_DELETE	/* input fields */		 \
-	((struct cont_op_in)		(cadi_op)		CRT_VAR) \
-	((d_string_t)			(cadi_principal_name)	CRT_VAR) \
-	((uint8_t)			(cadi_principal_type)	CRT_VAR)
 
 #define DAOS_ISEQ_CONT_ACL_DELETE_V8	/* input fields */		 \
 	((struct cont_op_v8_in)		(cadi_op)		CRT_VAR) \
 	((d_string_t)			(cadi_principal_name)	CRT_VAR) \
 	((uint8_t)			(cadi_principal_type)	CRT_VAR)
 
+#define DAOS_ISEQ_CONT_ACL_DELETE_V9	/* input fields */		 \
+	((struct cont_op_v9_in)		(cadi_op)		CRT_VAR) \
+	((d_string_t)			(cadi_principal_name)	CRT_VAR) \
+	((uint8_t)			(cadi_principal_type)	CRT_VAR)
+
 #define DAOS_OSEQ_CONT_ACL_DELETE	/* output fields */		 \
 	((struct cont_op_out)		(cado_op)		CRT_VAR)
 
-CRT_RPC_DECLARE(cont_acl_delete, DAOS_ISEQ_CONT_ACL_DELETE, DAOS_OSEQ_CONT_ACL_DELETE)
 CRT_RPC_DECLARE(cont_acl_delete_v8, DAOS_ISEQ_CONT_ACL_DELETE_V8, DAOS_OSEQ_CONT_ACL_DELETE)
+CRT_RPC_DECLARE(cont_acl_delete_v9, DAOS_ISEQ_CONT_ACL_DELETE_V9, DAOS_OSEQ_CONT_ACL_DELETE)
 
 /* clang-format on */
 
 static inline void
-cont_acl_delete_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			    d_string_t *cadi_principal_namep, uint8_t *cadi_principal_typep)
+cont_acl_delete_in_get_data(crt_rpc_t *rpc, d_string_t *cadi_principal_namep,
+			    uint8_t *cadi_principal_typep)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		*cadi_principal_namep = ((struct cont_acl_delete_v9_in *)in)->cadi_principal_name;
+		*cadi_principal_typep = ((struct cont_acl_delete_v9_in *)in)->cadi_principal_type;
+	} else {
 		*cadi_principal_namep = ((struct cont_acl_delete_v8_in *)in)->cadi_principal_name;
 		*cadi_principal_typep = ((struct cont_acl_delete_v8_in *)in)->cadi_principal_type;
-	} else {
-		*cadi_principal_namep = ((struct cont_acl_delete_in *)in)->cadi_principal_name;
-		*cadi_principal_typep = ((struct cont_acl_delete_in *)in)->cadi_principal_type;
 	}
 }
 
 static inline void
-cont_acl_delete_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
-			    d_string_t cadi_principal_name, uint8_t cadi_principal_type)
+cont_acl_delete_in_set_data(crt_rpc_t *rpc, d_string_t cadi_principal_name,
+			    uint8_t cadi_principal_type)
 {
 	void *in = crt_req_get(rpc);
 
-	if (cont_proto_ver >= CONT_PROTO_VER_WITH_SVC_OP_KEY) {
+	if (opc_get_rpc_ver(rpc->cr_opc) >= 9) {
+		((struct cont_acl_delete_v9_in *)in)->cadi_principal_name = cadi_principal_name;
+		((struct cont_acl_delete_v9_in *)in)->cadi_principal_type = cadi_principal_type;
+	} else {
 		((struct cont_acl_delete_v8_in *)in)->cadi_principal_name = cadi_principal_name;
 		((struct cont_acl_delete_v8_in *)in)->cadi_principal_type = cadi_principal_type;
-	} else {
-		((struct cont_acl_delete_in *)in)->cadi_principal_name = cadi_principal_name;
-		((struct cont_acl_delete_in *)in)->cadi_principal_type = cadi_principal_type;
 	}
 }
 
 static inline int
 cont_req_create_common(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,
-		       uint8_t proto_ver, uuid_t ci_pool_hdl, uuid_t ci_uuid, uuid_t ci_hdl,
-		       uint64_t *req_timep, crt_rpc_t **req)
+		       uint8_t proto_ver, uuid_t pool, uuid_t ci_pool_hdl, uuid_t ci_uuid,
+		       uuid_t ci_hdl, uint64_t *req_timep, crt_rpc_t **req)
 {
 	int                rc;
 	crt_opcode_t       opcode;
@@ -1119,6 +1160,12 @@ cont_req_create_common(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode
 	else
 		uuid_copy(in->ci_hdl, ci_hdl);
 
+	if (proto_ver >= CONT_PROTO_VER_WITH_POOL_UUID) {
+		struct cont_op_v9_in *in9 = crt_req_get(*req);
+
+		uuid_copy(in9->ci_pool, pool);
+	}
+
 	if (req_timep && (*req_timep == 0))
 		*req_timep = d_hlc_get();
 
@@ -1137,18 +1184,18 @@ int
 ds_cont_rpc_protocol(uint8_t *cont_ver);
 
 static inline int
-dc_cont_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,
+dc_cont_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc, uuid_t pool,
 		   uuid_t ci_pool_hdl, uuid_t ci_uuid, uuid_t ci_hdl, uint64_t *req_timep,
 		   crt_rpc_t **req)
 {
 	D_ASSERT(dc_cont_proto_version != 0);
 
-	return cont_req_create_common(crt_ctx, tgt_ep, opc, dc_cont_proto_version, ci_pool_hdl,
-				      ci_uuid, ci_hdl, req_timep, req);
+	return cont_req_create_common(crt_ctx, tgt_ep, opc, dc_cont_proto_version, pool,
+				      ci_pool_hdl, ci_uuid, ci_hdl, req_timep, req);
 }
 
 static inline int
-ds_cont_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,
+ds_cont_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc, uuid_t pool,
 		   uuid_t ci_pool_hdl, uuid_t ci_uuid, uuid_t ci_hdl, uint64_t *req_timep,
 		   crt_rpc_t **req)
 {
@@ -1159,8 +1206,8 @@ ds_cont_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t o
 	if (rc)
 		return rc;
 
-	return cont_req_create_common(crt_ctx, tgt_ep, opc, proto_ver, ci_pool_hdl, ci_uuid, ci_hdl,
-				      req_timep, req);
+	return cont_req_create_common(crt_ctx, tgt_ep, opc, proto_ver, pool, ci_pool_hdl, ci_uuid,
+				      ci_hdl, req_timep, req);
 }
 
 #endif /* __CONTAINER_RPC_H__ */

--- a/src/container/srv.c
+++ b/src/container/srv.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -85,11 +85,11 @@ static struct crt_corpc_ops ds_cont_tgt_snapshot_notify_co_ops = {
 	    .dr_corpc_ops = e,                                                                     \
 	},
 
-static struct daos_rpc_handler cont_handlers_v8[] = {
-    CONT_PROTO_CLI_RPC_LIST(8, ds_cont_op_handler_v8) CONT_PROTO_SRV_RPC_LIST};
+static struct daos_rpc_handler cont_handlers_v9[] = {CONT_PROTO_CLI_RPC_LIST(9)
+							 CONT_PROTO_SRV_RPC_LIST};
 
-static struct daos_rpc_handler cont_handlers_v7[] = {
-    CONT_PROTO_CLI_RPC_LIST(7, ds_cont_op_handler_v7) CONT_PROTO_SRV_RPC_LIST};
+static struct daos_rpc_handler cont_handlers_v8[] = {CONT_PROTO_CLI_RPC_LIST(8)
+							 CONT_PROTO_SRV_RPC_LIST};
 
 #undef X
 
@@ -154,9 +154,9 @@ struct dss_module cont_module = {
     .sm_proto_count = 2,
     .sm_init        = init,
     .sm_fini        = fini,
-    .sm_proto_fmt   = {&cont_proto_fmt_v7, &cont_proto_fmt_v8},
+    .sm_proto_fmt   = {&cont_proto_fmt_v8, &cont_proto_fmt_v9},
     .sm_cli_count   = {CONT_PROTO_CLI_COUNT, CONT_PROTO_CLI_COUNT},
-    .sm_handlers    = {cont_handlers_v7, cont_handlers_v8},
+    .sm_handlers    = {cont_handlers_v8, cont_handlers_v9},
     .sm_key         = &cont_module_key,
     .sm_metrics     = &cont_metrics,
 };

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1029,10 +1029,9 @@ cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop,
 }
 
 static int
-cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *svc, crt_rpc_t *rpc,
-	    int cont_proto_ver)
+cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *svc, crt_rpc_t *rpc)
 {
-	struct cont_create_in  *in = crt_req_get(rpc);
+	struct cont_op_in      *in       = crt_req_get(rpc);
 	daos_prop_t	       *prop_dup = NULL;
 	d_iov_t			key;
 	d_iov_t			value;
@@ -1047,14 +1046,13 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 	daos_prop_t            *cprop      = NULL;
 	int			rc;
 
-	D_DEBUG(DB_MD, DF_CONT": processing rpc %p\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid), rpc);
+	D_DEBUG(DB_MD, DF_CONT ": processing rpc %p\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc);
 
 	/* Verify the pool handle capabilities. */
 	if (!ds_sec_pool_can_create_cont(pool_hdl->sph_sec_capas)) {
-		D_ERROR(DF_CONT": permission denied to create cont\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cci_op.ci_uuid));
+		D_ERROR(DF_CONT ": permission denied to create cont\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 		D_GOTO(out, rc = -DER_NO_PERM);
 	}
 
@@ -1063,7 +1061,7 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 	if (rc != 0)
 		goto out;
 
-	cont_create_in_get_data(rpc, CONT_CREATE, cont_proto_ver, &cprop);
+	cont_create_in_get_data(rpc, &cprop);
 
 	/* Determine if the label property was supplied, and if so,
 	 * verify that it is not the default unset label.
@@ -1074,8 +1072,8 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 	if (lbl_ent != NULL && lbl_ent->dpe_str != NULL) {
 		if (strncmp(def_lbl_ent->dpe_str, lbl_ent->dpe_str,
 			    DAOS_PROP_LABEL_MAX_LEN) == 0) {
-			D_ERROR(DF_CONT": label is the same as default label\n",
-				DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
+			D_ERROR(DF_CONT ": label is the same as default label\n",
+				DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 			D_GOTO(out, rc = -DER_INVAL);
 		}
 		lbl = lbl_ent->dpe_str;
@@ -1089,30 +1087,26 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 	else
 		prop_dup = daos_prop_dup(&cont_prop_default, false, false);
 	if (prop_dup == NULL) {
-		D_ERROR(DF_CONT" daos_prop_dup failed.\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cci_op.ci_uuid));
+		D_ERROR(DF_CONT " daos_prop_dup failed.\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 		D_GOTO(out, rc = -DER_NOMEM);
 	}
 	rc = cont_create_prop_prepare(pool_hdl, prop_dup, cprop);
 	if (rc != 0) {
-		D_ERROR(DF_CONT" cont_create_prop_prepare failed: "DF_RC"\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cci_op.ci_uuid), DP_RC(rc));
+		D_ERROR(DF_CONT " cont_create_prop_prepare failed: " DF_RC "\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
 	/* Check if a container with this UUID and label already exists */
-	rc = cont_create_existence_check(tx, svc, pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid,
-					 lbl);
+	rc = cont_create_existence_check(tx, svc, pool_hdl->sph_pool->sp_uuid, in->ci_uuid, lbl);
 	if (rc != -DER_NONEXIST) {
 		if (rc == -DER_EXIST)
 			D_ERROR(DF_CONT ": container already exists\n",
-				DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
+				DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 		else
 			D_ERROR(DF_CONT ": container lookup failed: " DF_RC "\n",
-				DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid),
-				DP_RC(rc));
+				DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
@@ -1123,15 +1117,14 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 	 */
 
 	/* Create the container property KVS under the container KVS. */
-	d_iov_set(&key, in->cci_op.ci_uuid, sizeof(uuid_t));
+	d_iov_set(&key, in->ci_uuid, sizeof(uuid_t));
 	attr.dsa_class = RDB_KVS_GENERIC;
 	attr.dsa_order = 16;
 	rc = rdb_tx_create_kvs(tx, &svc->cs_conts, &key, &attr);
 	if (rc != 0) {
-		D_ERROR(DF_CONT" failed to create container attribute KVS: "
-			""DF_RC"\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cci_op.ci_uuid), DP_RC(rc));
+		D_ERROR(DF_CONT " failed to create container attribute KVS: "
+				"" DF_RC "\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
@@ -1148,7 +1141,7 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 	rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_ghce, &value);
 	if (rc != 0) {
 		DL_ERROR(rc, DF_CONT ": create ghce property failed",
-			 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
+			 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 		D_GOTO(out_kvs, rc);
 	}
 
@@ -1157,7 +1150,7 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 	rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_alloced_oid, &value);
 	if (rc != 0) {
 		DL_ERROR(rc, DF_CONT ": create alloced_oid prop failed",
-			 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
+			 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 		D_GOTO(out_kvs, rc);
 	}
 
@@ -1171,11 +1164,11 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 		rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_co_md_times, &value);
 		if (rc != 0) {
 			DL_ERROR(rc, DF_CONT ": create co_md_times failed",
-				 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
+				 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 			D_GOTO(out_kvs, rc);
 		}
-		D_DEBUG(DB_MD, DF_CONT": set metadata times: open="DF_X64", modify="DF_X64"\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid), mdtimes.otime,
+		D_DEBUG(DB_MD, DF_CONT ": set metadata times: open=" DF_X64 ", modify=" DF_X64 "\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), mdtimes.otime,
 			mdtimes.mtime);
 	}
 
@@ -1187,7 +1180,7 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 		rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_nhandles, &value);
 		if (rc != 0) {
 			DL_ERROR(rc, DF_CONT ": create nhandles failed",
-				 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
+				 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 			goto out_kvs;
 		}
 	}
@@ -1195,9 +1188,8 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 	/* write container properties to rdb. */
 	rc = cont_prop_write(tx, &kvs, prop_dup, true);
 	if (rc != 0) {
-		D_ERROR(DF_CONT" cont_prop_write failed: "DF_RC"\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cci_op.ci_uuid), DP_RC(rc));
+		D_ERROR(DF_CONT " cont_prop_write failed: " DF_RC "\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), DP_RC(rc));
 		D_GOTO(out_kvs, rc);
 	}
 
@@ -1207,15 +1199,15 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 		 * not be an entry with this label in cs_uuids. Just update.
 		 */
 		d_iov_set(&key, lbl, strnlen(lbl, DAOS_PROP_MAX_LABEL_BUF_LEN));
-		d_iov_set(&value, in->cci_op.ci_uuid, sizeof(uuid_t));
+		d_iov_set(&value, in->ci_uuid, sizeof(uuid_t));
 		rc = rdb_tx_update(tx, &svc->cs_uuids, &key, &value);
 		if (rc != 0) {
 			DL_ERROR(rc, DF_CONT ": update cs_uuids failed",
-				 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
+				 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 			D_GOTO(out_kvs, rc);
 		}
-		D_DEBUG(DB_MD, DF_CONT": creating container, label: %s\n",
-			DP_CONT(svc->cs_pool_uuid, in->cci_op.ci_uuid), lbl);
+		D_DEBUG(DB_MD, DF_CONT ": creating container, label: %s\n",
+			DP_CONT(svc->cs_pool_uuid, in->ci_uuid), lbl);
 	}
 
 	/* Create the snapshot KVS. */
@@ -1223,15 +1215,15 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 	rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_nsnapshots, &value);
 	if (rc != 0) {
 		DL_ERROR(rc, DF_CONT ": failed to update nsnapshots",
-			 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
+			 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 		D_GOTO(out_kvs, rc);
 	}
 	attr.dsa_class = RDB_KVS_INTEGER;
 	attr.dsa_order = 16;
 	rc = rdb_tx_create_kvs(tx, &kvs, &ds_cont_prop_snapshots, &attr);
 	if (rc != 0) {
-		D_ERROR(DF_CONT" failed to create container snapshots KVS: "DF_RC"\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid), DP_RC(rc));
+		D_ERROR(DF_CONT " failed to create container snapshots KVS: " DF_RC "\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), DP_RC(rc));
 		D_GOTO(out_kvs, rc);
 	}
 
@@ -1240,10 +1232,9 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 	attr.dsa_order = 16;
 	rc = rdb_tx_create_kvs(tx, &kvs, &ds_cont_attr_user, &attr);
 	if (rc != 0) {
-		D_ERROR(DF_CONT" failed to create container user attr KVS: "
-			""DF_RC"\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cci_op.ci_uuid), DP_RC(rc));
+		D_ERROR(DF_CONT " failed to create container user attr KVS: "
+				"" DF_RC "\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), DP_RC(rc));
 		D_GOTO(out_kvs, rc);
 	}
 
@@ -1252,10 +1243,9 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 	attr.dsa_order = 16;
 	rc = rdb_tx_create_kvs(tx, &kvs, &ds_cont_prop_handles, &attr);
 	if (rc != 0) {
-		D_ERROR(DF_CONT" failed to create container handle index KVS: "
-			""DF_RC"\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cci_op.ci_uuid), DP_RC(rc));
+		D_ERROR(DF_CONT " failed to create container handle index KVS: "
+				"" DF_RC "\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), DP_RC(rc));
 		D_GOTO(out_kvs, rc);
 	}
 
@@ -1265,10 +1255,9 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 		attr.dsa_order = 16;
 		rc = rdb_tx_create_kvs(tx, &kvs, &ds_cont_prop_oit_oids, &attr);
 		if (rc != 0) {
-			D_ERROR(DF_CONT" failed to create container oit oids KVS: "
-				""DF_RC"\n",
-				DP_CONT(pool_hdl->sph_pool->sp_uuid,
-					in->cci_op.ci_uuid), DP_RC(rc));
+			D_ERROR(DF_CONT " failed to create container oit oids KVS: "
+					"" DF_RC "\n",
+				DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), DP_RC(rc));
 			D_GOTO(out_kvs, rc);
 		}
 	}
@@ -1579,8 +1568,7 @@ static void
 cont_track_eph_leader_delete(struct cont_svc *svc, uuid_t cont_uuid);
 
 static int
-cont_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont, crt_rpc_t *rpc,
-	     int cont_proto_ver)
+cont_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont, crt_rpc_t *rpc)
 {
 	d_iov_t				val;
 	int				rc;
@@ -1590,7 +1578,7 @@ cont_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	uint32_t                        force;
 	struct daos_acl                *acl;
 
-	cont_destroy_in_get_data(rpc, opc_get(rpc->cr_opc), cont_proto_ver, &force, NULL);
+	cont_destroy_in_get_data(rpc, &force, NULL);
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p force=%u\n",
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, cont->c_uuid), rpc, force);
 
@@ -1658,8 +1646,7 @@ out:
 }
 
 static int
-cont_destroy_post(struct ds_pool_hdl *pool_hdl, struct cont_svc *svc, uuid_t uuid, crt_rpc_t *rpc,
-		  int cont_proto_ver)
+cont_destroy_post(struct ds_pool_hdl *pool_hdl, struct cont_svc *svc, uuid_t uuid, crt_rpc_t *rpc)
 {
 	struct rdb_tx           tx;
 	struct cont            *cont;
@@ -2629,10 +2616,10 @@ check_hdl_compatibility(struct rdb_tx *tx, struct cont *cont, uint64_t flags)
 
 static int
 cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont, crt_rpc_t *rpc,
-	  int cont_proto_ver, bool dup_op, struct ds_pool_svc_op_val *op_val)
+	  bool dup_op, struct ds_pool_svc_op_val *op_val)
 {
-	struct cont_open_in    *in = crt_req_get(rpc);
-	struct cont_open_out   *out = crt_reply_get(rpc);
+	struct cont_op_in       *in  = crt_req_get(rpc);
+	struct cont_open_v8_out *out = crt_reply_get(rpc);
 	d_iov_t			key;
 	d_iov_t			value;
 	daos_prop_t	       *prop = NULL;
@@ -2656,11 +2643,11 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont, cr
 	uint64_t                prop_bits;
 	uint32_t		pool_global_version = cont->c_svc->cs_pool->sp_global_version;
 
-	cont_open_in_get_data(rpc, opc_get(rpc->cr_opc), cont_proto_ver, &flags, &prop_bits, NULL);
+	cont_open_in_get_data(rpc, &flags, &prop_bits, NULL);
 	update_otime = ((flags & NOSTAT) == NOSTAT) ? false : true;
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p hdl=" DF_UUID " flags=" DF_X64 "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, cont->c_uuid), rpc, DP_UUID(in->coi_op.ci_hdl),
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, cont->c_uuid), rpc, DP_UUID(in->ci_hdl),
 		flags);
 
 	if (dup_op) {
@@ -2670,13 +2657,12 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont, cr
 	}
 
 	/* See if this container handle already exists. */
-	d_iov_set(&key, in->coi_op.ci_hdl, sizeof(uuid_t));
+	d_iov_set(&key, in->ci_hdl, sizeof(uuid_t));
 	d_iov_set(&value, &chdl, sizeof(chdl));
 	rc = rdb_tx_lookup(tx, &cont->c_svc->cs_hdls, &key, &value);
 	if (rc != -DER_NONEXIST) {
 		D_DEBUG(DB_MD, DF_CONT "/" DF_UUID ": Container handle already open.\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid, cont->c_uuid),
-			DP_UUID(in->coi_op.ci_hdl));
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, cont->c_uuid), DP_UUID(in->ci_hdl));
 		if (rc == 0 && chdl.ch_flags != flags) {
 			D_ERROR(DF_CONT": found conflicting container handle\n",
 				DP_CONT(cont->c_svc->cs_pool_uuid,
@@ -2840,7 +2826,7 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont, cr
 	}
 
 	if (opc_get(rpc->cr_opc) == CONT_OPEN_BYLABEL) {
-		struct cont_open_bylabel_out *out_lbl = crt_reply_get(rpc);
+		struct cont_open_bylabel_v8_out *out_lbl = crt_reply_get(rpc);
 
 		out_lbl->coo_md_otime = mdtimes.otime;
 		out_lbl->coo_md_mtime = mdtimes.mtime;
@@ -2857,8 +2843,8 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont, cr
 	}
 
 	/* update container capa to IV */
-	rc = cont_iv_capability_update(pool_hdl->sph_pool->sp_iv_ns, in->coi_op.ci_hdl,
-				       cont->c_uuid, flags, sec_capas, stat_pm_ver);
+	rc = cont_iv_capability_update(pool_hdl->sph_pool->sp_iv_ns, in->ci_hdl, cont->c_uuid,
+				       flags, sec_capas, stat_pm_ver);
 	if (rc != 0) {
 		DL_ERROR(rc, DF_CONT ": cont_iv_capability_update failed",
 			 DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid));
@@ -2948,8 +2934,7 @@ out:
 			out->coo_prop = prop;
 	}
 	if (rc != 0 && cont_hdl_opened)
-		cont_iv_capability_invalidate(pool_hdl->sph_pool->sp_iv_ns,
-					      in->coi_op.ci_hdl,
+		cont_iv_capability_invalidate(pool_hdl->sph_pool->sp_iv_ns, in->ci_hdl,
 					      CRT_IV_SYNC_EAGER);
 	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, cont->c_uuid), rpc, DP_RC(rc));
@@ -3143,7 +3128,7 @@ static int
 cont_close(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	   crt_rpc_t *rpc, bool *update_mtime)
 {
-	struct cont_close_in	       *in = crt_req_get(rpc);
+	struct cont_op_in              *in = crt_req_get(rpc);
 	d_iov_t				key;
 	d_iov_t				value;
 	struct container_hdl		chdl;
@@ -3152,30 +3137,27 @@ cont_close(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	int				rc;
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p hdl=" DF_UUID "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid), rpc,
-		DP_UUID(in->cci_op.ci_hdl));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_UUID(in->ci_hdl));
 
 	/* See if this container handle is already closed. */
-	d_iov_set(&key, in->cci_op.ci_hdl, sizeof(uuid_t));
+	d_iov_set(&key, in->ci_hdl, sizeof(uuid_t));
 	d_iov_set(&value, &chdl, sizeof(chdl));
 	rc = rdb_tx_lookup(tx, &cont->c_svc->cs_hdls, &key, &value);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST) {
-			D_DEBUG(DB_MD, DF_CONT": already closed: "DF_UUID"\n",
-				DP_CONT(cont->c_svc->cs_pool->sp_uuid,
-					cont->c_uuid),
-				DP_UUID(in->cci_op.ci_hdl));
+			D_DEBUG(DB_MD, DF_CONT ": already closed: " DF_UUID "\n",
+				DP_CONT(cont->c_svc->cs_pool->sp_uuid, cont->c_uuid),
+				DP_UUID(in->ci_hdl));
 			rc = 0;
 		}
 		D_GOTO(out, rc);
 	}
 
-	uuid_copy(rec.tcr_hdl, in->cci_op.ci_hdl);
+	uuid_copy(rec.tcr_hdl, in->ci_hdl);
 	rec.tcr_hce = chdl.ch_hce;
 
-	D_DEBUG(DB_MD, DF_CONT": closing: hdl="DF_UUID" hce="DF_U64"\n",
-		DP_CONT(cont->c_svc->cs_pool_uuid, in->cci_op.ci_uuid),
-		DP_UUID(rec.tcr_hdl), rec.tcr_hce);
+	D_DEBUG(DB_MD, DF_CONT ": closing: hdl=" DF_UUID " hce=" DF_U64 "\n",
+		DP_CONT(cont->c_svc->cs_pool_uuid, in->ci_uuid), DP_UUID(rec.tcr_hdl), rec.tcr_hce);
 
 	rc = cont_close_recs(rpc->cr_ctx, cont->c_svc, &rec, 1 /* nrecs */);
 	if (rc != 0)
@@ -3190,7 +3172,7 @@ cont_close(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 out:
 	*update_mtime = update_mtime_needed;
 	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid), rpc, DP_RC(rc));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_RC(rc));
 	return rc;
 }
 
@@ -3198,8 +3180,7 @@ out:
  * Currently this does not do much and is not used. Kept for future expansion.
  */
 static int
-cont_query_bcast(crt_context_t ctx, struct cont *cont, const uuid_t pool_hdl,
-		 const uuid_t cont_hdl, struct cont_query_out *query_out)
+cont_query_bcast(crt_context_t ctx, struct cont *cont, const uuid_t pool_hdl, const uuid_t cont_hdl)
 {
 	struct	cont_tgt_query_in	*in;
 	struct  cont_tgt_query_out	*out;
@@ -3216,7 +3197,7 @@ cont_query_bcast(crt_context_t ctx, struct cont *cont, const uuid_t pool_hdl,
 		D_GOTO(out, rc);
 
 	in = crt_req_get(rpc);
-	uuid_copy(in->tqi_pool_uuid, pool_hdl);
+	uuid_copy(in->tqi_pool_uuid, cont->c_svc->cs_pool_uuid);
 	uuid_copy(in->tqi_cont_uuid, cont->c_uuid);
 	out = crt_reply_get(rpc);
 	out->tqo_hae = DAOS_EPOCH_MAX;
@@ -3708,8 +3689,7 @@ hdl_has_query_access(struct container_hdl *hdl, struct cont *cont,
 }
 
 static int
-cont_status_check(struct rdb_tx *tx, struct ds_pool *pool, struct cont *cont,
-		  struct cont_query_in *in, daos_prop_t *prop,
+cont_status_check(struct rdb_tx *tx, struct ds_pool *pool, struct cont *cont, daos_prop_t *prop,
 		  uint32_t last_ver)
 {
 	struct daos_prop_entry	*entry;
@@ -3797,27 +3777,26 @@ out:
 
 static int
 cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-	   struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+	   struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	struct cont_query_in   *in  = crt_req_get(rpc);
-	struct cont_query_out  *out = crt_reply_get(rpc);
-	daos_cont_info_t	cinfo;
-	uint64_t                qbits;
-	daos_prop_t	       *prop = NULL;
-	uint32_t		last_ver = 0;
-	int			rc = 0;
+	struct cont_op_in        *in  = crt_req_get(rpc);
+	struct cont_query_v8_out *out = crt_reply_get(rpc);
+	daos_cont_info_t          cinfo;
+	uint64_t                  qbits;
+	daos_prop_t              *prop     = NULL;
+	uint32_t                  last_ver = 0;
+	int                       rc       = 0;
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p hdl=" DF_UUID "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cqi_op.ci_uuid), rpc,
-		DP_UUID(in->cqi_op.ci_hdl));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_UUID(in->ci_hdl));
 
-	cont_query_in_get_data(rpc, CONT_QUERY, cont_proto_ver, &qbits);
+	cont_query_in_get_data(rpc, &qbits);
 
 	if (!hdl_has_query_access(hdl, cont, qbits))
 		return -DER_NO_PERM;
 
 	/* Read container info */
-	rc = cont_info_read(tx, cont, cont_proto_ver, &cinfo);
+	rc = cont_info_read(tx, cont, opc_get_rpc_ver(rpc->cr_opc), &cinfo);
 	if (rc != 0) {
 		D_ERROR(DF_CONT": failed to read container info, "DF_RC"\n",
 			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
@@ -3838,8 +3817,7 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	if (qbits & DAOS_CO_QUERY_TGT) {
 		/* need RF if user query cont_info */
 		qbits |= (DAOS_CO_QUERY_PROP_REDUN_FAC | DAOS_CO_QUERY_PROP_REDUN_LVL);
-		rc = cont_query_bcast(rpc->cr_ctx, cont, in->cqi_op.ci_pool_hdl,
-				      in->cqi_op.ci_hdl, out);
+		rc = cont_query_bcast(rpc->cr_ctx, cont, in->ci_pool_hdl, in->ci_hdl);
 		if (rc)
 			return rc;
 	}
@@ -3854,9 +3832,8 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	rc            = cont_prop_read(tx, cont, qbits, &prop, true);
 	out->cqo_prop = prop;
 	if (rc) {
-		D_ERROR(DF_CONT": cont_prop_read failed "DF_RC"\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cqi_op.ci_uuid), DP_RC(rc));
+		D_ERROR(DF_CONT ": cont_prop_read failed " DF_RC "\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), DP_RC(rc));
 		goto out;
 	}
 
@@ -3865,12 +3842,10 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	 */
 	if ((qbits & DAOS_CO_QUERY_PROP_CO_STATUS) && cont_status_is_healthy(prop, &last_ver)) {
 		D_ASSERT(qbits & DAOS_CO_QUERY_PROP_REDUN_FAC);
-		rc = cont_status_check(tx, pool_hdl->sph_pool, cont, in, prop,
-				       last_ver);
+		rc = cont_status_check(tx, pool_hdl->sph_pool, cont, prop, last_ver);
 		if (rc) {
-			D_ERROR(DF_CONT": cont_status_verify failed "DF_RC"\n",
-				DP_CONT(pool_hdl->sph_pool->sp_uuid,
-					in->cqi_op.ci_uuid), DP_RC(rc));
+			D_ERROR(DF_CONT ": cont_status_verify failed " DF_RC "\n",
+				DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), DP_RC(rc));
 			goto out;
 		}
 	}
@@ -3884,8 +3859,7 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 		if (iv_prop == NULL)
 			return -DER_NOMEM;
 
-		rc = cont_iv_prop_fetch(pool_hdl->sph_pool->sp_uuid,
-					in->cqi_op.ci_uuid, iv_prop);
+		rc = cont_iv_prop_fetch(pool_hdl->sph_pool->sp_uuid, in->ci_uuid, iv_prop);
 		if (rc) {
 			D_ERROR("cont_iv_prop_fetch failed "DF_RC"\n",
 				DP_RC(rc));
@@ -4216,16 +4190,15 @@ out:
 
 int
 ds_cont_prop_set(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-		 struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+		 struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	struct cont_prop_set_in		*in  = crt_req_get(rpc);
+	struct cont_op_in               *in = crt_req_get(rpc);
 	daos_prop_t                     *prop_in;
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p hdl=" DF_UUID "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cpsi_op.ci_uuid), rpc,
-		DP_UUID(in->cpsi_op.ci_hdl));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_UUID(in->ci_hdl));
 
-	cont_prop_set_in_get_data(rpc, CONT_PROP_SET, cont_proto_ver, &prop_in, NULL, NULL, NULL);
+	cont_prop_set_in_get_data(rpc, &prop_in, NULL, NULL, NULL);
 
 	return set_prop(tx, pool_hdl->sph_pool, cont, hdl->ch_sec_capas, prop_in);
 }
@@ -4291,19 +4264,18 @@ out:
 
 int
 ds_cont_acl_update(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-		   struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+		   struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	struct cont_acl_update_in	*in  = crt_req_get(rpc);
-	int				rc = 0;
-	struct daos_acl			*acl_in;
-	struct daos_acl			*acl = NULL;
-	struct daos_ace			*ace;
+	struct cont_op_in *in = crt_req_get(rpc);
+	int                rc = 0;
+	struct daos_acl   *acl_in;
+	struct daos_acl   *acl = NULL;
+	struct daos_ace   *ace;
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p hdl=" DF_UUID "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->caui_op.ci_uuid), rpc,
-		DP_UUID(in->caui_op.ci_hdl));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_UUID(in->ci_hdl));
 
-	cont_acl_update_in_get_data(rpc, CONT_ACL_UPDATE, cont_proto_ver, &acl_in);
+	cont_acl_update_in_get_data(rpc, &acl_in);
 
 	if (daos_acl_validate(acl_in) != 0)
 		D_GOTO(out, rc = -DER_INVAL);
@@ -4325,7 +4297,7 @@ ds_cont_acl_update(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont 
 	}
 
 	/* Just need to re-set the ACL prop with the merged ACL */
-	rc = set_acl(tx, pool_hdl, cont, hdl, in->caui_op.ci_hdl, acl);
+	rc = set_acl(tx, pool_hdl, cont, hdl, in->ci_hdl, acl);
 
 out_acl:
 	daos_acl_free(acl);
@@ -4335,20 +4307,18 @@ out:
 
 int
 ds_cont_acl_delete(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-		   struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+		   struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	struct cont_acl_delete_in	*in  = crt_req_get(rpc);
-	d_string_t                       principal_name;
-	uint8_t                          principal_type;
-	struct daos_acl			*acl = NULL;
-	int				 rc = 0;
+	struct cont_op_in *in = crt_req_get(rpc);
+	d_string_t         principal_name;
+	uint8_t            principal_type;
+	struct daos_acl   *acl = NULL;
+	int                rc  = 0;
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p hdl=" DF_UUID "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cadi_op.ci_uuid), rpc,
-		DP_UUID(in->cadi_op.ci_hdl));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_UUID(in->ci_hdl));
 
-	cont_acl_delete_in_get_data(rpc, CONT_ACL_DELETE, cont_proto_ver, &principal_name,
-				    &principal_type);
+	cont_acl_delete_in_get_data(rpc, &principal_name, &principal_type);
 	rc = get_acl(tx, cont, &acl);
 	if (rc != 0)
 		D_GOTO(out, rc);
@@ -4361,7 +4331,7 @@ ds_cont_acl_delete(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont 
 	}
 
 	/* Re-set the ACL prop with the updated ACL */
-	rc = set_acl(tx, pool_hdl, cont, hdl, in->cadi_op.ci_hdl, acl);
+	rc = set_acl(tx, pool_hdl, cont, hdl, in->ci_hdl, acl);
 
 out_acl:
 	daos_acl_free(acl);
@@ -4371,94 +4341,86 @@ out:
 
 static int
 cont_attr_set(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-	      struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+	      struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	struct cont_attr_set_in		*in = crt_req_get(rpc);
+	struct cont_op_in               *in = crt_req_get(rpc);
 	crt_bulk_t                       bulk;
 	uint64_t                         count;
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p hdl=" DF_UUID "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->casi_op.ci_uuid), rpc,
-		DP_UUID(in->casi_op.ci_hdl));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_UUID(in->ci_hdl));
 
 	if (!ds_sec_cont_can_write_data(hdl->ch_sec_capas)) {
-		D_ERROR(DF_CONT": permission denied to set container attr\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->casi_op.ci_uuid));
+		D_ERROR(DF_CONT ": permission denied to set container attr\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 		return -DER_NO_PERM;
 	}
 
-	cont_attr_set_in_get_data(rpc, CONT_ATTR_SET, cont_proto_ver, &count, &bulk);
+	cont_attr_set_in_get_data(rpc, &count, &bulk);
 
 	return ds_rsvc_set_attr(cont->c_svc->cs_rsvc, tx, &cont->c_user, bulk, rpc, count);
 }
 
 static int
 cont_attr_del(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-	      struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+	      struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	struct cont_attr_del_in		*in = crt_req_get(rpc);
+	struct cont_op_in               *in = crt_req_get(rpc);
 	crt_bulk_t                       bulk;
 	uint64_t                         count;
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p hdl=" DF_UUID "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cadi_op.ci_uuid), rpc,
-		DP_UUID(in->cadi_op.ci_hdl));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_UUID(in->ci_hdl));
 
 	if (!ds_sec_cont_can_write_data(hdl->ch_sec_capas)) {
-		D_ERROR(DF_CONT": permission denied to del container attr\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cadi_op.ci_uuid));
+		D_ERROR(DF_CONT ": permission denied to del container attr\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 		return -DER_NO_PERM;
 	}
 
-	cont_attr_del_in_get_data(rpc, CONT_ATTR_DEL, cont_proto_ver, &count, &bulk);
+	cont_attr_del_in_get_data(rpc, &count, &bulk);
 	return ds_rsvc_del_attr(cont->c_svc->cs_rsvc, tx, &cont->c_user, bulk, rpc, count);
 }
 
 static int
 cont_attr_get(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-	      struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+	      struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	struct cont_attr_get_in		*in = crt_req_get(rpc);
-	uint64_t                         count;
-	uint64_t                         key_length;
-	crt_bulk_t                       bulk;
+	struct cont_op_in *in = crt_req_get(rpc);
+	uint64_t           count;
+	uint64_t           key_length;
+	crt_bulk_t         bulk;
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p hdl=" DF_UUID "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cagi_op.ci_uuid), rpc,
-		DP_UUID(in->cagi_op.ci_hdl));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_UUID(in->ci_hdl));
 
 	if (!ds_sec_cont_can_read_data(hdl->ch_sec_capas)) {
-		D_ERROR(DF_CONT": permission denied to get container attr\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cagi_op.ci_uuid));
+		D_ERROR(DF_CONT ": permission denied to get container attr\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 		return -DER_NO_PERM;
 	}
 
-	cont_attr_get_in_get_data(rpc, CONT_ATTR_GET, cont_proto_ver, &count, &key_length, &bulk);
+	cont_attr_get_in_get_data(rpc, &count, &key_length, &bulk);
 	return ds_rsvc_get_attr(cont->c_svc->cs_rsvc, tx, &cont->c_user, bulk, rpc, count,
 				key_length);
 }
 
 static int
 cont_attr_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-	       struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+	       struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	struct cont_attr_list_in	*in	    = crt_req_get(rpc);
-	crt_bulk_t                       bulk;
-	struct cont_attr_list_out	*out	    = crt_reply_get(rpc);
+	struct cont_op_in            *in = crt_req_get(rpc);
+	crt_bulk_t                    bulk;
+	struct cont_attr_list_v8_out *out = crt_reply_get(rpc);
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p hdl=" DF_UUID "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cali_op.ci_uuid), rpc,
-		DP_UUID(in->cali_op.ci_hdl));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_UUID(in->ci_hdl));
 
-	cont_attr_list_in_get_data(rpc, CONT_ATTR_LIST, cont_proto_ver, &bulk);
+	cont_attr_list_in_get_data(rpc, &bulk);
 
 	if (!ds_sec_cont_can_read_data(hdl->ch_sec_capas)) {
-		D_ERROR(DF_CONT": permission denied to list container attr\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cali_op.ci_uuid));
+		D_ERROR(DF_CONT ": permission denied to list container attr\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid));
 		return -DER_NO_PERM;
 	}
 
@@ -5548,7 +5510,7 @@ out_svc:
 
 static int
 cont_op_with_hdl(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-		 struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver, bool dup_op,
+		 struct container_hdl *hdl, crt_rpc_t *rpc, bool dup_op,
 		 struct ds_pool_svc_op_val *op_val, bool *update_mtime)
 {
 	struct cont_pool_metrics *metrics;
@@ -5558,73 +5520,73 @@ cont_op_with_hdl(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *c
 
 	switch (opc_get(rpc->cr_opc)) {
 	case CONT_QUERY:
-		rc = cont_query(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		rc = cont_query(tx, pool_hdl, cont, hdl, rpc);
 		if (likely(rc == 0)) {
 			metrics = pool_hdl->sph_pool->sp_metrics[DAOS_CONT_MODULE];
 			d_tm_inc_counter(metrics->query_total, 1);
 		}
 		return rc;
 	case CONT_ATTR_LIST:
-		return cont_attr_list(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		return cont_attr_list(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_ATTR_GET:
-		return cont_attr_get(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		return cont_attr_get(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_ATTR_SET:
 		if (dup_op)
 			return 0; /* reply rc will be op_val->ov_rc */
 		*update_mtime = true;
-		return cont_attr_set(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		return cont_attr_set(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_ATTR_DEL:
 		if (dup_op)
 			return 0; /* reply rc will be op_val->ov_rc */
 		*update_mtime = true;
-		return cont_attr_del(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		return cont_attr_del(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_EPOCH_AGGREGATE:
 		/* dead code? */
 		*update_mtime = true;
-		return ds_cont_epoch_aggregate(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		return ds_cont_epoch_aggregate(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_SNAP_LIST:
-		return ds_cont_snap_list(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		return ds_cont_snap_list(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_SNAP_CREATE:
 		if (dup_op) {
-			struct cont_epoch_op_out *out = crt_reply_get(rpc);
+			struct cont_epoch_op_v8_out *out = crt_reply_get(rpc);
 
 			out->ceo_epoch = *(daos_epoch_t *)op_val->ov_resvd;
 			return 0; /* reply rc will be op_val->ov_rc; */
 		}
 		*update_mtime = true;
-		return ds_cont_snap_create(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver, op_val);
+		return ds_cont_snap_create(tx, pool_hdl, cont, hdl, rpc, op_val);
 	case CONT_SNAP_DESTROY:
 		if (dup_op)
 			return 0; /* reply rc will be op_val->ov_rc */
 		*update_mtime = true;
-		return ds_cont_snap_destroy(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		return ds_cont_snap_destroy(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_PROP_SET:
 		if (dup_op)
 			return 0; /* reply rc will be op_val->ov_rc */
 		*update_mtime = true;
-		return ds_cont_prop_set(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		return ds_cont_prop_set(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_ACL_UPDATE:
 		if (dup_op)
 			return 0; /* reply rc will be op_val->ov_rc */
 		*update_mtime = true;
-		return ds_cont_acl_update(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		return ds_cont_acl_update(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_ACL_DELETE:
 		if (dup_op)
 			return 0; /* reply rc will be op_val->ov_rc */
 		*update_mtime = true;
-		return ds_cont_acl_delete(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		return ds_cont_acl_delete(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_SNAP_OIT_OID_GET:
-		return ds_cont_snap_oit_oid_get(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		return ds_cont_snap_oit_oid_get(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_SNAP_OIT_CREATE:
 		if (dup_op)
 			return 0; /* reply rc will be op_val->ov_rc */
 		*update_mtime = true;
-		return ds_cont_snap_oit_create(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		return ds_cont_snap_oit_create(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_SNAP_OIT_DESTROY:
 		if (dup_op)
 			return 0; /* reply rc will be op_val->ov_rc */
 		*update_mtime = true;
-		return ds_cont_snap_oit_destroy(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
+		return ds_cont_snap_oit_destroy(tx, pool_hdl, cont, hdl, rpc);
 	default:
 		D_ASSERT(0);
 	}
@@ -5638,7 +5600,7 @@ cont_op_with_hdl(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *c
  */
 static int
 cont_op_with_cont(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-		  crt_rpc_t *rpc, bool *update_mtime, int cont_proto_ver, bool dup_op,
+		  crt_rpc_t *rpc, bool *update_mtime, bool dup_op,
 		  struct ds_pool_svc_op_val *op_val)
 {
 	struct cont_op_in		*in = crt_req_get(rpc);
@@ -5654,7 +5616,7 @@ cont_op_with_cont(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *
 	switch (opc_get(rpc->cr_opc)) {
 	case CONT_OPEN:
 	case CONT_OPEN_BYLABEL:
-		rc = cont_open(tx, pool_hdl, cont, rpc, cont_proto_ver, dup_op, op_val);
+		rc = cont_open(tx, pool_hdl, cont, rpc, dup_op, op_val);
 		if ((rc == 0) && !dup_op)
 			d_tm_inc_counter(metrics->open_total, 1);
 		break;
@@ -5669,7 +5631,7 @@ cont_op_with_cont(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *
 	case CONT_DESTROY_BYLABEL:
 		if (dup_op)
 			break;
-		rc = cont_destroy(tx, pool_hdl, cont, rpc, cont_proto_ver);
+		rc = cont_destroy(tx, pool_hdl, cont, rpc);
 		if (likely(rc == 0))
 			d_tm_inc_counter(metrics->destroy_total, 1);
 		break;
@@ -5692,7 +5654,7 @@ cont_op_with_cont(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *
 			}
 			goto out;
 		}
-		rc = cont_op_with_hdl(tx, pool_hdl, cont, &hdl, rpc, cont_proto_ver, dup_op, op_val,
+		rc = cont_op_with_hdl(tx, pool_hdl, cont, &hdl, rpc, dup_op, op_val,
 				      &update_mtime_needed);
 		if (rc != 0)
 			goto out;
@@ -5776,14 +5738,14 @@ cont_op_is_write(crt_opcode_t opc)
  */
 static int
 cont_op_lookup(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *svc,
-	       crt_rpc_t *rpc, int cont_proto_ver, bool *is_dup, struct ds_pool_svc_op_val *valp)
+	       crt_rpc_t *rpc, bool *is_dup, struct ds_pool_svc_op_val *valp)
 {
 	struct cont_op_v8_in *in8 = crt_req_get(rpc);
 	crt_opcode_t          opc = opc_get(rpc->cr_opc);
 	int                   rc  = 0;
 
 	/* If client didn't provide a key (old protocol), skip */
-	if (cont_proto_ver < CONT_PROTO_VER_WITH_SVC_OP_KEY)
+	if (opc_get_rpc_ver(rpc->cr_opc) < CONT_PROTO_VER_WITH_SVC_OP_KEY)
 		goto out;
 
 	/* If the operation is not a write, skip (read-only ops not tracked for duplicates) */
@@ -5800,7 +5762,7 @@ out:
 /* Save results of the operation in svc_ops KVS, in the existing rdb_tx context. */
 static int
 cont_op_save(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *svc, crt_rpc_t *rpc,
-	     bool dup_op, int cont_proto_ver, int rc_in, struct ds_pool_svc_op_val *op_valp)
+	     bool dup_op, int rc_in, struct ds_pool_svc_op_val *op_valp)
 {
 	struct cont_op_v8_in     *in8 = crt_req_get(rpc);
 	crt_opcode_t              opc = opc_get(rpc->cr_opc);
@@ -5810,7 +5772,7 @@ cont_op_save(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *s
 		op_valp->ov_rc = rc_in;
 
 	/* If client didn't provide a key (old protocol), skip */
-	if (cont_proto_ver < CONT_PROTO_VER_WITH_SVC_OP_KEY)
+	if (opc_get_rpc_ver(rpc->cr_opc) < CONT_PROTO_VER_WITH_SVC_OP_KEY)
 		goto out;
 
 	/* If the operation is not a write, skip (read-only ops not tracked for duplicates) */
@@ -5829,26 +5791,25 @@ out:
  * handler.
  */
 static int
-cont_op_with_svc(struct ds_pool_hdl *pool_hdl, struct cont_svc *svc,
-		 crt_rpc_t *rpc, int cont_proto_ver)
+cont_op_with_svc(struct ds_pool_hdl *pool_hdl, struct cont_svc *svc, crt_rpc_t *rpc)
 {
-	struct cont_op_in            *in       = crt_req_get(rpc);
-	struct cont_op_out           *out      = crt_reply_get(rpc);
-	struct cont_open_bylabel_out *olbl_out = NULL;
-	struct rdb_tx                 tx;
-	crt_opcode_t                  opc  = opc_get(rpc->cr_opc);
-	struct cont                  *cont = NULL;
-	struct cont_pool_metrics     *metrics;
-	bool                          update_mtime = false;
-	const char                   *clbl         = NULL;
-	bool                          dup_op       = false;
-	struct ds_pool_svc_op_val     op_val          = {0};
-	struct cont_dbl_op_val       *cdbl_op_val     = NULL;
-	bool                          fi_pass_noreply = DAOS_FAIL_CHECK(DAOS_MD_OP_PASS_NOREPLY);
-	bool                          fi_fail_noreply = DAOS_FAIL_CHECK(DAOS_MD_OP_FAIL_NOREPLY);
-	bool                          fi_pass_nl_noreply;
-	bool                          fi_fail_nl_noreply;
-	int                           rc;
+	struct cont_op_in               *in       = crt_req_get(rpc);
+	struct cont_op_out              *out      = crt_reply_get(rpc);
+	struct cont_open_bylabel_v8_out *olbl_out = NULL;
+	struct rdb_tx                    tx;
+	crt_opcode_t                     opc  = opc_get(rpc->cr_opc);
+	struct cont                     *cont = NULL;
+	struct cont_pool_metrics        *metrics;
+	bool                             update_mtime    = false;
+	const char                      *clbl            = NULL;
+	bool                             dup_op          = false;
+	struct ds_pool_svc_op_val        op_val          = {0};
+	struct cont_dbl_op_val          *cdbl_op_val     = NULL;
+	bool                             fi_pass_noreply = DAOS_FAIL_CHECK(DAOS_MD_OP_PASS_NOREPLY);
+	bool                             fi_fail_noreply = DAOS_FAIL_CHECK(DAOS_MD_OP_FAIL_NOREPLY);
+	bool                             fi_pass_nl_noreply;
+	bool                             fi_fail_nl_noreply;
+	int                              rc;
 
 	fi_pass_nl_noreply = DAOS_FAIL_CHECK(DAOS_MD_OP_PASS_NOREPLY_NEWLDR);
 	fi_fail_nl_noreply = DAOS_FAIL_CHECK(DAOS_MD_OP_FAIL_NOREPLY_NEWLDR);
@@ -5863,7 +5824,7 @@ cont_op_with_svc(struct ds_pool_hdl *pool_hdl, struct cont_svc *svc,
 	else
 		ABT_rwlock_rdlock(svc->cs_lock);
 
-	rc = cont_op_lookup(&tx, pool_hdl, svc, rpc, cont_proto_ver, &dup_op, &op_val);
+	rc = cont_op_lookup(&tx, pool_hdl, svc, rpc, &dup_op, &op_val);
 	if (rc != 0)
 		goto out_lock;
 	else if (fi_fail_noreply || fi_fail_nl_noreply)
@@ -5873,35 +5834,33 @@ cont_op_with_svc(struct ds_pool_hdl *pool_hdl, struct cont_svc *svc,
 	case CONT_CREATE:
 		if (dup_op)
 			goto out_commit;
-		rc = cont_create(&tx, pool_hdl, svc, rpc, cont_proto_ver);
+		rc = cont_create(&tx, pool_hdl, svc, rpc);
 		if (likely(rc == 0)) {
 			metrics = pool_hdl->sph_pool->sp_metrics[DAOS_CONT_MODULE];
 			d_tm_inc_counter(metrics->create_total, 1);
 		}
 		break;
 	case CONT_OPEN_BYLABEL:
-		cont_op_in_get_label(rpc, opc, cont_proto_ver, &clbl);
+		cont_op_in_get_label(rpc, &clbl);
 		olbl_out = crt_reply_get(rpc);
 		rc       = cont_lookup_bylabel(&tx, svc, clbl, &cont);
 		if (rc != 0)
 			goto out_commit;
 		/* NB: call common cont_op_with_cont() same as CONT_OPEN case */
-		rc = cont_op_with_cont(&tx, pool_hdl, cont, rpc, &update_mtime, cont_proto_ver,
-				       dup_op, &op_val);
+		rc = cont_op_with_cont(&tx, pool_hdl, cont, rpc, &update_mtime, dup_op, &op_val);
 		uuid_copy(olbl_out->colo_uuid, cont->c_uuid);
 		break;
 	case CONT_DESTROY_BYLABEL:
 		cdbl_op_val = (struct cont_dbl_op_val *)op_val.ov_resvd;
 		if (dup_op)
 			goto out_commit;
-		cont_op_in_get_label(rpc, opc, cont_proto_ver, &clbl);
+		cont_op_in_get_label(rpc, &clbl);
 		rc = cont_lookup_bylabel(&tx, svc, clbl, &cont);
 		if (rc != 0)
 			goto out_commit;
 		cdbl_op_val->cdv_magic = CONT_DBL_OP_VAL_MAGIC;
 		uuid_copy(cdbl_op_val->cdv_uuid, cont->c_uuid);
-		rc = cont_op_with_cont(&tx, pool_hdl, cont, rpc, &update_mtime, cont_proto_ver,
-				       dup_op, &op_val);
+		rc = cont_op_with_cont(&tx, pool_hdl, cont, rpc, &update_mtime, dup_op, &op_val);
 		break;
 	default:
 		if ((opc == CONT_DESTROY) && dup_op)
@@ -5909,8 +5868,7 @@ cont_op_with_svc(struct ds_pool_hdl *pool_hdl, struct cont_svc *svc,
 		rc = cont_lookup(&tx, svc, in->ci_uuid, &cont);
 		if (rc != 0)
 			goto out_commit;
-		rc = cont_op_with_cont(&tx, pool_hdl, cont, rpc, &update_mtime, cont_proto_ver,
-				       dup_op, &op_val);
+		rc = cont_op_with_cont(&tx, pool_hdl, cont, rpc, &update_mtime, dup_op, &op_val);
 	}
 
 	if (rc != 0)
@@ -5926,7 +5884,7 @@ cont_op_with_svc(struct ds_pool_hdl *pool_hdl, struct cont_svc *svc,
 out_commit:
 	if ((rc == 0) && !dup_op && (fi_fail_noreply || fi_fail_nl_noreply))
 		rc = -DER_MISC;
-	rc = cont_op_save(&tx, pool_hdl, svc, rpc, dup_op, cont_proto_ver, rc, &op_val);
+	rc = cont_op_save(&tx, pool_hdl, svc, rpc, dup_op, rc, &op_val);
 	if (rc != 0)
 		goto out_contref;
 
@@ -5982,7 +5940,7 @@ out_lock:
 			uuid = &in->ci_uuid;
 		}
 
-		rc = cont_destroy_post(pool_hdl, svc, *uuid, rpc, cont_proto_ver);
+		rc = cont_destroy_post(pool_hdl, svc, *uuid, rpc);
 	}
 
 out:
@@ -6057,8 +6015,8 @@ cont_cli_opc_name(crt_opcode_t opc)
 }
 
 /* Look up the pool handle and the matching container service. */
-static void
-ds_cont_op_handler(crt_rpc_t *rpc, int cont_proto_ver)
+void
+ds_cont_op_handler(crt_rpc_t *rpc)
 {
 	struct cont_op_in		*in = crt_req_get(rpc);
 	struct cont_op_out		*out = crt_reply_get(rpc);
@@ -6088,8 +6046,8 @@ ds_cont_op_handler(crt_rpc_t *rpc, int cont_proto_ver)
 		D_GOTO(out, rc = -DER_NO_HDL);
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p proto=%d hdl=" DF_UUID ", opc=%u(%s)\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, cont_proto_ver,
-		DP_UUID(in->ci_hdl), opc, cont_cli_opc_name(opc));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc,
+		opc_get_rpc_ver(rpc->cr_opc), DP_UUID(in->ci_hdl), opc, cont_cli_opc_name(opc));
 
 	/*
 	 * TODO: How to map to the correct container service among those
@@ -6105,21 +6063,21 @@ ds_cont_op_handler(crt_rpc_t *rpc, int cont_proto_ver)
 		D_GOTO(out_pool_hdl, rc);
 	}
 
-	rc = cont_op_with_svc(pool_hdl, svc, rpc, cont_proto_ver);
+	rc = cont_op_with_svc(pool_hdl, svc, rpc);
 
 	ds_rsvc_set_hint(svc->cs_rsvc, &out->co_hint);
 	cont_svc_put_leader(svc);
 out_pool_hdl:
 	if (opc == CONT_OPEN_BYLABEL) {
-		cont_op_in_get_label(rpc, opc, cont_proto_ver, &lbl);
-		struct cont_open_bylabel_out	*lout = crt_reply_get(rpc);
+		cont_op_in_get_label(rpc, &lbl);
+		struct cont_open_bylabel_v8_out *lout = crt_reply_get(rpc);
 
 		D_DEBUG(DB_MD,
 			DF_CONT ":%s: replying rpc: %p hdl=" DF_UUID " opc=%u(%s) " DF_RC "\n",
 			DP_CONT(pool_hdl->sph_pool->sp_uuid, lout->colo_uuid), lbl, rpc,
 			DP_UUID(in->ci_hdl), opc, cont_cli_opc_name(opc), DP_RC(rc));
 	} else if (opc == CONT_DESTROY_BYLABEL) {
-		cont_op_in_get_label(rpc, opc, cont_proto_ver, &lbl);
+		cont_op_in_get_label(rpc, &lbl);
 		D_DEBUG(DB_MD, DF_UUID ":%s: replying rpc: %p opc=%u(%s), " DF_RC "\n",
 			DP_UUID(pool_hdl->sph_pool->sp_uuid), lbl, rpc, opc, cont_cli_opc_name(opc),
 			DP_RC(rc));
@@ -6132,11 +6090,11 @@ out_pool_hdl:
 out:
 	/* cleanup the properties for cont_query */
 	if (opc == CONT_QUERY) {
-		struct cont_query_out *cqo = crt_reply_get(rpc);
+		struct cont_query_v8_out *cqo = crt_reply_get(rpc);
 
 		prop = cqo->cqo_prop;
 	} else if ((opc == CONT_OPEN) || (opc == CONT_OPEN_BYLABEL)) {
-		struct cont_open_out *co_out = crt_reply_get(rpc);
+		struct cont_open_v8_out *co_out = crt_reply_get(rpc);
 
 		prop = co_out->coo_prop;
 	}
@@ -6144,24 +6102,6 @@ out:
 	out->co_rc = rc;
 	crt_reply_send(rpc);
 	daos_prop_free(prop);
-}
-
-void
-ds_cont_op_handler_v8(crt_rpc_t *rpc)
-{
-	return ds_cont_op_handler(rpc, 8);
-}
-
-void
-ds_cont_op_handler_v7(crt_rpc_t *rpc)
-{
-	return ds_cont_op_handler(rpc, 7);
-}
-
-void
-ds_cont_op_handler_v6(crt_rpc_t *rpc)
-{
-	return ds_cont_op_handler(rpc, 6);
 }
 
 int
@@ -6231,16 +6171,16 @@ out_svc:
 int
 ds_cont_svc_set_prop(uuid_t pool_uuid, const char *cont_id, d_rank_list_t *ranks, daos_prop_t *prop)
 {
-	int                       rc;
-	struct rsvc_client        client;
-	crt_endpoint_t            ep;
-	crt_opcode_t              opc = CONT_PROP_SET;
-	uuid_t                    cont_uuid;
-	uuid_t                    null_uuid;
-	struct dss_module_info   *info = dss_get_module_info();
-	crt_rpc_t                *rpc;
-	struct cont_prop_set_out *out;
-	uint8_t                   cont_ver;
+	int                          rc;
+	struct rsvc_client           client;
+	crt_endpoint_t               ep;
+	crt_opcode_t                 opc = CONT_PROP_SET;
+	uuid_t                       cont_uuid;
+	uuid_t                       null_uuid;
+	struct dss_module_info      *info = dss_get_module_info();
+	crt_rpc_t                   *rpc;
+	struct cont_prop_set_v8_out *out;
+	uint8_t                      cont_ver;
 
 	rc = ds_cont_rpc_protocol(&cont_ver);
 	if (rc)
@@ -6267,7 +6207,7 @@ rechoose:
 		D_GOTO(out_client, rc);
 	}
 
-	rc = ds_cont_req_create(info->dmi_ctx, &ep, opc, null_uuid, null_uuid, null_uuid,
+	rc = ds_cont_req_create(info->dmi_ctx, &ep, opc, pool_uuid, null_uuid, null_uuid, null_uuid,
 				NULL /* req_timep */, &rpc);
 	if (rc != 0) {
 		DL_ERROR(rc, DF_UUID "/%s: failed to create cont set prop rpc", DP_UUID(pool_uuid),
@@ -6275,11 +6215,11 @@ rechoose:
 		D_GOTO(out_client, rc);
 	}
 
-	cont_prop_set_in_set_data(rpc, opc, cont_ver, prop, pool_uuid);
+	cont_prop_set_in_set_data(rpc, prop, pool_uuid);
 	if (opc == CONT_PROP_SET_BYLABEL)
-		cont_prop_set_bylabel_in_set_label(rpc, opc, cont_ver, cont_id);
+		cont_prop_set_bylabel_in_set_label(rpc, cont_id);
 	else /* CONT_PROP_SET */
-		cont_prop_set_in_set_cont_uuid(rpc, opc, cont_ver, cont_uuid);
+		cont_prop_set_in_set_cont_uuid(rpc, cont_uuid);
 
 	rc  = dss_rpc_send(rpc);
 	out = crt_reply_get(rpc);
@@ -6308,18 +6248,18 @@ out:
 void
 ds_cont_set_prop_srv_handler(crt_rpc_t *rpc)
 {
-	int                       rc;
-	crt_opcode_t              opc = opc_get(rpc->cr_opc);
-	struct cont_svc          *svc;
-	struct cont_prop_set_out *out = crt_reply_get(rpc);
-	struct rdb_tx             tx;
-	uuid_t                    pool_uuid;
-	uuid_t                    cont_uuid;
-	const char               *cont_label                           = NULL;
-	char                      cont_id[DAOS_PROP_MAX_LABEL_BUF_LEN] = {0};
-	daos_prop_t              *prop;
-	struct cont              *cont;
-	uint8_t                   cont_ver;
+	int                          rc;
+	crt_opcode_t                 opc = opc_get(rpc->cr_opc);
+	struct cont_svc             *svc;
+	struct cont_prop_set_v8_out *out = crt_reply_get(rpc);
+	struct rdb_tx                tx;
+	uuid_t                       pool_uuid;
+	uuid_t                       cont_uuid;
+	const char                  *cont_label                           = NULL;
+	char                         cont_id[DAOS_PROP_MAX_LABEL_BUF_LEN] = {0};
+	daos_prop_t                 *prop;
+	struct cont                 *cont;
+	uint8_t                      cont_ver;
 
 	rc = ds_cont_rpc_protocol(&cont_ver);
 	if (rc)
@@ -6328,7 +6268,7 @@ ds_cont_set_prop_srv_handler(crt_rpc_t *rpc)
 	 * Server RPCs don't have pool or container handles. Just need the pool
 	 * and container IDs.
 	 */
-	cont_prop_set_in_get_data(rpc, opc, cont_ver, &prop, &pool_uuid, &cont_uuid, &cont_label);
+	cont_prop_set_in_get_data(rpc, &prop, &pool_uuid, &cont_uuid, &cont_label);
 	if (opc == CONT_PROP_SET_BYLABEL)
 		strncpy(cont_id, cont_label, sizeof(cont_id) - 1);
 	else /* CONT_PROP_SET */

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -95,17 +95,17 @@ read_snap_list(struct rdb_tx *tx, struct cont *cont, daos_epoch_t **buf, int *co
 
 int
 ds_cont_epoch_aggregate(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-			struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+			struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	struct cont_epoch_op_in	*in = crt_req_get(rpc);
+	struct cont_op_in       *in = crt_req_get(rpc);
 	daos_epoch_t             epoch;
 	uint64_t                 opts;
 	int			 rc = 0;
 
-	cont_epoch_op_in_get_data(rpc, CONT_EPOCH_AGGREGATE, cont_proto_ver, &epoch, &opts);
+	cont_epoch_op_in_get_data(rpc, &epoch, &opts);
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p epoch=" DF_U64 "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc, epoch);
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, epoch);
 
 	/* Verify handle has write access */
 	if (!ds_sec_cont_can_write_data(hdl->ch_sec_capas)) {
@@ -124,7 +124,7 @@ ds_cont_epoch_aggregate(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct 
 
 out:
 	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p epoch=" DF_U64 ", " DF_RC "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc, epoch, DP_RC(rc));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, epoch, DP_RC(rc));
 	return rc;
 }
 
@@ -288,17 +288,16 @@ out:
 
 int
 ds_cont_snap_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-		    struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver,
-		    struct ds_pool_svc_op_val *op_val)
+		    struct container_hdl *hdl, crt_rpc_t *rpc, struct ds_pool_svc_op_val *op_val)
 {
-	struct cont_epoch_op_in	       *in = crt_req_get(rpc);
-	struct cont_epoch_op_out       *out = crt_reply_get(rpc);
+	struct cont_op_in              *in  = crt_req_get(rpc);
+	struct cont_epoch_op_v8_out    *out = crt_reply_get(rpc);
 	daos_epoch_t			snap_eph;
 	uint64_t                        opts;
 	int				rc;
 
-	D_DEBUG(DB_MD, DF_CONT": processing rpc %p\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc);
+	D_DEBUG(DB_MD, DF_CONT ": processing rpc %p\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc);
 
 	/* Verify handle has write access */
 	if (!ds_sec_cont_can_write_data(hdl->ch_sec_capas)) {
@@ -308,32 +307,32 @@ ds_cont_snap_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont
 		goto out;
 	}
 
-	cont_epoch_op_in_get_data(rpc, CONT_SNAP_CREATE, cont_proto_ver, &snap_eph, &opts);
+	cont_epoch_op_in_get_data(rpc, &snap_eph, &opts);
 
-	rc = snap_create_bcast(tx, cont, in->cei_op.ci_hdl, opts, rpc->cr_ctx, &snap_eph);
+	rc = snap_create_bcast(tx, cont, in->ci_hdl, opts, rpc->cr_ctx, &snap_eph);
 	if (rc == 0) {
 		out->ceo_epoch = snap_eph;
 		*(daos_epoch_t *)op_val->ov_resvd = snap_eph;
 	}
 out:
 	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc, DP_RC(rc));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_RC(rc));
 	return rc;
 }
 
 int
 ds_cont_snap_oit_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-			struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+			struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	struct cont_epoch_op_in	       *in = crt_req_get(rpc);
+	struct cont_op_in              *in = crt_req_get(rpc);
 	uint64_t                        epoch;
 	uint64_t                        opts;
 	int				rc;
 	d_iov_t				key;
 	d_iov_t				value;
 
-	D_DEBUG(DB_MD, DF_CONT": processing rpc %p\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc);
+	D_DEBUG(DB_MD, DF_CONT ": processing rpc %p\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc);
 
 	/* Verify handle has write access */
 	if (!ds_sec_cont_can_write_data(hdl->ch_sec_capas)) {
@@ -343,7 +342,7 @@ ds_cont_snap_oit_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct 
 		goto out;
 	}
 
-	cont_epoch_op_in_get_data(rpc, CONT_SNAP_OIT_CREATE, cont_proto_ver, &epoch, &opts);
+	cont_epoch_op_in_get_data(rpc, &epoch, &opts);
 
 	d_iov_set(&key, &epoch, sizeof(daos_epoch_t));
 	d_iov_set(&value, NULL, 0);
@@ -354,26 +353,26 @@ ds_cont_snap_oit_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct 
 		goto out;
 	}
 
-	rc = snap_oit_create(tx, cont, in->cei_op.ci_hdl, DAOS_SNAP_OPT_OIT, rpc->cr_ctx, &epoch);
+	rc = snap_oit_create(tx, cont, in->ci_hdl, DAOS_SNAP_OPT_OIT, rpc->cr_ctx, &epoch);
 out:
 	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc, DP_RC(rc));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_RC(rc));
 	return rc;
 }
 
 int
 ds_cont_snap_oit_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-			 struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+			 struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	struct cont_epoch_op_in	       *in = crt_req_get(rpc);
+	struct cont_op_in              *in = crt_req_get(rpc);
 	uint64_t                        epoch;
 	uint64_t                        opts;
 	int				rc;
 	d_iov_t				key;
 	d_iov_t				value;
 
-	D_DEBUG(DB_MD, DF_CONT": processing rpc %p\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc);
+	D_DEBUG(DB_MD, DF_CONT ": processing rpc %p\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc);
 
 	/* Verify handle has write access */
 	if (!ds_sec_cont_can_write_data(hdl->ch_sec_capas)) {
@@ -383,7 +382,7 @@ ds_cont_snap_oit_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct
 		goto out;
 	}
 
-	cont_epoch_op_in_get_data(rpc, CONT_SNAP_OIT_DESTROY, cont_proto_ver, &epoch, &opts);
+	cont_epoch_op_in_get_data(rpc, &epoch, &opts);
 
 	d_iov_set(&key, &epoch, sizeof(daos_epoch_t));
 	d_iov_set(&value, NULL, 0);
@@ -411,15 +410,15 @@ ds_cont_snap_oit_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct
 
 out:
 	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc, DP_RC(rc));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_RC(rc));
 	return rc;
 }
 
 int
 ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-		     struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+		     struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	struct cont_epoch_op_in		*in = crt_req_get(rpc);
+	struct cont_op_in               *in = crt_req_get(rpc);
 	uint64_t                         epoch;
 	uint64_t                         opts;
 	d_iov_t				 key;
@@ -427,10 +426,10 @@ ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct con
 	uint32_t			 nsnapshots;
 	int				 rc;
 
-	cont_epoch_op_in_get_data(rpc, CONT_SNAP_DESTROY, cont_proto_ver, &epoch, &opts);
+	cont_epoch_op_in_get_data(rpc, &epoch, &opts);
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p epoch=" DF_U64 "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc, epoch);
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, epoch);
 
 	/* Verify the handle has write access */
 	if (!ds_sec_cont_can_write_data(hdl->ch_sec_capas)) {
@@ -489,28 +488,28 @@ ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct con
 	}
 
 	D_DEBUG(DB_MD, DF_CONT ": deleted snapshot [%lu]\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), epoch);
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), epoch);
 out:
 	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc, DP_RC(rc));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_RC(rc));
 	return rc;
 }
 
 int
 ds_cont_snap_oit_oid_get(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-			 struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+			 struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	daos_epoch_t                      epoch;
-	d_iov_t				  key;
-	d_iov_t				  value;
-	int				  rc;
-	struct cont_snap_oit_oid_get_in	 *in = crt_req_get(rpc);
-	struct cont_snap_oit_oid_get_out *out = crt_reply_get(rpc);
+	daos_epoch_t                         epoch;
+	d_iov_t                              key;
+	d_iov_t                              value;
+	int                                  rc;
+	struct cont_op_in                   *in  = crt_req_get(rpc);
+	struct cont_snap_oit_oid_get_v8_out *out = crt_reply_get(rpc);
 
-	cont_snap_oit_oid_get_in_get_data(rpc, CONT_SNAP_OIT_OID_GET, cont_proto_ver, &epoch);
+	cont_snap_oit_oid_get_in_get_data(rpc, &epoch);
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p epoch=" DF_U64 "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ogi_op.ci_uuid), rpc, epoch);
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, epoch);
 
 	/* Verify the handle has read access */
 	if (!ds_sec_cont_can_read_data(hdl->ch_sec_capas)) {
@@ -530,7 +529,7 @@ ds_cont_snap_oit_oid_get(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct
 	}
 out:
 	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ogi_op.ci_uuid), rpc, DP_RC(rc));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_RC(rc));
 	return rc;
 }
 
@@ -638,17 +637,16 @@ out:
 
 int
 ds_cont_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-		  struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
+		  struct container_hdl *hdl, crt_rpc_t *rpc)
 {
-	struct cont_snap_list_in	*in		= crt_req_get(rpc);
-	struct cont_snap_list_out	*out		= crt_reply_get(rpc);
-	crt_bulk_t                       bulk;
-	int				 snap_count;
-	int				 rc;
+	struct cont_op_in            *in  = crt_req_get(rpc);
+	struct cont_snap_list_v8_out *out = crt_reply_get(rpc);
+	crt_bulk_t                    bulk;
+	int                           snap_count;
+	int                           rc;
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p hdl=" DF_UUID "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->sli_op.ci_uuid), rpc,
-		DP_UUID(in->sli_op.ci_hdl));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_UUID(in->ci_hdl));
 
 	/* Verify the handle has read access */
 	if (!ds_sec_cont_can_read_data(hdl->ch_sec_capas)) {
@@ -658,7 +656,7 @@ ds_cont_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *
 		goto out;
 	}
 
-	cont_snap_list_in_get_data(rpc, CONT_SNAP_LIST, cont_proto_ver, &bulk);
+	cont_snap_list_in_get_data(rpc, &bulk);
 
 	rc = xfer_snap_list(tx, pool_hdl, cont, hdl, rpc, bulk, &snap_count);
 	if (rc)
@@ -667,7 +665,7 @@ ds_cont_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *
 
 out:
 	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->sli_op.ci_uuid), rpc, DP_RC(rc));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_RC(rc));
 	return rc;
 }
 

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -194,9 +194,7 @@ struct cont_iv_key {
 
 /* srv_container.c */
 void
-     ds_cont_op_handler_v8(crt_rpc_t *rpc);
-void ds_cont_op_handler_v7(crt_rpc_t *rpc);
-void ds_cont_op_handler_v6(crt_rpc_t *rpc);
+ds_cont_op_handler(crt_rpc_t *rpc);
 void
      ds_cont_set_prop_srv_handler(crt_rpc_t *rpc);
 int ds_cont_bcast_create(crt_context_t ctx, struct cont_svc *svc,
@@ -210,13 +208,13 @@ void cont_put(struct cont *cont);
 void cont_svc_put_leader(struct cont_svc *svc);
 int
 ds_cont_prop_set(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-		 struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver);
+		 struct container_hdl *hdl, crt_rpc_t *rpc);
 int
 ds_cont_acl_update(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-		   struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver);
+		   struct container_hdl *hdl, crt_rpc_t *rpc);
 int
     ds_cont_acl_delete(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-		       struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver);
+		       struct container_hdl *hdl, crt_rpc_t *rpc);
 int ds_cont_get_prop(uuid_t pool_uuid, uuid_t cont_uuid,
 		     daos_prop_t **prop_out);
 int ds_cont_leader_update_track_eph(uuid_t pool_uuid, uuid_t cont_uuid,
@@ -225,30 +223,29 @@ int ds_cont_leader_update_track_eph(uuid_t pool_uuid, uuid_t cont_uuid,
 /* srv_epoch.c */
 int
 ds_cont_snap_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-		    struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver,
-		    struct ds_pool_svc_op_val *op_val);
+		    struct container_hdl *hdl, crt_rpc_t *rpc, struct ds_pool_svc_op_val *op_val);
 
 int
 ds_cont_epoch_aggregate(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-			struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver);
+			struct container_hdl *hdl, crt_rpc_t *rpc);
 int
 ds_cont_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-		  struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver);
+		  struct container_hdl *hdl, crt_rpc_t *rpc);
 int
      ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-			  struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver);
+			  struct container_hdl *hdl, crt_rpc_t *rpc);
 int ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid, daos_epoch_t **snapshots,
 			  int *snap_count);
 void ds_cont_update_snap_iv(struct cont_svc *svc, uuid_t cont_uuid);
 int
 ds_cont_snap_oit_oid_get(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-			 struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver);
+			 struct container_hdl *hdl, crt_rpc_t *rpc);
 int
 ds_cont_snap_oit_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-			struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver);
+			struct container_hdl *hdl, crt_rpc_t *rpc);
 int
-      ds_cont_snap_oit_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-			       struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver);
+     ds_cont_snap_oit_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
+			      struct container_hdl *hdl, crt_rpc_t *rpc);
 
 /* srv_target.c */
 int ds_cont_tgt_destroy(uuid_t pool_uuid, uuid_t cont_uuid);

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -2046,20 +2046,16 @@ cont_query_one(void *vin)
 	int                          tid       = info->dmi_tgt_id;
 	struct xstream_cont_query   *pack_args = streams[tid].st_arg;
 	struct cont_tgt_query_in    *in        = pack_args->xcq_rpc_in;
-	struct ds_pool_hdl          *pool_hdl;
 	struct ds_pool_child        *pool_child;
 	daos_handle_t                vos_chdl;
 	vos_cont_info_t              vos_cinfo;
 	int                          rc;
 
 	info = dss_get_module_info();
-	pool_hdl = ds_pool_hdl_lookup(in->tqi_pool_uuid);
-	if (pool_hdl == NULL)
-		return -DER_NO_HDL;
 
-	pool_child = ds_pool_child_lookup(pool_hdl->sph_pool->sp_uuid);
+	pool_child = ds_pool_child_lookup(in->tqi_pool_uuid);
 	if (pool_child == NULL)
-		D_GOTO(ds_pool_hdl, rc = -DER_NO_HDL);
+		return -DER_NO_HDL;
 
 	rc = vos_cont_open(pool_child->spc_hdl, in->tqi_cont_uuid, &vos_chdl);
 	if (rc != 0) {
@@ -2080,8 +2076,6 @@ out:
 	vos_cont_close(vos_chdl);
 ds_child:
 	ds_pool_child_put(pool_child);
-ds_pool_hdl:
-	ds_pool_hdl_put(pool_hdl);
 	return rc;
 }
 
@@ -2125,8 +2119,7 @@ ds_cont_tgt_query_handler(crt_rpc_t *rpc)
 	struct cont_tgt_query_out	*out = crt_reply_get(rpc);
 	struct dss_coll_ops		coll_ops;
 	struct dss_coll_args		coll_args = { 0 };
-	struct xstream_cont_query	pack_args;
-	struct ds_pool_hdl		*pool_hdl;
+	struct xstream_cont_query        pack_args;
 
 	out->tqo_hae			= DAOS_EPOCH_MAX;
 
@@ -2145,18 +2138,12 @@ ds_cont_tgt_query_handler(crt_rpc_t *rpc)
 	coll_args.ca_aggregator		= &pack_args;
 	coll_args.ca_func_args		= &coll_args.ca_stream_args;
 
-	pool_hdl = ds_pool_hdl_lookup(in->tqi_pool_uuid);
-	if (pool_hdl == NULL)
-		D_GOTO(out, rc = -DER_NO_HDL);
-
-	rc = ds_pool_task_collective_reduce(pool_hdl->sph_pool->sp_uuid,
+	rc = ds_pool_task_collective_reduce(in->tqi_pool_uuid,
 					    PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
 					    &coll_ops, &coll_args, 0);
 
 	D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
 
-	ds_pool_hdl_put(pool_hdl);
-out:
 	out->tqo_hae	= MIN(out->tqo_hae, pack_args.xcq_hae);
 	out->tqo_rc	= (rc == 0 ? 0 : 1);
 
@@ -2501,16 +2488,17 @@ close:
 static int
 cont_oid_alloc(struct ds_pool_hdl *pool_hdl, crt_rpc_t *rpc)
 {
-	struct cont_oid_alloc_in	*in = crt_req_get(rpc);
-	struct cont_oid_alloc_out	*out;
-	d_sg_list_t			sgl;
-	d_iov_t				iov;
-	struct oid_iv_range		rg;
-	int				rc;
+	struct cont_op_in         *in = crt_req_get(rpc);
+	daos_size_t                num_oids;
+	struct cont_oid_alloc_out *out;
+	d_sg_list_t                sgl;
+	d_iov_t                    iov;
+	struct oid_iv_range        rg;
+	int                        rc;
 
-	D_DEBUG(DB_MD, DF_CONT": oid alloc: num_oids="DF_U64"\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->coai_op.ci_uuid),
-		in->num_oids);
+	cont_oid_alloc_in_get_data(rpc, &num_oids);
+	D_DEBUG(DB_MD, DF_CONT ": oid alloc: num_oids=" DF_U64 "\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), num_oids);
 
 	out = crt_reply_get(rpc);
 	D_ASSERT(out != NULL);
@@ -2521,20 +2509,19 @@ cont_oid_alloc(struct ds_pool_hdl *pool_hdl, crt_rpc_t *rpc)
 	sgl.sg_nr_out = 0;
 	sgl.sg_iovs = &iov;
 
-	rc = oid_iv_reserve(pool_hdl->sph_pool->sp_iv_ns, pool_hdl->sph_pool->sp_uuid,
-			    in->coai_op.ci_uuid, in->num_oids, &sgl);
+	rc = oid_iv_reserve(pool_hdl->sph_pool->sp_iv_ns, pool_hdl->sph_pool->sp_uuid, in->ci_uuid,
+			    num_oids, &sgl);
 	if (rc)
 		D_GOTO(out, rc);
 
 	out->oid = rg.oid;
 
-	D_DEBUG(DB_MD, DF_CONT": allocate "DF_X64"/"DF_U64"\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->coai_op.ci_uuid),
-		rg.oid, rg.num_oids);
+	D_DEBUG(DB_MD, DF_CONT ": allocate " DF_X64 "/" DF_U64 "\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rg.oid, rg.num_oids);
 out:
 	out->coao_op.co_rc = rc;
 	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->coai_op.ci_uuid), rpc, DP_RC(rc));
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), rpc, DP_RC(rc));
 
 	return rc;
 }

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -69,7 +69,7 @@ enum daos_module_id {
 #define DAOS_VOS_VERSION      1
 #define DAOS_MGMT_VERSION     4
 #define DAOS_POOL_VERSION     7
-#define DAOS_CONT_VERSION     8
+#define DAOS_CONT_VERSION     9
 #define DAOS_OBJ_VERSION      10
 #define DAOS_REBUILD_VERSION  5
 #define DAOS_RSVC_VERSION     5


### PR DESCRIPTION
Current cont_op_in types do not include a pool UUID field. An engine receiving such a request has to obtain the pool UUID by looking up the pool handle. If the handle is not cached locally, the engine is unable to fetch the pool handle from the PS because it doesn't have the pool UUID. Hence, we need to add a pool UUID field to a new version of cont_op_in.

This patch introduces version 9 (v9) of the container RPC protocol:

  - In v9, cont_op_v9_in includes the pool UUID field ci_pool. - All requests using a cont_op_in type gets a v9 version.
	  - Engine-to-engine CONT_PROP_SET_BYLABEL is changed directly.
      - cont_prop_set_v9_in no longer has cpsi_pool_uuid, for the new cpsi_op.ci_pool has that.
      - cont_tgt_query_in no longer contains the pool handle UUID. This engine-to-engine request is changed directly.
  - The v8 protocol remains unchanged.
  - The v7 and earlier stuff is removed.
  - Unnecessary opc and cont_proto_ver parameters are removed.
  - Unnecessary ds_cont_op_handler_{v6,v7,v8} are removed.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
