### PR TITLE
DAOS-18726 container: container create race in cont_child_create_start - b28

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1530,8 +1530,11 @@ static int
 cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid, uint32_t pm_ver, bool locked,
 			bool *started, struct ds_cont_child **cont_out)
 {
-	struct ds_pool_child	*pool_child;
-	int rc;
+	struct ds_pool_child *pool_child;
+	uint64_t              sched_seq1;
+	uint64_t              sched_seq2 = 0;
+	bool                  destroy    = true;
+	int                   rc;
 
 	pool_child = ds_pool_child_lookup(pool_uuid);
 	if (pool_child == NULL) {
@@ -1552,26 +1555,36 @@ cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid, uint32_t pm_ver, boo
 		return rc;
 	}
 
+	sched_seq1 = sched_cur_seq();
+
 	/* Hold sp_recov_lock to control the race with recovering container for pool. */
-	if (!locked)
+	if (!locked) {
 		ABT_rwlock_rdlock(pool_child->spc_pool->sp_recov_lock);
+		sched_seq2 = sched_cur_seq();
+	}
 
 	D_DEBUG(DB_MD, DF_CONT": creating new vos container\n",
 		DP_CONT(pool_uuid, cont_uuid));
 
 	rc = vos_cont_create(pool_child->spc_hdl, cont_uuid);
+	if (unlikely(rc == -DER_EXIST && !locked)) {
+		D_ASSERT(sched_seq1 != sched_seq2);
+		rc      = 0;
+		destroy = false;
+	}
+
 	if (!rc) {
 		rc = cont_child_start(pool_child, cont_uuid, started, cont_out);
 		if (rc == 0) {
 			if (cont_out != NULL)
 				(*cont_out)->sc_status_pm_ver = pm_ver;
-			else
+			else if (destroy)
 				D_DEBUG(DB_REBUILD,
 					"Re-create container " DF_UUID " in the pool " DF_UUID
 					" on the target %u/%u\n",
 					DP_UUID(cont_uuid), DP_UUID(pool_uuid), dss_self_rank(),
 					dss_get_module_info()->dmi_tgt_id);
-		} else {
+		} else if (destroy) {
 			int rc_tmp;
 
 			rc_tmp = vos_cont_destroy(pool_child->spc_hdl, cont_uuid);


### PR DESCRIPTION
If cont_child_create_start() is blocked because ds_pool::sp_recov_lock may be held by other, then multiple cont_child_create_start() sponsors may race to create related vos container shard. That should be allowed and properly handled.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
