### PR TITLE
DAOS-18976 rebuild: more delay when schedule FAIL_RECLAIM after net err

### DIFF
--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -728,7 +728,12 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 	int				i;
 	int				rc = 0;
 
-	if (rpt->rt_abort || arg->cont_child->sc_stopping) {
+	/* Check rt_finishing to allow rebuild_scan_leader to exit quickly when
+	 * rebuild_tgt_fini() is waiting for the refcount to drop. Without this,
+	 * a stale scan_leader continues scanning all VOS objects indefinitely,
+	 * blocking TLS cleanup and causing retries to fail with -DER_BUSY.
+	 */
+	if (rpt->rt_abort || rpt->rt_finishing || arg->cont_child->sc_stopping) {
 		D_DEBUG(DB_REBUILD, "rebuild is aborted\n");
 		return 1;
 	}

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -1211,6 +1211,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	struct rebuild_tgt_pool_tracker	*rpt = NULL;
 	struct ds_pool                  *pool    = NULL;
 	bool                             checker = false;
+	uint64_t                         ts_start, ts_now;
 	int				 rc;
 
 	rsi = crt_req_get(rpc);
@@ -1221,6 +1222,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	       rsi->rsi_rebuild_ver, rsi->rsi_rebuild_gen, rsi->rsi_master_rank,
 	       rsi->rsi_leader_term, RB_OP_STR(rsi->rsi_rebuild_op));
 
