### PR TITLE
DAOS-13899 test: do not set default mdtest params (#18217)

### DIFF
--- a/src/tests/ftest/aggregation/punching.py
+++ b/src/tests/ftest/aggregation/punching.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -29,8 +30,8 @@ class AggregationPunching(MdtestBase):
 
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=hw,medium
-        :avocado: tags=aggregation,mdtest,mdtest
-        :avocado: tags=AggregationPunching,aggregatepunching,test_aggregation_punching
+        :avocado: tags=aggregation,mdtest
+        :avocado: tags=AggregationPunching,test_aggregation_punching
         """
         if self.pool is None:
             self.add_pool(connect=False)

--- a/src/tests/ftest/aggregation/punching.yaml
+++ b/src/tests/ftest/aggregation/punching.yaml
@@ -27,7 +27,6 @@ mdtest:
   client_processes:
     np: 2
   test_dir: "/"
-  dfs_destroy: false
   iteration: 1
   manager: "MPICH"
   mdtest_params:

--- a/src/tests/ftest/datamover/large_dir.yaml
+++ b/src/tests/ftest/datamover/large_dir.yaml
@@ -26,14 +26,12 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 mdtest:
   client_ppn:
     dcp: 32
   api: DFS
   test_dir: "/"
-  dfs_destroy: false
   manager: "MPICH"
   dfs_oclass: EC_4P2G1
   dfs_dir_oclass: RP_3GX

--- a/src/tests/ftest/datamover/obj_large_posix.yaml
+++ b/src/tests/ftest/datamover/obj_large_posix.yaml
@@ -32,8 +32,9 @@ mdtest:
   client_processes:
     np: 30
   api: DFS
+  dfs_oclass: S1
+  dfs_dir_oclass: SX
   test_dir: "/"
-  dfs_destroy: false
   manager: "MPICH"
   num_of_files_dirs: 1667  # total 50K files and 50K dirs
   mdtest_flags:

--- a/src/tests/ftest/datamover/serial_large_posix.yaml
+++ b/src/tests/ftest/datamover/serial_large_posix.yaml
@@ -32,8 +32,9 @@ mdtest:
   client_processes:
     np: 30
   api: DFS
+  dfs_oclass: S1
+  dfs_dir_oclass: SX
   test_dir: "/"
-  dfs_destroy: false
   manager: "MPICH"
   num_of_files_dirs: 1667  # total 50K files and 50K dirs
   mdtest_flags:

--- a/src/tests/ftest/erasurecode/online_rebuild_mdtest.yaml
+++ b/src/tests/ftest/erasurecode/online_rebuild_mdtest.yaml
@@ -53,7 +53,6 @@ mdtest:
     np: 4
   api: DFS
   test_dir: /
-  dfs_destroy: False
   manager: MPICH
   flags: "-u -F -C"
   write_bytes: 524288

--- a/src/tests/ftest/io/large_file_count.yaml
+++ b/src/tests/ftest/io/large_file_count.yaml
@@ -58,7 +58,6 @@ mdtest:
     np: 30
   num_of_files_dirs: 33334     # creating total of 1M files
   test_dir: "/"
-  dfs_destroy: false
   manager: "MPICH"
   flags: "-F -C"
   write_bytes: 4096

--- a/src/tests/ftest/io/small_file_count.yaml
+++ b/src/tests/ftest/io/small_file_count.yaml
@@ -58,8 +58,6 @@ mdtest:
     np: 30
   num_of_files_dirs: 1667      # creating total of 50K files
   test_dir: "/"
-  iteration: 1
-  dfs_destroy: false
   manager: "MPICH"
   flags: "-F -C"
   write_bytes: 4096

--- a/src/tests/ftest/mdtest/small.yaml
+++ b/src/tests/ftest/mdtest/small.yaml
@@ -41,6 +41,7 @@ mdtest:
     ppn: 32
   dfs_oclass: S1
   dfs_dir_oclass: SX
+  dfs_destroy: True
   test_dir: "/"
   manager: "MPICH"
   mdtest_params:

--- a/src/tests/ftest/osa/offline_drain.yaml
+++ b/src/tests/ftest/osa/offline_drain.yaml
@@ -81,8 +81,6 @@ mdtest:
     np: 30
   num_of_files_dirs: 4067         # creating total of 120K files
   test_dir: "/"
-  iteration: 1
-  dfs_destroy: false
   dfs_oclass: RP_3G6
   manager: "MPICH"
   flags: "-u"

--- a/src/tests/ftest/osa/offline_extend.yaml
+++ b/src/tests/ftest/osa/offline_extend.yaml
@@ -68,8 +68,6 @@ mdtest:
     np: 2
   num_of_files_dirs: 100
   test_dir: "/"
-  iteration: 1
-  dfs_destroy: false
   dfs_oclass: RP_2G1
   dfs_dir_oclass: RP_2G1
   manager: "MPICH"

--- a/src/tests/ftest/osa/offline_parallel_test.yaml
+++ b/src/tests/ftest/osa/offline_parallel_test.yaml
@@ -67,8 +67,6 @@ mdtest:
     np: 2
   num_of_files_dirs: 100
   test_dir: "/"
-  iteration: 1
-  dfs_destroy: false
   dfs_oclass: RP_2G8
   dfs_dir_oclass: RP_2G8
   manager: "MPICH"

--- a/src/tests/ftest/osa/offline_reintegration.yaml
+++ b/src/tests/ftest/osa/offline_reintegration.yaml
@@ -80,8 +80,6 @@ mdtest:
     np: 2
   num_of_files_dirs: 100
   test_dir: "/"
-  iteration: 1
-  dfs_destroy: false
   dfs_oclass: RP_3G6
   dfs_dir_oclass: RP_3G6
   manager: "MPICH"

--- a/src/tests/ftest/osa/online_drain.yaml
+++ b/src/tests/ftest/osa/online_drain.yaml
@@ -67,7 +67,6 @@ mdtest:
   num_of_files_dirs: 100
   test_dir: "/tmp/"
   iteration: 10
-  dfs_destroy: false
   dfs_oclass: RP_2G4
   dfs_dir_oclass: RP_2G4
   manager: "MPICH"

--- a/src/tests/ftest/osa/online_extend.yaml
+++ b/src/tests/ftest/osa/online_extend.yaml
@@ -78,7 +78,6 @@ mdtest:
   num_of_files_dirs: 100
   test_dir: "/tmp/"
   iteration: 10
-  dfs_destroy: false
   dfs_oclass: RP_2G1
   dfs_dir_oclass: RP_2G1
   manager: "MPICH"

--- a/src/tests/ftest/osa/online_reintegration.yaml
+++ b/src/tests/ftest/osa/online_reintegration.yaml
@@ -71,8 +71,6 @@ mdtest:
     np: 2
   num_of_files_dirs: 100
   test_dir: "/tmp/"
-  iteration: 1
-  dfs_destroy: false
   dfs_oclass: RP_2G1
   dfs_dir_oclass: RP_2G1
   manager: "MPICH"

--- a/src/tests/ftest/performance/mdtest_easy.yaml
+++ b/src/tests/ftest/performance/mdtest_easy.yaml
@@ -43,7 +43,6 @@ mdtest: &mdtest_base
   num_of_files_dirs: 100000000
   stonewall_timer: 30
   stonewall_statusfile: stoneWallingStatusFile
-  dfs_destroy: false
 
 mdtest_s1: &mdtest_s1
   <<: *mdtest_base

--- a/src/tests/ftest/performance/mdtest_hard.yaml
+++ b/src/tests/ftest/performance/mdtest_hard.yaml
@@ -43,7 +43,6 @@ mdtest: &mdtest_base
   num_of_files_dirs: 100000000
   stonewall_timer: 30
   stonewall_statusfile: stoneWallingStatusFile
-  dfs_destroy: false
 
 mdtest_s1: &mdtest_s1
   <<: *mdtest_base

--- a/src/tests/ftest/pool/eviction_metrics.yaml
+++ b/src/tests/ftest/pool/eviction_metrics.yaml
@@ -31,7 +31,6 @@ container:
 mdtest:
   dfs_oclass: S1
   dfs_dir_oclass: SX
-  dfs_destroy: False
   manager: "MPICH"
   ppn: 32
   test_dir: "/"

--- a/src/tests/ftest/pool/verify_dtx.yaml
+++ b/src/tests/ftest/pool/verify_dtx.yaml
@@ -33,7 +33,6 @@ container:
   type: POSIX
 
 mdtest:
-  dfs_destroy: False
   manager: "MPICH"
   ppn: 32
   test_dir: "/"

--- a/src/tests/ftest/rebuild/mdtest.yaml
+++ b/src/tests/ftest/rebuild/mdtest.yaml
@@ -50,4 +50,3 @@ mdtest:
   read_bytes: 512KiB
   write_bytes: 512KiB
   num_of_files_dirs: 15625  # 1 million total files
-  dfs_destroy: false

--- a/src/tests/ftest/rebuild/widely_striped.yaml
+++ b/src/tests/ftest/rebuild/widely_striped.yaml
@@ -35,7 +35,6 @@ mdtest:
     np: 30
   num_of_files_dirs: 4067         # creating total of 120K files
   test_dir: "/"
-  dfs_destroy: false
   dfs_oclass: RP_3G1
   dfs_dir_oclass: RP_3G1
   manager: "MPICH"

--- a/src/tests/ftest/util/mdtest_utils.py
+++ b/src/tests/ftest/util/mdtest_utils.py
@@ -187,11 +187,11 @@ class MdtestCommand(ExecutableCommand):
         self.dfs_pool = FormattedParameter("--dfs.pool {}")
         self.dfs_cont = FormattedParameter("--dfs.cont {}")
         self.dfs_group = FormattedParameter("--dfs.group {}")
-        self.dfs_destroy = FormattedParameter("--dfs.destroy", True)
-        self.dfs_chunk = FormattedParameter("--dfs.chunk_size {}", 1048576)
-        self.dfs_oclass = FormattedParameter("--dfs.oclass {}", "S1")
+        self.dfs_destroy = FormattedParameter("--dfs.destroy", False)
+        self.dfs_chunk = FormattedParameter("--dfs.chunk_size {}")
+        self.dfs_oclass = FormattedParameter("--dfs.oclass {}")
         self.dfs_prefix = FormattedParameter("--dfs.prefix {}")
-        self.dfs_dir_oclass = FormattedParameter("--dfs.dir_oclass {}", "SX")
+        self.dfs_dir_oclass = FormattedParameter("--dfs.dir_oclass {}")
 
         # Include bullseye coverage file environment
         self.env["COVFILE"] = os.path.join(os.sep, "tmp", "test.cov")


### PR DESCRIPTION
Do not set a default oclass, dir_oclass or chunk size for mdtest. Either let the test specify exactly what it wants, or let DFS choose an appropriate default.

Test-tag: AggregationPunching DmvrLargeDir DmvrObjLargePosix DmvrSerialLargePosix EcodOnlineRebuildMdtest EvictionMetrics LargeFileCount MdtestEasy MdtestHard MdtestSmall OSAOfflineDrain OSAOfflineExtend OSAOfflineParallelTest OSAOfflineReintegration OSAOnlineDrain OSAOnlineExtend OSAOnlineReintegration RbldWidelyStriped RebuildMdtest SmallFileCount VerifyDTXMetrics

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
