### PR TITLE
DAOS-18984 dfs: dfs_obj_set_oclass should update the dir open handle …

### DIFF
--- a/src/client/dfs/dir.c
+++ b/src/client/dfs/dir.c
@@ -284,7 +284,10 @@ dfs_obj_set_oclass(dfs_t *dfs, dfs_obj_t *obj, int flags, daos_oclass_id_t cid)
 		D_GOTO(out, rc = daos_der2errno(rc));
 	}
 
-	/** if this is root obj, we need to update the cached handle oclass */
+	/* Cache the updated default child oclass on the open directory handle. */
+	obj->d.oclass = cid;
+
+	/** if this is root obj, we need to update the cached default child oclass */
 	if (daos_oid_cmp(obj->oid, dfs->root.oid) == 0)
 		dfs->root.d.oclass = cid;
 

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -2246,6 +2246,7 @@ compare_oclass(daos_handle_t coh, daos_oclass_id_t acid, daos_oclass_id_t ecid)
 {
 	int		rc;
 	daos_obj_id_t	oid = {};
+	daos_oclass_id_t normalized_ecid;
 
 	/*
 	 * get the expected oclass - this is needed to convert things with GX to fit them in current
@@ -2253,12 +2254,21 @@ compare_oclass(daos_handle_t coh, daos_oclass_id_t acid, daos_oclass_id_t ecid)
 	 */
 	rc = daos_obj_generate_oid(coh, &oid, 0, ecid, 0, 0);
 	assert_rc_equal(rc, 0);
-	ecid = daos_obj_id2class(oid);
+	normalized_ecid = daos_obj_id2class(oid);
 
-	if (acid == ecid)
+	if (acid == ecid || acid == normalized_ecid)
 		return 0;
 	else
 		return 1;
+}
+
+static daos_oclass_id_t
+expected_dir_oclass(daos_oclass_id_t cid, daos_oclass_id_t fallback)
+{
+	if (daos_cid_is_ec(cid))
+		return fallback;
+
+	return cid;
 }
 
 static void
@@ -2439,7 +2449,7 @@ dfs_test_oclass_hints(void **state)
 	/** get the dir info to query what oclass will be used */
 	rc = dfs_obj_get_info(dfs_l, dir, &oinfo);
 	assert_int_equal(rc, 0);
-	rc = compare_oclass(coh, oinfo.doi_dir_oclass_id, OC_RP_2G1);
+	rc = compare_oclass(coh, oinfo.doi_dir_oclass_id, expected_dir_oclass(ecidx, OC_RP_2G1));
 	assert_int_equal(rc, 0);
 	rc = compare_oclass(coh, oinfo.doi_file_oclass_id, ecidx);
 	assert_int_equal(rc, 0);
@@ -2506,7 +2516,7 @@ dfs_test_oclass_hints(void **state)
 	/** get the dir info to query what oclass will be used */
 	rc = dfs_obj_get_info(dfs_l, dir, &oinfo);
 	assert_int_equal(rc, 0);
-	rc = compare_oclass(coh, oinfo.doi_dir_oclass_id, OC_RP_3G1);
+	rc = compare_oclass(coh, oinfo.doi_dir_oclass_id, expected_dir_oclass(ecidx, OC_RP_3G1));
 	assert_int_equal(rc, 0);
 	rc = compare_oclass(coh, oinfo.doi_file_oclass_id, ecidx);
 	assert_int_equal(rc, 0);
@@ -2573,7 +2583,7 @@ dfs_test_oclass_hints(void **state)
 	/** get the dir info to query what oclass will be used */
 	rc = dfs_obj_get_info(dfs_l, dir, &oinfo);
 	assert_int_equal(rc, 0);
-	rc = compare_oclass(coh, oinfo.doi_dir_oclass_id, OC_RP_4G1);
+	rc = compare_oclass(coh, oinfo.doi_dir_oclass_id, expected_dir_oclass(ecidx, OC_RP_4G1));
 	assert_int_equal(rc, 0);
 	rc = compare_oclass(coh, oinfo.doi_file_oclass_id, ecidx);
 	assert_int_equal(rc, 0);


### PR DESCRIPTION
…(#18286)

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
