### PR TITLE
DAOS-18891 vos: debug patch for potential TX_RESTART during rebuild

### DIFF
--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -224,8 +224,8 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm, bool is_sysdb,
 		/* CPU may yield when umem_tx_begin, related object maybe evicted during that. */
 		rc = umem_tx_begin(umm, vos_txd_get(is_sysdb));
 		if (rc == 0 && obj != NULL && unlikely(vos_obj_is_evicted(obj))) {
-			D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted(1), need to restart TX.\n",
-				DP_UOID(obj->obj_id));
+			D_WARN("Obj " DF_UOID " is evicted(1), need to restart TX.\n",
+			       DP_UOID(obj->obj_id));
 			rc = umem_tx_end(umm, -DER_TX_RESTART);
 		}
 
@@ -247,8 +247,8 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm, bool is_sysdb,
 	if (rc == 0) {
 		/* CPU may yield when umem_tx_begin, related object maybe evicted during that. */
 		if (obj != NULL && unlikely(vos_obj_is_evicted(obj))) {
-			D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted(2), need to restart TX.\n",
-				DP_UOID(obj->obj_id));
+			D_WARN("Obj " DF_UOID " is evicted(2), need to restart TX.\n",
+			       DP_UOID(obj->obj_id));
 
 			return umem_tx_end(umm, -DER_TX_RESTART);
 		}

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2569,8 +2569,8 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 
 	D_ASSERT(ioc->ic_obj != NULL);
 	if (unlikely(vos_obj_is_evicted(ioc->ic_obj))) {
-		D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted during update, need to restart TX.\n",
-			DP_UOID(ioc->ic_oid));
+		D_WARN("Obj " DF_UOID " is evicted during update, need to restart TX.\n",
+		       DP_UOID(ioc->ic_oid));
 
 		D_GOTO(abort, err = -DER_TX_RESTART);
 	}
@@ -2611,8 +2611,11 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 
 	err = vos_obj_incarnate(ioc->ic_obj, &ioc->ic_epr, ioc->ic_bound, flags,
 				DAOS_INTENT_UPDATE, ioc->ic_ts_set);
-	if (err != 0)
+	if (err != 0) {
+		if (err == -DER_TX_RESTART && !dtx_is_valid_handle(dth))
+			D_ERROR("Update failed out here(1)\n");
 		goto abort;
+	}
 
 	if (dtx_is_valid_handle(dth))
 		minor_epc = dth->dth_op_seq;
@@ -2624,6 +2627,8 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	if (err) {
 		VOS_TX_LOG_FAIL(err, "Failed to update tree index: "DF_RC"\n",
 				DP_RC(err));
+		if (err == -DER_TX_RESTART && !dtx_is_valid_handle(dth))
+			D_ERROR("Update failed out here(2)\n");
 		goto abort;
 	}
 
@@ -2631,6 +2636,8 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	 * read conflict
 	 */
 	if (vos_ts_set_check_conflict(ioc->ic_ts_set, ioc->ic_epr.epr_hi)) {
+		if (!dtx_is_valid_handle(dth))
+			D_ERROR("Update failed out here(3)\n");
 		err = -DER_TX_RESTART;
 		goto abort;
 	}
@@ -2642,6 +2649,8 @@ abort:
 	    err == -DER_INPROGRESS) {
 		if (vos_ts_wcheck(ioc->ic_ts_set, ioc->ic_epr.epr_hi,
 				  ioc->ic_bound)) {
+			if (!dtx_is_valid_handle(dth))
+				D_ERROR("Update failed out here(4)\n");
 			err = -DER_TX_RESTART;
 		}
 	}


### PR DESCRIPTION
Only for test.

    Test-tag: pr test_rebuild_31 test_rebuild_32
    Skip-nlt: true
    Skip-unit-test-memcheck: true
    Skip-unit-tests: true
    Skip-unit-test: true
    Skip-checkpatch: true
    Skip-fault-injection-test: true
    Skip-func-test-el9: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
