### PR TITLE
DAOS-18891 object: retry if vos_update_end return -DER_AGAIN - b28

### DIFF
--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -796,6 +796,7 @@ agg_update_vos(struct ec_agg_param *agg_param, struct ec_agg_entry *entry,
 	struct dcs_iod_csums	*iod_csums = NULL;
 	int                      err;
 	int			 rc = 0;
+	uint64_t                 ts = daos_gettime_coarse();
 
 	ap = container_of(entry, struct ec_agg_param, ap_agg_entry);
 
@@ -829,9 +830,14 @@ agg_update_vos(struct ec_agg_param *agg_param, struct ec_agg_entry *entry,
 			}
 			D_ASSERT(iod_csums != NULL);
 		}
+
+again1:
 		rc = vos_obj_update(ap->ap_cont_handle, entry->ae_oid,
 				    entry->ae_cur_stripe.as_hi_epoch, 0, VOS_OF_CRIT,
 				    &entry->ae_dkey, 1, &iod, iod_csums, &sgl);
+
+		OBJ_CHECK_EAGAIN(rc, ts, "vos_obj_update", entry->ae_oid, again1);
+
 		if (csummer != NULL && iod_csums != NULL)
 			daos_csummer_free_ic(csummer, &iod_csums);
 		if (rc) {
@@ -844,8 +850,13 @@ agg_update_vos(struct ec_agg_param *agg_param, struct ec_agg_entry *entry,
 	recx.rx_nr         = ec_age2ss(entry);
 	epoch_range.epr_lo = ap->ap_epr.epr_lo;
 	epoch_range.epr_hi = entry->ae_cur_stripe.as_hi_epoch;
+
+again2:
 	err = vos_obj_array_remove(ap->ap_cont_handle, entry->ae_oid, &epoch_range, &entry->ae_dkey,
 				   &entry->ae_akey, &recx);
+
+	OBJ_CHECK_EAGAIN(err, ts, "vos_obj_array_remove", entry->ae_oid, again2);
+
 	if (err)
 		D_ERROR("array_remove fails: " DF_RC "\n", DP_RC(err));
 	if (!rc && err)
@@ -1817,6 +1828,7 @@ agg_process_holes(struct ec_agg_entry *entry)
 	struct ec_agg_param	*agg_param;
 	int			 tid, rc = 0;
 	int			*status;
+	uint64_t                 ts = daos_gettime_coarse();
 
 	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
 	/* If rebuild started, abort it before sending RPC to save conflict window with rebuild
@@ -1868,10 +1880,15 @@ agg_process_holes(struct ec_agg_entry *entry)
 		if (iod->iod_nr) {
 			/* write the reps to vos */
 			entry->ae_sgl.sg_nr = 1;
+
+again1:
 			rc = vos_obj_update(agg_param->ap_cont_handle, entry->ae_oid,
 					    entry->ae_cur_stripe.as_hi_epoch, 0, VOS_OF_CRIT,
 					    &entry->ae_dkey, 1, iod, stripe_ud.asu_iod_csums,
 					    &entry->ae_sgl);
+
+			OBJ_CHECK_EAGAIN(rc, ts, "vos_obj_update", entry->ae_oid, again1);
+
 			if (rc) {
 				DL_ERROR(rc, "vos_obj_update failed");
 				goto ev_out;
@@ -1884,10 +1901,13 @@ agg_process_holes(struct ec_agg_entry *entry)
 		recx.rx_nr = ec_age2cs(entry);
 		recx.rx_idx = (entry->ae_cur_stripe.as_stripenum * recx.rx_nr) |
 			      PARITY_INDICATOR;
+
+again2:
 		rc = vos_obj_array_remove(agg_param->ap_cont_handle,
 					  entry->ae_oid, &epoch_range,
 					  &entry->ae_dkey, &entry->ae_akey,
 					  &recx);
+		OBJ_CHECK_EAGAIN(rc, rc, "vos_obj_array_remove", entry->ae_oid, again2);
 	} else {
 		D_DEBUG(DB_EPC, "no valid hole, set ae_process_partial flag\n");
 		entry->ae_process_partial = 1;

--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -211,6 +211,22 @@ enum latency_type {
 	VOS_LATENCY,
 };
 
+#define OBJ_CHECK_EAGAIN(result, ts, func, oid, label)                                             \
+	do {                                                                                       \
+		if (unlikely((result) == -DER_AGAIN)) {                                            \
+			uint64_t now = daos_gettime_coarse();                                      \
+                                                                                                   \
+			if (now - ts > 30) {                                                       \
+				D_WARN("%s hit conflict on object " DF_UOID ", will retry.\n",     \
+				       func, DP_UOID(oid));                                        \
+				ts = now;                                                          \
+			}                                                                          \
+                                                                                                   \
+			ABT_thread_yield();                                                        \
+			goto label;                                                                \
+		}                                                                                  \
+	} while (0)
+
 static inline void
 obj_update_latency(uint32_t opc, uint32_t type, uint64_t latency, uint64_t io_size)
 {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2527,16 +2527,17 @@ failed:
 void
 ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 {
-	struct obj_ec_rep_in	*oer = crt_req_get(rpc);
-	struct obj_ec_rep_out	*oero = crt_reply_get(rpc);
-	daos_key_t		*dkey;
-	daos_iod_t		*iod;
-	struct dcs_iod_csums	*iod_csums;
-	struct bio_desc		*biod;
-	daos_recx_t		 recx = { 0 };
-	struct obj_io_context	 ioc;
-	daos_handle_t		 ioh = DAOS_HDL_INVAL;
-	int			 rc;
+	struct obj_ec_rep_in  *oer  = crt_req_get(rpc);
+	struct obj_ec_rep_out *oero = crt_reply_get(rpc);
+	daos_key_t            *dkey;
+	daos_iod_t            *iod;
+	struct dcs_iod_csums  *iod_csums;
+	struct bio_desc       *biod;
+	daos_recx_t            recx = {0};
+	struct obj_io_context  ioc  = {0};
+	daos_handle_t          ioh  = DAOS_HDL_INVAL;
+	uint64_t               ts   = daos_gettime_coarse();
+	int                    rc;
 
 	D_ASSERT(oer != NULL);
 	D_ASSERT(oero != NULL);
@@ -2561,6 +2562,8 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 	iod = (daos_iod_t *)&oer->er_iod;
 	if (iod->iod_nr == 0) /* nothing to replicate, directly remove parity */
 		goto remove_parity;
+
+again:
 	iod_csums = oer->er_iod_csums.ca_arrays;
 	rc        = vos_update_begin(ioc.ioc_coc->sc_hdl, oer->er_oid, oer->er_epoch_range.epr_hi,
 				     VOS_OF_REBUILD | VOS_OF_CRIT, dkey, 1, iod, iod_csums, 0, &ioh, NULL);
@@ -2589,6 +2592,8 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 end:
 	rc = vos_update_end(ioh, ioc.ioc_map_ver, dkey, rc, &ioc.ioc_io_size, NULL);
 	if (rc) {
+		OBJ_CHECK_EAGAIN(rc, ts, "vos_update_end", oer->er_oid, again);
+
 		D_ERROR(DF_UOID " vos_update_end failed: " DF_RC "\n", DP_UOID(oer->er_oid),
 			DP_RC(rc));
 		goto out_agg;
@@ -2598,6 +2603,8 @@ remove_parity:
 	recx.rx_idx = (oer->er_stripenum * recx.rx_nr) | PARITY_INDICATOR;
 	rc = vos_obj_array_remove(ioc.ioc_coc->sc_hdl, oer->er_oid, &oer->er_epoch_range, dkey,
 				  &iod->iod_name, &recx);
+	OBJ_CHECK_EAGAIN(rc, ts, "vos_obj_array_remove", oer->er_oid, remove_parity);
+
 out_agg:
 	ioc.ioc_coc->sc_ec_agg_updates--;
 out:
@@ -2608,19 +2615,19 @@ out:
 void
 ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 {
-	struct obj_ec_agg_in	*oea = crt_req_get(rpc);
-	struct obj_ec_agg_out	*oeao = crt_reply_get(rpc);
-	daos_key_t		*dkey;
-	struct bio_desc		*biod;
-	daos_iod_t		*iod = &oea->ea_iod;
-	struct dcs_iod_csums	*iod_csums = oea->ea_iod_csums.ca_arrays;
-
-	crt_bulk_t		 parity_bulk = oea->ea_bulk;
-	daos_recx_t		 recx = { 0 };
-	struct obj_io_context	 ioc;
-	daos_handle_t		 ioh = DAOS_HDL_INVAL;
-	int			 rc;
-	int			 rc1;
+	struct obj_ec_agg_in  *oea  = crt_req_get(rpc);
+	struct obj_ec_agg_out *oeao = crt_reply_get(rpc);
+	daos_key_t            *dkey;
+	struct bio_desc       *biod;
+	daos_iod_t            *iod         = &oea->ea_iod;
+	struct dcs_iod_csums  *iod_csums   = oea->ea_iod_csums.ca_arrays;
+	crt_bulk_t             parity_bulk = oea->ea_bulk;
+	daos_recx_t            recx        = {0};
+	struct obj_io_context  ioc         = {0};
+	daos_handle_t          ioh         = DAOS_HDL_INVAL;
+	uint64_t               ts          = daos_gettime_coarse();
+	int                    rc;
+	int                    rc1;
 
 	D_ASSERT(oea != NULL);
 	D_ASSERT(oeao != NULL);
@@ -2643,6 +2650,7 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 
 	dkey = (daos_key_t *)&oea->ea_dkey;
 	if (parity_bulk != CRT_BULK_NULL) {
+again1:
 		rc = vos_update_begin(ioc.ioc_coc->sc_hdl, oea->ea_oid, oea->ea_epoch_range.epr_hi,
 				      VOS_OF_REBUILD | VOS_OF_CRIT, dkey, 1, iod, iod_csums, 0,
 				      &ioh, NULL);
@@ -2672,6 +2680,8 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 end:
 		rc = vos_update_end(ioh, ioc.ioc_map_ver, dkey, rc, &ioc.ioc_io_size, NULL);
 		if (rc) {
+			OBJ_CHECK_EAGAIN(rc, ts, "vos_update_end", oea->ea_oid, again1);
+
 			if (rc == -DER_NO_PERM) {
 				/* Parity already exists, May need a
 				 * different error code.
@@ -2693,9 +2703,13 @@ end:
 	 */
 	recx.rx_idx = oea->ea_stripenum * obj_ioc2ec_ss(&ioc);
 	recx.rx_nr = obj_ioc2ec_ss(&ioc);
+again2:
 	rc1 = vos_obj_array_remove(ioc.ioc_coc->sc_hdl, oea->ea_oid,
 				  &oea->ea_epoch_range, dkey,
 				  &iod->iod_name, &recx);
+
+	OBJ_CHECK_EAGAIN(rc1, ts, "vos_obj_array_remove", oea->ea_oid, again2);
+
 	if (rc1)
 		D_ERROR(DF_UOID ": array_remove failed: " DF_RC "\n", DP_UOID(oea->ea_oid),
 			DP_RC(rc1));
@@ -2790,18 +2804,18 @@ out:
 void
 ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 {
-	struct obj_rw_in		*orw = crt_req_get(rpc);
-	struct obj_rw_out		*orwo = crt_reply_get(rpc);
-	daos_key_t			*dkey = &orw->orw_dkey;
-	struct obj_io_context		 ioc;
-	struct dtx_handle               *dth = NULL;
-	struct dtx_memberships		*mbs = NULL;
-	struct daos_shard_tgt		*tgts = NULL;
-	uint32_t			 tgt_cnt;
-	uint32_t			 opc = opc_get(rpc->cr_opc);
-	uint32_t			 dtx_flags = 0;
-	struct dtx_epoch		 epoch;
-	int				 rc;
+	struct obj_rw_in       *orw  = crt_req_get(rpc);
+	struct obj_rw_out      *orwo = crt_reply_get(rpc);
+	daos_key_t             *dkey = &orw->orw_dkey;
+	struct obj_io_context   ioc  = {0};
+	struct dtx_handle      *dth  = NULL;
+	struct dtx_memberships *mbs  = NULL;
+	struct daos_shard_tgt  *tgts = NULL;
+	uint32_t                tgt_cnt;
+	uint32_t                opc       = opc_get(rpc->cr_opc);
+	uint32_t                dtx_flags = 0;
+	struct dtx_epoch        epoch;
+	int                     rc;
 
 	D_ASSERT(orw != NULL);
 	D_ASSERT(orwo != NULL);
@@ -3251,11 +3265,11 @@ again:
 		d_tm_inc_counter(opm->opm_update_restart, 1);
 		goto again;
 	case -DER_AGAIN:
+		ABT_thread_yield();
 		need_abort = true;
 		exec_arg.flags |= ORF_RESEND;
 		flags = ORF_RESEND;
 		d_tm_inc_counter(opm->opm_update_retry, 1);
-		ABT_thread_yield();
 		goto again;
 	default:
 		break;
@@ -3573,14 +3587,14 @@ obj_enum_reply_bulk(crt_rpc_t *rpc)
 void
 ds_obj_enum_handler(crt_rpc_t *rpc)
 {
-	struct ds_obj_enum_arg	enum_arg = { 0 };
-	struct vos_iter_anchors	*anchors = NULL;
-	struct obj_key_enum_in	*oei;
-	struct obj_key_enum_out	*oeo;
-	struct obj_io_context	ioc;
-	daos_epoch_t		epoch = 0;
-	int			opc = opc_get(rpc->cr_opc);
-	int			rc = 0;
+	struct ds_obj_enum_arg   enum_arg = {0};
+	struct vos_iter_anchors *anchors  = NULL;
+	struct obj_key_enum_in  *oei;
+	struct obj_key_enum_out *oeo;
+	struct obj_io_context    ioc   = {0};
+	daos_epoch_t             epoch = 0;
+	int                      opc   = opc_get(rpc->cr_opc);
+	int                      rc    = 0;
 
 	oei = crt_req_get(rpc);
 	D_ASSERT(oei != NULL);
@@ -4163,10 +4177,10 @@ again:
 		flags = ORF_RESEND;
 		goto again;
 	case -DER_AGAIN:
+		ABT_thread_yield();
 		need_abort = true;
 		exec_arg.flags |= ORF_RESEND;
 		flags = ORF_RESEND;
-		ABT_thread_yield();
 		goto again;
 	default:
 		break;
@@ -4457,11 +4471,11 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 void
 ds_obj_sync_handler(crt_rpc_t *rpc)
 {
-	struct obj_sync_in	*osi;
-	struct obj_sync_out	*oso;
-	struct obj_io_context	 ioc;
-	daos_epoch_t		 epoch = d_hlc_get();
-	int			 rc;
+	struct obj_sync_in   *osi;
+	struct obj_sync_out  *oso;
+	struct obj_io_context ioc   = {0};
+	daos_epoch_t          epoch = d_hlc_get();
+	int                   rc;
 
 	osi = crt_req_get(rpc);
 	D_ASSERT(osi != NULL);
@@ -5589,18 +5603,18 @@ out:
 void
 ds_obj_cpd_handler(crt_rpc_t *rpc)
 {
-	struct obj_cpd_in	*oci = crt_req_get(rpc);
-	struct obj_cpd_out	*oco = crt_reply_get(rpc);
-	struct daos_cpd_args	*dcas = NULL;
-	struct obj_io_context	 ioc;
-	ABT_future		 future = ABT_FUTURE_NULL;
-	struct daos_cpd_bulk   **dcbs = NULL;
-	uint32_t		 dcb_nr = 0;
-	int			 tx_count = oci->oci_sub_heads.ca_count;
-	int			 rc = 0;
-	int			 i;
-	int			 j;
-	bool			 leader;
+	struct obj_cpd_in     *oci      = crt_req_get(rpc);
+	struct obj_cpd_out    *oco      = crt_reply_get(rpc);
+	struct daos_cpd_args  *dcas     = NULL;
+	struct obj_io_context  ioc      = {0};
+	ABT_future             future   = ABT_FUTURE_NULL;
+	struct daos_cpd_bulk **dcbs     = NULL;
+	uint32_t               dcb_nr   = 0;
+	int                    tx_count = oci->oci_sub_heads.ca_count;
+	int                    rc       = 0;
+	int                    i;
+	int                    j;
+	bool                   leader;
 
 	D_ASSERT(oci != NULL);
 
@@ -5753,11 +5767,11 @@ reply:
 void
 ds_obj_key2anchor_handler(crt_rpc_t *rpc)
 {
-	struct obj_key2anchor_in	*oki;
-	struct obj_key2anchor_out	*oko;
-	struct obj_io_context		ioc;
-	daos_key_t			*akey = NULL;
-	int				rc = 0;
+	struct obj_key2anchor_in  *oki;
+	struct obj_key2anchor_out *oko;
+	struct obj_io_context      ioc  = {0};
+	daos_key_t                *akey = NULL;
+	int                        rc   = 0;
 
 	oki = crt_req_get(rpc);
 	D_ASSERT(oki != NULL);
@@ -5935,10 +5949,10 @@ again:
 		flags = ORF_RESEND;
 		goto again;
 	case -DER_AGAIN:
+		ABT_thread_yield();
 		need_abort = true;
 		exec_arg.flags |= ORF_RESEND;
 		flags = ORF_RESEND;
-		ABT_thread_yield();
 		goto again;
 	default:
 		break;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -972,6 +972,7 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 	d_iov_t			*p_csum_iov = NULL;
 	d_iov_t			 csum_iov = {0};
 	d_iov_t                  packed_csum_iov = {0};
+	uint64_t                 ts              = daos_gettime_coarse();
 
 	D_ASSERT(mrone->mo_iod_num <= OBJ_ENUM_UNPACK_MAX_IODS);
 	for (i = 0; i < mrone->mo_iod_num; i++) {
@@ -1057,10 +1058,14 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 			break;
 		}
 
+again1:
 		rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
 				    mrone->mo_min_epoch, mrone->mo_version,
 				    VOS_OF_REBUILD, &mrone->mo_dkey, iod_cnt, &iods[start],
 				    iod_csums, &sgls[start]);
+
+		OBJ_CHECK_EAGAIN(rc, ts, "vos_obj_update (1)", mrone->mo_oid, again1);
+
 		daos_csummer_free_ic(csummer, &iod_csums);
 		if (rc) {
 			DL_ERROR(rc, DF_RB ": migrate failed", DP_RB_MRO(mrone));
@@ -1078,11 +1083,15 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 			D_GOTO(out, rc);
 		}
 
+again2:
 		rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
 				    mrone->mo_min_epoch, mrone->mo_version,
 				    VOS_OF_REBUILD, &mrone->mo_dkey, iod_cnt,
 				    &mrone->mo_iods[start], iod_csums,
 				    &sgls[start]);
+
+		OBJ_CHECK_EAGAIN(rc, ts, "vos_obj_update (2)", mrone->mo_oid, again2);
+
 		daos_csummer_free_ic(csummer, &iod_csums);
 		if (rc) {
 			DL_ERROR(rc, DF_RB ": migrate failed", DP_RB_MRO(mrone));
@@ -1112,7 +1121,8 @@ migrate_update_parity(struct migrate_one *mrone, daos_epoch_t parity_eph,
 	d_sg_list_t		 tmp_sgl;
 	daos_size_t		 write_nr;
 	struct dcs_iod_csums	*iod_csums = NULL;
-	int			rc = 0;
+	int                      rc        = 0;
+	uint64_t                 ts        = daos_gettime_coarse();
 
 	split_size = encode ? stride_nr : cell_nr;
 	tmp_sgl.sg_nr = tmp_sgl.sg_nr_out = 1;
@@ -1163,10 +1173,14 @@ migrate_update_parity(struct migrate_one *mrone, daos_epoch_t parity_eph,
 			D_GOTO(out, rc);
 		}
 
+again:
 		rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
 				    parity_eph, mrone->mo_version,
 				    VOS_OF_REBUILD, &mrone->mo_dkey, 1, iod, iod_csums,
 				    &tmp_sgl);
+
+		OBJ_CHECK_EAGAIN(rc, ts, "vos_obj_update", mrone->mo_oid, again);
+
 		if (rc != 0)
 			D_GOTO(out, rc);
 
@@ -1375,6 +1389,7 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 	uint32_t		tgt_off = 0;
 	int			 i;
 	int			 rc;
+	uint64_t                 ts = daos_gettime_coarse();
 
 	D_ASSERT(mrone->mo_iod_num <= OBJ_ENUM_UNPACK_MAX_IODS);
 	for (i = 0; i < mrone->mo_iod_num; i++) {
@@ -1506,10 +1521,12 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 	if (daos_oclass_is_ec(&mrone->mo_oca))
 		update_flags |= VOS_OF_EC;
 
+again:
 	rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
 			    mrone->mo_min_epoch, mrone->mo_version,
 			    update_flags, &mrone->mo_dkey, mrone->mo_iod_num,
 			    mrone->mo_iods, iod_csums, sgls);
+	OBJ_CHECK_EAGAIN(rc, ts, "vos_obj_update", mrone->mo_oid, again);
 out:
 	for (i = 0; i < mrone->mo_iod_num; i++) {
 		if (iov[i].iov_buf)
@@ -1543,11 +1560,14 @@ __migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	struct dcs_iod_csums *iod_csums  = NULL;
 	d_iov_t              *p_csum_iov = NULL;
 	int                   rc, rc1, i;
+	uint64_t              ts = daos_gettime_coarse();
 
 	if (daos_oclass_is_ec(&mrone->mo_oca))
 		mrone_recx_daos2_vos(mrone, iods, iod_num);
 
 	D_ASSERT(iod_num <= OBJ_ENUM_UNPACK_MAX_IODS);
+
+again:
 	rc = vos_update_begin(ds_cont->sc_hdl, mrone->mo_oid, update_eph, VOS_OF_REBUILD,
 			      &mrone->mo_dkey, iod_num, iods, mrone->mo_iods_csums,
 			      0, &ioh, NULL);
@@ -1665,6 +1685,8 @@ end:
 	if (rc == 0)
 		rc = rc1;
 
+	OBJ_CHECK_EAGAIN(rc, ts, "vos_update_end", mrone->mo_oid, again);
+
 	if (rc)
 		DL_ERROR(rc, DF_RB ": " DF_UOID " migrate error", DP_RB_MRO(mrone),
 			 DP_UOID(mrone->mo_oid));
@@ -1777,8 +1799,9 @@ static int
 migrate_punch(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 	      struct ds_cont_child *cont)
 {
-	int	rc = 0;
-	int	i;
+	uint64_t ts = daos_gettime_coarse();
+	int      rc = 0;
+	int      i;
 
 	/* Punch dkey */
 	if (mrone->mo_dkey_punch_eph != 0 && mrone->mo_dkey_punch_eph <= tls->mpt_max_eph) {
@@ -1837,9 +1860,13 @@ migrate_punch(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 						      mrone->mo_oid.id_shard))
 			mrone_recx_daos2_vos(mrone, mrone->mo_punch_iods, mrone->mo_punch_iod_num);
 
+again:
 		rc = vos_obj_update(cont->sc_hdl, mrone->mo_oid, mrone->mo_rec_punch_eph,
 				    mrone->mo_version, VOS_OF_REBUILD, &mrone->mo_dkey,
 				    mrone->mo_punch_iod_num, mrone->mo_punch_iods, NULL, NULL);
+
+		OBJ_CHECK_EAGAIN(rc, ts, "vos_obj_update", mrone->mo_oid, again);
+
 		D_DEBUG(DB_REBUILD,
 			DF_RB ": " DF_UOID " mrone %p punch %d eph " DF_U64 "records: " DF_RC "\n",
 			DP_RB_MPT(tls), DP_UOID(mrone->mo_oid), mrone, mrone->mo_punch_iod_num,

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -224,9 +224,9 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm, bool is_sysdb,
 		/* CPU may yield when umem_tx_begin, related object maybe evicted during that. */
 		rc = umem_tx_begin(umm, vos_txd_get(is_sysdb));
 		if (rc == 0 && obj != NULL && unlikely(vos_obj_is_evicted(obj))) {
-			D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted(1), need to restart TX.\n",
+			D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted(1), need to retry.\n",
 				DP_UOID(obj->obj_id));
-			rc = umem_tx_end(umm, -DER_TX_RESTART);
+			rc = umem_tx_end(umm, -DER_AGAIN);
 		}
 
 		return rc;
@@ -247,10 +247,10 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm, bool is_sysdb,
 	if (rc == 0) {
 		/* CPU may yield when umem_tx_begin, related object maybe evicted during that. */
 		if (obj != NULL && unlikely(vos_obj_is_evicted(obj))) {
-			D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted(2), need to restart TX.\n",
+			D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted(2), need to retry.\n",
 				DP_UOID(obj->obj_id));
 
-			return umem_tx_end(umm, -DER_TX_RESTART);
+			return umem_tx_end(umm, -DER_AGAIN);
 		}
 
 		dth->dth_local_tx_started = 1;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2572,10 +2572,10 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 		if (err != 0)
 			goto abort;
 	} else if (unlikely(vos_obj_is_evicted(ioc->ic_obj))) {
-		D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted during update, need to restart TX.\n",
+		D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted during update, need to retry.\n",
 			DP_UOID(ioc->ic_oid));
 
-		D_GOTO(abort, err = -DER_TX_RESTART);
+		D_GOTO(abort, err = -DER_AGAIN);
 	}
 
 	err = vos_ts_set_add(ioc->ic_ts_set, ioc->ic_cont->vc_ts_idx, NULL, 0);


### PR DESCRIPTION
On server side, for an update operation, there may be CPU yield between related vos_update_begin() and vos_update_end(). During yield interval, the object that is held via vos_update_begin() maybe evicted by others, such as by another failed modification against the same object shard or evicted under md-on-ssd mode. So vos_update_end() logic will check such case and return -DER_AGAIN instead of -DER_TX_RESTART to the caller for notification. And then related caller needs to retry update instead of fail out.

The patch also adds initialization for some local varilables in object module to avoid random corruption when handle some failure cases.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
