### PR TITLE
DAOS-18078 test: Fix pool/rf.py

### DIFF
--- a/src/tests/ftest/pool/rf.yaml
+++ b/src/tests/ftest/pool/rf.yaml
@@ -6,16 +6,12 @@ timeout: 300
 
 server_config:
   engines_per_host: 1
-  system_ram_reserved: 21
   engines:
     0:
-      storage:
-        0:
-          class: ram
-          scm_mount: /mnt/daos0
+      storage: auto
 
 pool:
-  scm_size: 1G
+  size: 10%
   properties: rd_fac:4
 
 container:


### PR DESCRIPTION
Remove the system_ram_reserved server config setting to make use of the default.  This should avoid the Available memory (RAM) insufficient error being seen with this test.  Also update the server storage and pool size settings to allow the test to be used to verify MD on SSD configurtations.

Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
