### PR TITLE
DAOS-18906 dfs: GIT (Global Inode Table) entries and associated funct…

### DIFF
--- a/src/client/dfs/common.c
+++ b/src/client/dfs/common.c
@@ -122,23 +122,24 @@ out:
 
 /*
  * Shared fetch helper for fetch_entry() and git_fetch_entry().
- * include_link_cnt=true extends the recx to cover the GIT link_cnt field.
+ * is_git_entry=true extends the recx to cover the GIT link_cnt field.
+ * fetch_sym=true additionally fetches the symlink value for symlink entries.
  */
 static int
-fetch_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool include_link_cnt,
-		   bool *exists, struct dfs_entry *entry, int xnr, char *xnames[], void *xvals[],
-		   daos_size_t *xsizes)
+fetch_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool is_git_entry,
+		   bool fetch_sym, bool *exists, struct dfs_entry *entry, int xnr, char *xnames[],
+		   void *xvals[], daos_size_t *xsizes)
 {
 	d_sg_list_t  l_sgl, *sgl;
 	d_iov_t      sg_iovs[INODE_AKEYS];
 	daos_iod_t   l_iod, *iod;
 	daos_recx_t  recx;
-	unsigned int i;
+	int          i;
 	char       **pxnames = NULL;
 	d_iov_t     *sg_iovx = NULL;
 	d_sg_list_t *sgls    = NULL;
 	daos_iod_t  *iods    = NULL;
-	int          rc      = 0;
+	int          rc;
 
 	if (xnr) {
 		D_ALLOC_ARRAY(pxnames, xnr);
@@ -157,7 +158,7 @@ fetch_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool in
 		if (iods == NULL)
 			D_GOTO(out, rc = ENOMEM);
 
-		for (i = 0; i < (unsigned int)xnr; i++) {
+		for (i = 0; i < xnr; i++) {
 			pxnames[i] = concat("x:", xnames[i]);
 			if (pxnames[i] == NULL)
 				D_GOTO(out, rc = ENOMEM);
@@ -184,7 +185,7 @@ fetch_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool in
 	d_iov_set(&iod->iod_name, INODE_AKEY_NAME, sizeof(INODE_AKEY_NAME) - 1);
 	iod->iod_nr    = 1;
 	recx.rx_idx    = 0;
-	recx.rx_nr     = include_link_cnt ? END_GIT_IDX : END_IDX;
+	recx.rx_nr     = is_git_entry ? END_IDX : END_L3_IDX;
 	iod->iod_recxs = &recx;
 	iod->iod_type  = DAOS_IOD_ARRAY;
 	iod->iod_size  = 1;
@@ -202,7 +203,7 @@ fetch_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool in
 	d_iov_set(&sg_iovs[i++], &entry->gid, sizeof(gid_t));
 	d_iov_set(&sg_iovs[i++], &entry->value_len, sizeof(daos_size_t));
 	d_iov_set(&sg_iovs[i++], &entry->obj_hlc, sizeof(uint64_t));
-	if (include_link_cnt)
+	if (is_git_entry)
 		d_iov_set(&sg_iovs[i++], &entry->link_cnt, sizeof(uint64_t));
 
 	sgl->sg_nr     = i;
@@ -215,18 +216,66 @@ fetch_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool in
 		*exists = false;
 		D_GOTO(out, rc = 0);
 	} else if (rc) {
-		D_ERROR("Failed to fetch entry " DF_RC "\n", DP_RC(rc));
 		D_GOTO(out, rc = daos_der2errno(rc));
 	}
 
-	for (i = 0; i < (unsigned int)xnr; i++)
+	for (i = 0; i < xnr; i++)
 		xsizes[i] = iods[i].iod_size;
 
-	*exists = (sgl->sg_nr_out != 0);
+	if (is_git_entry && (S_ISLNK(entry->mode) || S_ISDIR(entry->mode)))
+		D_GOTO(out, rc = EIO);
+
+	if (fetch_sym && S_ISLNK(entry->mode)) {
+		char       *value;
+		daos_size_t val_len;
+
+		/** symlink is empty */
+		if (entry->value_len == 0)
+			D_GOTO(out, rc = EIO);
+		val_len = entry->value_len;
+		D_ALLOC(value, val_len + 1);
+		if (value == NULL)
+			D_GOTO(out, rc = ENOMEM);
+
+		d_iov_set(&iod->iod_name, SLINK_AKEY_NAME, sizeof(SLINK_AKEY_NAME) - 1);
+		iod->iod_nr    = 1;
+		iod->iod_recxs = NULL;
+		iod->iod_type  = DAOS_IOD_SINGLE;
+		iod->iod_size  = DAOS_REC_ANY;
+
+		d_iov_set(&sg_iovs[0], value, val_len);
+		sgl->sg_nr     = 1;
+		sgl->sg_nr_out = 0;
+		sgl->sg_iovs   = sg_iovs;
+
+		rc = daos_obj_fetch(oh, th, DAOS_COND_DKEY_FETCH, dkey, 1, iod, sgl, NULL, NULL);
+		if (rc) {
+			D_FREE(value);
+			if (rc == -DER_NONEXIST) {
+				*exists = false;
+				D_GOTO(out, rc = 0);
+			}
+			D_GOTO(out, rc = daos_der2errno(rc));
+		}
+
+		/** make sure that the akey value size matches what is in the inode */
+		if (iod->iod_size != val_len) {
+			D_ERROR("Symlink value length inconsistent with inode data\n");
+			D_FREE(value);
+			D_GOTO(out, rc = EIO);
+		}
+		value[val_len] = 0;
+		entry->value   = value;
+	}
+
+	if (sgl->sg_nr_out == 0)
+		*exists = false;
+	else
+		*exists = true;
 out:
 	if (xnr) {
 		if (pxnames) {
-			for (i = 0; i < (unsigned int)xnr; i++)
+			for (i = 0; i < xnr; i++)
 				D_FREE(pxnames[i]);
 			D_FREE(pxnames);
 		}
@@ -242,10 +291,8 @@ fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char
 	    bool fetch_sym, bool *exists, struct dfs_entry *entry, int xnr, char *xnames[],
 	    void *xvals[], daos_size_t *xsizes)
 {
-	daos_iod_t  iod;
-	d_sg_list_t sgl;
-	daos_key_t  dkey;
-	int         rc;
+	daos_key_t dkey;
+	int        rc;
 
 	D_ASSERT(name);
 
@@ -255,60 +302,11 @@ fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char
 
 	d_iov_set(&dkey, (void *)name, len);
 
-	rc = fetch_entry_common(oh, th, &dkey, false, exists, entry, xnr, xnames, xvals, xsizes);
-	if (rc)
+	rc = fetch_entry_common(oh, th, &dkey, false, fetch_sym, exists, entry, xnr, xnames, xvals,
+				xsizes);
+	if (rc) {
+		D_ERROR("Failed to fetch entry %s " DF_RC "\n", name, DP_RC(rc));
 		return rc;
-
-	if (*exists && fetch_sym && S_ISLNK(entry->mode)) {
-		char       *value;
-		daos_size_t val_len;
-		d_iov_t     slink_iov;
-
-		/** symlink is empty */
-		if (entry->value_len == 0)
-			return EIO;
-		val_len = entry->value_len;
-		D_ALLOC(value, val_len + 1);
-		if (value == NULL)
-			return ENOMEM;
-
-		d_iov_set(&iod.iod_name, SLINK_AKEY_NAME, sizeof(SLINK_AKEY_NAME) - 1);
-		iod.iod_nr    = 1;
-		iod.iod_recxs = NULL;
-		iod.iod_type  = DAOS_IOD_SINGLE;
-		iod.iod_size  = DAOS_REC_ANY;
-
-		d_iov_set(&slink_iov, value, val_len);
-		sgl.sg_nr     = 1;
-		sgl.sg_nr_out = 0;
-		sgl.sg_iovs   = &slink_iov;
-
-		rc = daos_obj_fetch(oh, th, DAOS_COND_DKEY_FETCH, &dkey, 1, &iod, &sgl, NULL, NULL);
-		if (rc) {
-			D_FREE(value);
-			if (rc == -DER_NONEXIST) {
-				*exists = false;
-				return 0;
-			}
-			D_ERROR("Failed to fetch entry %s " DF_RC "\n", name, DP_RC(rc));
-			return daos_der2errno(rc);
-		}
-
-		/** make sure that the akey value size matches what is in the inode */
-		if (iod.iod_size != val_len) {
-			D_ERROR("Symlink value length inconsistent with inode data\n");
-			D_FREE(value);
-			return EIO;
-		}
-		value[val_len] = 0;
-
-		if (entry->value_len != 0) {
-			entry->value = value;
-		} else {
-			D_ERROR("Failed to load value for symlink\n");
-			D_FREE(value);
-			return EIO;
-		}
 	}
 
 	if (*exists)
@@ -351,11 +349,11 @@ punch_entry:
 
 /*
  * Shared insert helper for insert_entry() and git_insert_entry().
- * include_link_cnt=true extends the recx to cover the GIT link_cnt field.
- * Symlink akey is only written when include_link_cnt is false.
+ * is_git_entry=true extends the recx to cover the GIT link_cnt field.
+ * Symlink akey is only written when is_git_entry is false.
  */
 static int
-insert_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool include_link_cnt,
+insert_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool is_git_entry,
 		    uint64_t flags, struct dfs_entry *entry)
 {
 	d_sg_list_t  sgls[2];
@@ -367,10 +365,15 @@ insert_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool i
 	unsigned int nr_iods;
 	int          rc;
 
+	if (is_git_entry && (S_ISLNK(entry->mode) || S_ISDIR(entry->mode))) {
+		D_ERROR("GIT entry OID " DF_OID ": is not a regular file\n", DP_OID(entry->oid));
+		return EIO;
+	}
+
 	d_iov_set(&iods[0].iod_name, INODE_AKEY_NAME, sizeof(INODE_AKEY_NAME) - 1);
 	iods[0].iod_nr    = 1;
 	recx.rx_idx       = 0;
-	recx.rx_nr        = include_link_cnt ? END_GIT_IDX : END_IDX;
+	recx.rx_nr        = is_git_entry ? END_IDX : END_L3_IDX;
 	iods[0].iod_recxs = &recx;
 	iods[0].iod_type  = DAOS_IOD_ARRAY;
 	iods[0].iod_size  = 1;
@@ -389,11 +392,11 @@ insert_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool i
 	/** Add file size / symlink length. for now, file size cached in the entry is 0. */
 	d_iov_set(&sg_iovs[i++], &entry->value_len, sizeof(daos_size_t));
 	d_iov_set(&sg_iovs[i++], &entry->obj_hlc, sizeof(uint64_t));
-	if (include_link_cnt)
+	if (is_git_entry)
 		d_iov_set(&sg_iovs[i++], &entry->link_cnt, sizeof(uint64_t));
 
 	/** add the symlink as a separate akey (dentry only, never in GIT) */
-	if (!include_link_cnt && S_ISLNK(entry->mode)) {
+	if (S_ISLNK(entry->mode)) {
 		nr_iods = 2;
 		d_iov_set(&iods[1].iod_name, SLINK_AKEY_NAME, sizeof(SLINK_AKEY_NAME) - 1);
 		iods[1].iod_nr    = 1;
@@ -414,12 +417,8 @@ insert_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool i
 	sgls[0].sg_iovs   = sg_iovs;
 
 	rc = daos_obj_update(oh, th, flags, dkey, nr_iods, iods, sgls, NULL);
-	if (rc) {
-		/** don't log error if conditional failed */
-		if (rc != -DER_EXIST && rc != -DER_NO_PERM)
-			D_ERROR("Failed to insert entry, " DF_RC "\n", DP_RC(rc));
+	if (rc)
 		return daos_der2errno(rc);
-	}
 	return 0;
 }
 
@@ -428,9 +427,14 @@ insert_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const cha
 	     uint64_t flags, struct dfs_entry *entry)
 {
 	daos_key_t dkey;
+	int        rc;
 
 	d_iov_set(&dkey, (void *)name, len);
-	return insert_entry_common(oh, th, &dkey, false, flags, entry);
+	rc = insert_entry_common(oh, th, &dkey, false, flags, entry);
+	/** don't log error if conditional failed */
+	if (rc && rc != EEXIST && rc != EPERM)
+		D_ERROR("Failed to fetch entry %s " DF_RC "\n", name, DP_RC(rc));
+	return rc;
 }
 
 int
@@ -445,14 +449,15 @@ git_fetch_entry(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *oid, stru
 		return EINVAL;
 
 	d_iov_set(&dkey, oid, sizeof(daos_obj_id_t));
-	rc =
-	    fetch_entry_common(git_oh, th, &dkey, true, &exists, entry, xnr, xnames, xvals, xsizes);
-	if (rc)
+	rc = fetch_entry_common(git_oh, th, &dkey, true, false, &exists, entry, xnr, xnames, xvals,
+				xsizes);
+	if (rc) {
+		D_ERROR("Failed to fetch GIT entry for OID " DF_OID " " DF_RC "\n", DP_OID(*oid),
+			DP_RC(rc));
 		return rc;
-	if (!exists) {
-		D_ERROR("Entry not found in GIT\n");
-		return ENOENT;
 	}
+	if (!exists)
+		return ENOENT;
 	return 0;
 }
 
@@ -461,17 +466,22 @@ git_insert_entry(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *oid, uin
 		 struct dfs_entry *entry)
 {
 	daos_key_t dkey;
+	int        rc;
 
 	if (oid == NULL || entry == NULL)
 		return EINVAL;
-	D_ASSERT(!S_ISLNK(entry->mode));
 
 	d_iov_set(&dkey, oid, sizeof(daos_obj_id_t));
-	return insert_entry_common(git_oh, th, &dkey, true, flags, entry);
+	rc = insert_entry_common(git_oh, th, &dkey, true, flags, entry);
+	/** don't log error if conditional failed */
+	if (rc && rc != EEXIST && rc != EPERM)
+		D_ERROR("Failed to insert GIT entry for OID " DF_OID " " DF_RC "\n", DP_OID(*oid),
+			DP_RC(rc));
+	return rc;
 }
 
 int
-git_update_link_cnt(daos_handle_t git_oh, daos_handle_t th, struct dfs_entry *entry, int delta)
+git_update_link_cnt(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *oid, uint64_t value)
 {
 	daos_key_t      dkey;
 	d_sg_list_t     sgl;
@@ -481,38 +491,31 @@ git_update_link_cnt(daos_handle_t git_oh, daos_handle_t th, struct dfs_entry *en
 	struct timespec now;
 	int             rc;
 
-	if (entry == NULL)
-		return EINVAL;
-
-	if (delta < 0 && entry->link_cnt < (uint64_t)(-delta)) {
-		D_ERROR("link_cnt underflow: link_cnt=%lu, delta=%d\n", entry->link_cnt, delta);
+	if (value == 0) {
+		D_ERROR("link_cnt cannot be zero for OID " DF_OID "\n", DP_OID(*oid));
 		return EINVAL;
 	}
-
-	entry->link_cnt += delta;
 
 	rc = clock_gettime(CLOCK_REALTIME, &now);
 	if (rc)
 		return errno;
-	entry->ctime      = now.tv_sec;
-	entry->ctime_nano = now.tv_nsec;
 
-	d_iov_set(&dkey, &entry->oid, sizeof(daos_obj_id_t));
+	d_iov_set(&dkey, oid, sizeof(daos_obj_id_t));
 	d_iov_set(&iod.iod_name, INODE_AKEY_NAME, sizeof(INODE_AKEY_NAME) - 1);
 	iod.iod_nr      = 3;
-	recxs[0].rx_idx = LINK_CNT_IDX;
+	recxs[0].rx_idx = CTIME_IDX;
 	recxs[0].rx_nr  = sizeof(uint64_t);
-	recxs[1].rx_idx = CTIME_IDX;
+	recxs[1].rx_idx = CTIME_NSEC_IDX;
 	recxs[1].rx_nr  = sizeof(uint64_t);
-	recxs[2].rx_idx = CTIME_NSEC_IDX;
+	recxs[2].rx_idx = LINK_CNT_IDX;
 	recxs[2].rx_nr  = sizeof(uint64_t);
 	iod.iod_recxs   = recxs;
 	iod.iod_type    = DAOS_IOD_ARRAY;
 	iod.iod_size    = 1;
 
-	d_iov_set(&sg_iovs[0], &entry->link_cnt, sizeof(uint64_t));
-	d_iov_set(&sg_iovs[1], &entry->ctime, sizeof(uint64_t));
-	d_iov_set(&sg_iovs[2], &entry->ctime_nano, sizeof(uint64_t));
+	d_iov_set(&sg_iovs[0], &now.tv_sec, sizeof(uint64_t));
+	d_iov_set(&sg_iovs[1], &now.tv_nsec, sizeof(uint64_t));
+	d_iov_set(&sg_iovs[2], &value, sizeof(uint64_t));
 	sgl.sg_nr     = 3;
 	sgl.sg_nr_out = 0;
 	sgl.sg_iovs   = sg_iovs;

--- a/src/client/dfs/common.c
+++ b/src/client/dfs/common.c
@@ -120,28 +120,25 @@ out:
 	return rc;
 }
 
-int
-fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char *name, size_t len,
-	    bool fetch_sym, bool *exists, struct dfs_entry *entry, int xnr, char *xnames[],
-	    void *xvals[], daos_size_t *xsizes)
+/*
+ * Shared fetch helper for fetch_entry() and git_fetch_entry().
+ * include_link_cnt=true extends the recx to cover the GIT link_cnt field.
+ */
+static int
+fetch_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool include_link_cnt,
+		   bool *exists, struct dfs_entry *entry, int xnr, char *xnames[], void *xvals[],
+		   daos_size_t *xsizes)
 {
 	d_sg_list_t  l_sgl, *sgl;
 	d_iov_t      sg_iovs[INODE_AKEYS];
 	daos_iod_t   l_iod, *iod;
 	daos_recx_t  recx;
-	daos_key_t   dkey;
 	unsigned int i;
 	char       **pxnames = NULL;
 	d_iov_t     *sg_iovx = NULL;
 	d_sg_list_t *sgls    = NULL;
 	daos_iod_t  *iods    = NULL;
-	int          rc;
-
-	D_ASSERT(name);
-
-	/** TODO - not supported yet */
-	if (strcmp(name, ".") == 0)
-		return ENOTSUP;
+	int          rc      = 0;
 
 	if (xnr) {
 		D_ALLOC_ARRAY(pxnames, xnr);
@@ -160,7 +157,7 @@ fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char
 		if (iods == NULL)
 			D_GOTO(out, rc = ENOMEM);
 
-		for (i = 0; i < xnr; i++) {
+		for (i = 0; i < (unsigned int)xnr; i++) {
 			pxnames[i] = concat("x:", xnames[i]);
 			if (pxnames[i] == NULL)
 				D_GOTO(out, rc = ENOMEM);
@@ -184,11 +181,10 @@ fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char
 		iod = &l_iod;
 	}
 
-	d_iov_set(&dkey, (void *)name, len);
 	d_iov_set(&iod->iod_name, INODE_AKEY_NAME, sizeof(INODE_AKEY_NAME) - 1);
 	iod->iod_nr    = 1;
 	recx.rx_idx    = 0;
-	recx.rx_nr     = END_IDX;
+	recx.rx_nr     = include_link_cnt ? END_GIT_IDX : END_IDX;
 	iod->iod_recxs = &recx;
 	iod->iod_type  = DAOS_IOD_ARRAY;
 	iod->iod_size  = 1;
@@ -206,63 +202,103 @@ fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char
 	d_iov_set(&sg_iovs[i++], &entry->gid, sizeof(gid_t));
 	d_iov_set(&sg_iovs[i++], &entry->value_len, sizeof(daos_size_t));
 	d_iov_set(&sg_iovs[i++], &entry->obj_hlc, sizeof(uint64_t));
+	if (include_link_cnt)
+		d_iov_set(&sg_iovs[i++], &entry->link_cnt, sizeof(uint64_t));
 
 	sgl->sg_nr     = i;
 	sgl->sg_nr_out = 0;
 	sgl->sg_iovs   = sg_iovs;
 
-	rc = daos_obj_fetch(oh, th, DAOS_COND_DKEY_FETCH, &dkey, xnr + 1, iods ? iods : iod,
+	rc = daos_obj_fetch(oh, th, DAOS_COND_DKEY_FETCH, dkey, xnr + 1, iods ? iods : iod,
 			    sgls ? sgls : sgl, NULL, NULL);
 	if (rc == -DER_NONEXIST) {
 		*exists = false;
 		D_GOTO(out, rc = 0);
 	} else if (rc) {
-		D_ERROR("Failed to fetch entry %s " DF_RC "\n", name, DP_RC(rc));
+		D_ERROR("Failed to fetch entry " DF_RC "\n", DP_RC(rc));
 		D_GOTO(out, rc = daos_der2errno(rc));
 	}
 
-	for (i = 0; i < xnr; i++)
+	for (i = 0; i < (unsigned int)xnr; i++)
 		xsizes[i] = iods[i].iod_size;
 
-	if (fetch_sym && S_ISLNK(entry->mode)) {
+	*exists = (sgl->sg_nr_out != 0);
+out:
+	if (xnr) {
+		if (pxnames) {
+			for (i = 0; i < (unsigned int)xnr; i++)
+				D_FREE(pxnames[i]);
+			D_FREE(pxnames);
+		}
+		D_FREE(sg_iovx);
+		D_FREE(sgls);
+		D_FREE(iods);
+	}
+	return rc;
+}
+
+int
+fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char *name, size_t len,
+	    bool fetch_sym, bool *exists, struct dfs_entry *entry, int xnr, char *xnames[],
+	    void *xvals[], daos_size_t *xsizes)
+{
+	daos_iod_t  iod;
+	d_sg_list_t sgl;
+	daos_key_t  dkey;
+	int         rc;
+
+	D_ASSERT(name);
+
+	/** TODO - not supported yet */
+	if (strcmp(name, ".") == 0)
+		return ENOTSUP;
+
+	d_iov_set(&dkey, (void *)name, len);
+
+	rc = fetch_entry_common(oh, th, &dkey, false, exists, entry, xnr, xnames, xvals, xsizes);
+	if (rc)
+		return rc;
+
+	if (*exists && fetch_sym && S_ISLNK(entry->mode)) {
 		char       *value;
 		daos_size_t val_len;
+		d_iov_t     slink_iov;
 
 		/** symlink is empty */
 		if (entry->value_len == 0)
-			D_GOTO(out, rc = EIO);
+			return EIO;
 		val_len = entry->value_len;
 		D_ALLOC(value, val_len + 1);
 		if (value == NULL)
-			D_GOTO(out, rc = ENOMEM);
+			return ENOMEM;
 
-		d_iov_set(&iod->iod_name, SLINK_AKEY_NAME, sizeof(SLINK_AKEY_NAME) - 1);
-		iod->iod_nr    = 1;
-		iod->iod_recxs = NULL;
-		iod->iod_type  = DAOS_IOD_SINGLE;
-		iod->iod_size  = DAOS_REC_ANY;
+		d_iov_set(&iod.iod_name, SLINK_AKEY_NAME, sizeof(SLINK_AKEY_NAME) - 1);
+		iod.iod_nr    = 1;
+		iod.iod_recxs = NULL;
+		iod.iod_type  = DAOS_IOD_SINGLE;
+		iod.iod_size  = DAOS_REC_ANY;
 
-		d_iov_set(&sg_iovs[0], value, val_len);
-		sgl->sg_nr     = 1;
-		sgl->sg_nr_out = 0;
-		sgl->sg_iovs   = sg_iovs;
+		d_iov_set(&slink_iov, value, val_len);
+		sgl.sg_nr     = 1;
+		sgl.sg_nr_out = 0;
+		sgl.sg_iovs   = &slink_iov;
 
-		rc = daos_obj_fetch(oh, th, DAOS_COND_DKEY_FETCH, &dkey, 1, iod, sgl, NULL, NULL);
+		rc = daos_obj_fetch(oh, th, DAOS_COND_DKEY_FETCH, &dkey, 1, &iod, &sgl, NULL, NULL);
 		if (rc) {
 			D_FREE(value);
 			if (rc == -DER_NONEXIST) {
 				*exists = false;
-				D_GOTO(out, rc = 0);
+				return 0;
 			}
 			D_ERROR("Failed to fetch entry %s " DF_RC "\n", name, DP_RC(rc));
-			D_GOTO(out, rc = daos_der2errno(rc));
+			return daos_der2errno(rc);
 		}
 
 		/** make sure that the akey value size matches what is in the inode */
-		if (iod->iod_size != val_len) {
+		if (iod.iod_size != val_len) {
 			D_ERROR("Symlink value length inconsistent with inode data\n");
 			D_FREE(value);
-			D_GOTO(out, rc = EIO);
+			return EIO;
 		}
 		value[val_len] = 0;
 
@@ -271,25 +307,12 @@ fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char
 		} else {
 			D_ERROR("Failed to load value for symlink\n");
 			D_FREE(value);
-			D_GOTO(out, rc = EIO);
+			return EIO;
 		}
 	}
 
-	if (sgl->sg_nr_out == 0)
-		*exists = false;
-	else
-		*exists = true;
-out:
-	if (xnr) {
-		if (pxnames) {
-			for (i = 0; i < xnr; i++)
-				D_FREE(pxnames[i]);
-			D_FREE(pxnames);
-		}
-		D_FREE(sg_iovx);
-		D_FREE(sgls);
-		D_FREE(iods);
-	}
+	if (*exists)
+		entry->link_cnt = 1;
 	return rc;
 }
 
@@ -326,25 +349,28 @@ punch_entry:
 	return daos_der2errno(rc);
 }
 
-int
-insert_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char *name, size_t len,
-	     uint64_t flags, struct dfs_entry *entry)
+/*
+ * Shared insert helper for insert_entry() and git_insert_entry().
+ * include_link_cnt=true extends the recx to cover the GIT link_cnt field.
+ * Symlink akey is only written when include_link_cnt is false.
+ */
+static int
+insert_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool include_link_cnt,
+		    uint64_t flags, struct dfs_entry *entry)
 {
 	d_sg_list_t  sgls[2];
 	d_iov_t      sg_iovs[INODE_AKEYS];
 	d_iov_t      sym_iov;
 	daos_iod_t   iods[2];
 	daos_recx_t  recx;
-	daos_key_t   dkey;
 	unsigned int i;
 	unsigned int nr_iods;
 	int          rc;
 
-	d_iov_set(&dkey, (void *)name, len);
 	d_iov_set(&iods[0].iod_name, INODE_AKEY_NAME, sizeof(INODE_AKEY_NAME) - 1);
 	iods[0].iod_nr    = 1;
 	recx.rx_idx       = 0;
-	recx.rx_nr        = END_IDX;
+	recx.rx_nr        = include_link_cnt ? END_GIT_IDX : END_IDX;
 	iods[0].iod_recxs = &recx;
 	iods[0].iod_type  = DAOS_IOD_ARRAY;
 	iods[0].iod_size  = 1;
@@ -363,9 +389,11 @@ insert_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const cha
 	/** Add file size / symlink length. for now, file size cached in the entry is 0. */
 	d_iov_set(&sg_iovs[i++], &entry->value_len, sizeof(daos_size_t));
 	d_iov_set(&sg_iovs[i++], &entry->obj_hlc, sizeof(uint64_t));
+	if (include_link_cnt)
+		d_iov_set(&sg_iovs[i++], &entry->link_cnt, sizeof(uint64_t));
 
-	/** add the symlink as a separate akey */
-	if (S_ISLNK(entry->mode)) {
+	/** add the symlink as a separate akey (dentry only, never in GIT) */
+	if (!include_link_cnt && S_ISLNK(entry->mode)) {
 		nr_iods = 2;
 		d_iov_set(&iods[1].iod_name, SLINK_AKEY_NAME, sizeof(SLINK_AKEY_NAME) - 1);
 		iods[1].iod_nr    = 1;
@@ -385,14 +413,199 @@ insert_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const cha
 	sgls[0].sg_nr_out = 0;
 	sgls[0].sg_iovs   = sg_iovs;
 
-	rc = daos_obj_update(oh, th, flags, &dkey, nr_iods, iods, sgls, NULL);
+	rc = daos_obj_update(oh, th, flags, dkey, nr_iods, iods, sgls, NULL);
 	if (rc) {
 		/** don't log error if conditional failed */
 		if (rc != -DER_EXIST && rc != -DER_NO_PERM)
-			D_ERROR("Failed to insert entry '%s', " DF_RC "\n", name, DP_RC(rc));
+			D_ERROR("Failed to insert entry, " DF_RC "\n", DP_RC(rc));
 		return daos_der2errno(rc);
 	}
 	return 0;
+}
+
+int
+insert_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char *name, size_t len,
+	     uint64_t flags, struct dfs_entry *entry)
+{
+	daos_key_t dkey;
+
+	d_iov_set(&dkey, (void *)name, len);
+	return insert_entry_common(oh, th, &dkey, false, flags, entry);
+}
+
+int
+git_fetch_entry(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *oid, struct dfs_entry *entry,
+		int xnr, char *xnames[], void *xvals[], daos_size_t *xsizes)
+{
+	daos_key_t dkey;
+	bool       exists;
+	int        rc;
+
+	if (oid == NULL || entry == NULL)
+		return EINVAL;
+
+	d_iov_set(&dkey, oid, sizeof(daos_obj_id_t));
+	rc =
+	    fetch_entry_common(git_oh, th, &dkey, true, &exists, entry, xnr, xnames, xvals, xsizes);
+	if (rc)
+		return rc;
+	if (!exists) {
+		D_ERROR("Entry not found in GIT\n");
+		return ENOENT;
+	}
+	return 0;
+}
+
+int
+git_insert_entry(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *oid, uint64_t flags,
+		 struct dfs_entry *entry)
+{
+	daos_key_t dkey;
+
+	if (oid == NULL || entry == NULL)
+		return EINVAL;
+	D_ASSERT(!S_ISLNK(entry->mode));
+
+	d_iov_set(&dkey, oid, sizeof(daos_obj_id_t));
+	return insert_entry_common(git_oh, th, &dkey, true, flags, entry);
+}
+
+int
+git_update_link_cnt(daos_handle_t git_oh, daos_handle_t th, struct dfs_entry *entry, int delta)
+{
+	daos_key_t      dkey;
+	d_sg_list_t     sgl;
+	d_iov_t         sg_iovs[3];
+	daos_iod_t      iod;
+	daos_recx_t     recxs[3];
+	struct timespec now;
+	int             rc;
+
+	if (entry == NULL)
+		return EINVAL;
+
+	if (delta < 0 && entry->link_cnt < (uint64_t)(-delta)) {
+		D_ERROR("link_cnt underflow: link_cnt=%lu, delta=%d\n", entry->link_cnt, delta);
+		return EINVAL;
+	}
+
+	entry->link_cnt += delta;
+
+	rc = clock_gettime(CLOCK_REALTIME, &now);
+	if (rc)
+		return errno;
+	entry->ctime      = now.tv_sec;
+	entry->ctime_nano = now.tv_nsec;
+
+	d_iov_set(&dkey, &entry->oid, sizeof(daos_obj_id_t));
+	d_iov_set(&iod.iod_name, INODE_AKEY_NAME, sizeof(INODE_AKEY_NAME) - 1);
+	iod.iod_nr      = 3;
+	recxs[0].rx_idx = LINK_CNT_IDX;
+	recxs[0].rx_nr  = sizeof(uint64_t);
+	recxs[1].rx_idx = CTIME_IDX;
+	recxs[1].rx_nr  = sizeof(uint64_t);
+	recxs[2].rx_idx = CTIME_NSEC_IDX;
+	recxs[2].rx_nr  = sizeof(uint64_t);
+	iod.iod_recxs   = recxs;
+	iod.iod_type    = DAOS_IOD_ARRAY;
+	iod.iod_size    = 1;
+
+	d_iov_set(&sg_iovs[0], &entry->link_cnt, sizeof(uint64_t));
+	d_iov_set(&sg_iovs[1], &entry->ctime, sizeof(uint64_t));
+	d_iov_set(&sg_iovs[2], &entry->ctime_nano, sizeof(uint64_t));
+	sgl.sg_nr     = 3;
+	sgl.sg_nr_out = 0;
+	sgl.sg_iovs   = sg_iovs;
+
+	rc = daos_obj_update(git_oh, th, DAOS_COND_DKEY_UPDATE, &dkey, 1, &iod, &sgl, NULL);
+	if (rc) {
+		D_ERROR("Failed to update link_cnt in GIT " DF_RC "\n", DP_RC(rc));
+		return daos_der2errno(rc);
+	}
+	return 0;
+}
+
+int
+git_copy_xattr(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *dst_oid, daos_handle_t src_oh,
+	       const char *src_name)
+{
+	daos_key_t      src_dkey, dst_dkey;
+	daos_anchor_t   anchor = {0};
+	d_sg_list_t     sgl, fsgl;
+	d_iov_t         iov, fiov;
+	daos_iod_t      iod;
+	void           *val_buf;
+	char            enum_buf[ENUM_XDESC_BUF];
+	daos_key_desc_t kds[ENUM_DESC_NR];
+	int             rc = 0;
+
+	if (src_name == NULL || dst_oid == NULL)
+		return EINVAL;
+
+	d_iov_set(&src_dkey, (void *)src_name, strlen(src_name));
+	d_iov_set(&dst_dkey, dst_oid, sizeof(daos_obj_id_t));
+
+	iod.iod_nr    = 1;
+	iod.iod_recxs = NULL;
+	iod.iod_type  = DAOS_IOD_SINGLE;
+	iod.iod_size  = DFS_MAX_XATTR_LEN;
+
+	D_ALLOC(val_buf, DFS_MAX_XATTR_LEN);
+	if (val_buf == NULL)
+		return ENOMEM;
+
+	fsgl.sg_nr     = 1;
+	fsgl.sg_nr_out = 0;
+	fsgl.sg_iovs   = &fiov;
+
+	sgl.sg_nr     = 1;
+	sgl.sg_nr_out = 0;
+	d_iov_set(&iov, enum_buf, ENUM_XDESC_BUF);
+	sgl.sg_iovs = &iov;
+
+	while (!daos_anchor_is_eof(&anchor)) {
+		uint32_t number = ENUM_DESC_NR;
+		uint32_t i;
+		char    *ptr;
+
+		memset(enum_buf, 0, ENUM_XDESC_BUF);
+		rc = daos_obj_list_akey(src_oh, th, &src_dkey, &number, kds, &sgl, &anchor, NULL);
+		if (rc) {
+			D_ERROR("daos_obj_list_akey() failed " DF_RC "\n", DP_RC(rc));
+			D_GOTO(out, rc = daos_der2errno(rc));
+		}
+
+		if (number == 0)
+			continue;
+
+		for (ptr = enum_buf, i = 0; i < number; i++) {
+			if (kds[i].kd_key_len < 2 || strncmp("x:", ptr, 2) != 0) {
+				ptr += kds[i].kd_key_len;
+				continue;
+			}
+
+			d_iov_set(&iod.iod_name, ptr, kds[i].kd_key_len);
+			iod.iod_size = DFS_MAX_XATTR_LEN;
+			d_iov_set(&fiov, val_buf, DFS_MAX_XATTR_LEN);
+
+			rc = daos_obj_fetch(src_oh, th, 0, &src_dkey, 1, &iod, &fsgl, NULL, NULL);
+			if (rc) {
+				D_ERROR("daos_obj_fetch() xattr failed " DF_RC "\n", DP_RC(rc));
+				D_GOTO(out, rc = daos_der2errno(rc));
+			}
+
+			d_iov_set(&fiov, val_buf, iod.iod_size);
+			rc = daos_obj_update(git_oh, th, 0, &dst_dkey, 1, &iod, &fsgl, NULL);
+			if (rc) {
+				D_ERROR("daos_obj_update() xattr failed " DF_RC "\n", DP_RC(rc));
+				D_GOTO(out, rc = daos_der2errno(rc));
+			}
+			ptr += kds[i].kd_key_len;
+		}
+	}
+out:
+	D_FREE(val_buf);
+	return rc;
 }
 
 int

--- a/src/client/dfs/common.c
+++ b/src/client/dfs/common.c
@@ -216,6 +216,12 @@ fetch_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool is
 		*exists = false;
 		D_GOTO(out, rc = 0);
 	} else if (rc) {
+		if (is_git_entry)
+			D_ERROR("Failed to fetch GIT entry for OID " DF_OID " " DF_RC "\n",
+				DP_OID(*(daos_obj_id_t *)dkey->iov_buf), DP_RC(rc));
+		else
+			D_ERROR("Failed to fetch entry %s " DF_RC "\n", (const char *)dkey->iov_buf,
+				DP_RC(rc));
 		D_GOTO(out, rc = daos_der2errno(rc));
 	}
 
@@ -304,10 +310,8 @@ fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char
 
 	rc = fetch_entry_common(oh, th, &dkey, false, fetch_sym, exists, entry, xnr, xnames, xvals,
 				xsizes);
-	if (rc) {
-		D_ERROR("Failed to fetch entry %s " DF_RC "\n", name, DP_RC(rc));
+	if (rc)
 		return rc;
-	}
 
 	if (*exists)
 		entry->link_cnt = 1;
@@ -417,8 +421,18 @@ insert_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool i
 	sgls[0].sg_iovs   = sg_iovs;
 
 	rc = daos_obj_update(oh, th, flags, dkey, nr_iods, iods, sgls, NULL);
-	if (rc)
+	if (rc) {
+		/** don't log error if conditional failed */
+		if (rc != -DER_EXIST && rc != -DER_NO_PERM) {
+			if (is_git_entry)
+				D_ERROR("Failed to insert GIT entry for OID " DF_OID " " DF_RC "\n",
+					DP_OID(*(daos_obj_id_t *)dkey->iov_buf), DP_RC(rc));
+			else
+				D_ERROR("Failed to insert entry %s " DF_RC "\n",
+					(const char *)dkey->iov_buf, DP_RC(rc));
+		}
 		return daos_der2errno(rc);
+	}
 	return 0;
 }
 
@@ -427,14 +441,9 @@ insert_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const cha
 	     uint64_t flags, struct dfs_entry *entry)
 {
 	daos_key_t dkey;
-	int        rc;
 
 	d_iov_set(&dkey, (void *)name, len);
-	rc = insert_entry_common(oh, th, &dkey, false, flags, entry);
-	/** don't log error if conditional failed */
-	if (rc && rc != EEXIST && rc != EPERM)
-		D_ERROR("Failed to fetch entry %s " DF_RC "\n", name, DP_RC(rc));
-	return rc;
+	return insert_entry_common(oh, th, &dkey, false, flags, entry);
 }
 
 int
@@ -451,11 +460,8 @@ git_fetch_entry(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *oid, stru
 	d_iov_set(&dkey, oid, sizeof(daos_obj_id_t));
 	rc = fetch_entry_common(git_oh, th, &dkey, true, false, &exists, entry, xnr, xnames, xvals,
 				xsizes);
-	if (rc) {
-		D_ERROR("Failed to fetch GIT entry for OID " DF_OID " " DF_RC "\n", DP_OID(*oid),
-			DP_RC(rc));
+	if (rc)
 		return rc;
-	}
 	if (!exists)
 		return ENOENT;
 	return 0;
@@ -466,18 +472,12 @@ git_insert_entry(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *oid, uin
 		 struct dfs_entry *entry)
 {
 	daos_key_t dkey;
-	int        rc;
 
 	if (oid == NULL || entry == NULL)
 		return EINVAL;
 
 	d_iov_set(&dkey, oid, sizeof(daos_obj_id_t));
-	rc = insert_entry_common(git_oh, th, &dkey, true, flags, entry);
-	/** don't log error if conditional failed */
-	if (rc && rc != EEXIST && rc != EPERM)
-		D_ERROR("Failed to insert GIT entry for OID " DF_OID " " DF_RC "\n", DP_OID(*oid),
-			DP_RC(rc));
-	return rc;
+	return insert_entry_common(git_oh, th, &dkey, true, flags, entry);
 }
 
 int

--- a/src/client/dfs/common.c
+++ b/src/client/dfs/common.c
@@ -261,6 +261,8 @@ fetch_entry_common(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey, bool is
 				*exists = false;
 				D_GOTO(out, rc = 0);
 			}
+			D_ERROR("Failed to fetch entry %s " DF_RC "\n", (const char *)dkey->iov_buf,
+				DP_RC(rc));
 			D_GOTO(out, rc = daos_der2errno(rc));
 		}
 

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -63,7 +63,7 @@
 #define DFS_OBJ_GLOB_MAGIC 0xdf500b90
 
 /** Number of A-keys for attributes in any object entry */
-#define INODE_AKEYS        12
+#define INODE_AKEYS            13
 #define INODE_AKEY_NAME    "DFS_INODE"
 #define SLINK_AKEY_NAME    "DFS_SLINK"
 #define MODE_IDX           0
@@ -79,6 +79,10 @@
 #define SIZE_IDX           (GID_IDX + sizeof(gid_t))
 #define HLC_IDX            (SIZE_IDX + sizeof(daos_size_t))
 #define END_IDX            (HLC_IDX + sizeof(uint64_t))
+
+/** GIT (Global Index Table) inode layout extends the base inode with link_cnt */
+#define LINK_CNT_IDX           END_IDX
+#define END_GIT_IDX            (LINK_CNT_IDX + sizeof(uint64_t))
 
 /*
  * END IDX for layout V2 (2.0) is at the current offset where we store the mtime nsec, but also need
@@ -232,6 +236,8 @@ struct dfs_entry {
 	gid_t            gid;
 	/** Sym Link value */
 	char            *value;
+	/** Hard link count: always 1 for regular dentries, real count when read from GIT */
+	uint64_t         link_cnt;
 };
 
 /** enum for hash entry type */
@@ -422,6 +428,18 @@ fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char
 int
 remove_entry(dfs_t *dfs, daos_handle_t th, daos_handle_t parent_oh, const char *name, size_t len,
 	     struct dfs_entry entry);
+/** GIT (Global Index Table) entry operations */
+int
+git_fetch_entry(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *oid, struct dfs_entry *entry,
+		int xnr, char *xnames[], void *xvals[], daos_size_t *xsizes);
+int
+git_insert_entry(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *oid, uint64_t flags,
+		 struct dfs_entry *entry);
+int
+git_update_link_cnt(daos_handle_t git_oh, daos_handle_t th, struct dfs_entry *entry, int delta);
+int
+git_copy_xattr(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *dst_oid, daos_handle_t src_oh,
+	       const char *src_name);
 int
 open_dir(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, struct dfs_entry *entry,
 	 size_t len, dfs_obj_t *dir);

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -78,11 +78,11 @@
 #define GID_IDX            (UID_IDX + sizeof(uid_t))
 #define SIZE_IDX           (GID_IDX + sizeof(gid_t))
 #define HLC_IDX            (SIZE_IDX + sizeof(daos_size_t))
-#define END_IDX            (HLC_IDX + sizeof(uint64_t))
+#define END_L3_IDX             (HLC_IDX + sizeof(uint64_t))
 
-/** GIT (Global Index Table) inode layout extends the base inode with link_cnt */
-#define LINK_CNT_IDX           END_IDX
-#define END_GIT_IDX            (LINK_CNT_IDX + sizeof(uint64_t))
+/** GIT (Global Inode Table) layout extends the base inode with link_cnt */
+#define LINK_CNT_IDX           END_L3_IDX
+#define END_IDX                (LINK_CNT_IDX + sizeof(uint64_t))
 
 /*
  * END IDX for layout V2 (2.0) is at the current offset where we store the mtime nsec, but also need
@@ -184,7 +184,7 @@ struct dfs {
 	daos_obj_id_t        super_oid;
 	/** Open object handle of SB */
 	daos_handle_t        super_oh;
-	/** Global Index Table object OID */
+	/** Global Inode Table object OID */
 	daos_obj_id_t        git_oid;
 	/** Open object handle of GIT */
 	daos_handle_t        git_oh;
@@ -428,7 +428,6 @@ fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char
 int
 remove_entry(dfs_t *dfs, daos_handle_t th, daos_handle_t parent_oh, const char *name, size_t len,
 	     struct dfs_entry entry);
-/** GIT (Global Index Table) entry operations */
 int
 git_fetch_entry(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *oid, struct dfs_entry *entry,
 		int xnr, char *xnames[], void *xvals[], daos_size_t *xsizes);
@@ -436,7 +435,7 @@ int
 git_insert_entry(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *oid, uint64_t flags,
 		 struct dfs_entry *entry);
 int
-git_update_link_cnt(daos_handle_t git_oh, daos_handle_t th, struct dfs_entry *entry, int delta);
+git_update_link_cnt(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *oid, uint64_t value);
 int
 git_copy_xattr(daos_handle_t git_oh, daos_handle_t th, daos_obj_id_t *dst_oid, daos_handle_t src_oh,
 	       const char *src_name);

--- a/src/client/dfs/mnt.c
+++ b/src/client/dfs/mnt.c
@@ -722,7 +722,7 @@ dfs_mount_int(daos_handle_t poh, daos_handle_t coh, int flags, daos_epoch_t epoc
 		dfs->root_stbuf.st_atim.tv_nsec = root_dir.mtime_nano;
 	}
 
-	/** Open Global Index Table object */
+	/** Open Global Inode Table object */
 	if (!daos_obj_id_is_nil(dfs->git_oid)) {
 		rc = daos_obj_open(dfs->coh, dfs->git_oid, omode, &dfs->git_oh, NULL);
 		if (rc) {
@@ -1201,7 +1201,7 @@ dfs_global2local(daos_handle_t poh, daos_handle_t coh, int flags, d_iov_t glob, 
 		D_GOTO(err_dfs, rc = daos_der2errno(rc));
 	}
 
-	/* Open GIT (Global Index Table) Object */
+	/* Open GIT (Global Inode Table) Object */
 	if (!daos_obj_id_is_nil(dfs->git_oid)) {
 		rc = daos_obj_open(coh, dfs->git_oid, obj_mode, &dfs->git_oh, NULL);
 		if (rc) {

--- a/src/client/dfs/obj.c
+++ b/src/client/dfs/obj.c
@@ -957,7 +957,7 @@ statx_task(tse_task_t *task)
 	d_iov_set(&op_args->iod.iod_name, INODE_AKEY_NAME, sizeof(INODE_AKEY_NAME) - 1);
 	op_args->iod.iod_nr    = 1;
 	op_args->recx.rx_idx   = 0;
-	op_args->recx.rx_nr    = END_IDX;
+	op_args->recx.rx_nr    = END_L3_IDX;
 	op_args->iod.iod_recxs = &op_args->recx;
 	op_args->iod.iod_type  = DAOS_IOD_ARRAY;
 	op_args->iod.iod_size  = 1;

--- a/src/tests/daos_mw_fi.c
+++ b/src/tests/daos_mw_fi.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2023 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -33,7 +34,7 @@
 #include <daos/common.h>
 
 /** Copied from dfs.c (TODO: create an internal header file) */
-#define INODE_AKEYS	12
+#define INODE_AKEYS     13
 #define INODE_AKEY_NAME	"DFS_INODE"
 #define SLINK_AKEY_NAME	"DFS_SLINK"
 #define MODE_IDX	0

--- a/src/tests/daos_mw_fi.c
+++ b/src/tests/daos_mw_fi.c
@@ -49,7 +49,10 @@
 #define GID_IDX		(UID_IDX + sizeof(uid_t))
 #define SIZE_IDX	(GID_IDX + sizeof(gid_t))
 #define HLC_IDX		(SIZE_IDX + sizeof(daos_size_t))
-#define END_IDX		(HLC_IDX + sizeof(uint64_t))
+#define END_L3_IDX      (HLC_IDX + sizeof(uint64_t))
+/** GIT (Global Inode Table) layout extends the base inode with link_cnt */
+#define LINK_CNT_IDX    END_L3_IDX
+#define END_IDX         (LINK_CNT_IDX + sizeof(uint64_t))
 
 enum {
 	PUNCH_SB,

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -3562,7 +3562,7 @@ test_pipeline_find(void **state, daos_oclass_id_t dir_oclass)
 }
 
 /*
- * Tests for GIT (Global Index Table) internal functions.
+ * Tests for GIT (Global Inode Table) internal functions.
  *
  * dfs_mt->git_oh is a plain KV object opened during mount.  All four tests
  * use synthetic OIDs as dkeys so they are self-contained and do not interfere
@@ -3682,9 +3682,8 @@ dfs_test_git_update_link_cnt(void **state)
 	assert_int_equal(rc, 0);
 
 	/* increment: 2 -> 3 */
-	rc = git_update_link_cnt(dfs_mt->git_oh, DAOS_TX_NONE, &entry, 1);
+	rc = git_update_link_cnt(dfs_mt->git_oh, DAOS_TX_NONE, &entry.oid, entry.link_cnt + 1);
 	assert_int_equal(rc, 0);
-	assert_int_equal(entry.link_cnt, 3);
 
 	rc = git_fetch_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, &fetched, 0, NULL, NULL, NULL);
 	assert_int_equal(rc, 0);
@@ -3692,19 +3691,18 @@ dfs_test_git_update_link_cnt(void **state)
 	print_message("git_update_link_cnt increment (2->3): OK\n");
 
 	/* decrement: 3 -> 2 */
-	rc = git_update_link_cnt(dfs_mt->git_oh, DAOS_TX_NONE, &entry, -1);
+	rc = git_update_link_cnt(dfs_mt->git_oh, DAOS_TX_NONE, &entry.oid, fetched.link_cnt - 1);
 	assert_int_equal(rc, 0);
-	assert_int_equal(entry.link_cnt, 2);
 
 	rc = git_fetch_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, &fetched, 0, NULL, NULL, NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(fetched.link_cnt, 2);
 	print_message("git_update_link_cnt decrement (3->2): OK\n");
 
-	/* underflow guard: delta=-5 on link_cnt=2 must return EINVAL */
-	rc = git_update_link_cnt(dfs_mt->git_oh, DAOS_TX_NONE, &entry, -5);
+	/* zero-value guard: link_cnt=0 must return EINVAL */
+	rc = git_update_link_cnt(dfs_mt->git_oh, DAOS_TX_NONE, &entry.oid, 0);
 	assert_int_equal(rc, EINVAL);
-	print_message("git_update_link_cnt underflow guard: OK\n");
+	print_message("git_update_link_cnt zero-value guard: OK\n");
 }
 
 /*

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -12,6 +12,7 @@
 #include <daos_types.h>
 #include <daos/placement.h>
 #include <pthread.h>
+#include "../../client/dfs/dfs_internal.h"
 
 /** global DFS mount used for all tests */
 static uuid_t		co_uuid;
@@ -3560,6 +3561,242 @@ test_pipeline_find(void **state, daos_oclass_id_t dir_oclass)
 	assert_int_equal(rc, 0);
 }
 
+/*
+ * Tests for GIT (Global Index Table) internal functions.
+ *
+ * dfs_mt->git_oh is a plain KV object opened during mount.  All four tests
+ * use synthetic OIDs as dkeys so they are self-contained and do not interfere
+ * with the rest of the container.
+ */
+
+/* Build a fully populated dfs_entry for use in GIT tests. */
+static void
+git_test_make_entry(struct dfs_entry *e, daos_obj_id_t oid)
+{
+	memset(e, 0, sizeof(*e));
+	e->mode       = S_IFREG | 0644;
+	e->oid        = oid;
+	e->mtime      = 1000;
+	e->mtime_nano = 500;
+	e->ctime      = 2000;
+	e->ctime_nano = 750;
+	e->chunk_size = 1048576;
+	e->oclass     = OC_SX;
+	e->uid        = 1001;
+	e->gid        = 1002;
+	e->value_len  = 0;
+	e->obj_hlc    = 0;
+	e->link_cnt   = 2;
+}
+
+/*
+ * Test 1: git_insert_entry / git_fetch_entry round-trip.
+ * Also verifies ENOENT for a missing OID.
+ */
+static void
+dfs_test_git_insert_fetch(void **state)
+{
+	test_arg_t      *arg         = *state;
+	struct dfs_entry entry_in    = {0};
+	struct dfs_entry entry_out   = {0};
+	daos_obj_id_t    oid         = {.hi = 0xDEAD0001ULL, .lo = 0xBEEF0001ULL};
+	daos_obj_id_t    missing_oid = {.hi = 0xDEAD0099ULL, .lo = 0xBEEF0099ULL};
+	int              rc;
+
+	if (arg->myrank != 0)
+		return;
+
+	/* fetch of non-existent OID must return ENOENT */
+	rc = git_fetch_entry(dfs_mt->git_oh, DAOS_TX_NONE, &missing_oid, &entry_out, 0, NULL, NULL,
+			     NULL);
+	assert_int_equal(rc, ENOENT);
+
+	git_test_make_entry(&entry_in, oid);
+
+	rc = git_insert_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, DAOS_COND_DKEY_INSERT, &entry_in);
+	assert_int_equal(rc, 0);
+	print_message("git_insert_entry: OK\n");
+
+	rc = git_fetch_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, &entry_out, 0, NULL, NULL, NULL);
+	assert_int_equal(rc, 0);
+
+	assert_int_equal(entry_out.mode, entry_in.mode);
+	assert_int_equal(entry_out.oid.hi, entry_in.oid.hi);
+	assert_int_equal(entry_out.oid.lo, entry_in.oid.lo);
+	assert_int_equal(entry_out.mtime, entry_in.mtime);
+	assert_int_equal(entry_out.mtime_nano, entry_in.mtime_nano);
+	assert_int_equal(entry_out.ctime, entry_in.ctime);
+	assert_int_equal(entry_out.ctime_nano, entry_in.ctime_nano);
+	assert_int_equal(entry_out.chunk_size, entry_in.chunk_size);
+	assert_int_equal(entry_out.oclass, entry_in.oclass);
+	assert_int_equal(entry_out.uid, entry_in.uid);
+	assert_int_equal(entry_out.gid, entry_in.gid);
+	assert_int_equal(entry_out.link_cnt, entry_in.link_cnt);
+	print_message("git_fetch_entry round-trip: OK\n");
+}
+
+/*
+ * Test 2: git_insert_entry insert-once semantics (DAOS_COND_DKEY_INSERT).
+ * Inserting the same OID twice must return EEXIST.
+ */
+static void
+dfs_test_git_insert_once(void **state)
+{
+	test_arg_t      *arg   = *state;
+	struct dfs_entry entry = {0};
+	daos_obj_id_t    oid   = {.hi = 0xDEAD0002ULL, .lo = 0xBEEF0002ULL};
+	int              rc;
+
+	if (arg->myrank != 0)
+		return;
+
+	git_test_make_entry(&entry, oid);
+
+	rc = git_insert_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, DAOS_COND_DKEY_INSERT, &entry);
+	assert_int_equal(rc, 0);
+
+	/* second insert of the same OID must fail */
+	rc = git_insert_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, DAOS_COND_DKEY_INSERT, &entry);
+	assert_int_equal(rc, EEXIST);
+	print_message("git_insert_entry insert-once semantics: OK\n");
+}
+
+/*
+ * Test 3: git_update_link_cnt — increment, decrement, and underflow guard.
+ */
+static void
+dfs_test_git_update_link_cnt(void **state)
+{
+	test_arg_t      *arg     = *state;
+	struct dfs_entry entry   = {0};
+	struct dfs_entry fetched = {0};
+	daos_obj_id_t    oid     = {.hi = 0xDEAD0003ULL, .lo = 0xBEEF0003ULL};
+	int              rc;
+
+	if (arg->myrank != 0)
+		return;
+
+	git_test_make_entry(&entry, oid); /* link_cnt = 2 */
+
+	rc = git_insert_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, DAOS_COND_DKEY_INSERT, &entry);
+	assert_int_equal(rc, 0);
+
+	/* increment: 2 -> 3 */
+	rc = git_update_link_cnt(dfs_mt->git_oh, DAOS_TX_NONE, &entry, 1);
+	assert_int_equal(rc, 0);
+	assert_int_equal(entry.link_cnt, 3);
+
+	rc = git_fetch_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, &fetched, 0, NULL, NULL, NULL);
+	assert_int_equal(rc, 0);
+	assert_int_equal(fetched.link_cnt, 3);
+	print_message("git_update_link_cnt increment (2->3): OK\n");
+
+	/* decrement: 3 -> 2 */
+	rc = git_update_link_cnt(dfs_mt->git_oh, DAOS_TX_NONE, &entry, -1);
+	assert_int_equal(rc, 0);
+	assert_int_equal(entry.link_cnt, 2);
+
+	rc = git_fetch_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, &fetched, 0, NULL, NULL, NULL);
+	assert_int_equal(rc, 0);
+	assert_int_equal(fetched.link_cnt, 2);
+	print_message("git_update_link_cnt decrement (3->2): OK\n");
+
+	/* underflow guard: delta=-5 on link_cnt=2 must return EINVAL */
+	rc = git_update_link_cnt(dfs_mt->git_oh, DAOS_TX_NONE, &entry, -5);
+	assert_int_equal(rc, EINVAL);
+	print_message("git_update_link_cnt underflow guard: OK\n");
+}
+
+/*
+ * Test 4: git_copy_xattr — xattrs set on a dentry are copied to GIT.
+ * Uses dfs_setxattr to set two xattrs on a real file, then calls
+ * git_copy_xattr and verifies the akeys appear under the GIT dkey.
+ */
+static void
+dfs_test_git_copy_xattr(void **state)
+{
+	test_arg_t      *arg       = *state;
+	dfs_obj_t       *obj       = NULL;
+	struct dfs_entry git_entry = {0};
+	struct dfs_entry fetched   = {0};
+	daos_obj_id_t    git_oid;
+	daos_handle_t    dir_oh;
+	const char      *fname  = "git_xattr_test_file";
+	const char      *xname1 = "user.attr1";
+	const char      *xval1  = "value_one";
+	const char      *xname2 = "user.attr2";
+	const char      *xval2  = "value_two";
+	char            *xnames[2];
+	char             xbuf1[64];
+	char             xbuf2[64];
+	void            *xvals[2];
+	daos_size_t      xsizes[2];
+	int              rc;
+
+	if (arg->myrank != 0)
+		return;
+
+	/* create a regular file */
+	rc = dfs_open(dfs_mt, NULL, fname, S_IFREG | 0644, O_RDWR | O_CREAT, 0, 0, NULL, &obj);
+	assert_int_equal(rc, 0);
+
+	/* set two xattrs */
+	rc = dfs_setxattr(dfs_mt, obj, xname1, xval1, strlen(xval1) + 1, 0);
+	assert_int_equal(rc, 0);
+	rc = dfs_setxattr(dfs_mt, obj, xname2, xval2, strlen(xval2) + 1, 0);
+	assert_int_equal(rc, 0);
+
+	/* get the file's OID to use as the GIT dkey */
+	rc = dfs_obj2id(obj, &git_oid);
+	assert_int_equal(rc, 0);
+
+	/* insert a GIT entry for this OID */
+	git_test_make_entry(&git_entry, git_oid);
+	rc = git_insert_entry(dfs_mt->git_oh, DAOS_TX_NONE, &git_oid, DAOS_COND_DKEY_INSERT,
+			      &git_entry);
+	assert_int_equal(rc, 0);
+
+	/* open the root dir object to use as src_oh */
+	rc = daos_obj_open(dfs_mt->coh, dfs_mt->root.oid, DAOS_OO_RO, &dir_oh, NULL);
+	assert_int_equal(rc, 0);
+
+	/* copy xattrs from the dentry in root dir -> GIT */
+	rc = git_copy_xattr(dfs_mt->git_oh, DAOS_TX_NONE, &git_oid, dir_oh, fname);
+	assert_int_equal(rc, 0);
+	print_message("git_copy_xattr: OK\n");
+
+	rc = daos_obj_close(dir_oh, NULL);
+	assert_int_equal(rc, 0);
+
+	/* verify both xattrs via git_fetch_entry */
+	xnames[0] = (char *)xname1;
+	xnames[1] = (char *)xname2;
+	memset(xbuf1, 0, sizeof(xbuf1));
+	memset(xbuf2, 0, sizeof(xbuf2));
+	xvals[0]  = xbuf1;
+	xvals[1]  = xbuf2;
+	xsizes[0] = sizeof(xbuf1);
+	xsizes[1] = sizeof(xbuf2);
+
+	rc = git_fetch_entry(dfs_mt->git_oh, DAOS_TX_NONE, &git_oid, &fetched, 2, xnames, xvals,
+			     xsizes);
+	assert_int_equal(rc, 0);
+
+	assert_int_equal(xsizes[0], strlen(xval1) + 1);
+	assert_string_equal(xbuf1, xval1);
+	print_message("git_fetch_entry xattr1 verified in GIT: OK\n");
+
+	assert_int_equal(xsizes[1], strlen(xval2) + 1);
+	assert_string_equal(xbuf2, xval2);
+	print_message("git_fetch_entry xattr2 verified in GIT: OK\n");
+
+	/* inode fields must be untouched */
+	assert_int_equal(fetched.link_cnt, git_entry.link_cnt);
+
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+}
+
 static void
 dfs_test_pipeline_find(void **state)
 {
@@ -3572,62 +3809,52 @@ dfs_test_pipeline_find(void **state)
 }
 
 static const struct CMUnitTest dfs_unit_tests[] = {
-	{ "DFS_UNIT_TEST1: DFS mount / umount",
-	  dfs_test_mount, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST2: DFS container modes",
-	  dfs_test_modes, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST3: DFS lookup / lookup_rel",
-	  dfs_test_lookup, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST4: Simple Symlinks",
-	  dfs_test_syml, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST5: Symlinks with / without O_NOFOLLOW",
-	  dfs_test_syml_follow, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST6: multi-threads read shared file",
-	  dfs_test_read_shared_file, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST7: DFS lookupx",
-	  dfs_test_lookupx, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST8: DFS IO sync error code",
-	  dfs_test_io_error_code, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST9: DFS IO async error code",
-	  dfs_test_io_error_code, async_enable, test_case_teardown},
-	{ "DFS_UNIT_TEST10: multi-threads mkdir same dir",
-	  dfs_test_mt_mkdir, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST11: Simple rename",
-	  dfs_test_rename, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST12: DFS API compat",
-	  dfs_test_compat, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST13: DFS l2g/g2l_all",
-	  dfs_test_handles, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST14: multi-threads connect to same container",
-	  dfs_test_mt_connect, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST15: DFS chown",
-	  dfs_test_chown, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST16: DFS stat mtime",
-	  dfs_test_mtime, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST17: multi-threads async IO",
-	  dfs_test_async_io_th, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST18: async IO",
-	  dfs_test_async_io, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST19: DFS readdir",
-	  dfs_test_readdir, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST20: dfs oclass hints",
-	  dfs_test_oclass_hints, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST21: dfs multiple pools",
-	  dfs_test_multiple_pools, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST22: dfs extended attributes",
-	  dfs_test_xattrs, test_case_teardown},
-	{ "DFS_UNIT_TEST23: dfs MWC container checker",
-	  dfs_test_checker, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST24: dfs MWC SB fix",
-	  dfs_test_fix_sb, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST25: dfs MWC root fix",
-	  dfs_test_relink_root, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST26: dfs MWC chunk size fix",
-	  dfs_test_fix_chunk_size, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST27: dfs pipeline find",
-	  dfs_test_pipeline_find, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST28: dfs open/lookup flags",
-	  dfs_test_oflags, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST1: DFS mount / umount", dfs_test_mount, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST2: DFS container modes", dfs_test_modes, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST3: DFS lookup / lookup_rel", dfs_test_lookup, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST4: Simple Symlinks", dfs_test_syml, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST5: Symlinks with / without O_NOFOLLOW", dfs_test_syml_follow, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST6: multi-threads read shared file", dfs_test_read_shared_file, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST7: DFS lookupx", dfs_test_lookupx, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST8: DFS IO sync error code", dfs_test_io_error_code, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST9: DFS IO async error code", dfs_test_io_error_code, async_enable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST10: multi-threads mkdir same dir", dfs_test_mt_mkdir, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST11: Simple rename", dfs_test_rename, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST12: DFS API compat", dfs_test_compat, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST13: DFS l2g/g2l_all", dfs_test_handles, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST14: multi-threads connect to same container", dfs_test_mt_connect, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST15: DFS chown", dfs_test_chown, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST16: DFS stat mtime", dfs_test_mtime, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST17: multi-threads async IO", dfs_test_async_io_th, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST18: async IO", dfs_test_async_io, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST19: DFS readdir", dfs_test_readdir, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST20: dfs oclass hints", dfs_test_oclass_hints, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST21: dfs multiple pools", dfs_test_multiple_pools, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST22: dfs extended attributes", dfs_test_xattrs, test_case_teardown},
+    {"DFS_UNIT_TEST23: dfs MWC container checker", dfs_test_checker, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST24: dfs MWC SB fix", dfs_test_fix_sb, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST25: dfs MWC root fix", dfs_test_relink_root, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST26: dfs MWC chunk size fix", dfs_test_fix_chunk_size, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST27: dfs pipeline find", dfs_test_pipeline_find, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST28: dfs open/lookup flags", dfs_test_oflags, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST29: GIT insert/fetch round-trip", dfs_test_git_insert_fetch, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST30: GIT insert-once semantics", dfs_test_git_insert_once, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST31: GIT update link_cnt", dfs_test_git_update_link_cnt, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST32: GIT copy xattr", dfs_test_git_copy_xattr, async_disable, test_case_teardown},
 };
 
 static int

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -12,7 +12,6 @@
 #include <daos_types.h>
 #include <daos/placement.h>
 #include <pthread.h>
-#include "../../client/dfs/dfs_internal.h"
 
 /** global DFS mount used for all tests */
 static uuid_t		co_uuid;
@@ -3561,240 +3560,6 @@ test_pipeline_find(void **state, daos_oclass_id_t dir_oclass)
 	assert_int_equal(rc, 0);
 }
 
