### PR TITLE
DAOS-18949 container: improper assertion in cont_child_create_start

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1531,9 +1531,7 @@ cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid, uint32_t pm_ver, boo
 			bool *started, struct ds_cont_child **cont_out)
 {
 	struct ds_pool_child *pool_child;
-	uint64_t              sched_seq1;
-	uint64_t              sched_seq2 = 0;
-	bool                  destroy    = true;
+	bool                  destroy = true;
 	int                   rc;
 
 	pool_child = ds_pool_child_lookup(pool_uuid);
@@ -1555,20 +1553,15 @@ cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid, uint32_t pm_ver, boo
 		return rc;
 	}
 
-	sched_seq1 = sched_cur_seq();
-
 	/* Hold sp_recov_lock to control the race with recovering container for pool. */
-	if (!locked) {
+	if (!locked)
 		ABT_rwlock_rdlock(pool_child->spc_pool->sp_recov_lock);
-		sched_seq2 = sched_cur_seq();
-	}
 
 	D_DEBUG(DB_MD, DF_CONT": creating new vos container\n",
 		DP_CONT(pool_uuid, cont_uuid));
 
 	rc = vos_cont_create(pool_child->spc_hdl, cont_uuid);
 	if (unlikely(rc == -DER_EXIST && !locked)) {
-		D_ASSERT(sched_seq1 != sched_seq2);
 		rc      = 0;
 		destroy = false;
 	}


### PR DESCRIPTION
The caller for cont_child_create_start() may not hold sp_recov_lock in advance, then the logic of cont_child_create_start() will try to take such lock by itself. Such ABT_rwlock_rdlock() maybe blocked by race or maybe not if there is no race. So it is not true to assume there will be CPU yield for such ABT rdlock. Then related assertion check "D_ASSERT(sched_seq1 != sched_seq2)" should be removed.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
