### PR TITLE
DAOS-18978 dfs: add oclass and split_offset selection logic

### DIFF
--- a/src/client/dfs/common.c
+++ b/src/client/dfs/common.c
@@ -194,6 +194,7 @@ fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char
 	iod->iod_size  = 1;
 
 	entry->tail_oid   = DAOS_OBJ_NIL;
+	entry->split_off  = 0;
 	entry->tail_state = DFS_TAIL_NONE;
 	i = 0;
 	d_iov_set(&sg_iovs[i++], &entry->mode, sizeof(mode_t));
@@ -210,6 +211,7 @@ fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char
 	d_iov_set(&sg_iovs[i++], &entry->obj_hlc, sizeof(uint64_t));
 	if (ver >= DFS_PL_LAYOUT_VERSION) {
 		d_iov_set(&sg_iovs[i++], &entry->tail_oid, sizeof(daos_obj_id_t));
+		d_iov_set(&sg_iovs[i++], &entry->split_off, sizeof(daos_size_t));
 		d_iov_set(&sg_iovs[i++], &entry->tail_state, sizeof(uint8_t));
 	}
 
@@ -387,6 +389,7 @@ insert_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const cha
 	d_iov_set(&sg_iovs[i++], &entry->obj_hlc, sizeof(uint64_t));
 	if (ver >= DFS_PL_LAYOUT_VERSION) {
 		d_iov_set(&sg_iovs[i++], &entry->tail_oid, sizeof(daos_obj_id_t));
+		d_iov_set(&sg_iovs[i++], &entry->split_off, sizeof(daos_size_t));
 		d_iov_set(&sg_iovs[i++], &entry->tail_state, sizeof(uint8_t));
 	}
 