+	ts_start = daos_gettime_coarse();
 	rc = ds_pool_lookup(rsi->rsi_pool_uuid, &pool);
 	if (rc) {
 		D_ERROR("Can not find pool " DF_UUID ": %d\n", DP_UUID(rsi->rsi_pool_uuid), rc);
@@ -1327,6 +1329,35 @@ tls_lookup:
 	tls = rebuild_pool_tls_lookup(rsi->rsi_pool_uuid, rsi->rsi_rebuild_ver,
 				      rsi->rsi_rebuild_gen);
 	if (tls != NULL) {
+		struct rebuild_tgt_pool_tracker *tmp;
+
+		/* Check whether the TLS belongs to an rpt that is finishing
+		 * (rt_finishing == 1). rpt_lookup() skips such rpts, so the
+		 * scan handler arrives here with a NULL rpt but a live TLS.
+		 * This is a transient window between rebuild_tgt_fini() setting
+		 * rt_finishing and the subsequent rebuild_pool_tls_destroy().
+		 * Yield to let the finishing rpt's scan_leader exit and drop
+		 * its refcount so TLS cleanup can proceed, then retry.
+		 */
+		d_list_for_each_entry(tmp, &rebuild_gst.rg_tgt_tracker_list, rt_list) {
+			if (uuid_compare(tmp->rt_pool_uuid, rsi->rsi_pool_uuid) == 0 &&
+			    tmp->rt_rebuild_ver == rsi->rsi_rebuild_ver &&
+			    tmp->rt_rebuild_gen == rsi->rsi_rebuild_gen && tmp->rt_finishing) {
+				ts_now = daos_gettime_coarse();
+				if (ts_now > ts_start + 30) {
+					D_INFO(DF_UUID " %s ver %d/gen %u waited previous rebuild "
+						       "finishing more than 30 seconds\n",
+					       DP_UUID(rsi->rsi_pool_uuid),
+					       RB_OP_STR(tmp->rt_rebuild_op), rsi->rsi_rebuild_ver,
+					       rsi->rsi_rebuild_gen);
+					break;
+				} else {
+					dss_sleep(1000);
+					goto tls_lookup;
+				}
+			}
+		}
+
 		D_WARN("the previous rebuild "DF_UUID"/%d is not cleanup yet\n",
 		       DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_rebuild_ver);
 		D_GOTO(out_delete, rc = -DER_BUSY);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1457,7 +1457,9 @@ rebuild_leader_start(struct ds_pool *pool, struct rebuild_task *task,
 	rc = rebuild_scan_broadcast(pool, *p_rgt, &task->dst_tgts,
 				    task->dst_new_layout_version, task->dst_rebuild_op);
 	if (rc)
-		D_ERROR("object scan failed: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, "pool " DF_UUID ": %s, ver %d, object scan broadcast failed.",
+			 DP_UUID(pool->sp_uuid), RB_OP_STR(task->dst_rebuild_op),
+			 task->dst_map_ver);
 	else
 		rc = 1;
 
@@ -1516,11 +1518,20 @@ retry_rebuild_task(struct rebuild_task *task, int error, daos_rebuild_opc_t *opc
 	*opc = RB_OP_REBUILD;
 }
 
+static bool
+rebuild_failed_due_to_network(int err)
+{
+	return daos_crt_network_error(err) || err == -DER_TIMEDOUT;
+}
+
+#define RB_DELAY_AFTER_NET_ERR (30)
+
 static int
 rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 			       struct rebuild_global_pool_tracker *rgt, uint32_t obj_reclaim_ver,
 			       int ret)
 {
+	uint64_t delay_sec = 5;
 	int rc = 0;
 	int rc1;
 
@@ -1536,9 +1547,11 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 
 		DL_INFO(ret, DF_UUID" retry opc %u/%u", DP_UUID(task->dst_pool_uuid),
 			task->dst_rebuild_op, task->dst_map_ver);
+		if (rebuild_failed_due_to_network(ret))
+			delay_sec = RB_DELAY_AFTER_NET_ERR;
 		rc = ds_rebuild_schedule(pool, task->dst_map_ver, task->dst_reclaim_eph,
-					 task->dst_new_layout_version,
-					 &task->dst_tgts, task->dst_rebuild_op, 5);
+					 task->dst_new_layout_version, &task->dst_tgts,
+					 task->dst_rebuild_op, delay_sec);
 		return rc;
 	}
 
@@ -1559,13 +1572,16 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		/* If current job failed */
 		rgt->rgt_status.rs_state = DRS_IN_PROGRESS;
 
+		if (rebuild_failed_due_to_network(rgt->rgt_status.rs_errno))
+			delay_sec = RB_DELAY_AFTER_NET_ERR;
+
 		if (task->dst_rebuild_op == RB_OP_RECLAIM ||
 		    task->dst_rebuild_op == RB_OP_FAIL_RECLAIM) {
 			DL_INFO(ret, DF_UUID" retry opc %u/%u", DP_UUID(task->dst_pool_uuid),
 				task->dst_rebuild_op, task->dst_map_ver);
 			rc = ds_rebuild_schedule(pool, task->dst_map_ver, rgt->rgt_stable_epoch,
 						 task->dst_new_layout_version, &task->dst_tgts,
-						 task->dst_rebuild_op, 5);
+						 task->dst_rebuild_op, delay_sec);
 			return rc;
 		}
 
@@ -1581,10 +1597,10 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 				DF_UUID" opc %u/%u, schedule RB_OP_FAIL_RECLAIM.",
 				DP_UUID(task->dst_pool_uuid), task->dst_rebuild_op,
 				task->dst_map_ver);
-			rc = ds_rebuild_schedule(pool, task->dst_reclaim_ver - 1,
-						 rgt->rgt_stable_epoch,
-						 task->dst_new_layout_version,
-						 &task->dst_tgts, RB_OP_FAIL_RECLAIM, 5);
+			rc =
+			    ds_rebuild_schedule(pool, task->dst_reclaim_ver - 1,
+						rgt->rgt_stable_epoch, task->dst_new_layout_version,
+						&task->dst_tgts, RB_OP_FAIL_RECLAIM, delay_sec);
 			if (rc)
 				D_ERROR(DF_UUID "schedule reclaim fail: "DF_RC"\n",
 					DP_UUID(task->dst_pool_uuid), DP_RC(rc));
