### PR TITLE
DAOS-18963 cart: Add rpc origin address

### DIFF
--- a/src/cart/crt_bulk.c
+++ b/src/cart/crt_bulk.c
@@ -1,7 +1,7 @@
 /*
  * (C) Copyright 2016-2022 Intel Corporation.
  * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -254,8 +254,8 @@ crt_bulk_transfer(struct crt_bulk_desc *bulk_desc, crt_bulk_cb_t complete_cb,
 
 	rc = crt_hg_bulk_transfer(bulk_desc, complete_cb, arg, opid, false);
 	if (rc != 0)
-		DL_ERROR(rc, "crt_hg_bulk_transfer() failed");
-
+		DL_ERROR(rc, "crt_hg_bulk_transfer() failed; origin=%s",
+			 crt_req_origin_addr_get(bulk_desc->bd_rpc));
 out:
 	return rc;
 }
@@ -274,8 +274,8 @@ crt_bulk_bind_transfer(struct crt_bulk_desc *bulk_desc,
 
 	rc = crt_hg_bulk_transfer(bulk_desc, complete_cb, arg, opid, true);
 	if (rc != 0)
-		D_ERROR("crt_hg_bulk_transfer() failed, rc: %d.\n", rc);
-
+		DL_ERROR(rc, "crt_hg_bulk_transfer() failed; origin=%s",
+			 crt_req_origin_addr_get(bulk_desc->bd_rpc));
 out:
 	return rc;
 }

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1453,8 +1453,8 @@ crt_hg_reply_send_cb(const struct hg_cb_info *hg_cbinfo)
 	 * see CART-146 for details
 	 */
 	if (hg_ret != HG_SUCCESS)
-		D_WARN("hg_cbinfo->ret: " DF_HG_RC ", opc: %#x.\n",
-		       DP_HG_RC(hg_ret), opc);
+		D_WARN("hg_cbinfo->ret: " DF_HG_RC ", opc: %#x from %s\n", DP_HG_RC(hg_ret), opc,
+		       crt_rpc_priv_get_origin_addr(rpc_priv));
 
 	/* corresponding to the crt_req_addref in crt_hg_reply_send */
 	RPC_DECREF(rpc_priv);
@@ -1858,4 +1858,41 @@ crt_hg_bulk_transfer(struct crt_bulk_desc *bulk_desc, crt_bulk_cb_t complete_cb,
 
 out:
 	return rc;
+}
+
+char *
+crt_rpc_priv_get_origin_addr(struct crt_rpc_priv *rpc_priv)
+{
+	const struct hg_info *hg_info;
+	char                  addr[48];
+	hg_size_t             addr_size = 48;
+	int                   rc;
+
+	if (rpc_priv->crp_orig_uri != NULL)
+		return rpc_priv->crp_orig_uri;
+
+	hg_info = HG_Get_info(rpc_priv->crp_hg_hdl);
+	if (hg_info == NULL)
+		return "NOINFO";
+
+	rc = HG_Addr_to_string(hg_info->hg_class, addr, (hg_size_t *)&addr_size, hg_info->addr);
+	if (rc != 0)
+		return "NONE";
+
+	D_ALLOC(rpc_priv->crp_orig_uri, addr_size);
+	if (rpc_priv->crp_orig_uri == NULL)
+		return "NOMEM";
+
+	memcpy(rpc_priv->crp_orig_uri, addr, addr_size);
+
+	return rpc_priv->crp_orig_uri;
+}
+
+char *
+crt_req_origin_addr_get(crt_rpc_t *rpc_pub)
+{
+	struct crt_rpc_priv *rpc_priv;
+
+	rpc_priv = container_of(rpc_pub, struct crt_rpc_priv, crp_pub);
+	return crt_rpc_priv_get_origin_addr(rpc_priv);
 }

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -1,5 +1,7 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -36,10 +38,18 @@
 			break;                                                                     \
                                                                                                    \
 		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
