### PR TITLE
DAOS-18927 test: remove dfs tag from dfuse build tests (#18160)

### DIFF
--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -239,7 +239,7 @@ class DaosBuild(TestWithServers):
 
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=hw,medium
-        :avocado: tags=daosio,dfuse,daos_cmd
+        :avocado: tags=daosio,dfs,dfuse,daos_cmd
         :avocado: tags=DaosBuild,test_dfuse_daos_build_wb
         """
         run_build_test(self, "writeback")

--- a/src/tests/ftest/dfuse/daos_build_vm.py
+++ b/src/tests/ftest/dfuse/daos_build_vm.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -26,7 +26,7 @@ class DaosBuildVM(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=vm
-        :avocado: tags=daosio,dfs,dfuse,ioil
+        :avocado: tags=daosio,dfuse,ioil
         :avocado: tags=DaosBuildVM,test_dfuse_daos_build_wt_il
         """
         run_build_test(self, "writethrough", il_lib='libioil.so', run_on_vms=True)
@@ -42,7 +42,7 @@ class DaosBuildVM(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=vm
-        :avocado: tags=daosio,dfs,dfuse,pil4dfs
+        :avocado: tags=daosio,dfuse,pil4dfs
         :avocado: tags=DaosBuildVM,test_dfuse_daos_build_wt_pil4dfs
         """
         run_build_test(self, "nocache", il_lib='libpil4dfs.so', run_on_vms=True)


### PR DESCRIPTION
Remove the dfs tag from long-running dfuse build tests since it is overkill to run them. Tag just the pr build test with dfuse.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
