### PR TITLE
DAOS-18937 cq: fix copyright wildcard match (#18170)

### DIFF
--- a/utils/cq/check_update_copyright.sh
+++ b/utils/cq/check_update_copyright.sh
@@ -55,13 +55,13 @@ targets=(
     '*README*'
     '*LICENSE*'
     '*NOTICE*'
+    '*Makefile'
+    '*SConscript'
+    '*SConstruct'
+    '*.env'
     # Entries without a wildcard
-    'Makefile'
     'Jenkinsfile'
-    'SConscript'
-    'SConstruct'
     'copyright'
-    '.env'
 )
 
 function git_reset() {


### PR DESCRIPTION
Add wildcard to some entries so they are matched.
For example, *SConscript would match src/cart/SConscript

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
