### PR TITLE
DAOS-18802 build: disable preprocessor build of CART source (#17998)

### DIFF
--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -517,6 +517,7 @@ class PreReqComponent():
                               ['warning', 'warn', 'error'], ignorecase=2))
         opts.Add(('SANITIZERS', 'Instrument C code with google sanitizers', None))
         opts.Add(BoolVariable('CMOCKA_FILTER_SUPPORTED', 'Allows to filter cmocka tests', False))
+        opts.Add(BoolVariable('CRT_PP', 'Preprocess CaRT sources', False))
 
         opts.Update(self.__env)
 

--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -1,4 +1,5 @@
 # (C) Copyright 2016-2022 Intel Corporation.
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -75,18 +76,22 @@ def scons():
 
     cart_targets = denv.SharedObject(SRC)
 
-    compiler = env.get('COMPILER').lower()
-    if compiler != 'covc':
-        pp_env = denv.Clone()
-        pp_files = []
-        for src in SRC:
-            # Some day, the preprocess builder should be fixed so it can do multiple commands
-            # in parallel but until then, just submit them one at a time
-            pp_files.extend(pp_env.Preprocess(src))
-        parsed_files = parse_pp(pp_env, pp_files)
-        header = consolidate_pp(pp_env, parsed_files)
+    # Preprocess the CaRT sources if CRT_PP is set to True
+    crt_pp = env.get('CRT_PP')
+    if crt_pp:
+        print("Warning: Preprocessing of CaRT sources is enabled")
+        compiler = env.get('COMPILER').lower()
+        if compiler != 'covc':
+            pp_env = denv.Clone()
+            pp_files = []
+            for src in SRC:
+                # Some day, the preprocess builder should be fixed so it can do multiple commands
+                # in parallel but until then, just submit them one at a time
+                pp_files.extend(pp_env.Preprocess(src))
+            parsed_files = parse_pp(pp_env, pp_files)
+            header = consolidate_pp(pp_env, parsed_files)
 
-        Depends(cart_targets, header)
+            Depends(cart_targets, header)
 
     cart_lib = denv.d_library('cart', [cart_targets, swim_targets], SHLIBVERSION=CART_VERSION)
     denv.InstallVersionedLib('$PREFIX/lib64/', cart_lib, SHLIBVERSION=CART_VERSION)


### PR DESCRIPTION
Disable cart preprocessor build by default.
Add CRT_PP build option to enable preprocessor build when needed.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
