### PR TITLE
DAOS-18957 mgmt: improper assert

### DIFF
--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -489,8 +489,11 @@ ds_mgmt_pool_query_targets(uuid_t pool_uuid, d_rank_list_t *svc_ranks, d_rank_t 
 			goto out;
 		}
 		if (mem_file_bytes) {
-			D_ASSERT(i == 0 || *mem_file_bytes == mem_bytes);
-			*mem_file_bytes = mem_bytes;
+			if (*mem_file_bytes == 0) {
+				*mem_file_bytes = mem_bytes;
+			} else {
+				D_ASSERT(mem_bytes == 0 || *mem_file_bytes == mem_bytes);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix the improper assert in ds_mgmt_pool_query_targets() which overlooked the case of querying down target.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