-/*
- * Tests for GIT (Global Inode Table) internal functions.
- *
- * dfs_mt->git_oh is a plain KV object opened during mount.  All four tests
- * use synthetic OIDs as dkeys so they are self-contained and do not interfere
- * with the rest of the container.
- */
-
-/* Build a fully populated dfs_entry for use in GIT tests. */
-static void
-git_test_make_entry(struct dfs_entry *e, daos_obj_id_t oid)
-{
-	memset(e, 0, sizeof(*e));
-	e->mode       = S_IFREG | 0644;
-	e->oid        = oid;
-	e->mtime      = 1000;
-	e->mtime_nano = 500;
-	e->ctime      = 2000;
-	e->ctime_nano = 750;
-	e->chunk_size = 1048576;
-	e->oclass     = OC_SX;
-	e->uid        = 1001;
-	e->gid        = 1002;
-	e->value_len  = 0;
-	e->obj_hlc    = 0;
-	e->link_cnt   = 2;
-}
-
-/*
- * Test 1: git_insert_entry / git_fetch_entry round-trip.
- * Also verifies ENOENT for a missing OID.
- */
-static void
-dfs_test_git_insert_fetch(void **state)
-{
-	test_arg_t      *arg         = *state;
-	struct dfs_entry entry_in    = {0};
-	struct dfs_entry entry_out   = {0};
-	daos_obj_id_t    oid         = {.hi = 0xDEAD0001ULL, .lo = 0xBEEF0001ULL};
-	daos_obj_id_t    missing_oid = {.hi = 0xDEAD0099ULL, .lo = 0xBEEF0099ULL};
-	int              rc;
-
-	if (arg->myrank != 0)
-		return;
-
-	/* fetch of non-existent OID must return ENOENT */
-	rc = git_fetch_entry(dfs_mt->git_oh, DAOS_TX_NONE, &missing_oid, &entry_out, 0, NULL, NULL,
-			     NULL);
-	assert_int_equal(rc, ENOENT);
-
-	git_test_make_entry(&entry_in, oid);
-
-	rc = git_insert_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, DAOS_COND_DKEY_INSERT, &entry_in);
-	assert_int_equal(rc, 0);
-	print_message("git_insert_entry: OK\n");
-
-	rc = git_fetch_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, &entry_out, 0, NULL, NULL, NULL);
-	assert_int_equal(rc, 0);
-
-	assert_int_equal(entry_out.mode, entry_in.mode);
-	assert_int_equal(entry_out.oid.hi, entry_in.oid.hi);
-	assert_int_equal(entry_out.oid.lo, entry_in.oid.lo);
-	assert_int_equal(entry_out.mtime, entry_in.mtime);
-	assert_int_equal(entry_out.mtime_nano, entry_in.mtime_nano);
-	assert_int_equal(entry_out.ctime, entry_in.ctime);
-	assert_int_equal(entry_out.ctime_nano, entry_in.ctime_nano);
-	assert_int_equal(entry_out.chunk_size, entry_in.chunk_size);
-	assert_int_equal(entry_out.oclass, entry_in.oclass);
-	assert_int_equal(entry_out.uid, entry_in.uid);
-	assert_int_equal(entry_out.gid, entry_in.gid);
-	assert_int_equal(entry_out.link_cnt, entry_in.link_cnt);
-	print_message("git_fetch_entry round-trip: OK\n");
-}
-
-/*
- * Test 2: git_insert_entry insert-once semantics (DAOS_COND_DKEY_INSERT).
- * Inserting the same OID twice must return EEXIST.
- */
-static void
-dfs_test_git_insert_once(void **state)
-{
-	test_arg_t      *arg   = *state;
-	struct dfs_entry entry = {0};
-	daos_obj_id_t    oid   = {.hi = 0xDEAD0002ULL, .lo = 0xBEEF0002ULL};
-	int              rc;
-
-	if (arg->myrank != 0)
-		return;
-
-	git_test_make_entry(&entry, oid);
-
-	rc = git_insert_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, DAOS_COND_DKEY_INSERT, &entry);
-	assert_int_equal(rc, 0);
-
-	/* second insert of the same OID must fail */
-	rc = git_insert_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, DAOS_COND_DKEY_INSERT, &entry);
-	assert_int_equal(rc, EEXIST);
-	print_message("git_insert_entry insert-once semantics: OK\n");
-}
-
-/*
- * Test 3: git_update_link_cnt — increment, decrement, and underflow guard.
- */
-static void
-dfs_test_git_update_link_cnt(void **state)
-{
-	test_arg_t      *arg     = *state;
-	struct dfs_entry entry   = {0};
-	struct dfs_entry fetched = {0};
-	daos_obj_id_t    oid     = {.hi = 0xDEAD0003ULL, .lo = 0xBEEF0003ULL};
-	int              rc;
-
-	if (arg->myrank != 0)
-		return;
-
-	git_test_make_entry(&entry, oid); /* link_cnt = 2 */
-
-	rc = git_insert_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, DAOS_COND_DKEY_INSERT, &entry);
-	assert_int_equal(rc, 0);
-
-	/* increment: 2 -> 3 */
-	rc = git_update_link_cnt(dfs_mt->git_oh, DAOS_TX_NONE, &entry.oid, entry.link_cnt + 1);
-	assert_int_equal(rc, 0);
-
-	rc = git_fetch_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, &fetched, 0, NULL, NULL, NULL);
-	assert_int_equal(rc, 0);
-	assert_int_equal(fetched.link_cnt, 3);
-	print_message("git_update_link_cnt increment (2->3): OK\n");
-
-	/* decrement: 3 -> 2 */
-	rc = git_update_link_cnt(dfs_mt->git_oh, DAOS_TX_NONE, &entry.oid, fetched.link_cnt - 1);
-	assert_int_equal(rc, 0);
-
-	rc = git_fetch_entry(dfs_mt->git_oh, DAOS_TX_NONE, &oid, &fetched, 0, NULL, NULL, NULL);
-	assert_int_equal(rc, 0);
-	assert_int_equal(fetched.link_cnt, 2);
-	print_message("git_update_link_cnt decrement (3->2): OK\n");
-
-	/* zero-value guard: link_cnt=0 must return EINVAL */
-	rc = git_update_link_cnt(dfs_mt->git_oh, DAOS_TX_NONE, &entry.oid, 0);
-	assert_int_equal(rc, EINVAL);
-	print_message("git_update_link_cnt zero-value guard: OK\n");
-}
-
-/*
- * Test 4: git_copy_xattr — xattrs set on a dentry are copied to GIT.
- * Uses dfs_setxattr to set two xattrs on a real file, then calls
- * git_copy_xattr and verifies the akeys appear under the GIT dkey.
- */
-static void
-dfs_test_git_copy_xattr(void **state)
-{
-	test_arg_t      *arg       = *state;
-	dfs_obj_t       *obj       = NULL;
-	struct dfs_entry git_entry = {0};
-	struct dfs_entry fetched   = {0};
-	daos_obj_id_t    git_oid;
-	daos_handle_t    dir_oh;
-	const char      *fname  = "git_xattr_test_file";
-	const char      *xname1 = "user.attr1";
-	const char      *xval1  = "value_one";
-	const char      *xname2 = "user.attr2";
-	const char      *xval2  = "value_two";
-	char            *xnames[2];
-	char             xbuf1[64];
-	char             xbuf2[64];
-	void            *xvals[2];
-	daos_size_t      xsizes[2];
-	int              rc;
-
-	if (arg->myrank != 0)
-		return;
-
-	/* create a regular file */
-	rc = dfs_open(dfs_mt, NULL, fname, S_IFREG | 0644, O_RDWR | O_CREAT, 0, 0, NULL, &obj);
-	assert_int_equal(rc, 0);
-
-	/* set two xattrs */
-	rc = dfs_setxattr(dfs_mt, obj, xname1, xval1, strlen(xval1) + 1, 0);
-	assert_int_equal(rc, 0);
-	rc = dfs_setxattr(dfs_mt, obj, xname2, xval2, strlen(xval2) + 1, 0);
-	assert_int_equal(rc, 0);
-
-	/* get the file's OID to use as the GIT dkey */
-	rc = dfs_obj2id(obj, &git_oid);
-	assert_int_equal(rc, 0);
-
-	/* insert a GIT entry for this OID */
-	git_test_make_entry(&git_entry, git_oid);
-	rc = git_insert_entry(dfs_mt->git_oh, DAOS_TX_NONE, &git_oid, DAOS_COND_DKEY_INSERT,
-			      &git_entry);
-	assert_int_equal(rc, 0);
-
-	/* open the root dir object to use as src_oh */
-	rc = daos_obj_open(dfs_mt->coh, dfs_mt->root.oid, DAOS_OO_RO, &dir_oh, NULL);
-	assert_int_equal(rc, 0);
-
-	/* copy xattrs from the dentry in root dir -> GIT */
-	rc = git_copy_xattr(dfs_mt->git_oh, DAOS_TX_NONE, &git_oid, dir_oh, fname);
-	assert_int_equal(rc, 0);
-	print_message("git_copy_xattr: OK\n");
-
-	rc = daos_obj_close(dir_oh, NULL);
-	assert_int_equal(rc, 0);
-
-	/* verify both xattrs via git_fetch_entry */
-	xnames[0] = (char *)xname1;
-	xnames[1] = (char *)xname2;
-	memset(xbuf1, 0, sizeof(xbuf1));
-	memset(xbuf2, 0, sizeof(xbuf2));
-	xvals[0]  = xbuf1;
-	xvals[1]  = xbuf2;
-	xsizes[0] = sizeof(xbuf1);
-	xsizes[1] = sizeof(xbuf2);
-
-	rc = git_fetch_entry(dfs_mt->git_oh, DAOS_TX_NONE, &git_oid, &fetched, 2, xnames, xvals,
-			     xsizes);
-	assert_int_equal(rc, 0);
-
-	assert_int_equal(xsizes[0], strlen(xval1) + 1);
-	assert_string_equal(xbuf1, xval1);
-	print_message("git_fetch_entry xattr1 verified in GIT: OK\n");
-
-	assert_int_equal(xsizes[1], strlen(xval2) + 1);
-	assert_string_equal(xbuf2, xval2);
-	print_message("git_fetch_entry xattr2 verified in GIT: OK\n");
-
-	/* inode fields must be untouched */
-	assert_int_equal(fetched.link_cnt, git_entry.link_cnt);
-
-	rc = dfs_release(obj);
-	assert_int_equal(rc, 0);
-}
-
 static void
 dfs_test_pipeline_find(void **state)
 {
@@ -3807,52 +3572,62 @@ dfs_test_pipeline_find(void **state)
 }
 
 static const struct CMUnitTest dfs_unit_tests[] = {
-    {"DFS_UNIT_TEST1: DFS mount / umount", dfs_test_mount, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST2: DFS container modes", dfs_test_modes, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST3: DFS lookup / lookup_rel", dfs_test_lookup, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST4: Simple Symlinks", dfs_test_syml, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST5: Symlinks with / without O_NOFOLLOW", dfs_test_syml_follow, async_disable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST6: multi-threads read shared file", dfs_test_read_shared_file, async_disable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST7: DFS lookupx", dfs_test_lookupx, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST8: DFS IO sync error code", dfs_test_io_error_code, async_disable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST9: DFS IO async error code", dfs_test_io_error_code, async_enable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST10: multi-threads mkdir same dir", dfs_test_mt_mkdir, async_disable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST11: Simple rename", dfs_test_rename, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST12: DFS API compat", dfs_test_compat, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST13: DFS l2g/g2l_all", dfs_test_handles, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST14: multi-threads connect to same container", dfs_test_mt_connect, async_disable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST15: DFS chown", dfs_test_chown, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST16: DFS stat mtime", dfs_test_mtime, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST17: multi-threads async IO", dfs_test_async_io_th, async_disable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST18: async IO", dfs_test_async_io, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST19: DFS readdir", dfs_test_readdir, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST20: dfs oclass hints", dfs_test_oclass_hints, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST21: dfs multiple pools", dfs_test_multiple_pools, async_disable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST22: dfs extended attributes", dfs_test_xattrs, test_case_teardown},
-    {"DFS_UNIT_TEST23: dfs MWC container checker", dfs_test_checker, async_disable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST24: dfs MWC SB fix", dfs_test_fix_sb, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST25: dfs MWC root fix", dfs_test_relink_root, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST26: dfs MWC chunk size fix", dfs_test_fix_chunk_size, async_disable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST27: dfs pipeline find", dfs_test_pipeline_find, async_disable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST28: dfs open/lookup flags", dfs_test_oflags, async_disable, test_case_teardown},
-    {"DFS_UNIT_TEST29: GIT insert/fetch round-trip", dfs_test_git_insert_fetch, async_disable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST30: GIT insert-once semantics", dfs_test_git_insert_once, async_disable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST31: GIT update link_cnt", dfs_test_git_update_link_cnt, async_disable,
-     test_case_teardown},
-    {"DFS_UNIT_TEST32: GIT copy xattr", dfs_test_git_copy_xattr, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST1: DFS mount / umount",
+	  dfs_test_mount, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST2: DFS container modes",
+	  dfs_test_modes, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST3: DFS lookup / lookup_rel",
+	  dfs_test_lookup, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST4: Simple Symlinks",
+	  dfs_test_syml, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST5: Symlinks with / without O_NOFOLLOW",
+	  dfs_test_syml_follow, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST6: multi-threads read shared file",
+	  dfs_test_read_shared_file, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST7: DFS lookupx",
+	  dfs_test_lookupx, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST8: DFS IO sync error code",
+	  dfs_test_io_error_code, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST9: DFS IO async error code",
+	  dfs_test_io_error_code, async_enable, test_case_teardown},
+	{ "DFS_UNIT_TEST10: multi-threads mkdir same dir",
+	  dfs_test_mt_mkdir, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST11: Simple rename",
+	  dfs_test_rename, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST12: DFS API compat",
+	  dfs_test_compat, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST13: DFS l2g/g2l_all",
+	  dfs_test_handles, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST14: multi-threads connect to same container",
+	  dfs_test_mt_connect, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST15: DFS chown",
+	  dfs_test_chown, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST16: DFS stat mtime",
+	  dfs_test_mtime, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST17: multi-threads async IO",
+	  dfs_test_async_io_th, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST18: async IO",
+	  dfs_test_async_io, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST19: DFS readdir",
+	  dfs_test_readdir, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST20: dfs oclass hints",
+	  dfs_test_oclass_hints, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST21: dfs multiple pools",
+	  dfs_test_multiple_pools, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST22: dfs extended attributes",
+	  dfs_test_xattrs, test_case_teardown},
+	{ "DFS_UNIT_TEST23: dfs MWC container checker",
+	  dfs_test_checker, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST24: dfs MWC SB fix",
+	  dfs_test_fix_sb, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST25: dfs MWC root fix",
+	  dfs_test_relink_root, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST26: dfs MWC chunk size fix",
+	  dfs_test_fix_chunk_size, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST27: dfs pipeline find",
+	  dfs_test_pipeline_find, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST28: dfs open/lookup flags",
+	  dfs_test_oflags, async_disable, test_case_teardown},
 };
 
 static int


### PR DESCRIPTION
DAOS-18906 dfs: GIT (Global Inode Table) entries and associated functions

The Global Inode Table (GIT) stores per-inode metadata using the same layout as a directory entry (dentry) with one additional field: link_cnt. Dentry layout is unchanged at 12 fields (END_IDX); GIT entries extend it to 13 (END_GIT_IDX).  INODE_AKEYS is bumped from 12 to 13 only to size the shared sg_iovs[] array large enough for GIT entries.

- dfs_internal.h: add LINK_CNT_IDX / END_GIT_IDX layout constants; add link_cnt field to struct dfs_entry; bump INODE_AKEYS 12→13; declare git_{fetch,insert}_entry(), git_update_link_cnt(), git_copy_xattr().

- common.c: refactor fetch_entry() / insert_entry() behind static helpers fetch_entry_common() / insert_entry_common(), parameterised by include_link_cnt, so both dentry and GIT paths share the same I/O logic.  When include_link_cnt=true the recx extends to END_GIT_IDX and link_cnt is included in the iov set; symlink handling is skipped for GIT.  fetch_entry() sets link_cnt=1 for normal dentries.  Implement git_{fetch,insert}_entry(), git_update_link_cnt(), and git_copy_xattr() on top of these helpers.

- daos_mw_fi.c: sync local INODE_AKEYS copy to 13.

- dfs_unit_test.c: add DFS_UNIT_TEST29–32 covering GIT insert/fetch round-trip, insert-once (EEXIST), link_cnt inc/dec/underflow, and xattr copy.

Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
