### PR TITLE
DAOS-18857 build: use env.get() for optional env var checks

### DIFF
--- a/site_scons/site_tools/compiler_setup.py
+++ b/site_scons/site_tools/compiler_setup.py
@@ -58,9 +58,9 @@ def _base_setup(env):
 
     env.AppendIfSupported(CCFLAGS=DESIRED_FLAGS)
 
-    if 'SANITIZERS' in env and env['SANITIZERS'] != "":
+    if env.get('SANITIZERS'):
 
-        if "HEAP_PROFILER" in env and env['HEAP_PROFILER']:
+        if env.get('HEAP_PROFILER'):
             print('Google Sanitizers and Gperftools.Heap.Profiler can not be mixed')
             Exit(2)
 
@@ -92,7 +92,7 @@ def _base_setup(env):
                 env.AppendUnique(LINKFLAGS=flag)
                 print(f"Enabling {flag.split('=')[1]} sanitizer for C code")
 
-    if 'HEAP_PROFILER' in env and env['HEAP_PROFILER']:
+    if env.get('HEAP_PROFILER'):
         env.AppendUnique(LINKFLAGS="-ltcmalloc")
         print("Enabling Gperftools Heap Profiler")
 
@@ -223,7 +223,7 @@ def _check_func(env, func_name):
     """Check if a function is usable"""
     denv = env.Clone()
     # NOTE Remove sanitizers to not scramble the test output
-    if 'SANITIZERS' in denv and denv['SANITIZERS'] != "":
+    if denv.get('SANITIZERS'):
         for sanitizer in denv['SANITIZERS'].split(','):
             flag = f"-fsanitize={sanitizer}"
             if flag not in denv["CCFLAGS"]:
@@ -232,7 +232,7 @@ def _check_func(env, func_name):
             denv["LINKFLAGS"].remove(flag)
 
     # NOTE Remove Heap Profiler to not scramble the test output
-    if 'HEAP_PROFILER' in denv and denv['HEAP_PROFILER']:
+    if denv.get('HEAP_PROFILER'):
         denv["LINKFLAGS"].remove("-ltcmalloc")
 
     config = Configure(denv)


### PR DESCRIPTION
### Description

Replace the verbose `'KEY' in env and env['KEY']` pattern with the idiomatic `env.get('KEY')` form for `SANITIZERS` and `HEAP_PROFILER` checks throughout `compiler_setup.py`, as suggested in PR #18068 review.

`env.get()` returns `None` when the key is absent, which is falsy — semantically equivalent to the original guards.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
