### PR TITLE
DAOS-16765 test: pool/verify_space.py - Increase timeout (#15453)

### DIFF
--- a/src/tests/ftest/pool/verify_space.py
+++ b/src/tests/ftest/pool/verify_space.py
@@ -196,7 +196,7 @@ class VerifyPoolSpace(TestWithServers):
         self._compare_system_pool_size(pool_size, compare_methods)
 
     def test_verify_pool_space(self):
-        """Test ID: DAOS-3672.
+        """Test ID: DAOS-3672
 
         Test steps:
         1) Start servers and list associated storage, verify correctness

--- a/src/tests/ftest/pool/verify_space.yaml
+++ b/src/tests/ftest/pool/verify_space.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 3
   test_clients: 1
 
-timeout: 600
+timeout: 750
 
 server_config:
   # Test will require code changes if more than one rank/engine per host


### PR DESCRIPTION
In the past few passing runs, the test had ~100 sec test time remaining at the end with 600 sec timeout. This means the test usually takes ~500 sec. Set the timeout to
normal test duration * 1.5 = 750 sec

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-medium-md-on-ssd: false
Test-tag: test_verify_pool_space
Test-repeat: 5

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
