### PR TITLE
DAOS-18977 dfuse: disable pre-read for timed cache in write-through mode

### DIFF
--- a/src/client/dfuse/ops/open.c
+++ b/src/client/dfuse/ops/open.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -65,6 +66,16 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		 * kernel cache to be used.  If not then use pre-read.
 		 * This should mean that pre-read is only used on the first read, and on files
 		 * which pre-existed in the container.
+		 *
+		 * For timed cache with write-through mode, avoid the pre-read path but otherwise
+		 * keep the existing cache reuse behavior unchanged.
+		 *
+		 * TODO: The current pre-read validation only detects file shrink via a returned
+		 * length mismatch in dfuse_cb_pre_read_complete(). It does not detect a file being
+		 * rewritten at the same size, replaced by rename at the same size, or grown after
+		 * the stat/open snapshot used to launch the async pre-read. Build-style workloads
+		 * hit exactly those patterns, so pre-read is disabled here until it has a stronger
+		 * freshness check.
 		 */
 
 		/* TODO: This probably wants reflowing to not reference ie_open_count */
@@ -73,7 +84,7 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		     dfuse_dcache_get_valid(ie, ie->ie_dfs->dfc_data_timeout))) {
 			fi_out.keep_cache = 1;
 		} else {
-			prefetch = true;
+			prefetch = ie->ie_dfs->dfc_wb_cache;
 		}
 	} else if (ie->ie_dfs->dfc_data_otoc) {
 		/* Open to close caching, this allows the use of shared mmap */

--- a/src/client/dfuse/ops/read.c
+++ b/src/client/dfuse/ops/read.c
@@ -615,8 +615,13 @@ dfuse_cb_pre_read_complete(struct dfuse_event *ev)
 	}
 
 	/* If the length is not as expected then the file has been modified since the last stat so
-	 * discard this cache and use regular reads.  Note that this will only detect files which
-	 * have shrunk in size, not grown.
+	 * discard this cache and use regular reads.
+	 *
+	 * TODO: This validation is too weak. A length mismatch only detects one class of change,
+	 * primarily shrink. It does not detect files that were rewritten at the same size,
+	 * replaced by rename at the same size, or grown after the snapshot used for pre-read.
+	 * Timed-cache write-through workloads can hit those patterns, so the open path currently
+	 * disables pre-read there until this validation is strengthened.
 	 */
 	if (ev->de_len != ev->de_readahead_len) {
 		daos_event_fini(&ev->de_ev);

--- a/src/tests/ftest/dfuse/read.yaml
+++ b/src/tests/ftest/dfuse/read.yaml
@@ -20,4 +20,4 @@ container:
   type: POSIX
   control_method: daos
 dfuse:
-  disable_wb_cache: true
+  disable_wb_cache: false


### PR DESCRIPTION
Disable the dfuse pre-read path when timed data cache is enabled but
write-back cache is disabled.

The timed-cache write-through path can hit build-style workloads where
files are rewritten, replaced by rename, or grown after the stat/open
snapshot used to launch async pre-read. The current pre-read validation
only detects a returned length mismatch, which is not sufficient to
catch those cases.

Keep existing timed-cache behavior otherwise, but avoid pre-read in this
mode until the pre-read freshness check is strengthened.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
