### PR TITLE
DAOS-18866 vos: reduce tx restart

### DIFF
--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2567,8 +2567,11 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	if (err != 0)
 		goto abort;
 
-	D_ASSERT(ioc->ic_obj != NULL);
-	if (unlikely(vos_obj_is_evicted(ioc->ic_obj))) {
+	if (ioc->ic_obj == NULL) {
+		err = vos_obj_acquire(ioc->ic_cont, ioc->ic_oid, true, &ioc->ic_obj);
+		if (err != 0)
+			goto abort;
+	} else if (unlikely(vos_obj_is_evicted(ioc->ic_obj))) {
 		D_DEBUG(DB_IO, "Obj " DF_UOID " is evicted during update, need to restart TX.\n",
 			DP_UOID(ioc->ic_oid));
 
@@ -2755,9 +2758,12 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		goto error;
 	}
 
-	rc = vos_obj_acquire(ioc->ic_cont, ioc->ic_oid, true, &ioc->ic_obj);
-	if (rc != 0)
-		goto error;
+	/* Hold the object for the evictable md-on-ssd phase2 pool */
+	if (vos_pool_is_evictable(vos_cont2pool(ioc->ic_cont))) {
+		rc = vos_obj_acquire(ioc->ic_cont, ioc->ic_oid, true, &ioc->ic_obj);
+		if (rc != 0)
+			goto error;
+	}
 
 	rc = dkey_update_begin(ioc);
 	if (rc != 0) {


### PR DESCRIPTION
For pmem and md-on-ssd phase1 mode, move the object hold from vos_update_begin() to vos_update_end() to reduce tx restarts.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
