### PR TITLE
DAOS-18950 object: migrate_cont_iter_cb() error, drop ds_pool

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -3719,7 +3719,7 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 			DP_UUID(tls->mpt_pool_uuid), DP_RC(rc));
 		if (rc == -DER_SHUTDOWN)
 			rc = 0;
-		return rc;
+		D_GOTO(free, rc);
 	}
 
 	arg.yield_freq	= DEFAULT_YIELD_FREQ;


### PR DESCRIPTION
Before this change, if migrate_cont_iter_cb() gets an error (e.g., -DER_CONT_NONEXIST) while launching cont_fetch_start_ult(), a reference taken on struct ds_pool (in fetch_arg->pool) still exists, and is not dropped in the error handling path. Instead, migrate_cont_iter_cb() returns the error directly (and the cleanup in cont_fetch_end_ult is not run). Later, a pool destroy was observed to hang in ds_pool_stop() because the loop waiting for all references to be dropped did not finish.

With this change, the error handling will redirect to the free: label where cont_fetch_end_ult is invoked, that drops the reference to the ds_pool. This is expected to avoid a lingering reference on the ds_pool and a resulting pool destroy hang.

Features: rebuild ec_online_rebuild ec_offline_rebuild

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
