### PR TITLE
DAOS-18640 test: per_server_fault_domain.yaml - Decrease generated data

### DIFF
--- a/src/tests/ftest/container/per_server_fault_domain.yaml
+++ b/src/tests/ftest/container/per_server_fault_domain.yaml
@@ -22,7 +22,7 @@ server_config:
 
 pool:
   size: 200G
-  properties: space_rb:8
+  properties: space_rb:10
 
 container:
   control_method: daos

--- a/src/tests/ftest/container/per_server_fault_domain.yaml
+++ b/src/tests/ftest/container/per_server_fault_domain.yaml
@@ -22,7 +22,7 @@ server_config:
 
 pool:
   size: 200G
-  properties: space_rb:5
+  properties: space_rb:8
 
 container:
   control_method: daos

--- a/src/tests/ftest/container/per_server_fault_domain.yaml
+++ b/src/tests/ftest/container/per_server_fault_domain.yaml
@@ -22,7 +22,7 @@ server_config:
 
 pool:
   size: 200G
-  properties: space_rb:10
+  properties: space_rb:5
 
 container:
   control_method: daos
@@ -34,7 +34,7 @@ ior:
     flags: -v -w -k
   api: DFS
   transfer_size: 1M
-  block_size: 20G
+  block_size: 10G
   dfs_oclass: RP_3GX
 
 cont_property:


### PR DESCRIPTION
Some tests in per_server_fault_domain.py are failing due to rebuild timeout after stopping the ranks. dmg pool query during rebuild from one test shows that the NVMe imbalance hit 98% during rebuild (49% before rebuild), which made rebuild take too long. The best fix is to reduce the amount of data written, in this case reduced from 20GiB to 10GiB. As a result, the NVMe imbalance during rebuild reduced to 27-49% depending on the test and all tests passed.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-large: false
Test-tag: PerServerFaultDomainTest
Test-repeat: 3

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