-		D_TRACE_DEBUG(mask, (rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,     \
-			      (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,  \
-			      (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,           \
-			      ##__VA_ARGS__);                                                      \
+		if ((rpc)->crp_coll) {                                                             \
+			D_TRACE_DEBUG(mask, (rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,      \
+				      (rpc)->crp_pub.cr_opc, _module, _opc,                        \
+				      (rpc)->crp_req_hdr.cch_rpcid, ##__VA_ARGS__);                \
+		} else {                                                                           \
+			D_TRACE_DEBUG(mask, (rpc),                                                 \
+				      "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d orig=%s] " fmt,  \
+				      (rpc)->crp_pub.cr_opc, _module, _opc,                        \
+				      (rpc)->crp_req_hdr.cch_rpcid, (rpc)->crp_pub.cr_ep.ep_rank,  \
+				      (rpc)->crp_pub.cr_ep.ep_tag,                                 \
+				      crt_rpc_priv_get_origin_addr((rpc)), ##__VA_ARGS__);         \
+		}                                                                                  \
 	} while (0)
 
 /* Log an error with an RPC descriptor */
@@ -49,10 +59,17 @@
 		char *_opc;                                                                        \
                                                                                                    \
 		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
-		D_TRACE_ERROR((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,           \
-			      (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,  \
-			      (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,           \
-			      ##__VA_ARGS__);                                                      \
+		if ((rpc)->crp_coll) {                                                             \
+			D_TRACE_ERROR((rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,            \
+				      (rpc)->crp_pub.cr_opc, _module, _opc,                        \
+				      (rpc)->crp_req_hdr.cch_rpcid, ##__VA_ARGS__);                \
+		} else {                                                                           \
+			D_TRACE_ERROR(                                                             \
+			    (rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d orig=%s] " fmt,     \
+			    (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,    \
+			    (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,             \
+			    crt_rpc_priv_get_origin_addr((rpc)), ##__VA_ARGS__);                   \
+		}                                                                                  \
 	} while (0)
 
 /* Log a warning with an RPC descriptor */
@@ -62,10 +79,17 @@
 		char *_opc;                                                                        \
                                                                                                    \
 		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
-		D_TRACE_WARN((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,            \
-			     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
-			     (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,            \
-			     ##__VA_ARGS__);                                                       \
+		if ((rpc)->crp_coll) {                                                             \
+			D_TRACE_WARN((rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,             \
+				     (rpc)->crp_pub.cr_opc, _module, _opc,                         \
+				     (rpc)->crp_req_hdr.cch_rpcid, ##__VA_ARGS__);                 \
+		} else {                                                                           \
+			D_TRACE_WARN(                                                              \
+			    (rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d orig=%s] " fmt,     \
+			    (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,    \
+			    (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,             \
+			    crt_rpc_priv_get_origin_addr((rpc)), ##__VA_ARGS__);                   \
+		}                                                                                  \
 	} while (0)
 
 /* Log an info message with an RPC descriptor */
@@ -75,10 +99,17 @@
 		char *_opc;                                                                        \
                                                                                                    \
 		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
-		D_TRACE_INFO((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,            \
-			     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
-			     (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,            \
-			     ##__VA_ARGS__);                                                       \
+		if ((rpc)->crp_coll) {                                                             \
+			D_TRACE_INFO((rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,             \
+				     (rpc)->crp_pub.cr_opc, _module, _opc,                         \
+				     (rpc)->crp_req_hdr.cch_rpcid, ##__VA_ARGS__);                 \
+		} else {                                                                           \
+			D_TRACE_INFO(                                                              \
+			    (rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] orig=%s" fmt,      \
+			    (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,    \
+			    (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,             \
+			    crt_rpc_priv_get_origin_addr((rpc)), ##__VA_ARGS__);                   \
+		}                                                                                  \
 	} while (0)
 /**
  * If \a cond is false, this is equivalent to an RPC_ERROR (i.e., \a mask is

--- a/src/cart/crt_internal_fns.h
+++ b/src/cart/crt_internal_fns.h
@@ -1,6 +1,7 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -77,5 +78,7 @@ crt_trigger_hlc_error_cb(void);
 void
 crt_trigger_event_cbs(d_rank_t rank, uint64_t incarnation, enum crt_event_source src,
 		      enum crt_event_type type);
+char *
+crt_rpc_priv_get_origin_addr(struct crt_rpc_priv *rpc_priv);
 
 #endif /* __CRT_INTERNAL_FNS_H__ */

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1,6 +1,7 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -579,6 +580,7 @@ crt_rpc_priv_free(struct crt_rpc_priv *rpc_priv)
 
 	RPC_TRACE(DB_TRACE, rpc_priv, "destroying\n");
 
+	D_FREE(rpc_priv->crp_orig_uri);
 	D_FREE(rpc_priv);
 }
 
@@ -1542,8 +1544,8 @@ crt_reply_send(crt_rpc_t *req)
 		RPC_TRACE(DB_ALL, rpc_priv, "reply_send\n");
 		rc = crt_hg_reply_send(rpc_priv);
 		if (rc != 0)
-			D_ERROR("crt_hg_reply_send failed, rc: %d,opc: %#x.\n",
-				rc, rpc_priv->crp_pub.cr_opc);
+			D_ERROR("crt_hg_reply_send failed, rc: %d opc: %#x orig: %s\n", rc,
+				rpc_priv->crp_pub.cr_opc, crt_req_origin_addr_get(req));
 	}
 
 	rpc_priv->crp_reply_pending = 0;

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -1,6 +1,7 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -155,7 +156,8 @@ struct crt_rpc_priv {
 	hg_handle_t		crp_hg_hdl; /* HG request handle */
 	hg_addr_t		crp_hg_addr; /* target na address */
 	struct crt_hg_hdl	*crp_hdl_reuse; /* reused hg_hdl */
-	crt_phy_addr_t		crp_tgt_uri; /* target uri address */
+	char                    *crp_tgt_uri;   /* target uri address */
+	char                    *crp_orig_uri;  /* where the RPC comes from */
 	crt_rpc_t		*crp_ul_req; /* uri lookup request */
 
 	uint32_t		crp_ul_retry; /* uri lookup retry counter */

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1,6 +1,7 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2343,6 +2344,15 @@ int crt_context_quota_limit_set(crt_context_t crt_ctx, crt_quota_type_t quota, i
  *                             failure.
  */
 int crt_context_quota_limit_get(crt_context_t crt_ctx, crt_quota_type_t quota, int *value);
+
+/**
+ * Get the rpc origin address.
+ *
+ * \param[in] rpc		pointer to RPC request
+ * \return			the origin address of the RPC
+ */
+char *
+crt_req_origin_addr_get(crt_rpc_t *rpc);
 
 /**
  * Get the proto version of an RPC request.


### PR DESCRIPTION
- Add stringified rpc origin address to rpc_priv
- Print origin from RPC_* (e.g. RPC_INFO() ) macros, as well as during failed bulk transfers or failures to send reply

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
