### PR TITLE
DAOS-17616 test: increase storage format timeout for daos_server_restart

### DIFF
--- a/src/tests/ftest/control/daos_server_helper.py
+++ b/src/tests/ftest/control/daos_server_helper.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -81,7 +82,7 @@ class DaosPrivHelperTest(TestWithServers):
 
         # Run format command under non-root user
         self.log_step("Perform SCM format")
-        result = self.server_managers[0].dmg.storage_format()
+        result = self.server_managers[0].storage_format()
         if result is None:
             self.fail("Failed to format storage")
 

--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -21,7 +21,7 @@ class DaosServerTest(TestWithServers):
 
     @fail_on(ServerFailed)
     @fail_on(CommandFailure)
-    def restart_daos_server(self, force=False):
+    def restart_daos_server(self):
         """Perform server stop and start.
 
         Args:
@@ -36,7 +36,7 @@ class DaosServerTest(TestWithServers):
         for pool in self.pool:
             pool.skip_cleanup()
         self.log.info("=Restart daos_server, dmg storage_format.")
-        self.server_managers[0].dmg.storage_format(force)
+        self.server_managers[0].storage_format()
         self.log.info("=Restart daos_server, detect_engine_start().")
         self.server_managers[0].detect_engine_start()
         self.log.info("=Restart daos_agent, stop")

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -669,9 +669,7 @@ class DaosServerManager(SubprocessManager):
 
         # Format storage and wait for server to change ownership
         self.log.info("<SERVER> Formatting hosts: <%s>", self.dmg.hostlist)
-        # Temporarily increasing timeout to avoid CI errors until DAOS-5764 can
-        # be further investigated.
-        self.dmg.storage_format(timeout=self.storage_format_timeout.value)
+        self.storage_format()
 
         # Wait for all the engines to start
         self.detect_engine_start()
@@ -1001,6 +999,23 @@ class DaosServerManager(SubprocessManager):
                 "investigate/report.***", regex, detected)
         # set stopped servers state to make teardown happy
         self.update_expected_states(None, ["stopped", "excluded", "errored"])
+
+    def storage_format(self, **kwargs):
+        """Wrapper for dmg storage format that uses self.storage_format_timeout.
+
+        Args:
+            kwargs (dict): keyword args for DmgCommand.storage_format
+
+        Returns:
+            CmdResult: an avocado CmdResult object containing the dmg command
+                information, e.g. exit status, stdout, stderr, etc.
+
+        Raises:
+            CommandFailure: if the dmg storage format command fails.
+        """
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = self.storage_format_timeout.value
+        return self.dmg.storage_format(**kwargs)
 
     @fail_on(CommandFailure)
     def system_exclude(self, ranks, copy=False, rank_hosts=None):


### PR DESCRIPTION
Increase the dmg storage format timeout for daos_server_restart.py and daos_server_helper.py by having them use the same format timeout as the framework.

Test-tag: DaosPrivHelperTest DaosServerTest pr,hw,medium test_setup,hw,medium

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