@@ -954,8 +957,6 @@ int
 dfs_get_sb_layout(daos_key_t *dkey, daos_iod_t *iods[], int *akey_count, int *dfs_entry_key_size,
 		  int *dfs_entry_size)
 {
-	struct dfs_entry entry;
-
 	if (dkey == NULL || akey_count == NULL)
 		return EINVAL;
 
@@ -965,13 +966,7 @@ dfs_get_sb_layout(daos_key_t *dkey, daos_iod_t *iods[], int *akey_count, int *df
 
 	*akey_count         = SB_AKEYS;
 	*dfs_entry_key_size = sizeof(INODE_AKEY_NAME) - 1;
-	/** Can't just use sizeof(struct dfs_entry) because it's not accurate */
-	*dfs_entry_size =
-	    D_ALIGNUP(sizeof(entry.mode) + sizeof(entry.oid) + sizeof(entry.mtime) +
-			  sizeof(entry.ctime) + sizeof(entry.chunk_size) + sizeof(entry.oclass) +
-			  sizeof(entry.mtime_nano) + sizeof(entry.ctime_nano) + sizeof(entry.uid) +
-			  sizeof(entry.gid) + sizeof(entry.value_len) + sizeof(entry.obj_hlc),
-		      32);
+	*dfs_entry_size     = dfs_inode_record_size(DFS_LAYOUT_VERSION);
 
 	set_sb_params(true, *iods, dkey);
 

--- a/src/client/dfs/dfs-progressive-layout.md
+++ b/src/client/dfs/dfs-progressive-layout.md
@@ -60,10 +60,17 @@ The 1000-target threshold is an initial value and should be validated with perfo
 
 ### 2) Head EC data/parity selection
 
+Progressive layout is only enabled for the default file-oclass path.
+
+If the user explicitly selects a file object class through container create parameters,
+directory settings, or the DFS API, use that class directly and do not apply progressive
+layout for that file.
+
 When progressive layout is enabled:
 
 - Select head EC data/parity using the same RF/domain logic as dc_set_oclass().
 - Keep this behavior aligned with existing DAOS defaults for array objects.
+- Use the default DAOS GX class for the tail object.
 - On large systems with many fault domains and targets, EC16P3 is commonly selected by this logic.
 
 Only the redundancy group count (G value) and split_off are introduced as additional policy choices here.
@@ -72,7 +79,7 @@ Only the redundancy group count (G value) and split_off are introduced as additi
 
 Choose a fixed head group count from this set (the predefined group number values for object classes):
 
-- {1, 2, 3, 4, 6, 8, 12, 16, 32}
+- {1, 2, 4, 6, 8, 12, 16, 32}
 
 Inputs:
 

--- a/src/client/dfs/dfs-progressive-layout.md
+++ b/src/client/dfs/dfs-progressive-layout.md
@@ -55,6 +55,8 @@ Progressive layout is disabled when the pool does not have enough targets to ben
 
 - If target_nr < 1000, disable progressive layout.
 - In this case, use the default DFS file class behavior (GX-style sharding selected by existing DAOS logic).
+- For testing only, set `DFS_PL_BYPASS_TARGET_LIMIT=1` to bypass the 1000-target gate while keeping the
+  default-selection requirement unchanged.
 
 The 1000-target threshold is an initial value and should be validated with performance and rebuild benchmarks.
 

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -66,8 +66,8 @@
 /** Magic value for serializing / deserializing a DFS object handle */
 #define DFS_OBJ_GLOB_MAGIC 0xdf500b90
 
-/** Number of A-keys for attributes in any object entry */
-#define INODE_AKEYS            14
+/** Number of serialized inode record fragments for any object entry */
+#define INODE_AKEYS            15
 #define INODE_AKEY_NAME    "DFS_INODE"
 #define SLINK_AKEY_NAME    "DFS_SLINK"
 #define MODE_IDX           0
@@ -84,7 +84,8 @@
 #define HLC_IDX            (SIZE_IDX + sizeof(daos_size_t))
 #define END_L3_IDX             (HLC_IDX + sizeof(uint64_t))
 #define TAIL_OID_IDX           END_L3_IDX
-#define TAIL_STATE_IDX         (TAIL_OID_IDX + sizeof(daos_obj_id_t))
+#define SPLIT_OFF_IDX          (TAIL_OID_IDX + sizeof(daos_obj_id_t))
+#define TAIL_STATE_IDX         (SPLIT_OFF_IDX + sizeof(daos_size_t))
 #define END_IDX                (TAIL_STATE_IDX + sizeof(uint8_t))
 
 /*
@@ -146,6 +147,8 @@ struct dfs_obj {
 		struct {
 			/** Optional tail array object id for progressive layout */
 			daos_obj_id_t tail_oid;
+			/** Logical file offset where progressive layout switches to tail */
+			daos_size_t   split_off;
 			/** Optional tail array object handle for progressive layout */
 			daos_handle_t tail_oh;
 			/** Whether this open regular file uses progressive layout */
@@ -238,8 +241,10 @@ struct dfs_entry {
 	daos_size_t      chunk_size;
 	/** oclass of file or all files in a dir */
 	daos_oclass_id_t oclass;
-	/** Optional tail object id for progressive-layout regular files */
+	/** Tail object id for progressive-layout regular files */
 	daos_obj_id_t    tail_oid;
+	/** Split point for progressive-layout regular files */
+	daos_size_t      split_off;
 	/** Informational tail state encoded on disk as a single byte */
 	uint8_t          tail_state;
 	/** uid - not enforced at this level. */

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -207,6 +207,12 @@ struct dfs {
 	daos_oclass_hints_t  file_oclass_hint;
 	/** Object class hint for dirs */
 	daos_oclass_hints_t  dir_oclass_hint;
+	/** Cached pool target count for progressive-layout selection */
+	uint32_t             pl_target_nr;
+	/** Cached total SCM capacity for progressive-layout selection */
+	uint64_t             pl_total_scm;
+	/** Cached total NVMe capacity for progressive-layout selection */
+	uint64_t             pl_total_nvme;
 	/** Optional prefix to account for when resolving an absolute path */
 	char                *prefix;
 	daos_size_t          prefix_len;

--- a/src/client/dfs/lookup.c
+++ b/src/client/dfs/lookup.c
@@ -154,6 +154,7 @@ lookup_rel_path_loop:
 			}
 
 			obj->f.has_tail = dfs_entry_has_tail(dfs->layout_v, &entry);
+			obj->f.split_off = obj->f.has_tail ? entry.split_off : 0;
 			if (obj->f.has_tail) {
 				oid_cp(&obj->f.tail_oid, entry.tail_oid);
 				rc = daos_array_open_with_attr(
@@ -480,6 +481,7 @@ lookup_rel_int(dfs_t *dfs, dfs_obj_t *parent, const char *name, int flags, dfs_o
 		}
 
 		obj->f.has_tail = dfs_entry_has_tail(dfs->layout_v, &entry);
+		obj->f.split_off = obj->f.has_tail ? entry.split_off : 0;
 		if (obj->f.has_tail) {
 			oid_cp(&obj->f.tail_oid, entry.tail_oid);
 			rc = daos_array_open_with_attr(

--- a/src/client/dfs/mnt.c
+++ b/src/client/dfs/mnt.c
@@ -28,6 +28,36 @@ static struct d_hash_table *poh_hash;
 /** hashtable for container open handles */
 static struct d_hash_table *coh_hash;
 
+static void
+dfs_set_pl_pool_info(dfs_t *dfs, const daos_pool_info_t *pool_info)
+{
+	if (dfs == NULL || pool_info == NULL)
+		return;
+
+	dfs->pl_target_nr  = pool_info->pi_ntargets;
+	dfs->pl_total_nvme = pool_info->pi_space.ps_space.s_total[DAOS_MEDIA_NVME];
+	dfs->pl_total_scm  = pool_info->pi_space.ps_space.s_total[DAOS_MEDIA_SCM];
+}
+
+static void
+dfs_cache_pl_pool_info(dfs_t *dfs)
+{
+	daos_pool_info_t pool_info = {.pi_bits = DPI_SPACE};
+	int              rc;
+
+	if (dfs == NULL)
+		return;
+
+	rc = daos_pool_query(dfs->poh, NULL, &pool_info, NULL, NULL);
+	if (rc != 0) {
+		D_WARN("daos_pool_query() failed while caching PL pool info, " DF_RC "\n",
+		       DP_RC(rc));
+		return;
+	}
+
+	dfs_set_pl_pool_info(dfs, &pool_info);
+}
+
 static inline struct dfs_mnt_hdls *
 hdl_obj(d_list_t *rlink)
 {
@@ -657,6 +687,8 @@ dfs_mount_int(daos_handle_t poh, daos_handle_t coh, int flags, daos_epoch_t epoc
 			D_GOTO(err_super, rc);
 	}
 
+	dfs_cache_pl_pool_info(dfs);
+
 	/*
 	 * If container was created with balanced mode, only balanced mode
 	 * mounting should be allowed.
@@ -983,6 +1015,9 @@ struct dfs_glob {
 	daos_obj_id_t    super_oid;
 	daos_obj_id_t    root_oid;
 	daos_epoch_t     th_epoch;
+	uint32_t         pl_target_nr;
+	uint64_t         pl_total_scm;
+	uint64_t         pl_total_nvme;
 };
 
 static inline void
@@ -1001,6 +1036,9 @@ swap_dfs_glob(struct dfs_glob *dfs_params)
 	D_SWAP16S(&dfs_params->oclass);
 	D_SWAP16S(&dfs_params->dir_oclass);
 	D_SWAP16S(&dfs_params->file_oclass);
+	D_SWAP32S(&dfs_params->pl_target_nr);
+	D_SWAP64S(&dfs_params->pl_total_scm);
+	D_SWAP64S(&dfs_params->pl_total_nvme);
 	/* skip cont_uuid */
 	/* skip coh_uuid */
 }
@@ -1073,6 +1111,9 @@ dfs_local2global(dfs_t *dfs, d_iov_t *glob)
 	dfs_params->dir_oclass  = dfs->attr.da_dir_oclass_id;
 	dfs_params->file_oclass = dfs->attr.da_file_oclass_id;
 	dfs_params->th_epoch    = dfs->th_epoch;
+	dfs_params->pl_target_nr  = dfs->pl_target_nr;
+	dfs_params->pl_total_scm  = dfs->pl_total_scm;
+	dfs_params->pl_total_nvme = dfs->pl_total_nvme;
 	uuid_copy(dfs_params->coh_uuid, coh_uuid);
 	uuid_copy(dfs_params->cont_uuid, cont_uuid);
 
@@ -1140,6 +1181,9 @@ dfs_global2local(daos_handle_t poh, daos_handle_t coh, int flags, d_iov_t glob, 
 	dfs->attr.da_oclass_id      = dfs_params->oclass;
 	dfs->attr.da_dir_oclass_id  = dfs_params->dir_oclass;
 	dfs->attr.da_file_oclass_id = dfs_params->file_oclass;
+	dfs->pl_target_nr           = dfs_params->pl_target_nr;
+	dfs->pl_total_scm           = dfs_params->pl_total_scm;
+	dfs->pl_total_nvme          = dfs_params->pl_total_nvme;
 
 	dfs->super_oid       = dfs_params->super_oid;
 	dfs->root.oid        = dfs_params->root_oid;

--- a/src/client/dfs/obj.c
+++ b/src/client/dfs/obj.c
@@ -13,6 +13,7 @@
 #include <daos/container.h>
 #include <daos/event.h>
 #include <daos/object.h>
+#include <daos/pool.h>
 
 #include "dfs_internal.h"
 
@@ -32,6 +33,118 @@ open_file_tail(dfs_t *dfs, daos_obj_id_t tail_oid, int daos_mode, daos_size_t ch
 	if (rc != 0) {
 		D_ERROR("daos_array_open_with_attr() failed, " DF_RC "\n", DP_RC(rc));
 		return daos_der2errno(rc);
+	}
+
+	return 0;
+}
+
+/* Pick the compact head class by keeping the tail redundancy family and reducing group count. */
+static daos_oclass_id_t
+file_head_oclass(daos_oclass_id_t tail_cid, uint32_t max_groups)
+{
+	static const uint32_t head_groups[] = {32, 16, 12, 8, 6, 4, 2, 1};
+	enum daos_obj_redun   ord;
+	uint32_t              group_nr;
+	int                   i;
+
+	if (max_groups == 0)
+		return OC_UNKNOWN;
+
+	/*
+	 * Bias the head toward a compact layout by starting from one eighth of the maximum scalable
+	 * group count of the default tail class. This keeps the head materially smaller than the
+	 * tail while still allowing it to grow with larger systems.
+	 */
+	group_nr = max_groups / 8;
+	/*
+	 * The compact head policy is bounded to the predefined non-GX class set we support here, so
+	 * clamp the computed target into that range before snapping it to an actual class.
+	 */
+	group_nr = min(max(group_nr, 1U), 32U);
+	/*
+	 * DAOS only provides explicit classes for a fixed set of group counts. Pick the largest
+	 * supported count that does not exceed the compact target so we preserve the intended
+	 * compactness without inventing an unsupported class id.
+	 */
+	for (i = 0; i < ARRAY_SIZE(head_groups); i++) {
+		if (head_groups[i] <= group_nr)
+			return OBJ_CLASS_DEF(tail_cid >> OC_REDUN_SHIFT, head_groups[i]);
+	}
+
+	ord = tail_cid >> OC_REDUN_SHIFT;
+	return OBJ_CLASS_DEF(ord, 1);
+}
+
+/* Resolve file head/tail oclasses, applying PL only when no explicit file class was selected. */
+static int
+file_oclasses(dfs_t *dfs, dfs_obj_t *parent, daos_oclass_id_t cid, daos_oclass_id_t *head_cid,
+	      daos_oclass_id_t *tail_cid, bool *has_tail)
+{
+	daos_pool_info_t         pool_info = {0};
+	struct daos_oclass_attr *tail_attr;
+	uint32_t                 max_groups;
+	int                      rc;
+
+	if (head_cid == NULL || tail_cid == NULL || has_tail == NULL)
+		return EINVAL;
+
+	if (cid == 0) {
+		/* Respect explicit file-class choices before considering progressive layout
+		 * defaults. */
+		if (parent->d.oclass == 0)
+			cid = dfs->attr.da_file_oclass_id;
+		else
+			cid = parent->d.oclass;
+	}
+
+	*head_cid = cid;
+	*tail_cid = OC_UNKNOWN;
+	*has_tail = false;
+
+	if (cid != 0 || !dfs_file_layout_has_tail(dfs->layout_v, S_IFREG))
+		return 0;
+
+	rc = daos_pool_query(dfs->poh, NULL, &pool_info, NULL, NULL);
+	if (rc != 0) {
+		D_ERROR("daos_pool_query() failed " DF_RC "\n", DP_RC(rc));
+		return daos_der2errno(rc);
+	}
+
+	if (pool_info.pi_ntargets < 1000)
+		return 0;
+
+	/* Use the default DAOS file class as the wide tail and derive the compact head from it. */
+	rc = daos_obj_get_oclass(dfs->coh, DAOS_OT_ARRAY_BYTE, dfs->file_oclass_hint, 0, tail_cid);
+	if (rc != 0) {
+		D_ERROR("daos_obj_get_oclass() failed " DF_RC "\n", DP_RC(rc));
+		return daos_der2errno(rc);
+	}
+
+	tail_attr = daos_oclass_id2attr(*tail_cid, &max_groups);
+	if (tail_attr == NULL)
+		return EINVAL;
+
+	if (max_groups == 0)
+		goto out;
+
+	/* Keep the tail redundancy family and only compact the head by reducing its group count. */
+	*head_cid = file_head_oclass(*tail_cid, max_groups);
+	if (*head_cid == OC_UNKNOWN)
+		goto out;
+
+	*has_tail = true;
+
+out:
+	if (*has_tail) {
+		char head_oclass_name[MAX_OBJ_CLASS_NAME_LEN] = "unknown";
+		char tail_oclass_name[MAX_OBJ_CLASS_NAME_LEN] = "none";
+
+		if (daos_oclass_id2name(*head_cid, head_oclass_name) != 0)
+			snprintf(head_oclass_name, sizeof(head_oclass_name), "%u", *head_cid);
+		if (daos_oclass_id2name(*tail_cid, tail_oclass_name) != 0)
+			snprintf(tail_oclass_name, sizeof(tail_oclass_name), "%u", *tail_cid);
+		D_DEBUG(DB_TRACE, "file create oclass selection: head=%s(%u), tail=%s(%u)\n",
+			head_oclass_name, *head_cid, tail_oclass_name, *tail_cid);
 	}
 
 	return 0;
@@ -168,6 +281,7 @@ static int
 open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, daos_size_t chunk_size,
 	  struct dfs_entry *entry, daos_size_t *size, size_t len, dfs_obj_t *file)
 {
+	daos_oclass_id_t tail_cid = OC_UNKNOWN;
 	bool exists;
 	int  daos_mode;
 	bool oexcl  = flags & O_EXCL;
@@ -183,13 +297,9 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, daos_s
 		 * - Without O_EXCL we can just open the file.
 		 */
 
-		/** set oclass for file. order: API, parent dir, cont default */
-		if (cid == 0) {
-			if (parent->d.oclass == 0)
-				cid = dfs->attr.da_file_oclass_id;
-			else
-				cid = parent->d.oclass;
-		}
+		rc = file_oclasses(dfs, parent, cid, &cid, &tail_cid, &file->f.has_tail);
+		if (rc != 0)
+			return rc;
 
 		/** same logic for chunk size */
 		if (chunk_size == 0) {
@@ -204,9 +314,13 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, daos_s
 		if (rc != 0)
 			return rc;
 		oid_cp(&entry->oid, file->oid);
+		entry->oclass     = cid;
+		entry->tail_oid   = DAOS_OBJ_NIL;
+		entry->tail_state = DFS_TAIL_NONE;
+		file->f.tail_oid  = DAOS_OBJ_NIL;
 
-		if (dfs_file_layout_has_tail(dfs->layout_v, file->mode)) {
-			rc = oid_gen(dfs, cid, true, &file->f.tail_oid);
+		if (file->f.has_tail) {
+			rc = oid_gen(dfs, tail_cid, true, &file->f.tail_oid);
 			if (rc != 0)
 				return rc;
 			oid_cp(&entry->tail_oid, file->f.tail_oid);
@@ -819,7 +933,8 @@ dfs_obj_global2local(dfs_t *dfs, int flags, d_iov_t glob, dfs_obj_t **_obj)
 	obj->mode               = obj_glob->mode;
 	obj->dfs                = dfs;
 	obj->flags              = flags ? flags : obj_glob->flags;
-	obj->f.has_tail         = dfs_file_layout_has_tail(dfs->layout_v, obj->mode);
+	obj->f.has_tail         = dfs_file_layout_has_tail(dfs->layout_v, obj->mode) &&
+			  !daos_obj_id_is_nil(obj->f.tail_oid);
 
 	daos_mode = get_daos_obj_mode(obj->flags);
 	if (daos_mode == -1) {

--- a/src/client/dfs/obj.c
+++ b/src/client/dfs/obj.c
@@ -97,8 +97,8 @@ file_head_oclass(daos_oclass_id_t tail_cid, uint32_t max_groups)
 
 /* Derive the split point from the selected head group count and pool budget. */
 static daos_size_t
-file_split_off(const daos_pool_info_t *pool_info, daos_oclass_id_t head_cid,
-	       daos_oclass_id_t tail_cid, daos_size_t chunk_size)
+file_split_off(uint32_t target_nr, uint64_t total_scm, uint64_t total_nvme,
+	       daos_oclass_id_t head_cid, daos_oclass_id_t tail_cid, daos_size_t chunk_size)
 {
 	struct daos_oclass_attr *head_attr;
 	struct daos_oclass_attr *tail_attr;
@@ -109,8 +109,7 @@ file_split_off(const daos_pool_info_t *pool_info, daos_oclass_id_t head_cid,
 	unsigned int             data_cells;
 	daos_size_t              split_off;
 
-	if (pool_info == NULL || head_cid == OC_UNKNOWN || tail_cid == OC_UNKNOWN ||
-	    chunk_size == 0)
+	if (target_nr == 0 || head_cid == OC_UNKNOWN || tail_cid == OC_UNKNOWN || chunk_size == 0)
 		return 0;
 
 	/*
@@ -118,14 +117,10 @@ file_split_off(const daos_pool_info_t *pool_info, daos_oclass_id_t head_cid,
 	 * the selected media total. This keeps the split point stable for the container rather than
 	 * tied to transient free-space fluctuations.
 	 */
-	if (pool_info->pi_ntargets == 0)
-		return 0;
-	if (pool_info->pi_space.ps_space.s_total[DAOS_MEDIA_NVME] != 0)
-		target_capacity =
-		    pool_info->pi_space.ps_space.s_total[DAOS_MEDIA_NVME] / pool_info->pi_ntargets;
+	if (total_nvme != 0)
+		target_capacity = total_nvme / target_nr;
 	else
-		target_capacity =
-		    pool_info->pi_space.ps_space.s_total[DAOS_MEDIA_SCM] / pool_info->pi_ntargets;
+		target_capacity = total_scm / target_nr;
 	if (target_capacity == 0)
 		return 0;
 
@@ -162,7 +157,6 @@ file_oclasses(dfs_t *dfs, dfs_obj_t *parent, daos_oclass_id_t cid, daos_size_t c
 	      daos_oclass_id_t *head_cid, daos_oclass_id_t *tail_cid, daos_size_t *split_off,
 	      bool *has_tail)
 {
-	daos_pool_info_t         pool_info = {.pi_bits = DPI_SPACE};
 	struct daos_oclass_attr *tail_attr;
 	daos_size_t              local_split_off = 0;
 	uint32_t                 max_groups;
@@ -189,13 +183,10 @@ file_oclasses(dfs_t *dfs, dfs_obj_t *parent, daos_oclass_id_t cid, daos_size_t c
 	if (cid != 0 || !dfs_file_layout_has_tail(dfs->layout_v, S_IFREG))
 		return 0;
 
-	rc = daos_pool_query(dfs->poh, NULL, &pool_info, NULL, NULL);
-	if (rc != 0) {
-		D_ERROR("daos_pool_query() failed " DF_RC "\n", DP_RC(rc));
-		return daos_der2errno(rc);
-	}
+	if (dfs->pl_target_nr == 0)
+		return 0;
 
-	if (pool_info.pi_ntargets < 1000 && !pl_bypass_target_limit())
+	if (dfs->pl_target_nr < 1000 && !pl_bypass_target_limit())
 		return 0;
 
 	/* Use the default DAOS file class as the wide tail and derive the compact head from it. */
@@ -217,7 +208,8 @@ file_oclasses(dfs_t *dfs, dfs_obj_t *parent, daos_oclass_id_t cid, daos_size_t c
 	if (*head_cid == OC_UNKNOWN)
 		goto out;
 
-	local_split_off = file_split_off(&pool_info, *head_cid, *tail_cid, chunk_size);
+	local_split_off = file_split_off(dfs->pl_target_nr, dfs->pl_total_scm, dfs->pl_total_nvme,
+					 *head_cid, *tail_cid, chunk_size);
 	if (local_split_off == 0)
 		goto out;
 

--- a/src/client/dfs/obj.c
+++ b/src/client/dfs/obj.c
@@ -17,6 +17,26 @@
 
 #include "dfs_internal.h"
 
+/* 0.2% per-target budget for data that should remain in the compact head object. */
+#define DFS_PL_HEAD_BUDGET_NUM         2ULL
+/* Denominator for the head budget fraction. */
+#define DFS_PL_HEAD_BUDGET_DEN         1000ULL
+/* Do not switch to the tail before 64 MiB of logical file data. */
+#define DFS_PL_SPLIT_OFF_MIN           (64ULL << 20)
+/* Cap the head region at 64 GiB even on very large systems. */
+#define DFS_PL_SPLIT_OFF_MAX           (64ULL << 30)
+/* Test-only override to bypass the PL target-count gate for default-selection testing. */
+#define DFS_PL_BYPASS_TARGET_LIMIT_ENV "DFS_PL_BYPASS_TARGET_LIMIT"
+
+static bool
+pl_bypass_target_limit(void)
+{
+	bool enabled = false;
+
+	d_getenv_bool(DFS_PL_BYPASS_TARGET_LIMIT_ENV, &enabled);
+	return enabled;
+}
+
 static int
 open_file_tail(dfs_t *dfs, daos_obj_id_t tail_oid, int daos_mode, daos_size_t chunk_size,
 	       daos_handle_t *tail_oh)
@@ -75,17 +95,81 @@ file_head_oclass(daos_oclass_id_t tail_cid, uint32_t max_groups)
 	return OBJ_CLASS_DEF(ord, 1);
 }
 
+/* Derive the split point from the selected head group count and pool budget. */
+static daos_size_t
+file_split_off(const daos_pool_info_t *pool_info, daos_oclass_id_t head_cid,
+	       daos_oclass_id_t tail_cid, daos_size_t chunk_size)
+{
+	struct daos_oclass_attr *head_attr;
+	struct daos_oclass_attr *tail_attr;
+	unsigned __int128        raw_split_off;
+	uint64_t                 target_capacity;
+	uint64_t                 per_target_budget;
+	uint32_t                 head_groups = 0;
+	unsigned int             data_cells;
+	daos_size_t              split_off;
+
+	if (pool_info == NULL || head_cid == OC_UNKNOWN || tail_cid == OC_UNKNOWN ||
+	    chunk_size == 0)
+		return 0;
+
+	/*
+	 * Pool query exposes aggregate pool capacity, so use per-target pool capacity derived from
+	 * the selected media total. This keeps the split point stable for the container rather than
+	 * tied to transient free-space fluctuations.
+	 */
+	if (pool_info->pi_ntargets == 0)
+		return 0;
+	if (pool_info->pi_space.ps_space.s_total[DAOS_MEDIA_NVME] != 0)
+		target_capacity =
+		    pool_info->pi_space.ps_space.s_total[DAOS_MEDIA_NVME] / pool_info->pi_ntargets;
+	else
+		target_capacity =
+		    pool_info->pi_space.ps_space.s_total[DAOS_MEDIA_SCM] / pool_info->pi_ntargets;
+	if (target_capacity == 0)
+		return 0;
+
+	head_attr = daos_oclass_id2attr(head_cid, &head_groups);
+	tail_attr = daos_oclass_id2attr(tail_cid, NULL);
+	if (head_attr == NULL || tail_attr == NULL || head_groups == 0)
+		return 0;
+
+	data_cells = daos_oclass_is_ec(tail_attr) ? tail_attr->u.ec.e_k : 1;
+	if (data_cells == 0)
+		return 0;
+
+	per_target_budget = (target_capacity * DFS_PL_HEAD_BUDGET_NUM) / DFS_PL_HEAD_BUDGET_DEN;
+	if (per_target_budget == 0)
+		return 0;
+
+	raw_split_off = (unsigned __int128)head_groups * data_cells * per_target_budget;
+	if (raw_split_off < DFS_PL_SPLIT_OFF_MIN)
+		split_off = DFS_PL_SPLIT_OFF_MIN;
+	else if (raw_split_off > DFS_PL_SPLIT_OFF_MAX)
+		split_off = DFS_PL_SPLIT_OFF_MAX;
+	else
+		split_off = (daos_size_t)raw_split_off;
+
+	if (split_off % chunk_size != 0)
+		split_off = ((split_off / chunk_size) + 1) * chunk_size;
+
+	return split_off;
+}
+
 /* Resolve file head/tail oclasses, applying PL only when no explicit file class was selected. */
 static int
-file_oclasses(dfs_t *dfs, dfs_obj_t *parent, daos_oclass_id_t cid, daos_oclass_id_t *head_cid,
-	      daos_oclass_id_t *tail_cid, bool *has_tail)
+file_oclasses(dfs_t *dfs, dfs_obj_t *parent, daos_oclass_id_t cid, daos_size_t chunk_size,
+	      daos_oclass_id_t *head_cid, daos_oclass_id_t *tail_cid, daos_size_t *split_off,
+	      bool *has_tail)
 {
-	daos_pool_info_t         pool_info = {0};
+	daos_pool_info_t         pool_info = {.pi_bits = DPI_SPACE};
 	struct daos_oclass_attr *tail_attr;
+	daos_size_t              local_split_off = 0;
 	uint32_t                 max_groups;
 	int                      rc;
 
-	if (head_cid == NULL || tail_cid == NULL || has_tail == NULL)
+	if (head_cid == NULL || tail_cid == NULL || split_off == NULL || has_tail == NULL ||
+	    chunk_size == 0)
 		return EINVAL;
 
 	if (cid == 0) {
@@ -97,9 +181,10 @@ file_oclasses(dfs_t *dfs, dfs_obj_t *parent, daos_oclass_id_t cid, daos_oclass_i
 			cid = parent->d.oclass;
 	}
 
-	*head_cid = cid;
-	*tail_cid = OC_UNKNOWN;
-	*has_tail = false;
+	*head_cid  = cid;
+	*tail_cid  = OC_UNKNOWN;
+	*split_off = 0;
+	*has_tail  = false;
 
 	if (cid != 0 || !dfs_file_layout_has_tail(dfs->layout_v, S_IFREG))
 		return 0;
@@ -110,7 +195,7 @@ file_oclasses(dfs_t *dfs, dfs_obj_t *parent, daos_oclass_id_t cid, daos_oclass_i
 		return daos_der2errno(rc);
 	}
 
-	if (pool_info.pi_ntargets < 1000)
+	if (pool_info.pi_ntargets < 1000 && !pl_bypass_target_limit())
 		return 0;
 
 	/* Use the default DAOS file class as the wide tail and derive the compact head from it. */
@@ -132,9 +217,20 @@ file_oclasses(dfs_t *dfs, dfs_obj_t *parent, daos_oclass_id_t cid, daos_oclass_i
 	if (*head_cid == OC_UNKNOWN)
 		goto out;
 
-	*has_tail = true;
+	local_split_off = file_split_off(&pool_info, *head_cid, *tail_cid, chunk_size);
+	if (local_split_off == 0)
+		goto out;
+
+	*split_off = local_split_off;
+	*has_tail  = true;
 
 out:
+	if (!*has_tail && *tail_cid != OC_UNKNOWN) {
+		*head_cid  = *tail_cid;
+		*tail_cid  = OC_UNKNOWN;
+		*split_off = 0;
+	}
+
 	if (*has_tail) {
 		char head_oclass_name[MAX_OBJ_CLASS_NAME_LEN] = "unknown";
 		char tail_oclass_name[MAX_OBJ_CLASS_NAME_LEN] = "none";
@@ -143,8 +239,10 @@ out:
 			snprintf(head_oclass_name, sizeof(head_oclass_name), "%u", *head_cid);
 		if (daos_oclass_id2name(*tail_cid, tail_oclass_name) != 0)
 			snprintf(tail_oclass_name, sizeof(tail_oclass_name), "%u", *tail_cid);
-		D_DEBUG(DB_TRACE, "file create oclass selection: head=%s(%u), tail=%s(%u)\n",
-			head_oclass_name, *head_cid, tail_oclass_name, *tail_cid);
+		D_DEBUG(DB_TRACE,
+			"file create oclass selection: head=%s(%u), tail=%s(%u), split_off=" DF_U64
+			"\n",
+			head_oclass_name, *head_cid, tail_oclass_name, *tail_cid, *split_off);
 	}
 
 	return 0;
@@ -207,9 +305,11 @@ dfs_obj_get_info(dfs_t *dfs, dfs_obj_t *obj, dfs_obj_info_t *info)
 		return EINVAL;
 
 	info->doi_oid = obj->oid;
+	info->doi_tail_oid  = DAOS_OBJ_NIL;
+	info->doi_split_off = 0;
 
 	switch (obj->mode & S_IFMT) {
-	case S_IFDIR:
+	case S_IFDIR: {
 		/** the oclass of the directory object itself */
 		info->doi_oclass_id = daos_obj_id2class(obj->oid);
 
@@ -224,6 +324,11 @@ dfs_obj_get_info(dfs_t *dfs, dfs_obj_t *obj, dfs_obj_info_t *info)
 				else
 					rc = daos_obj_get_oclass(dfs->coh, DAOS_OT_MULTI_HASHED, 0,
 								 0, &info->doi_dir_oclass_id);
+				if (rc) {
+					D_ERROR("daos_obj_get_oclass() failed " DF_RC "\n",
+						DP_RC(rc));
+					return daos_der2errno(rc);
+				}
 			}
 			info->doi_file_oclass_id = obj->d.oclass;
 		} else {
@@ -255,6 +360,7 @@ dfs_obj_get_info(dfs_t *dfs, dfs_obj_t *obj, dfs_obj_info_t *info)
 		else
 			info->doi_chunk_size = DFS_DEFAULT_CHUNK_SIZE;
 		break;
+	}
 	case S_IFREG: {
 		daos_size_t cell_size;
 
@@ -263,6 +369,10 @@ dfs_obj_get_info(dfs_t *dfs, dfs_obj_t *obj, dfs_obj_info_t *info)
 			return daos_der2errno(rc);
 
 		info->doi_oclass_id = daos_obj_id2class(obj->oid);
+		if (obj->f.has_tail) {
+			info->doi_tail_oid  = obj->f.tail_oid;
+			info->doi_split_off = obj->f.split_off;
+		}
 		break;
 	}
 	case S_IFLNK:
@@ -297,10 +407,6 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, daos_s
 		 * - Without O_EXCL we can just open the file.
 		 */
 
-		rc = file_oclasses(dfs, parent, cid, &cid, &tail_cid, &file->f.has_tail);
-		if (rc != 0)
-			return rc;
-
 		/** same logic for chunk size */
 		if (chunk_size == 0) {
 			if (parent->d.chunk_size == 0)
@@ -309,6 +415,11 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, daos_s
 				chunk_size = parent->d.chunk_size;
 		}
 
+		rc = file_oclasses(dfs, parent, cid, chunk_size, &cid, &tail_cid,
+				   &file->f.split_off, &file->f.has_tail);
+		if (rc != 0)
+			return rc;
+
 		/** Get new OID for the file */
 		rc = oid_gen(dfs, cid, true, &file->oid);
 		if (rc != 0)
@@ -316,6 +427,7 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, daos_s
 		oid_cp(&entry->oid, file->oid);
 		entry->oclass     = cid;
 		entry->tail_oid   = DAOS_OBJ_NIL;
+		entry->split_off  = 0;
 		entry->tail_state = DFS_TAIL_NONE;
 		file->f.tail_oid  = DAOS_OBJ_NIL;
 
@@ -329,6 +441,7 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, daos_s
 		}
 
 		/** Open the array object for the file */
+		entry->split_off = file->f.split_off;
 		rc = daos_array_open_with_attr(dfs->coh, file->oid, DAOS_TX_NONE, DAOS_OO_RW, 1,
 					       chunk_size, &file->oh, NULL);
 		if (rc != 0) {
@@ -426,6 +539,7 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, daos_s
 	}
 
 	file->f.has_tail = dfs_entry_has_tail(dfs->layout_v, entry);
+	file->f.split_off = file->f.has_tail ? entry->split_off : 0;
 	if (file->f.has_tail) {
 		oid_cp(&file->f.tail_oid, entry->tail_oid);
 		rc = open_file_tail(dfs, file->f.tail_oid, daos_mode, entry->chunk_size,
@@ -704,6 +818,7 @@ dfs_dup(dfs_t *dfs, dfs_obj_t *obj, int flags, dfs_obj_t **_new_obj)
 			D_GOTO(out_free, rc = daos_der2errno(rc));
 
 		new_obj->f.has_tail = obj->f.has_tail;
+		new_obj->f.split_off = obj->f.split_off;
 		if (obj->f.has_tail) {
 			oid_cp(&new_obj->f.tail_oid, obj->f.tail_oid);
 			rc = daos_array_local2global(obj->f.tail_oh, &tail_ghdl);
@@ -782,6 +897,7 @@ struct dfs_obj_glob {
 	daos_obj_id_t tail_oid;
 	daos_obj_id_t parent_oid;
 	daos_size_t   chunk_size;
+	daos_size_t   split_off;
 	uuid_t        cont_uuid;
 	uuid_t        coh_uuid;
 	char          name[DFS_MAX_NAME + 1];
@@ -808,6 +924,7 @@ swap_obj_glob(struct dfs_obj_glob *array_glob)
 	D_SWAP64S(&array_glob->parent_oid.hi);
 	D_SWAP64S(&array_glob->parent_oid.lo);
 	D_SWAP64S(&array_glob->chunk_size);
+	D_SWAP64S(&array_glob->split_off);
 	/* skip cont_uuid */
 	/* skip coh_uuid */
 }
@@ -867,6 +984,7 @@ dfs_obj_local2global(dfs_t *dfs, dfs_obj_t *obj, d_iov_t *glob)
 	oid_cp(&obj_glob->oid, obj->oid);
 	oid_cp(&obj_glob->tail_oid, obj->f.tail_oid);
 	oid_cp(&obj_glob->parent_oid, obj->parent_oid);
+	obj_glob->split_off = obj->f.split_off;
 	uuid_copy(obj_glob->coh_uuid, coh_uuid);
 	uuid_copy(obj_glob->cont_uuid, cont_uuid);
 	strncpy(obj_glob->name, obj->name, DFS_MAX_NAME);
@@ -928,6 +1046,7 @@ dfs_obj_global2local(dfs_t *dfs, int flags, d_iov_t glob, dfs_obj_t **_obj)
 	oid_cp(&obj->oid, obj_glob->oid);
 	oid_cp(&obj->f.tail_oid, obj_glob->tail_oid);
 	oid_cp(&obj->parent_oid, obj_glob->parent_oid);
+	obj->f.split_off = obj_glob->split_off;
 	strncpy(obj->name, obj_glob->name, DFS_MAX_NAME);
 	obj->name[DFS_MAX_NAME] = '\0';
 	obj->mode               = obj_glob->mode;
@@ -1226,6 +1345,7 @@ statx_task(tse_task_t *task)
 	d_iov_set(&op_args->sg_iovs[i++], &op_args->entry.obj_hlc, sizeof(uint64_t));
 	if (args->dfs->layout_v >= DFS_PL_LAYOUT_VERSION) {
 		d_iov_set(&op_args->sg_iovs[i++], &op_args->entry.tail_oid, sizeof(daos_obj_id_t));
+		d_iov_set(&op_args->sg_iovs[i++], &op_args->entry.split_off, sizeof(daos_size_t));
 		d_iov_set(&op_args->sg_iovs[i++], &op_args->entry.tail_state, sizeof(uint8_t));
 	}
 	op_args->sgl.sg_nr     = i;

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2018-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -114,6 +114,10 @@ typedef struct {
 	daos_oclass_id_t        doi_file_oclass_id;
 	/** Object id */
 	daos_obj_id_t           doi_oid;
+	/** Tail object id for progressive-layout files, or nil when absent */
+	daos_obj_id_t           doi_tail_oid;
+	/** Logical file offset where progressive layout switches from head to tail */
+	daos_size_t             doi_split_off;
 } dfs_obj_info_t;
 
 /**
@@ -906,8 +910,8 @@ int
 dfs_get_mode(dfs_obj_t *obj, mode_t *mode);
 
 /**
- * Retrieve some attributes of DFS object. Those include the object class and
- * the chunk size.
+ * Retrieve some attributes of DFS object. Those include the object class,
+ * chunk size, and progressive-layout metadata when applicable.
  *
  * \param[in]   dfs     Pointer to the mounted file system.
  * \param[in]   obj	Open object handle to query.
@@ -919,16 +923,16 @@ int
 dfs_obj_get_info(dfs_t *dfs, dfs_obj_t *obj, dfs_obj_info_t *info);
 
 /**
- * Set the object class on a directory for new files or sub-dirs that are
- * created in that dir.  This does not change the chunk size for existing files
- * or dirs in that directory, nor it does change the object class of the
- * directory itself. Note that this is only supported on directories and will
- * fail if called on non-directory objects.
+ * Set the default object class on a directory for new files or sub-dirs that
+ * are created in that dir. This does not change the object class of any
+ * existing file or sub-dir in that directory, nor does it change the object
+ * class of the directory itself. Note that this is only supported on
+ * directories and will fail if called on non-directory objects.
  *
  * \param[in]   dfs     Pointer to the mounted file system.
  * \param[in]   obj	Open object handle to access.
  * \param[in]	flags	Flags for setting oclass (currently ignored)
- * \param[in]   cid	object class.
+ * \param[in]   cid	default object class for new entries created in this directory.
  *
  * \return		0 on success, errno code on failure.
  */

--- a/src/tests/ftest/daos_test/dfs.py
+++ b/src/tests/ftest/daos_test/dfs.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -34,7 +35,10 @@ class DaosCoreTestDfs(DaosCoreBase):
         :avocado: tags=daos_test,dfs_test,dfs
         :avocado: tags=DaosCoreTestDfs,test_daos_dfs_unit
         """
-        self.run_subtest(os.path.join(self.bin, "dfs_test"))
+        self.run_subtest(
+            os.path.join(self.bin, "dfs_test"),
+            env={"DFS_PL_BYPASS_TARGET_LIMIT": "1"},
+        )
 
     def test_daos_dfs_parallel(self):
         """Jira ID: DAOS-5409.

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -52,11 +52,12 @@ class DaosCoreBase(TestWithServers):
         path = "/".join(["/run/daos_tests", name, "*"])
         return self.params.get(self.get_test_name(), path, default)
 
-    def run_subtest(self, command=None):
+    def run_subtest(self, command=None, env=None):
         """Run the executable with a subtest argument.
 
         Args:
             command (str, optional): command to run. Defaults to None which will yield daos_test.
+            env (dict, optional): environment variable overrides for the command.
         """
         if command is None:
             command = os.path.join(self.bin, "daos_test")
@@ -89,6 +90,8 @@ class DaosCoreBase(TestWithServers):
         daos_test_env["COVFILE"] = "/tmp/test.cov"
         daos_test_env["POOL_SCM_SIZE"] = str(scm_size)
         daos_test_env["POOL_NVME_SIZE"] = str(nvme_size)
+        if env:
+            daos_test_env.update(env)
         parameters = " ".join(filter(None, [f"-n {dmg_config_file}", f"-{subtest}", str(args)]))
         daos_test_cmd = get_cmocka_command(command, parameters)
         job = get_job_manager(self, "Orterun", daos_test_cmd, mpi_type="openmpi")

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -13,6 +13,11 @@
 #include <daos/placement.h>
 #include <pthread.h>
 
+#define DFS_PL_HEAD_BUDGET_NUM 2ULL
+#define DFS_PL_HEAD_BUDGET_DEN 1000ULL
+#define DFS_PL_SPLIT_OFF_MIN   (64ULL << 20)
+#define DFS_PL_SPLIT_OFF_MAX   (64ULL << 30)
+
 /** global DFS mount used for all tests */
 static uuid_t		co_uuid;
 static daos_handle_t	co_hdl;
@@ -3581,63 +3586,294 @@ dfs_test_pipeline_find(void **state)
 	test_pipeline_find(state, OC_RP_3GX);
 }
 
+static daos_oclass_id_t
+expected_pl_head_oclass(daos_oclass_id_t tail_cid, uint32_t max_groups)
+{
+	static const uint32_t head_groups[] = {32, 16, 12, 8, 6, 4, 2, 1};
+	uint32_t              group_nr;
+	int                   i;
+
+	if (max_groups == 0)
+		return OC_UNKNOWN;
+
+	group_nr = min(max(max_groups / 8, 1U), 32U);
+	for (i = 0; i < ARRAY_SIZE(head_groups); i++) {
+		if (head_groups[i] <= group_nr)
+			return OBJ_CLASS_DEF(tail_cid >> OC_REDUN_SHIFT, head_groups[i]);
+	}
+
+	return OBJ_CLASS_DEF(tail_cid >> OC_REDUN_SHIFT, 1);
+}
+
+static daos_size_t
+expected_pl_split_off(const daos_pool_info_t *pool_info, daos_oclass_id_t head_cid,
+		      daos_oclass_id_t tail_cid, daos_size_t chunk_size)
+{
+	struct daos_oclass_attr *tail_attr;
+	struct daos_oclass_attr *head_attr;
+	unsigned __int128        raw_split_off;
+	uint64_t                 target_capacity;
+	uint64_t                 per_target_budget;
+	uint32_t                 head_groups = 0;
+	unsigned int             data_cells;
+	daos_size_t              split_off;
+
+	if (pool_info == NULL || chunk_size == 0 || head_cid == OC_UNKNOWN ||
+	    tail_cid == OC_UNKNOWN)
+		return 0;
+	if (pool_info->pi_ntargets == 0)
+		return 0;
+
+	if (pool_info->pi_space.ps_space.s_total[DAOS_MEDIA_NVME] != 0)
+		target_capacity =
+		    pool_info->pi_space.ps_space.s_total[DAOS_MEDIA_NVME] / pool_info->pi_ntargets;
+	else
+		target_capacity =
+		    pool_info->pi_space.ps_space.s_total[DAOS_MEDIA_SCM] / pool_info->pi_ntargets;
+	if (target_capacity == 0)
+		return 0;
+
+	head_attr = daos_oclass_id2attr(head_cid, &head_groups);
+	tail_attr = daos_oclass_id2attr(tail_cid, NULL);
+	if (head_attr == NULL || tail_attr == NULL || head_groups == 0)
+		return 0;
+
+	data_cells = daos_oclass_is_ec(tail_attr) ? tail_attr->u.ec.e_k : 1;
+	if (data_cells == 0)
+		return 0;
+
+	per_target_budget = (target_capacity * DFS_PL_HEAD_BUDGET_NUM) / DFS_PL_HEAD_BUDGET_DEN;
+	if (per_target_budget == 0)
+		return 0;
+
+	raw_split_off = (unsigned __int128)head_groups * data_cells * per_target_budget;
+	if (raw_split_off < DFS_PL_SPLIT_OFF_MIN)
+		split_off = DFS_PL_SPLIT_OFF_MIN;
+	else if (raw_split_off > DFS_PL_SPLIT_OFF_MAX)
+		split_off = DFS_PL_SPLIT_OFF_MAX;
+	else
+		split_off = (daos_size_t)raw_split_off;
+
+	if (split_off % chunk_size != 0)
+		split_off = ((split_off / chunk_size) + 1) * chunk_size;
+
+	return split_off;
+}
+
+static void
+assert_file_oclass_selection(dfs_t *dfs, daos_handle_t coh, const daos_pool_info_t *pool_info,
+			     dfs_obj_t *parent, const char *name, daos_oclass_id_t cid,
+			     daos_oclass_id_t exp_head, daos_oclass_id_t exp_tail,
+			     bool exp_has_tail)
+{
+	dfs_obj_t       *obj;
+	dfs_obj_info_t   info = {0};
+	daos_oclass_id_t actual_cid;
+	daos_size_t      exp_split_off;
+	char             exp_head_name[MAX_OBJ_CLASS_NAME_LEN] = "unknown";
+	char             act_head_name[MAX_OBJ_CLASS_NAME_LEN] = "unknown";
+	char             exp_tail_name[MAX_OBJ_CLASS_NAME_LEN] = "none";
+	char             act_tail_name[MAX_OBJ_CLASS_NAME_LEN] = "none";
+	int              rc;
+
+	rc = dfs_open(dfs, parent, name, S_IFREG | S_IWUSR | S_IRUSR, O_RDWR | O_CREAT | O_EXCL,
+		      cid, 0, NULL, &obj);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_obj_get_info(dfs, obj, &info);
+	assert_int_equal(rc, 0);
+	actual_cid = daos_obj_id2class(info.doi_oid);
+	daos_oclass_id2name(exp_head, exp_head_name);
+	daos_oclass_id2name(actual_cid, act_head_name);
+	rc = compare_oclass(coh, actual_cid, exp_head);
+	print_message("PL test '%s': head expected=%s actual=%s\n", name, exp_head_name,
+		      act_head_name);
+	assert_rc_equal(rc, 0);
+
+	exp_split_off =
+	    exp_has_tail ? expected_pl_split_off(pool_info, exp_head, exp_tail, info.doi_chunk_size)
+			 : 0;
+	print_message("PL test '%s': tail expected_present=%d actual_present=%d split_off "
+		      "expected=%zu actual=%zu chunk=%zu\n",
+		      name, exp_has_tail, !daos_obj_id_is_nil(info.doi_tail_oid), exp_split_off,
+		      info.doi_split_off, info.doi_chunk_size);
+	assert_int_equal(!daos_obj_id_is_nil(info.doi_tail_oid), exp_has_tail);
+	assert_int_equal(info.doi_split_off, exp_split_off);
+	if (exp_has_tail) {
+		actual_cid = daos_obj_id2class(info.doi_tail_oid);
+		daos_oclass_id2name(exp_tail, exp_tail_name);
+		daos_oclass_id2name(actual_cid, act_tail_name);
+		rc = compare_oclass(coh, actual_cid, exp_tail);
+		print_message("PL test '%s': tail expected=%s actual=%s\n", name, exp_tail_name,
+			      act_tail_name);
+		assert_rc_equal(rc, 0);
+	} else {
+		assert_true(daos_obj_id_is_nil(info.doi_tail_oid));
+	}
+
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+	rc = dfs_remove(dfs, parent, name, 0, NULL);
+	assert_int_equal(rc, 0);
+}
+
+static void
+dfs_test_pl_oclass_selection(void **state)
+{
+	test_arg_t              *arg = *state;
+	struct daos_oclass_attr *tail_attr;
+	daos_pool_info_t         pool_info = {.pi_bits = DPI_SPACE};
+	dfs_obj_t               *dir;
+	dfs_t                   *dfs_l;
+	daos_handle_t            coh;
+	daos_oclass_id_t         default_tail;
+	daos_oclass_id_t         default_head;
+	daos_oclass_id_t         explicit_cid;
+	char                     default_tail_name[MAX_OBJ_CLASS_NAME_LEN] = "unknown";
+	char                     default_head_name[MAX_OBJ_CLASS_NAME_LEN] = "unknown";
+	char                     explicit_name[MAX_OBJ_CLASS_NAME_LEN]     = "unknown";
+	uint32_t                 max_groups                                = 0;
+	bool                     bypass_target_limit                       = false;
+	bool                     has_tail;
+	dfs_attr_t               dattr = {0};
+	int                      rc;
+
+	if (arg->myrank != 0)
+		return;
+
+	/* Use a known explicit file class for the override cases below. */
+	rc = dfs_suggest_oclass(dfs_mt, "file:single", &explicit_cid);
+	assert_int_equal(rc, 0);
+	daos_oclass_id2name(explicit_cid, explicit_name);
+
+	/* Start from a container with default file-class selection enabled. */
+	rc = dfs_cont_create_with_label(arg->pool.poh, "pl_oclass_sel", &dattr, NULL, &coh, &dfs_l);
+	assert_int_equal(rc, 0);
+
+	/* Query the pool and resolve the default wide file class through the public hint API. */
+	rc = daos_pool_query(arg->pool.poh, NULL, &pool_info, NULL, NULL);
+	assert_rc_equal(rc, 0);
+	rc = dfs_suggest_oclass(dfs_l, "file:max", &default_tail);
+	assert_int_equal(rc, 0);
+	tail_attr = daos_oclass_id2attr(default_tail, &max_groups);
+	assert_non_null(tail_attr);
+	d_getenv_bool("DFS_PL_BYPASS_TARGET_LIMIT", &bypass_target_limit);
+
+	/*
+	 * PL should create a tail on the default-selection path when the tail class has a valid
+	 * group count and the pool passes the target gate, or when that gate is bypassed for tests.
+	 * Otherwise the file stays single-oid.
+	 */
+	has_tail = (pool_info.pi_ntargets >= 1000 || bypass_target_limit) && max_groups != 0;
+	/* When PL is active, the head should be the compact head class derived from the default
+	 * tail. */
+	default_head = has_tail ? expected_pl_head_oclass(default_tail, max_groups) : default_tail;
+	assert_true(!has_tail || default_head != OC_UNKNOWN);
+	daos_oclass_id2name(default_tail, default_tail_name);
+	daos_oclass_id2name(default_head, default_head_name);
+	print_message("PL default stage: ntargets=%u bypass_target_limit=%d max_groups=%u "
+		      "expected_tail=%s expected_head=%s has_tail=%d\n",
+		      pool_info.pi_ntargets, bypass_target_limit, max_groups, default_tail_name,
+		      default_head_name, has_tail);
+
+	/* Default file creation should use PL selection: compact head plus default tail when
+	 * enabled. */
+	print_message("PL stage: default file selection\n");
+	assert_file_oclass_selection(dfs_l, coh, &pool_info, NULL, "pl_default", 0, default_head,
+				     default_tail, has_tail);
+
+	/* Create a directory-level override to verify that parent settings disable default PL
+	 * selection. */
+	rc = dfs_open(dfs_l, NULL, "pl_dir", S_IFDIR | S_IWUSR | S_IRUSR, O_RDWR | O_CREAT | O_EXCL,
+		      0, 0, NULL, &dir);
+	assert_int_equal(rc, 0);
+	rc = dfs_obj_set_oclass(dfs_l, dir, 0, explicit_cid);
+	assert_int_equal(rc, 0);
+	/* A file created under that directory should use the explicit class directly and have no
+	 * tail. */
+	print_message("PL stage: directory override explicit_cid=%s\n", explicit_name);
+	assert_file_oclass_selection(dfs_l, coh, &pool_info, dir, "pl_dir_file", 0, explicit_cid,
+				     OC_UNKNOWN, false);
+	rc = dfs_release(dir);
+	assert_int_equal(rc, 0);
+	rc = dfs_remove(dfs_l, NULL, "pl_dir", 1, NULL);
+	assert_int_equal(rc, 0);
+
+	/* An explicit API oclass on create should also bypass PL and create a single object. */
+	print_message("PL stage: API override explicit_cid=%s\n", explicit_name);
+	assert_file_oclass_selection(dfs_l, coh, &pool_info, NULL, "pl_api", explicit_cid,
+				     explicit_cid, OC_UNKNOWN, false);
+
+	/* Tear down the default-selection container before checking container-wide explicit
+	 * override. */
+	rc = dfs_umount(dfs_l);
+	assert_int_equal(rc, 0);
+	rc = daos_cont_close(coh, NULL);
+	assert_success(rc);
+	rc = daos_cont_destroy(arg->pool.poh, "pl_oclass_sel", 0, NULL);
+	assert_success(rc);
+
+	/* Recreate the container with an explicit file oclass and confirm that PL stays disabled.
+	 */
+	dattr.da_file_oclass_id = explicit_cid;
+	rc = dfs_cont_create_with_label(arg->pool.poh, "pl_oclass_sel_exp", &dattr, NULL, &coh,
+					&dfs_l);
+	assert_int_equal(rc, 0);
+	/* Files in this container should inherit the configured class directly and never get a
+	 * tail. */
+	print_message("PL stage: container override explicit_cid=%s\n", explicit_name);
+	assert_file_oclass_selection(dfs_l, coh, &pool_info, NULL, "pl_container", 0, explicit_cid,
+				     OC_UNKNOWN, false);
+	rc = dfs_umount(dfs_l);
+	assert_int_equal(rc, 0);
+	rc = daos_cont_close(coh, NULL);
+	assert_success(rc);
+	rc = daos_cont_destroy(arg->pool.poh, "pl_oclass_sel_exp", 0, NULL);
+	assert_success(rc);
+}
+
 static const struct CMUnitTest dfs_unit_tests[] = {
-	{ "DFS_UNIT_TEST1: DFS mount / umount",
-	  dfs_test_mount, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST2: DFS container modes",
-	  dfs_test_modes, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST3: DFS lookup / lookup_rel",
-	  dfs_test_lookup, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST4: Simple Symlinks",
-	  dfs_test_syml, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST5: Symlinks with / without O_NOFOLLOW",
-	  dfs_test_syml_follow, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST6: multi-threads read shared file",
-	  dfs_test_read_shared_file, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST7: DFS lookupx",
-	  dfs_test_lookupx, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST8: DFS IO sync error code",
-	  dfs_test_io_error_code, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST9: DFS IO async error code",
-	  dfs_test_io_error_code, async_enable, test_case_teardown},
-	{ "DFS_UNIT_TEST10: multi-threads mkdir same dir",
-	  dfs_test_mt_mkdir, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST11: Simple rename",
-	  dfs_test_rename, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST12: DFS API compat",
-	  dfs_test_compat, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST13: DFS l2g/g2l_all",
-	  dfs_test_handles, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST14: multi-threads connect to same container",
-	  dfs_test_mt_connect, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST15: DFS chown",
-	  dfs_test_chown, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST16: DFS stat mtime",
-	  dfs_test_mtime, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST17: multi-threads async IO",
-	  dfs_test_async_io_th, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST18: async IO",
-	  dfs_test_async_io, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST19: DFS readdir",
-	  dfs_test_readdir, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST20: dfs oclass hints",
-	  dfs_test_oclass_hints, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST21: dfs multiple pools",
-	  dfs_test_multiple_pools, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST22: dfs extended attributes",
-	  dfs_test_xattrs, test_case_teardown},
-	{ "DFS_UNIT_TEST23: dfs MWC container checker",
-	  dfs_test_checker, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST24: dfs MWC SB fix",
-	  dfs_test_fix_sb, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST25: dfs MWC root fix",
-	  dfs_test_relink_root, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST26: dfs MWC chunk size fix",
-	  dfs_test_fix_chunk_size, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST27: dfs pipeline find",
-	  dfs_test_pipeline_find, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST28: dfs open/lookup flags",
-	  dfs_test_oflags, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST1: DFS mount / umount", dfs_test_mount, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST2: DFS container modes", dfs_test_modes, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST3: DFS lookup / lookup_rel", dfs_test_lookup, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST4: Simple Symlinks", dfs_test_syml, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST5: Symlinks with / without O_NOFOLLOW", dfs_test_syml_follow, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST6: multi-threads read shared file", dfs_test_read_shared_file, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST7: DFS lookupx", dfs_test_lookupx, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST8: DFS IO sync error code", dfs_test_io_error_code, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST9: DFS IO async error code", dfs_test_io_error_code, async_enable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST10: multi-threads mkdir same dir", dfs_test_mt_mkdir, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST11: Simple rename", dfs_test_rename, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST12: DFS API compat", dfs_test_compat, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST13: DFS l2g/g2l_all", dfs_test_handles, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST14: multi-threads connect to same container", dfs_test_mt_connect, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST15: DFS chown", dfs_test_chown, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST16: DFS stat mtime", dfs_test_mtime, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST17: multi-threads async IO", dfs_test_async_io_th, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST18: async IO", dfs_test_async_io, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST19: DFS readdir", dfs_test_readdir, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST20: dfs oclass hints", dfs_test_oclass_hints, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST21: dfs multiple pools", dfs_test_multiple_pools, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST22: dfs extended attributes", dfs_test_xattrs, test_case_teardown},
+    {"DFS_UNIT_TEST23: dfs MWC container checker", dfs_test_checker, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST24: dfs MWC SB fix", dfs_test_fix_sb, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST25: dfs MWC root fix", dfs_test_relink_root, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST26: dfs MWC chunk size fix", dfs_test_fix_chunk_size, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST27: dfs pipeline find", dfs_test_pipeline_find, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST28: dfs open/lookup flags", dfs_test_oflags, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST29: dfs progressive layout oclass selection", dfs_test_pl_oclass_selection,
+     async_disable, test_case_teardown},
 };
 
 static int


### PR DESCRIPTION
- object class selection logic for head and tail
- split offset calculation based on pool
- update tail status to none if oclass explicitly selected

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