@@ -1596,8 +1612,8 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 			D_GOTO(complete, rc);
 
 		rc = ds_rebuild_schedule(pool, task->dst_map_ver, rgt->rgt_stable_epoch,
-					 task->dst_new_layout_version, &task->dst_tgts,
-					 retry_opc, 5);
+					 task->dst_new_layout_version, &task->dst_tgts, retry_opc,
+					 delay_sec);
 		DL_INFO(rc, DF_UUID" opc %u/%u, error %d, re-scheduled opc %u.",
 			DP_UUID(task->dst_pool_uuid), task->dst_rebuild_op, task->dst_map_ver,
 			rgt->rgt_status.rs_errno, retry_opc);
@@ -1613,7 +1629,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		obj_reclaim_ver = obj_reclaim_ver > 0 ? obj_reclaim_ver : task->dst_map_ver;
 		rc              = ds_rebuild_schedule(pool, obj_reclaim_ver, rgt->rgt_reclaim_epoch,
 						      task->dst_new_layout_version, &task->dst_tgts,
-						      RB_OP_RECLAIM, 5);
+						      RB_OP_RECLAIM, delay_sec);
 		if (rc != 0)
 			D_ERROR("reschedule reclaim, "DF_UUID" failed: "DF_RC"\n",
 				DP_UUID(task->dst_pool_uuid), DP_RC(rc));
@@ -1823,7 +1839,7 @@ out_task:
 	return;
 }
 
-bool
+static bool
 pool_is_rebuilding(uuid_t pool_uuid)
 {
 	struct rebuild_task *task;
@@ -1835,13 +1851,27 @@ pool_is_rebuilding(uuid_t pool_uuid)
 	return false;
 }
 
+static bool
+pool_reclaim_in_queue(uuid_t pool_uuid)
+{
+	struct rebuild_task *task;
+
+	d_list_for_each_entry(task, &rebuild_gst.rg_queue_list, dst_list) {
+		if (uuid_compare(task->dst_pool_uuid, pool_uuid) == 0 &&
+		    (task->dst_rebuild_op == RB_OP_RECLAIM ||
+		     task->dst_rebuild_op == RB_OP_FAIL_RECLAIM))
+			return true;
+	}
+	return false;
+}
+
 #define REBUILD_MAX_INFLIGHT	10
 static void
 rebuild_ults(void *arg)
 {
 	struct rebuild_task *task;
 	struct rebuild_task *task_tmp;
-	int		    rc;
+	int                  rc;
 
 	while (DAOS_FAIL_CHECK(DAOS_REBUILD_HANG))
 		ABT_thread_yield();
@@ -1863,6 +1893,19 @@ rebuild_ults(void *arg)
 
 		task = d_list_entry(rebuild_gst.rg_queue_list.next, struct rebuild_task, dst_list);
 		while (&rebuild_gst.rg_queue_list != &task->dst_list) {
+			/* make sure the reclaim runs first */
+			if ((task->dst_rebuild_op == RB_OP_REBUILD ||
+			     task->dst_rebuild_op == RB_OP_UPGRADE) &&
+			    pool_reclaim_in_queue(task->dst_pool_uuid)) {
+				D_DEBUG(DB_REBUILD, "pool " DF_UUID " %s, ver %d wait reclaim\n",
+					DP_UUID(task->dst_pool_uuid),
+					RB_OP_STR(task->dst_rebuild_op), task->dst_map_ver);
+				task = d_list_entry(task->dst_list.next, struct rebuild_task,
+						    dst_list);
+				dss_sleep(0);
+				continue;
+			}
+
 			/* If a pool is currently handling a rebuild, wait for it to finish.
 			 * Skip this pool now if its rebuild task is scheduled for later
 			 * (allow for merging of other tasks into this one in ds_rebuild_schedule().
@@ -1901,7 +1944,7 @@ rebuild_ults(void *arg)
 			}
 
 		}
-		dss_sleep(0);
+		dss_sleep(1000);
 	}
 
 	/* If there are still rebuild task in queue and running list, then


### PR DESCRIPTION
When rebuild failed as network failure, delay 30 Seconds to schedule FAIL_RELAIM task.
For example when a rank dead, it firstly get -DER_HG or other network failure, but the pool map possibly has not changed to mark it as DOWN. If run FAIL_RECLAIM immediately the SCAN bcast possibly will fail and the retry will fail it again.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
