### PR TITLE
DAOS-18971 test: telemetry/pool_space_metrics.py telemetry_pool_space_metrics test timeout

### DIFF
--- a/src/tests/ftest/telemetry/pool_space_metrics.yaml
+++ b/src/tests/ftest/telemetry/pool_space_metrics.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 2
   test_clients: 1
 
-timeout: 180
+timeout: 220
 
 server_config:
   name: daos_server


### PR DESCRIPTION
Description: Increase telemetry_pool_space_metrics test time

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-repeat: 5
Test-tag: test_telemetry_pool_metrics

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
