### PR TITLE
DAOS-623 test: adjust dfs test suite to allow doing subtests (#18276)

### DIFF
--- a/src/tests/suite/dfs_par_test.c
+++ b/src/tests/suite/dfs_par_test.c
@@ -1,6 +1,7 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
  * (C) Copyright 2026 Google LLC
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1017,21 +1018,29 @@ dfs_teardown(void **state)
 }
 
 int
-run_dfs_par_test(int rank, int size)
+run_dfs_par_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc = 0;
+	int selected = sub_tests_size;
+
+	if (sub_tests_size == 0) {
+		sub_tests = NULL;
+		selected  = ARRAY_SIZE(dfs_par_tests);
+	}
 
 	par_barrier(PAR_COMM_WORLD);
-	rc = cmocka_run_group_tests_name("DAOS_FileSystem_DFS_Parallel", dfs_par_tests, dfs_setup,
-					 dfs_teardown);
+	rc = run_daos_sub_tests("DAOS_FileSystem_DFS_Parallel", dfs_par_tests,
+				ARRAY_SIZE(dfs_par_tests), sub_tests, selected, dfs_setup,
+				dfs_teardown);
 	par_barrier(PAR_COMM_WORLD);
 
 	/** run tests again with DTX */
 	d_setenv("DFS_USE_DTX", "1", 1);
 
 	par_barrier(PAR_COMM_WORLD);
-	rc += cmocka_run_group_tests_name("DAOS_FileSystem_DFS_Parallel_DTX", dfs_par_tests,
-					  dfs_setup, dfs_teardown);
+	rc += run_daos_sub_tests("DAOS_FileSystem_DFS_Parallel_DTX", dfs_par_tests,
+				 ARRAY_SIZE(dfs_par_tests), sub_tests, selected, dfs_setup,
+				 dfs_teardown);
 	par_barrier(PAR_COMM_WORLD);
 	return rc;
 }

--- a/src/tests/suite/dfs_sys_unit_test.c
+++ b/src/tests/suite/dfs_sys_unit_test.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -991,14 +992,20 @@ dfs_sys_teardown(void **state)
 }
 
 int
-run_dfs_sys_unit_test(int rank, int size)
+run_dfs_sys_unit_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc = 0;
+	int selected = sub_tests_size;
+
+	if (sub_tests_size == 0) {
+		sub_tests = NULL;
+		selected  = ARRAY_SIZE(dfs_sys_unit_tests);
+	}
 
 	par_barrier(PAR_COMM_WORLD);
-	rc = cmocka_run_group_tests_name("DAOS_FileSystem_DFS_Sys_Unit",
-					 dfs_sys_unit_tests, dfs_sys_setup,
-					 dfs_sys_teardown);
+	rc = run_daos_sub_tests("DAOS_FileSystem_DFS_Sys_Unit", dfs_sys_unit_tests,
+				ARRAY_SIZE(dfs_sys_unit_tests), sub_tests, selected, dfs_sys_setup,
+				dfs_sys_teardown);
 	par_barrier(PAR_COMM_WORLD);
 	return rc;
 }

--- a/src/tests/suite/dfs_test.c
+++ b/src/tests/suite/dfs_test.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -10,6 +11,7 @@
  */
 #define D_LOGFAC	DD_FAC(tests)
 
+#include <ctype.h>
 #include <getopt.h>
 #include "dfs_test.h"
 
@@ -33,6 +35,7 @@ print_usage(int rank)
 	print_message("dfs_test -u|--unit\n");
 	print_message("dfs_test -s|--sys\n");
 	print_message("Default <daos_tests> runs all tests\n=============\n");
+	print_message("dfs_test -t|--subtests SUBTESTS\n");
 	print_message("dfs_test -E|--exclude TESTS\n");
 	print_message("dfs_test -n|--dmg_config\n");
 	print_message("\n=============================\n");
