### PR TITLE
DAOS-18235 test: pool/verify_space.py - Remove system_ram_reserved

### DIFF
--- a/src/tests/ftest/pool/verify_space.yaml
+++ b/src/tests/ftest/pool/verify_space.yaml
@@ -10,7 +10,6 @@ server_config:
   engines:
     0:
       storage: auto
-  system_ram_reserved: 5
 
 pool_rank_0:
   size: 100G

--- a/src/tests/ftest/pool/verify_space.yaml
+++ b/src/tests/ftest/pool/verify_space.yaml
@@ -10,6 +10,7 @@ server_config:
   engines:
     0:
       storage: auto
+  system_ram_reserved: 5
 
 pool_rank_0:
   size: 100G

--- a/src/tests/ftest/pool/verify_space.yaml
+++ b/src/tests/ftest/pool/verify_space.yaml
@@ -10,7 +10,6 @@ server_config:
   engines:
     0:
       storage: auto
-  system_ram_reserved: 1
 
 pool_rank_0:
   size: 100G


### PR DESCRIPTION
The test intermittently fails during storage format due to "Available memory (RAM) insufficient" error. This is because too little memory is allocated to non-DAOS system processes due to "system_ram_reserved: 1" (unit is GiB) in server config (test yaml). If we increase it, the system would have more space. The error message indicated that "want 159 GiB RAM but only have 158 GiB", increasing it by 1 should resolve, but use the default 64GiB by removing the field because that's the common real-world use case.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-medium: false
Test-tag: test_verify_pool_space
Test-repeat: 5

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
