### PR TITLE
DAOS-18889 object: client retry conditional ops for DER_TX_RESTART case - b28

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -3232,6 +3232,18 @@ again:
 		if (opc != DAOS_OBJ_RPC_UPDATE)
 			break;
 
+		/*
+		 * For conditional update/insert, the -DER_TX_RESTART maybe caused by race among
+		 * unsorted conditional insert operations on non-leader(s). Directly restart the
+		 * transaction with newer epoch may cause more conflict. Instead, let's make the
+		 * client to retry with random delay via replying -DER_INPROGRESS (to avoid fail
+		 * old client if reply with -DER_TX_RESTART).
+		 */
+		if (orw->orw_api_flags & DAOS_COND_MASK) {
+			rc = -DER_INPROGRESS;
+			break;
+		}
+
 		/* Only standalone updates use this RPC. Retry with newer epoch. */
 		orw->orw_epoch = d_hlc_get();
 		exec_arg.flags |= ORF_RESEND;
@@ -4133,6 +4145,18 @@ again:
 	rc = dtx_leader_end(dlh, ioc.ioc_coc, rc);
 	switch (rc) {
 	case -DER_TX_RESTART:
+		/*
+		 * For conditional punch, the -DER_TX_RESTART maybe caused by race among
+		 * unsorted conditional operations on non-leader(s). Directly restart the
+		 * transaction with newer epoch may cause more conflict. Instead, let's
+		 * make the client to retry with random delay via replying -DER_INPROGRESS
+		 * (to avoid fail old client if reply -DER_TX_RESTART).
+		 */
+		if (opi->opi_api_flags & DAOS_COND_PUNCH) {
+			rc = -DER_INPROGRESS;
+			break;
+		}
+
 		/* Only standalone punches use this RPC. Retry with newer epoch. */
 		opi->opi_epoch = d_hlc_get();
 		exec_arg.flags |= ORF_RESEND;


### PR DESCRIPTION
On DTX non-leader, the order of two conditional modifications against the same object shard is uncontrolled. If the one with newer epoch is handled before the older one, then related ilog logic may regard them as potential conflict, then return -DER_TX_RESTART to the caller when handle the old one. Under such case, directly restart related DTX (on DTX leader) with newer epoch may still generate conflict, because hlc epsilon boundary covers relative large range of epoch. Then let's ask client to retry the operation with random delay that will much reduce the possibility of subsequent epoch conflict.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