@@ -53,19 +56,19 @@ run_specified_tests(const char *tests, int rank, int size,
 			daos_test_print(rank, "\n\n=================");
 			daos_test_print(rank, "DFS parallel tests..");
 			daos_test_print(rank, "=====================");
-			nr_failed += run_dfs_par_test(rank, size);
+			nr_failed += run_dfs_par_test(rank, size, sub_tests, sub_tests_size);
 			break;
 		case 'u':
 			daos_test_print(rank, "\n\n=================");
 			daos_test_print(rank, "DFS unit tests..");
 			daos_test_print(rank, "=====================");
-			nr_failed += run_dfs_unit_test(rank, size);
+			nr_failed += run_dfs_unit_test(rank, size, sub_tests, sub_tests_size);
 			break;
 		case 's':
 			daos_test_print(rank, "\n\n=================");
 			daos_test_print(rank, "DFS Sys unit tests..");
 			daos_test_print(rank, "=====================");
-			nr_failed += run_dfs_sys_unit_test(rank, size);
+			nr_failed += run_dfs_sys_unit_test(rank, size, sub_tests, sub_tests_size);
 			break;
 
 		default:
@@ -83,8 +86,11 @@ main(int argc, char **argv)
 {
 	test_arg_t *arg;
 	char        tests[64];
+	char       *sub_tests_str         = NULL;
 	char       *exclude_str           = NULL;
 	char       *cmocka_message_output = NULL;
+	int         sub_tests[1024];
+	int         sub_tests_idx         = 0;
 	int         ntests                = 0;
 	int         nr_failed             = 0;
 	int         nr_total_failed       = 0;
@@ -101,14 +107,13 @@ main(int argc, char **argv)
 	par_size(PAR_COMM_WORLD, &size);
 	par_barrier(PAR_COMM_WORLD);
 
-	static struct option long_options[] = {
-		{"all",		no_argument,		NULL,	'a'},
-		{"dmg_config",	required_argument,	NULL,	'n'},
-		{"parallel",	no_argument,		NULL,	'p'},
-		{"unit",	no_argument,		NULL,	'u'},
-		{"sys",		no_argument,		NULL,	's'},
-		{NULL,		0,			NULL,	0}
-	};
+	static struct option long_options[] = {{"all", no_argument, NULL, 'a'},
+					       {"dmg_config", required_argument, NULL, 'n'},
+					       {"parallel", no_argument, NULL, 'p'},
+					       {"subtests", required_argument, NULL, 't'},
+					       {"unit", no_argument, NULL, 'u'},
+					       {"sys", no_argument, NULL, 's'},
+					       {NULL, 0, NULL, 0}};
 
 	rc = daos_init();
 	if (rc) {
@@ -118,8 +123,7 @@ main(int argc, char **argv)
 
 	memset(tests, 0, sizeof(tests));
 
-	while ((opt = getopt_long(argc, argv, "aE:n:pus",
-				  long_options, &index)) != -1) {
+	while ((opt = getopt_long(argc, argv, "aE:n:pst:u", long_options, &index)) != -1) {
 		if (strchr(all_tests, opt) != NULL) {
 			tests[ntests] = opt;
 			ntests++;
@@ -130,6 +134,9 @@ main(int argc, char **argv)
 			break;
 		case 'n':
 			dmg_config_file = optarg;
+			break;
+		case 't':
+			sub_tests_str = optarg;
 			break;
 		case 'E':
 			exclude_str = optarg;
@@ -143,6 +150,58 @@ main(int argc, char **argv)
 
 	if (strlen(tests) == 0)
 		strncpy(tests, all_tests, sizeof(TESTS));
+
+	if (sub_tests_str != NULL) {
+		char *ptr = sub_tests_str;
+		char *tmp;
+		int   start = -1;
+		int   end   = -1;
+
+		while (*ptr) {
+			int number = -1;
+
+			while (!isdigit(*ptr) && *ptr)
+				ptr++;
+
+			if (!*ptr)
+				break;
+
+			tmp = ptr;
+			while (isdigit(*ptr))
+				ptr++;
+
+			number = atoi(tmp);
+			if (*ptr == '-') {
+				if (start != -1) {
+					print_message("str is %s\n", sub_tests_str);
+					return -1;
+				}
+				start = number;
+				continue;
+			}
+
+			if (start != -1)
+				end = number;
+			else
+				start = number;
+
+			if (start != -1 || end != -1) {
+				if (end != -1) {
+					int i;
+
+					for (i = start; i <= end; i++) {
+						sub_tests[sub_tests_idx] = i;
+						sub_tests_idx++;
+					}
+				} else {
+					sub_tests[sub_tests_idx] = start;
+					sub_tests_idx++;
+				}
+				start = -1;
+				end   = -1;
+			}
+		}
+	}
 
 	if (svc_nreplicas > ARRAY_SIZE(arg->pool.ranks) && rank == 0) {
 		print_message("at most %zu service replicas allowed\n",
@@ -179,7 +238,7 @@ main(int argc, char **argv)
 	}
 	d_freeenv_str(&cmocka_message_output);
 
-	nr_failed = run_specified_tests(tests, rank, size, NULL, 0);
+	nr_failed = run_specified_tests(tests, rank, size, sub_tests, sub_tests_idx);
 
 exit:
 	par_allreduce(PAR_COMM_WORLD, &nr_failed, &nr_total_failed, 1, PAR_INT, PAR_SUM);

--- a/src/tests/suite/dfs_test.h
+++ b/src/tests/suite/dfs_test.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -16,9 +17,12 @@
 #include <daos_fs.h>
 #include <daos_fs_sys.h>
 
-int run_dfs_unit_test(int rank, int size);
-int run_dfs_par_test(int rank, int size);
-int run_dfs_sys_unit_test(int rank, int size);
+int
+run_dfs_unit_test(int rank, int size, int *sub_tests, int sub_tests_size);
+int
+run_dfs_par_test(int rank, int size, int *sub_tests, int sub_tests_size);
+int
+run_dfs_sys_unit_test(int rank, int size, int *sub_tests, int sub_tests_size);
 
 static inline void
 dfs_test_share(daos_handle_t poh, daos_handle_t coh, int rank, dfs_t **dfs)

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -3688,21 +3688,29 @@ dfs_teardown(void **state)
 }
 
 int
-run_dfs_unit_test(int rank, int size)
+run_dfs_unit_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc = 0;
+	int selected = sub_tests_size;
+
+	if (sub_tests_size == 0) {
+		sub_tests = NULL;
+		selected  = ARRAY_SIZE(dfs_unit_tests);
+	}
 
 	par_barrier(PAR_COMM_WORLD);
-	rc = cmocka_run_group_tests_name("DAOS_FileSystem_DFS_Unit", dfs_unit_tests, dfs_setup,
-					 dfs_teardown);
+	rc = run_daos_sub_tests("DAOS_FileSystem_DFS_Unit", dfs_unit_tests,
+				ARRAY_SIZE(dfs_unit_tests), sub_tests, selected, dfs_setup,
+				dfs_teardown);
 	par_barrier(PAR_COMM_WORLD);
 
 	/** run tests again with DTX */
 	d_setenv("DFS_USE_DTX", "1", 1);
 
 	par_barrier(PAR_COMM_WORLD);
-	rc += cmocka_run_group_tests_name("DAOS_FileSystem_DFS_Unit_DTX", dfs_unit_tests,
-					  dfs_setup, dfs_teardown);
+	rc += run_daos_sub_tests("DAOS_FileSystem_DFS_Unit_DTX", dfs_unit_tests,
+				 ARRAY_SIZE(dfs_unit_tests), sub_tests, selected, dfs_setup,
+				 dfs_teardown);
 	par_barrier(PAR_COMM_WORLD);
 	return rc;
 }


### PR DESCRIPTION
Quick-Functional: true
Test-tag: DaosCoreTestDfs

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
