### PR TITLE
DAOS-18949 container: Fix sched_seq assert failures

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1045,7 +1045,7 @@ cont_child_start(struct ds_pool_child *pool_child, const uuid_t co_uuid,
 		D_DEBUG(DB_MD, DF_CONT "[%d]: Container is being destroying (s=%d, d=%d)\n",
 			DP_CONT(pool_child->spc_uuid, co_uuid), tgt_id, cont_child->sc_stopping,
 			cont_child->sc_destroying);
-		rc = -DER_CONT_NONEXIST;
+		rc = -DER_CONT_DESTROYING;
 	} else if (cont_child->sc_stopping) {
 		D_DEBUG(DB_MD, DF_CONT "[%d]: Container is being stopped (s=%d, d=%d)\n",
 			DP_CONT(pool_child->spc_uuid, co_uuid), tgt_id, cont_child->sc_stopping,
@@ -1503,14 +1503,10 @@ ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
 	if (rc != 0)
 		return rc;
 
-	/**
-	 * Return -DER_CONT_NONEXIST to simplify caller-side handling.
-	 * This may return -DER_CONT_DESTROYING in the future if needed.
-	 **/
 	if ((*ds_cont)->sc_destroying) {
 		cont_child_put(tls->dt_cont_cache, *ds_cont);
 		*ds_cont = NULL;
-		return -DER_CONT_NONEXIST;
+		return -DER_CONT_DESTROYING;
 	}
 
 	if ((*ds_cont)->sc_stopping) {

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1850,21 +1850,23 @@ migrate_get_cont_child(struct migrate_pool_tls *tls, uuid_t cont_uuid,
 		 */
 		rc = ds_cont_child_open_create(tls->mpt_pool_uuid, cont_uuid, false, &cont_child);
 		if (rc != 0) {
-			if (rc == -DER_CONT_NONEXIST)
+			if (rc == -DER_CONT_DESTROYING)
 				D_DEBUG(DB_REBUILD,
 					DF_RB ": container " DF_UUID
 					      "already destroyed or destroying\n",
 					DP_RB_MPT(tls), DP_UUID(cont_uuid));
+			D_ASSERT(cont_child == NULL);
 			return rc;
 		}
 	} else {
 		rc = ds_cont_child_lookup(tls->mpt_pool_uuid, cont_uuid, &cont_child);
 		if (rc != 0) {
-			if (rc == -DER_CONT_NONEXIST)
+			if (rc == -DER_CONT_NONEXIST || rc == -DER_CONT_DESTROYING)
 				D_DEBUG(DB_REBUILD,
 					DF_RB ": container " DF_UUID
 					      "already destroyed or destroying\n",
 					DP_RB_MPT(tls), DP_UUID(cont_uuid));
+			D_ASSERT(cont_child == NULL);
 			return rc;
 		}
 	}
@@ -2262,7 +2264,8 @@ migrate_one_ult(void *arg)
 	 *   (nonexistent)
 	 * This is just a workaround...
 	 */
-	if (rc != 0 && rc != -DER_CONT_NONEXIST && rc != -DER_DATA_LOSS && tls->mpt_status == 0) {
+	if (rc != 0 && rc != -DER_CONT_NONEXIST && rc != -DER_CONT_DESTROYING &&
+	    rc != -DER_DATA_LOSS && tls->mpt_status == 0) {
 		DL_ERROR(rc, DF_RB ": " DF_UOID " rebuild failed, set mpt_fini for tgt %d.",
 			 DP_RB_MPT(tls), DP_UOID(mrone->mo_oid), dss_get_module_info()->dmi_tgt_id);
 		tls->mpt_status = rc;
@@ -3274,9 +3277,10 @@ migrate_obj_epoch(struct migrate_pool_tls *tls, struct iter_obj_arg *arg, daos_e
 			 * to rebuild the data, see obj_list_common.
 			 */
 			/* If the container is being destroyed, it may return
-			 * -DER_CONT_NONEXIST, see obj_ioc_init().
+			 * -DER_CONT_NONEXIST or -DER_CONT_DESTROYING, see obj_ioc_init().
 			 */
-			if (rc == -DER_DATA_LOSS || rc == -DER_CONT_NONEXIST) {
+			if (rc == -DER_DATA_LOSS || rc == -DER_CONT_NONEXIST ||
+			    rc == -DER_CONT_DESTROYING) {
 				D_WARN(DF_RB ": mo replicas for " DF_UOID " %d\n", DP_RB_MPT(tls),
 				       DP_UOID(arg->oid), rc);
 				num = 0;
@@ -3531,7 +3535,7 @@ free:
 	if (arg->epoch == DAOS_EPOCH_MAX)
 		tls->mpt_obj_count++;
 
-	if (rc == -DER_CONT_NONEXIST) {
+	if (rc == -DER_CONT_NONEXIST || rc == -DER_CONT_DESTROYING) {
 		struct ds_cont_child *cont_child = NULL;
 
 		/* check again to see if the container is being destroyed. */
@@ -4377,7 +4381,7 @@ reint_post_cont_iter_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	D_ASSERT(daos_handle_is_valid(cont_toh));
 
 	rc = ds_cont_child_lookup(tls->mpt_pool_uuid, entry->ie_couuid, &cont_child);
-	if (rc == -DER_CONT_NONEXIST) {
+	if (rc == -DER_CONT_NONEXIST || rc == -DER_CONT_DESTROYING) {
 		D_DEBUG(DB_REBUILD, DF_RB" co_uuid "DF_UUID" already destroyed or destroying, "
 			DF_RC"\n", DP_RB_MPT(tls), DP_UUID(entry->ie_couuid), DP_RC(rc));
 		rc = 0;

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -942,7 +942,7 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	}
 
 	rc = ds_cont_child_lookup(rpt->rt_pool_uuid, entry->ie_couuid, &cont_child);
-	if (rc == -DER_CONT_NONEXIST) {
+	if (rc == -DER_CONT_NONEXIST || rc == -DER_CONT_DESTROYING) {
 		D_DEBUG(DB_REBUILD, DF_RB " co_uuid " DF_UUID " already destroyed or destroying\n",
 			DP_RB_RPT(rpt), DP_UUID(arg->co_uuid));
 		rc = 0;


### PR DESCRIPTION
The assertion "sched_seq1 != sched_seq2" in cont_child_create_start has been triggered likely by the following scenario:

    cont_child_create_start
      cont_child_start (the one near the beginning)
        if cont_child->sc_destroy
          returned -DER_CONT_NONEXIST
      vos_cont_create: -DER_EXIST
      assertion failed due to no schduling

This patch changes cont_child_start and ds_cont_child_lookup to return -DER_CONT_DESTROYING instead of -DER_CONT_NONEXIST, so that the scenario above won't reach the vos_cont_create call.

Features: container

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
