### PR TITLE
DAOS-18982 test: increase dfuse/fio_small pool size

### DIFF
--- a/src/tests/ftest/dfuse/fio_pil4dfs_small.py
+++ b/src/tests/ftest/dfuse/fio_pil4dfs_small.py
@@ -8,6 +8,7 @@
 import os
 
 from dfuse_utils import get_dfuse, start_dfuse
+from file_utils import create_directory
 from fio_test_base import FioBase
 
 
@@ -42,13 +43,17 @@ class FioPil4dfsSmall(FioBase):
             self.log_step('Start dfuse')
             dfuse = get_dfuse(self, self.hostlist_clients)
             start_dfuse(self, dfuse, pool, container)
-            self.fio_cmd.update_directory(dfuse.mount_dir.value)
 
             # Run with various fio parameters
             for variant in self.params.get("variants", '/run/fio/global/*'):
                 self.log_step(
                     f'Run fio with direct={variant[0]}, blocksize={variant[1]}, '
                     f'size={variant[2]}, rw={variant[3]}')
+                fio_dir = os.path.join(dfuse.mount_dir.value, 'dir')
+                result = create_directory(self.log, self.hostlist_clients[:1], fio_dir)
+                if not result.passed:
+                    self.fail(f"Error creating {fio_dir} on {result.failed_hosts}")
+                self.fio_cmd.update_directory(self.label_generator.get_label(fio_dir))
                 self.fio_cmd.update('global', 'direct', variant[0], 'global.direct')
                 self.fio_cmd.update('global', 'blocksize', variant[1], 'global.blocksize')
                 self.fio_cmd.update('global', 'size', variant[2], 'global.size')

--- a/src/tests/ftest/dfuse/fio_pil4dfs_small.yaml
+++ b/src/tests/ftest/dfuse/fio_pil4dfs_small.yaml
@@ -20,8 +20,7 @@ server_config:
       storage: auto
 
 pool:
-  scm_size: 2G
-  nvme_size: 20G
+  size: 100%
 
 container:
   type: POSIX

--- a/src/tests/ftest/dfuse/fio_small.py
+++ b/src/tests/ftest/dfuse/fio_small.py
@@ -5,7 +5,10 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
+import os
+
 from dfuse_utils import get_dfuse, start_dfuse
+from file_utils import create_directory
 from fio_test_base import FioBase
 
 
@@ -38,13 +41,17 @@ class FioSmall(FioBase):
             self.log_step('Start dfuse')
             dfuse = get_dfuse(self, self.hostlist_clients)
             start_dfuse(self, dfuse, pool, container)
-            self.fio_cmd.update_directory(dfuse.mount_dir.value)
 
             # Run with various fio parameters
             for variant in self.params.get("variants", '/run/fio/global/*'):
                 self.log_step(
                     f'Run fio with direct={variant[0]}, blocksize={variant[1]}, '
                     f'size={variant[2]}, rw={variant[3]}')
+                fio_dir = os.path.join(dfuse.mount_dir.value, 'dir')
+                result = create_directory(self.log, self.hostlist_clients[:1], fio_dir)
+                if not result.passed:
+                    self.fail(f"Error creating {fio_dir} on {result.failed_hosts}")
+                self.fio_cmd.update_directory(self.label_generator.get_label(fio_dir))
                 self.fio_cmd.update('global', 'direct', variant[0], 'global.direct')
                 self.fio_cmd.update('global', 'blocksize', variant[1], 'global.blocksize')
                 self.fio_cmd.update('global', 'size', variant[2], 'global.size')

--- a/src/tests/ftest/dfuse/fio_small.yaml
+++ b/src/tests/ftest/dfuse/fio_small.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 2
   test_clients: 1
 
-timeout: 360
+timeout: 420
 
 server_config:
   name: daos_server
@@ -20,8 +20,7 @@ server_config:
       storage: auto
 
 pool:
-  scm_size: 2G
-  nvme_size: 20G
+  size: 100%
 
 container:
   type: POSIX


### PR DESCRIPTION
Increase dfuse/fio_small and dfuse/fio_pil4dfs_small pool size to 100G since there seems to be space pressure causing low performance.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
