### PR TITLE
DAOS-18859 test: No fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -329,10 +329,10 @@ pipeline {
                      defaultValue: true,
                      description: 'Run the Fault injection testing test stage')
         booleanParam(name: 'CI_TEST_EL_RPMs',
-                     defaultValue: true,
+                     defaultValue: false,
                      description: 'Run the Test RPMs on EL stage')
         booleanParam(name: 'CI_TEST_LEAP_RPMs',
-                     defaultValue: true,
+                     defaultValue: false,
                      description: 'Run the Test RPMs on Leap test stage')
         booleanParam(name: 'CI_FUNCTIONAL_TEST_SKIP',
                      defaultValue: false,
@@ -395,7 +395,7 @@ pipeline {
                defaultValue: 'ci_nlt_1',
                description: 'Label to use for NLT tests')
         string(name: 'FUNCTIONAL_HARDWARE_MEDIUM_LABEL',
-               defaultValue: 'ci_nvme5',
+               defaultValue: 'ci_node-hdr-120_122-125',
                description: 'Label to use for the Functional Hardware Medium (MD on SSD) stages')
         string(name: 'FUNCTIONAL_HARDWARE_MEDIUM_VERBS_PROVIDER_LABEL',
                defaultValue: 'ci_ofed5',
@@ -612,7 +612,8 @@ pipeline {
                                            build_deps: 'no',
                                            stash_opt: true,
                                            scons_args: sconsArgs() +
-                                                      ' PREFIX=/opt/daos TARGET_TYPE=release'))
+                                                      ' PREFIX=/opt/daos TARGET_TYPE=release' +
+                                                      ' BUILD_TYPE=debug SANITIZERS=address'))
                             sh label: 'Generate RPMs',
                                 script: './ci/rpm/gen_rpms.sh el9 "' + env.DAOS_RELVAL + '"'
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -613,7 +613,7 @@ pipeline {
                                            stash_opt: true,
                                            scons_args: sconsArgs() +
                                                       ' PREFIX=/opt/daos TARGET_TYPE=release' +
-                                                      ' BUILD_TYPE=debug SANITIZERS=address'))
+                                                      ' BUILD_TYPE=debug SANITIZERS=thread'))
                             sh label: 'Generate RPMs',
                                 script: './ci/rpm/gen_rpms.sh el9 "' + env.DAOS_RELVAL + '"'
                         }

--- a/SConstruct
+++ b/SConstruct
@@ -371,7 +371,8 @@ def load_local(env_script, env):
 
 
 # Environment variables that are kept when SCONS_ENV=minimal (the default).
-MINIMAL_ENV = ('HOME', 'TERM', 'SSH_AUTH_SOCK', 'http_proxy', 'https_proxy', 'PKG_CONFIG_PATH',
+MINIMAL_ENV = ('HOME', 'TERM', 'SSH_AUTH_SOCK', 'http_proxy', 'https_proxy',
+               'no_proxy', 'NO_PROXY', 'PKG_CONFIG_PATH',
                'MODULEPATH', 'MODULESHOME', 'MODULESLOADED', 'I_MPI_ROOT', 'COVFILE')
 
 # Environment variables that are also kept when LD_PRELOAD is set.

--- a/ci/rpm/build.sh
+++ b/ci/rpm/build.sh
@@ -25,8 +25,10 @@ if [ -e "${ci_envs}" ]; then
   source "${ci_envs}"
 fi
 
-: "${SCONS_FAULTS_ARGS:=BUILD_TYPE=dev}"
-SCONS_ARGS="${SCONS_FAULTS_ARGS}"
+: "${SCONS_FAULTS_ARGS:=BUILD_TYPE=debug}"
+# Always add SANITIZERS=address for DAOS-18859 UAF debugging, regardless of
+# what SCONS_FAULTS_ARGS was set to by the Jenkins environment.
+SCONS_ARGS="${SCONS_FAULTS_ARGS} SANITIZERS=address"
 
 : "${CHROOT_NAME:='rocky+epel-8-x86_64'}"
 : "${TARGET:='el8'}"

--- a/ci/rpm/build.sh
+++ b/ci/rpm/build.sh
@@ -26,9 +26,9 @@ if [ -e "${ci_envs}" ]; then
 fi
 
 : "${SCONS_FAULTS_ARGS:=BUILD_TYPE=debug}"
-# Always add SANITIZERS=address for DAOS-18859 UAF debugging, regardless of
+# Always add SANITIZERS=thread for DAOS-18859 race debugging, regardless of
 # what SCONS_FAULTS_ARGS was set to by the Jenkins environment.
-SCONS_ARGS="${SCONS_FAULTS_ARGS} SANITIZERS=address"
+SCONS_ARGS="${SCONS_FAULTS_ARGS} SANITIZERS=thread"
 
 : "${CHROOT_NAME:='rocky+epel-8-x86_64'}"
 : "${TARGET:='el8'}"

--- a/ci/unit/required_packages.sh
+++ b/ci/unit/required_packages.sh
@@ -39,6 +39,7 @@ pkgs="boost-python3$PY_MINOR_VER-devel                               \
       hwloc-devel                                                    \
       libasan                                                        \
       libipmctl-devel                                                \
+      libtsan                                                        \
       libyaml-devel                                                  \
       numactl                                                        \
       numactl-devel                                                  \

--- a/src/client/kv/dc_kv.c
+++ b/src/client/kv/dc_kv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -94,12 +95,19 @@ kv_hdl2ptr(daos_handle_t oh)
 
 daos_handle_t daos_kv2objhandle(daos_handle_t kv_oh)
 {
-	struct dc_kv *dk = kv_hdl2ptr(kv_oh);
+	struct dc_kv *dk;
+	daos_handle_t oh;
 
-	if (dk)
-		return dk->daos_oh;
+	dk = kv_hdl2ptr(kv_oh);
+	if (dk == NULL) {
+		oh = DAOS_HDL_INVAL;
+		goto out;
+	}
+	oh = dk->daos_oh;
+	kv_decref(dk);
 
-	return DAOS_HDL_INVAL;
+out:
+	return oh;
 }
 
 static void

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -46,13 +46,29 @@ def is_release_build(benv):
     return benv.get("BUILD_TYPE") == "release"
 
 
+def get_sanitizers(benv):
+    """Return the list of requested C sanitizers, or an empty list if none."""
+    if 'SANITIZERS' not in benv or benv['SANITIZERS'] == "":
+        return []
+    return benv['SANITIZERS'].split(',')
+
+
 def get_build_flags(benv):
     """Return string of build flags"""
     if is_release_build(benv):
         return '-buildmode=pie'
-    if 'SANITIZERS' in benv and benv['SANITIZERS'] != "":
+    sanitizers = get_sanitizers(benv)
+    if 'address' in sanitizers:
         return '-asan'
-    # enable race detector for non-release builds
+    if 'thread' in sanitizers:
+        # Go's own -race flag uses a statically-linked, bundled TSan-derived runtime that is
+        # incompatible with the system libtsan pulled in by C libraries built with
+        # -fsanitize=thread (Go's build system explicitly forbids combining -race with
+        # -asan/-msan for the same reason).  Build the Go binary itself with no sanitizer flag;
+        # it still picks up thread-sanitizer instrumentation transitively via the C libraries it
+        # links against (see the CGO_CFLAGS/CGO_LDFLAGS additions below).
+        return ''
+    # enable race detector for non-release, non-sanitizer builds
     return '-race'
 
 
@@ -153,6 +169,16 @@ def scons():
         install_dir('include/spdk')
 
     denv.Tool('go_builder')
+
+    # Go's build system only auto-injects -fsanitize=address/-fsanitize=memory into cgo's own
+    # CGO_CFLAGS/CGO_LDFLAGS for -asan/-msan; there is no equivalent auto-injection for thread
+    # sanitizer (Go's own -race flag is intentionally not used with SANITIZERS=thread -- see
+    # get_build_flags() above).  Add it explicitly here so the small inline C snippets in the
+    # CGO preambles (weak-symbol ASAN/TSan glue) compile consistently with the rest of the
+    # thread-sanitizer-instrumented binary.
+    if 'thread' in get_sanitizers(denv):
+        denv.AppendENVPath("CGO_CFLAGS", "-fsanitize=thread", sep=" ")
+        denv.AppendENVPath("CGO_LDFLAGS", "-fsanitize=thread", sep=" ")
 
     # Sets CGO_LDFLAGS for rpath options
     denv.d_add_rpaths("..", True, True)

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -51,9 +51,19 @@ const char *__lsan_default_options(void) {
 // other DAOS Go binaries where it is silenced by default (report_bugs=0) to
 // avoid noise unrelated to this investigation.  Values explicitly set via
 // TSAN_OPTIONS in the environment still take precedence over this default.
+//
+// Guarded by __SANITIZE_THREAD__ (defined by GCC/Clang only when this
+// translation unit is actually compiled with -fsanitize=thread): when
+// SANITIZERS is unset, Go falls back to its own native -race flag, which
+// links Go's own bundled TSan-derived runtime.  That runtime already defines
+// __tsan_default_options() itself, so defining it unconditionally here causes
+// "multiple definition of `__tsan_default_options'" at link time for any
+// ordinary -race build (observed across EL8/EL9/Leap15 in build_023).
+#ifdef __SANITIZE_THREAD__
 const char *__tsan_default_options(void) {
 	return "halt_on_error=0:report_signal_unsafe=0:history_size=7:second_deadlock_stack=1";
 }
+#endif
 
 // Weak reference — resolves to the real LSAN function in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -25,6 +25,7 @@ import (
 
 /*
 #include "util.h"
+#include <stdlib.h>
 
 // Weak reference — resolves to the real LSAN function in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);
@@ -32,10 +33,17 @@ extern void __attribute__((weak)) __lsan_do_leak_check(void);
 // Go's runtime calls exit_group() directly when it exits, bypassing libc's exit()
 // and therefore ASAN's registered atexit() handlers.  Call the leak-checker explicitly
 // so that an ASAN report is written to log_path when leaks are detected.
+//
+// __lsan_do_leak_check() is LSAN's on-demand API: unlike the implicit atexit-based
+// check, it ignores ASAN_OPTIONS=detect_leaks=0 and always performs a stop-the-world
+// scan.  On some CI hosts this scan aborts with "LeakSanitizer has encountered a
+// fatal error", failing the command even though the underlying operation succeeded.
+// Make the call opt-in via DAOS_ASAN_LEAK_CHECK=1 so routine CLI invocations are
+// unaffected.
 // Note: use-after-free crashes are reported immediately by ASAN's signal handler and
 // do not depend on this call.
 static void run_asan_fini(void) {
-	if (__lsan_do_leak_check)
+	if (__lsan_do_leak_check && getenv("DAOS_ASAN_LEAK_CHECK"))
 		__lsan_do_leak_check();
 }
 */

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -25,6 +25,19 @@ import (
 
 /*
 #include "util.h"
+
+// Weak reference — resolves to the real LSAN function in ASAN builds, NULL otherwise.
+extern void __attribute__((weak)) __lsan_do_leak_check(void);
+
+// Go's runtime calls exit_group() directly when it exits, bypassing libc's exit()
+// and therefore ASAN's registered atexit() handlers.  Call the leak-checker explicitly
+// so that an ASAN report is written to log_path when leaks are detected.
+// Note: use-after-free crashes are reported immediately by ASAN's signal handler and
+// do not depend on this call.
+static void run_asan_fini(void) {
+	if (__lsan_do_leak_check)
+		__lsan_do_leak_check();
+}
 */
 import "C"
 
@@ -331,6 +344,10 @@ func (cmd *poolAutoTestCmd) Execute(_ []string) error {
 	ap.deadline_limit = C.int(cmd.DeadlineLimit)
 
 	rc := C.pool_autotest_hdlr(ap)
+	// Explicit ASAN/LSAN finalization: Go exits via exit_group syscall which bypasses
+	// libc's exit() and therefore ASAN's atexit() handlers.  Force the report here so
+	// that the log_path file is written before the process terminates.
+	C.run_asan_fini()
 	if err := daosError(rc); err != nil {
 		return errors.Wrapf(err, "failed to run autotest for pool %s", cmd.PoolID())
 	}

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -32,6 +32,17 @@ import (
 // the build for genuine system headers.  Declare getenv() directly instead.
 extern char *getenv(const char *name);
 
+// Compiled-in default LSAN options, used whenever ASAN_OPTIONS/LSAN_OPTIONS is not
+// set in the environment.  Without this hook, LSAN falls back to its own default of
+// detect_leaks=1 and performs a stop-the-world ptrace-based scan whenever the
+// process exits through any path that runs libc atexit handlers.  That scan aborts
+// with "LeakSanitizer has encountered a fatal error" on some CI hosts (likely a
+// ptrace restriction).  Values explicitly set via ASAN_OPTIONS/LSAN_OPTIONS in the
+// environment still take precedence over this compiled-in default.
+const char *__lsan_default_options(void) {
+	return "detect_leaks=0";
+}
+
 // Weak reference — resolves to the real LSAN function in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);
 

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -43,6 +43,18 @@ const char *__lsan_default_options(void) {
 	return "detect_leaks=0";
 }
 
+// Compiled-in default TSAN options for the daos CLI, used whenever
+// TSAN_OPTIONS is not set in the environment.  This binary is the reproduction
+// target for DAOS-18859 (the suspected use-after-free is a race between a
+// background CaRT/Mercury TLS thread and the main thread, both inside this
+// process, during pool connect) so TSan reporting is enabled here, unlike the
+// other DAOS Go binaries where it is silenced by default (report_bugs=0) to
+// avoid noise unrelated to this investigation.  Values explicitly set via
+// TSAN_OPTIONS in the environment still take precedence over this default.
+const char *__tsan_default_options(void) {
+	return "halt_on_error=0:report_signal_unsafe=0:history_size=7:second_deadlock_stack=1";
+}
+
 // Weak reference — resolves to the real LSAN function in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);
 

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -25,7 +25,12 @@ import (
 
 /*
 #include "util.h"
-#include <stdlib.h>
+
+// Note: intentionally not "#include <stdlib.h>" -- SCons' Go dependency scanner
+// (site_scons/site_tools/go_builder.py) treats every "#include <...>" line in a
+// CGO preamble as a DAOS public header located under src/include/, which breaks
+// the build for genuine system headers.  Declare getenv() directly instead.
+extern char *getenv(const char *name);
 
 // Weak reference — resolves to the real LSAN function in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);

--- a/src/control/cmd/daos_server/asan.go
+++ b/src/control/cmd/daos_server/asan.go
@@ -1,0 +1,28 @@
+//
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+/*
+// Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
+extern void __attribute__((weak)) __lsan_do_leak_check(void);
+
+// Go exits via exit_group syscall, bypassing libc exit() and ASAN's atexit handlers.
+// Call these explicitly before the process terminates so that ASAN reports are written
+// to log_path even when the process exits via Go's runtime.
+static void run_asan_fini(void) {
+	if (__lsan_do_leak_check)
+		__lsan_do_leak_check();
+}
+*/
+import "C"
+
+// runASANFini explicitly invokes ASAN/LSAN finalization.  Must be called at every
+// exit point in main() because Go's runtime calls exit_group() directly, bypassing
+// libc's exit() and therefore ASAN's registered atexit() handlers.
+func runASANFini() {
+	C.run_asan_fini()
+}

--- a/src/control/cmd/daos_server/asan.go
+++ b/src/control/cmd/daos_server/asan.go
@@ -7,14 +7,23 @@
 package main
 
 /*
+#include <stdlib.h>
+
 // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);
 
 // Go exits via exit_group syscall, bypassing libc exit() and ASAN's atexit handlers.
 // Call these explicitly before the process terminates so that ASAN reports are written
 // to log_path even when the process exits via Go's runtime.
+//
+// __lsan_do_leak_check() is LSAN's on-demand API: unlike the implicit atexit-based
+// check, it ignores ASAN_OPTIONS=detect_leaks=0 and always performs a stop-the-world
+// scan.  On some CI hosts this scan aborts with "LeakSanitizer has encountered a
+// fatal error" (observed with daos_server nvme reset on CI hardware), failing the
+// command even though the underlying operation succeeded.  Make the call opt-in via
+// DAOS_ASAN_LEAK_CHECK=1 so routine CLI invocations are unaffected.
 static void run_asan_fini(void) {
-	if (__lsan_do_leak_check)
+	if (__lsan_do_leak_check && getenv("DAOS_ASAN_LEAK_CHECK"))
 		__lsan_do_leak_check();
 }
 */

--- a/src/control/cmd/daos_server/asan.go
+++ b/src/control/cmd/daos_server/asan.go
@@ -13,6 +13,23 @@ package main
 // the build for genuine system headers.  Declare getenv() directly instead.
 extern char *getenv(const char *name);
 
+// Compiled-in default LSAN options, used whenever ASAN_OPTIONS/LSAN_OPTIONS is not
+// set in the environment.  daos_server_helper is spawned as a privileged sub-process
+// by daos_server (see pbin.ExecReq, which sets child.Env = os.Environ()) and so only
+// inherits whatever environment daos_server itself was started with -- routine
+// invocations (e.g. "daos_server nvme reset" from the ftest framework) do not set
+// ASAN_OPTIONS at all.  Without this hook, LSAN falls back to its own default of
+// detect_leaks=1 and performs a stop-the-world ptrace-based scan whenever the
+// process exits through any path that runs libc atexit handlers (including from
+// within CGO/SPDK C code, which does not bypass atexit() the way Go's own exit path
+// does).  That scan aborts with "LeakSanitizer has encountered a fatal error" on
+// some CI hosts (likely a ptrace restriction).  Values explicitly set via
+// ASAN_OPTIONS/LSAN_OPTIONS in the environment still take precedence over this
+// compiled-in default.
+const char *__lsan_default_options(void) {
+	return "detect_leaks=0";
+}
+
 // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);
 

--- a/src/control/cmd/daos_server/asan.go
+++ b/src/control/cmd/daos_server/asan.go
@@ -39,9 +39,19 @@ const char *__lsan_default_options(void) {
 // without needing a separate non-instrumented build of the linked C
 // libraries.  Values explicitly set via TSAN_OPTIONS in the environment still
 // take precedence over this default.
+//
+// Guarded by __SANITIZE_THREAD__ (defined by GCC/Clang only when this
+// translation unit is actually compiled with -fsanitize=thread): when
+// SANITIZERS is unset, Go falls back to its own native -race flag, which
+// links Go's own bundled TSan-derived runtime.  That runtime already defines
+// __tsan_default_options() itself, so defining it unconditionally here causes
+// "multiple definition of `__tsan_default_options'" at link time for any
+// ordinary -race build (observed across EL8/EL9/Leap15 in build_023).
+#ifdef __SANITIZE_THREAD__
 const char *__tsan_default_options(void) {
 	return "report_bugs=0";
 }
+#endif
 
 // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);

--- a/src/control/cmd/daos_server/asan.go
+++ b/src/control/cmd/daos_server/asan.go
@@ -7,7 +7,11 @@
 package main
 
 /*
-#include <stdlib.h>
+// Note: intentionally not "#include <stdlib.h>" -- SCons' Go dependency scanner
+// (site_scons/site_tools/go_builder.py) treats every "#include <...>" line in a
+// CGO preamble as a DAOS public header located under src/include/, which breaks
+// the build for genuine system headers.  Declare getenv() directly instead.
+extern char *getenv(const char *name);
 
 // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);

--- a/src/control/cmd/daos_server/asan.go
+++ b/src/control/cmd/daos_server/asan.go
@@ -30,6 +30,19 @@ const char *__lsan_default_options(void) {
 	return "detect_leaks=0";
 }
 
+// Compiled-in default TSAN options for daos_server.  This is a control-plane
+// management daemon, not the DAOS-18859 reproduction target (the suspected
+// race is client-side, inside the daos CLI process during pool connect -- see
+// pool.go).  Silence TSan reporting outright: report_bugs is a genuine,
+// documented sanitizer_common flag that keeps all instrumentation active but
+// suppresses bug reports, avoiding noise unrelated to this investigation
+// without needing a separate non-instrumented build of the linked C
+// libraries.  Values explicitly set via TSAN_OPTIONS in the environment still
+// take precedence over this default.
+const char *__tsan_default_options(void) {
+	return "report_bugs=0";
+}
+
 // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);
 

--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -89,6 +90,7 @@ func exitWithError(log *logging.LeveledLogger, err error) {
 	if fault.HasResolution(err) {
 		log.Error(fault.ShowResolutionFor(err))
 	}
+	runASANFini()
 	os.Exit(1)
 }
 
@@ -216,12 +218,15 @@ func main() {
 	if err := parseOpts(os.Args[1:], &opts, log); err != nil {
 		if errors.Cause(err) == context.Canceled {
 			log.Infof("%s (pid %d) shutting down", build.ControlPlaneName, os.Getpid())
+			runASANFini()
 			os.Exit(0)
 		}
 		if fe, ok := errors.Cause(err).(*flags.Error); ok && fe.Type == flags.ErrHelp {
 			log.Info(fe.Error())
+			runASANFini()
 			os.Exit(0)
 		}
 		exitWithError(log, err)
 	}
+	runASANFini()
 }

--- a/src/control/cmd/daos_server_helper/asan.go
+++ b/src/control/cmd/daos_server_helper/asan.go
@@ -42,9 +42,19 @@ const char *__lsan_default_options(void) {
 // flag that keeps all instrumentation active but suppresses bug reports.
 // Values explicitly set via TSAN_OPTIONS in the environment still take
 // precedence over this default.
+//
+// Guarded by __SANITIZE_THREAD__ (defined by GCC/Clang only when this
+// translation unit is actually compiled with -fsanitize=thread): when
+// SANITIZERS is unset, Go falls back to its own native -race flag, which
+// links Go's own bundled TSan-derived runtime.  That runtime already defines
+// __tsan_default_options() itself, so defining it unconditionally here causes
+// "multiple definition of `__tsan_default_options'" at link time for any
+// ordinary -race build (observed across EL8/EL9/Leap15 in build_023).
+#ifdef __SANITIZE_THREAD__
 const char *__tsan_default_options(void) {
 	return "report_bugs=0";
 }
+#endif
 
 // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);

--- a/src/control/cmd/daos_server_helper/asan.go
+++ b/src/control/cmd/daos_server_helper/asan.go
@@ -1,0 +1,28 @@
+//
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+/*
+// Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
+extern void __attribute__((weak)) __lsan_do_leak_check(void);
+
+// Go exits via exit_group syscall, bypassing libc exit() and ASAN's atexit handlers.
+// Call these explicitly before the process terminates so that ASAN reports are written
+// to log_path even when the process exits via Go's runtime.
+static void run_asan_fini(void) {
+	if (__lsan_do_leak_check)
+		__lsan_do_leak_check();
+}
+*/
+import "C"
+
+// runASANFini explicitly invokes ASAN/LSAN finalization.  Must be called at every
+// exit point in main() because Go's runtime calls exit_group() directly, bypassing
+// libc's exit() and therefore ASAN's registered atexit() handlers.
+func runASANFini() {
+	C.run_asan_fini()
+}

--- a/src/control/cmd/daos_server_helper/asan.go
+++ b/src/control/cmd/daos_server_helper/asan.go
@@ -7,14 +7,23 @@
 package main
 
 /*
+#include <stdlib.h>
+
 // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);
 
 // Go exits via exit_group syscall, bypassing libc exit() and ASAN's atexit handlers.
 // Call these explicitly before the process terminates so that ASAN reports are written
 // to log_path even when the process exits via Go's runtime.
+//
+// __lsan_do_leak_check() is LSAN's on-demand API: unlike the implicit atexit-based
+// check, it ignores ASAN_OPTIONS=detect_leaks=0 and always performs a stop-the-world
+// scan.  On some CI hosts this scan aborts with "LeakSanitizer has encountered a
+// fatal error" (observed with daos_server nvme reset on CI hardware), failing the
+// command even though the underlying operation succeeded.  Make the call opt-in via
+// DAOS_ASAN_LEAK_CHECK=1 so routine CLI invocations are unaffected.
 static void run_asan_fini(void) {
-	if (__lsan_do_leak_check)
+	if (__lsan_do_leak_check && getenv("DAOS_ASAN_LEAK_CHECK"))
 		__lsan_do_leak_check();
 }
 */

--- a/src/control/cmd/daos_server_helper/asan.go
+++ b/src/control/cmd/daos_server_helper/asan.go
@@ -30,6 +30,22 @@ const char *__lsan_default_options(void) {
 	return "detect_leaks=0";
 }
 
+// Compiled-in default TSAN options for daos_server_helper.  This is a
+// privileged sub-process spawned by daos_server (pbin.ExecReq sets
+// child.Env = os.Environ(), so it inherits whatever environment daos_server
+// itself was started with) and is not the DAOS-18859 reproduction target (the
+// suspected race is client-side, inside the daos CLI process during pool
+// connect -- see pool.go).  This binary needs its own compiled-in default
+// rather than relying on inheriting daos_server's environment, since a
+// compiled-in default applies regardless of invocation path.  Silence TSan
+// reporting outright: report_bugs is a genuine, documented sanitizer_common
+// flag that keeps all instrumentation active but suppresses bug reports.
+// Values explicitly set via TSAN_OPTIONS in the environment still take
+// precedence over this default.
+const char *__tsan_default_options(void) {
+	return "report_bugs=0";
+}
+
 // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);
 

--- a/src/control/cmd/daos_server_helper/asan.go
+++ b/src/control/cmd/daos_server_helper/asan.go
@@ -13,6 +13,23 @@ package main
 // the build for genuine system headers.  Declare getenv() directly instead.
 extern char *getenv(const char *name);
 
+// Compiled-in default LSAN options, used whenever ASAN_OPTIONS/LSAN_OPTIONS is not
+// set in the environment.  daos_server_helper is spawned as a privileged sub-process
+// by daos_server (see pbin.ExecReq, which sets child.Env = os.Environ()) and so only
+// inherits whatever environment daos_server itself was started with -- routine
+// invocations (e.g. "daos_server nvme reset" from the ftest framework) do not set
+// ASAN_OPTIONS at all.  Without this hook, LSAN falls back to its own default of
+// detect_leaks=1 and performs a stop-the-world ptrace-based scan whenever the
+// process exits through any path that runs libc atexit handlers (including from
+// within CGO/SPDK C code, which does not bypass atexit() the way Go's own exit path
+// does).  That scan aborts with "LeakSanitizer has encountered a fatal error" on
+// some CI hosts (likely a ptrace restriction).  Values explicitly set via
+// ASAN_OPTIONS/LSAN_OPTIONS in the environment still take precedence over this
+// compiled-in default.
+const char *__lsan_default_options(void) {
+	return "detect_leaks=0";
+}
+
 // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);
 

--- a/src/control/cmd/daos_server_helper/asan.go
+++ b/src/control/cmd/daos_server_helper/asan.go
@@ -7,7 +7,11 @@
 package main
 
 /*
-#include <stdlib.h>
+// Note: intentionally not "#include <stdlib.h>" -- SCons' Go dependency scanner
+// (site_scons/site_tools/go_builder.py) treats every "#include <...>" line in a
+// CGO preamble as a DAOS public header located under src/include/, which breaks
+// the build for genuine system headers.  Declare getenv() directly instead.
+extern char *getenv(const char *name);
 
 // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
 extern void __attribute__((weak)) __lsan_do_leak_check(void);

--- a/src/control/cmd/daos_server_helper/main.go
+++ b/src/control/cmd/daos_server_helper/main.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 // (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -24,6 +25,7 @@ func main() {
 	addMethodHandlers(app)
 
 	err := app.Run()
+	runASANFini()
 	if err != nil {
 		os.Exit(1)
 	}

--- a/src/control/cmd/ddb/commands_wrapper.go
+++ b/src/control/cmd/ddb/commands_wrapper.go
@@ -23,6 +23,16 @@ import (
 
  #include <ddb.h>
  #include <daos_errno.h>
+
+ // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
+ extern void __attribute__((weak)) __lsan_do_leak_check(void);
+
+ // Go exits via exit_group syscall, bypassing libc exit() and ASAN's atexit handlers.
+ // Call these explicitly at the end of the ddb session so that ASAN reports are written.
+ static void run_asan_fini(void) {
+     if (__lsan_do_leak_check)
+         __lsan_do_leak_check();
+ }
 */
 import "C"
 
@@ -62,6 +72,9 @@ func InitDdb(log *logging.LeveledLogger) (*DdbContext, func(), error) {
 
 	return ctx, func() {
 		C.ddb_fini()
+		// Explicit ASAN/LSAN finalization: Go exits via exit_group syscall which bypasses
+		// libc's exit() and therefore ASAN's atexit() handlers.  Force the report here.
+		C.run_asan_fini()
 		runtime.UnlockOSThread()
 	}, nil
 }

--- a/src/control/cmd/ddb/commands_wrapper.go
+++ b/src/control/cmd/ddb/commands_wrapper.go
@@ -23,7 +23,12 @@ import (
 
  #include <ddb.h>
  #include <daos_errno.h>
- #include <stdlib.h>
+
+ // Note: intentionally not "#include <stdlib.h>" -- SCons' Go dependency scanner
+ // (site_scons/site_tools/go_builder.py) treats every "#include <...>" line in a
+ // CGO preamble as a DAOS public header located under src/include/, which breaks
+ // the build for genuine system headers.  Declare getenv() directly instead.
+ extern char *getenv(const char *name);
 
  // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
  extern void __attribute__((weak)) __lsan_do_leak_check(void);

--- a/src/control/cmd/ddb/commands_wrapper.go
+++ b/src/control/cmd/ddb/commands_wrapper.go
@@ -49,9 +49,19 @@ import (
  // sanitizer_common flag that keeps all instrumentation active but suppresses
  // bug reports.  Values explicitly set via TSAN_OPTIONS in the environment
  // still take precedence over this default.
+ //
+ // Guarded by __SANITIZE_THREAD__ (defined by GCC/Clang only when this
+ // translation unit is actually compiled with -fsanitize=thread): when
+ // SANITIZERS is unset, Go falls back to its own native -race flag, which
+ // links Go's own bundled TSan-derived runtime.  That runtime already defines
+ // __tsan_default_options() itself, so defining it unconditionally here
+ // causes "multiple definition of `__tsan_default_options'" at link time for
+ // any ordinary -race build (observed across EL8/EL9/Leap15 in build_023).
+ #ifdef __SANITIZE_THREAD__
  const char *__tsan_default_options(void) {
      return "report_bugs=0";
  }
+ #endif
 
  // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
  extern void __attribute__((weak)) __lsan_do_leak_check(void);

--- a/src/control/cmd/ddb/commands_wrapper.go
+++ b/src/control/cmd/ddb/commands_wrapper.go
@@ -41,6 +41,18 @@ import (
      return "detect_leaks=0";
  }
 
+ // Compiled-in default TSAN options for ddb.  This is a standalone diagnostic
+ // tool, not the DAOS-18859 reproduction target (the suspected race is
+ // client-side, inside the daos CLI process during pool connect -- see
+ // pool.go) and not part of this investigation's active test path.  Silence
+ // TSan reporting outright: report_bugs is a genuine, documented
+ // sanitizer_common flag that keeps all instrumentation active but suppresses
+ // bug reports.  Values explicitly set via TSAN_OPTIONS in the environment
+ // still take precedence over this default.
+ const char *__tsan_default_options(void) {
+     return "report_bugs=0";
+ }
+
  // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
  extern void __attribute__((weak)) __lsan_do_leak_check(void);
 

--- a/src/control/cmd/ddb/commands_wrapper.go
+++ b/src/control/cmd/ddb/commands_wrapper.go
@@ -30,6 +30,17 @@ import (
  // the build for genuine system headers.  Declare getenv() directly instead.
  extern char *getenv(const char *name);
 
+ // Compiled-in default LSAN options, used whenever ASAN_OPTIONS/LSAN_OPTIONS is not
+ // set in the environment.  Without this hook, LSAN falls back to its own default of
+ // detect_leaks=1 and performs a stop-the-world ptrace-based scan whenever the
+ // process exits through any path that runs libc atexit handlers.  That scan aborts
+ // with "LeakSanitizer has encountered a fatal error" on some CI hosts (likely a
+ // ptrace restriction).  Values explicitly set via ASAN_OPTIONS/LSAN_OPTIONS in the
+ // environment still take precedence over this compiled-in default.
+ const char *__lsan_default_options(void) {
+     return "detect_leaks=0";
+ }
+
  // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
  extern void __attribute__((weak)) __lsan_do_leak_check(void);
 

--- a/src/control/cmd/ddb/commands_wrapper.go
+++ b/src/control/cmd/ddb/commands_wrapper.go
@@ -23,14 +23,21 @@ import (
 
  #include <ddb.h>
  #include <daos_errno.h>
+ #include <stdlib.h>
 
  // Weak references — resolve to real ASAN/LSAN functions in ASAN builds, NULL otherwise.
  extern void __attribute__((weak)) __lsan_do_leak_check(void);
 
  // Go exits via exit_group syscall, bypassing libc exit() and ASAN's atexit handlers.
  // Call these explicitly at the end of the ddb session so that ASAN reports are written.
+ //
+ // __lsan_do_leak_check() is LSAN's on-demand API: unlike the implicit atexit-based
+ // check, it ignores ASAN_OPTIONS=detect_leaks=0 and always performs a stop-the-world
+ // scan, which can abort with "LeakSanitizer has encountered a fatal error" on some CI
+ // hosts.  Make the call opt-in via DAOS_ASAN_LEAK_CHECK=1 so routine ddb invocations
+ // are unaffected.
  static void run_asan_fini(void) {
-     if (__lsan_do_leak_check)
+     if (__lsan_do_leak_check && getenv("DAOS_ASAN_LEAK_CHECK"))
          __lsan_do_leak_check();
  }
 */

--- a/src/control/lib/spdk/ctests/nvme_control_ut.c
+++ b/src/control/lib/spdk/ctests/nvme_control_ut.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2019-2021 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -22,7 +22,7 @@
 	#pragma GCC diagnostic ignored "-Wframe-larger-than="
 #endif
 
-static struct ret_t	*test_ret;
+static struct ret_t *test_ret;
 
 /**
  * ==============================
@@ -299,15 +299,11 @@ int
 main(void)
 {
 	const struct CMUnitTest tests[] = {
-		cmocka_unit_test_setup_teardown(test_discover_null_controllers,
-						setup, teardown),
-		cmocka_unit_test_setup_teardown(test_discover_set_controllers,
-						setup, teardown),
-		cmocka_unit_test_setup_teardown(test_discover_probe_fail, setup,
-						teardown),
-		cmocka_unit_test_setup_teardown(test_collect, setup, teardown),
-		cmocka_unit_test_setup_teardown(test_get_controller, setup,
-						teardown),
+	    cmocka_unit_test_setup_teardown(test_discover_null_controllers, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_discover_set_controllers, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_discover_probe_fail, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_collect, setup, teardown),
+	    cmocka_unit_test_setup_teardown(test_get_controller, setup, teardown),
 	};
 
 	return cmocka_run_group_tests_name("control_nvme_control_ut", tests,

--- a/src/control/lib/spdk/src/nvme_control.c
+++ b/src/control/lib/spdk/src/nvme_control.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -522,6 +523,7 @@ daos_spdk_init(int mem_sz, char *env_ctx, size_t nr_pcil, char **pcil)
 	}
 
 out:
+	free(opts.pci_allowed);
 	ret->rc = rc;
 	return ret;
 }

--- a/src/control/lib/spdk/src/nvme_control_common.c
+++ b/src/control/lib/spdk/src/nvme_control_common.c
@@ -138,6 +138,8 @@ free_ctrlr_fields(struct nvme_ctrlr_t *ctrlr)
 		free(ctrlr->vendor_id);
 	if (ctrlr->pci_type != NULL)
 		free(ctrlr->pci_type);
+	if (ctrlr->pci_addr != NULL)
+		free(ctrlr->pci_addr);
 }
 
 void

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -235,6 +235,9 @@ d_aligned_alloc(size_t alignment, size_t size, bool zero)
 {
 	void *buf;
 
+	/* POSIX requires size to be a multiple of alignment; round up to satisfy
+	 * strict allocators (e.g. ASAN) without changing the callers. */
+	size = D_ALIGNUP(size, alignment);
 	buf = aligned_alloc(alignment, size);
 	if (unlikely(track_arg != NULL)) {
 		if (buf != NULL)

--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -1201,6 +1201,54 @@ test_gurt_alloc(void **state)
 	d_log_fini();
 }
 
+/* d_aligned_alloc must round size up to a multiple of alignment before calling
+ * aligned_alloc, which is required by the C11 standard.  Strict allocators such
+ * as ASAN abort when size is not a multiple of alignment. */
+static void
+test_gurt_aligned_alloc(void **state)
+{
+	char   zero_ref[512] = {0};
+	char  *ptr;
+	size_t alignment = 64;
+
+	/* Baseline: size already a multiple of alignment; verify alignment and
+	 * zero-initialisation. */
+	D_ALIGNED_ALLOC(ptr, alignment, sizeof(zero_ref));
+	assert_non_null(ptr);
+	assert_int_equal((uintptr_t)ptr % alignment, 0);
+	assert_memory_equal(ptr, &zero_ref[0], sizeof(zero_ref));
+	D_FREE(ptr);
+
+	/* Regression: size NOT a multiple of alignment (exact case from the
+	 * ticket: aligned_alloc(64, 516784) where 516784 % 64 == 48). */
+	D_ALIGNED_ALLOC(ptr, alignment, 516784);
+	assert_non_null(ptr);
+	assert_int_equal((uintptr_t)ptr % alignment, 0);
+	D_FREE(ptr);
+
+	/* size < alignment: rounded-up size equals alignment itself; verify
+	 * alignment and zero-initialisation. */
+	D_ALIGNED_ALLOC(ptr, alignment, 1);
+	assert_non_null(ptr);
+	assert_int_equal((uintptr_t)ptr % alignment, 0);
+	assert_memory_equal(ptr, &zero_ref[0], 1);
+	D_FREE(ptr);
+
+	/* size < alignment: rounded-up size equals alignment itself; verify
+	 * alignment and zero-initialisation. */
+	D_ALIGNED_ALLOC(ptr, alignment, alignment - 1);
+	assert_non_null(ptr);
+	assert_int_equal((uintptr_t)ptr % alignment, 0);
+	assert_memory_equal(ptr, &zero_ref[0], alignment - 1);
+	D_FREE(ptr);
+
+	/* Non-zero path (no zeroing) with unaligned size. */
+	D_ALIGNED_ALLOC_NZ(ptr, alignment, 513);
+	assert_non_null(ptr);
+	assert_int_equal((uintptr_t)ptr % alignment, 0);
+	D_FREE(ptr);
+}
+
 struct hash_thread_arg {
 	struct test_hash_entry	**entries;
 	struct d_hash_table	 *thtab;
@@ -2744,6 +2792,7 @@ main(int argc, char **argv)
 	    cmocka_unit_test(test_gurt_hash_insert_lookup_delete),
 	    cmocka_unit_test(test_gurt_hash_decref),
 	    cmocka_unit_test(test_gurt_alloc),
+	    cmocka_unit_test(test_gurt_aligned_alloc),
 	    cmocka_unit_test(test_gurt_hash_parallel_same_operations),
 	    cmocka_unit_test(test_gurt_hash_parallel_different_operations),
 	    cmocka_unit_test(test_gurt_hash_parallel_refcounting),

--- a/src/tests/ftest/pool/autotest.py
+++ b/src/tests/ftest/pool/autotest.py
@@ -1,8 +1,11 @@
 """
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import os
+
 from apricot import TestWithServers
 from exception_utils import CommandFailure
 
@@ -26,6 +29,21 @@ class PoolAutotestTest(TestWithServers):
         self.add_pool()
         self.pool.set_query_data()
         daos_cmd = self.get_daos_command()
+
+        # Propagate ASAN_OPTIONS to the daos client process when running with
+        # ASAN-instrumented RPMs (DAOS-18859 debugging).  If ASAN_OPTIONS is
+        # already set in the test environment (e.g. via avocado yaml), use it;
+        # otherwise fall back to a sensible default so the ASAN report goes to
+        # stderr (captured in daos.log) and halt_on_error surfaces the UAF.
+        asan_opts = os.environ.get(
+            "ASAN_OPTIONS",
+            "halt_on_error=1:atexit=1:leak_check_at_exit=1:"
+            "use_sigaltstack=1:detect_odr_violation=0:disable_coredump=1:"
+            "handle_segv=2:handle_abort=2:handle_sigfpe=2:"
+            "handle_sigill=2:handle_sigbus=2:detect_leaks=1:"
+            "max_leaks=100000:print_stats=1")
+        daos_cmd.env["ASAN_OPTIONS"] = asan_opts
+
         self.log_step("Autotest start")
         try:
             daos_cmd.pool_autotest(pool=self.pool.identifier)

--- a/src/tests/ftest/pool/autotest.py
+++ b/src/tests/ftest/pool/autotest.py
@@ -28,10 +28,20 @@ class PoolAutotestTest(TestWithServers):
         self.pool.set_query_data()
         daos_cmd = self.get_daos_command()
 
-        # Propagate ASAN_OPTIONS to the daos client process when running with
-        # ASAN-instrumented RPMs (DAOS-18859 debugging).  Leak detection is
-        # disabled (detect_leaks=0) to avoid noise from non-DAOS allocations;
-        # UAF/buffer-overflow detection (the main goal) is unaffected.
+        # Propagate ASAN_OPTIONS and TSAN_OPTIONS to the daos client process when
+        # running with sanitizer-instrumented RPMs (DAOS-18859 debugging).  Both are
+        # set unconditionally: whichever sanitizer's runtime is not actually loaded
+        # simply ignores its corresponding *_OPTIONS variable, so this works
+        # regardless of which sanitizer the RPM was built with.  This process is the
+        # DAOS-18859 reproduction target -- the suspected use-after-free is a race
+        # between a background CaRT/Mercury TLS thread and the main thread, both
+        # inside this process, during pool connect -- so reporting is enabled for
+        # both sanitizers here (unlike the other DAOS Go binaries, where TSan
+        # reporting is silenced by default to avoid unrelated noise).
+        #
+        # ASAN: leak detection is disabled (detect_leaks=0) to avoid noise from
+        # non-DAOS allocations; UAF/buffer-overflow detection (the main goal) is
+        # unaffected.
         daos_cmd.env["ASAN_OPTIONS"] = (
             "halt_on_error=0:"
             "atexit=1:"
@@ -46,6 +56,15 @@ class PoolAutotestTest(TestWithServers):
             "handle_sigbus=2:"
             "detect_leaks=0:"
             "print_stats=0"
+        )
+        # TSAN: report_signal_unsafe=0 avoids noise from DAOS's own extensive use of
+        # signal handlers for crash/error handling; history_size/second_deadlock_stack
+        # give deeper stack traces in any race report.
+        daos_cmd.env["TSAN_OPTIONS"] = (
+            "halt_on_error=0:"
+            "report_signal_unsafe=0:"
+            "history_size=7:"
+            "second_deadlock_stack=1"
         )
 
         self.log_step("Autotest start")

--- a/src/tests/ftest/pool/autotest.py
+++ b/src/tests/ftest/pool/autotest.py
@@ -4,8 +4,6 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import os
-
 from apricot import TestWithServers
 from exception_utils import CommandFailure
 
@@ -31,18 +29,24 @@ class PoolAutotestTest(TestWithServers):
         daos_cmd = self.get_daos_command()
 
         # Propagate ASAN_OPTIONS to the daos client process when running with
-        # ASAN-instrumented RPMs (DAOS-18859 debugging).  If ASAN_OPTIONS is
-        # already set in the test environment (e.g. via avocado yaml), use it;
-        # otherwise fall back to a sensible default so the ASAN report goes to
-        # stderr (captured in daos.log) and halt_on_error surfaces the UAF.
-        asan_opts = os.environ.get(
-            "ASAN_OPTIONS",
-            "halt_on_error=1:atexit=1:leak_check_at_exit=1:"
-            "use_sigaltstack=1:detect_odr_violation=0:disable_coredump=1:"
-            "handle_segv=2:handle_abort=2:handle_sigfpe=2:"
-            "handle_sigill=2:handle_sigbus=2:detect_leaks=1:"
-            "max_leaks=100000:print_stats=1")
-        daos_cmd.env["ASAN_OPTIONS"] = asan_opts
+        # ASAN-instrumented RPMs (DAOS-18859 debugging).  Leak detection is
+        # disabled (detect_leaks=0) to avoid noise from non-DAOS allocations;
+        # UAF/buffer-overflow detection (the main goal) is unaffected.
+        daos_cmd.env["ASAN_OPTIONS"] = (
+            "halt_on_error=0:"
+            "atexit=1:"
+            "leak_check_at_exit=0:"
+            "use_sigaltstack=1:"
+            "detect_odr_violation=0:"
+            "disable_coredump=1:"
+            "handle_segv=2:"
+            "handle_abort=2:"
+            "handle_sigfpe=2:"
+            "handle_sigill=2:"
+            "handle_sigbus=2:"
+            "detect_leaks=0:"
+            "print_stats=0"
+        )
 
         self.log_step("Autotest start")
         try:

--- a/src/tests/ftest/pool/autotest.yaml
+++ b/src/tests/ftest/pool/autotest.yaml
@@ -1,3 +1,6 @@
+#  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
 hosts:
   servers: !mux
     1_server:
@@ -15,6 +18,6 @@ server_config:
     0:
       storage: auto
       env_vars:
-        - ASAN_OPTIONS=halt_on_error=0:atexit=1:leak_check_at_exit=0:use_sigaltstack=1:detect_odr_violation=0:disable_coredump=1:handle_segv=2:handle_abort=2:handle_sigfpe=2:handle_sigill=2:handle_sigbus=2:detect_leaks=1:max_leaks=100000:print_stats=1
+        - ASAN_OPTIONS=halt_on_error=0:atexit=1:leak_check_at_exit=0:use_sigaltstack=1:detect_odr_violation=0:disable_coredump=1:handle_segv=2:handle_abort=2:handle_sigfpe=2:handle_sigill=2:handle_sigbus=2:detect_leaks=0:print_stats=1
 pool:
   size: 90%

--- a/src/tests/ftest/pool/autotest.yaml
+++ b/src/tests/ftest/pool/autotest.yaml
@@ -14,5 +14,7 @@ server_config:
   engines:
     0:
       storage: auto
+      env_vars:
+        - ASAN_OPTIONS=halt_on_error=0:atexit=1:leak_check_at_exit=0:use_sigaltstack=1:detect_odr_violation=0:disable_coredump=1:handle_segv=2:handle_abort=2:handle_sigfpe=2:handle_sigill=2:handle_sigbus=2:detect_leaks=1:max_leaks=100000:print_stats=1
 pool:
   size: 90%

--- a/src/tests/ftest/pool/autotest.yaml
+++ b/src/tests/ftest/pool/autotest.yaml
@@ -19,5 +19,11 @@ server_config:
       storage: auto
       env_vars:
         - ASAN_OPTIONS=halt_on_error=0:atexit=1:leak_check_at_exit=0:use_sigaltstack=1:detect_odr_violation=0:disable_coredump=1:handle_segv=2:handle_abort=2:handle_sigfpe=2:handle_sigill=2:handle_sigbus=2:detect_leaks=0:print_stats=1
+        # daos_engine is not the DAOS-18859 reproduction target (the suspected race is
+        # client-side, inside the daos CLI process during pool connect); silence TSan
+        # reporting here to avoid noise, which also sidesteps the known false-positive
+        # risk from Argobots ULT stack-switching (not tracked correctly by TSan without
+        # __tsan_switch_to_fiber annotations Argobots does not have).
+        - TSAN_OPTIONS=report_bugs=0
 pool:
   size: 90%

--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -114,11 +114,6 @@ if [ "${STAGE_NAME}" == "Functional Hardware 24" ]; then
     launch_node_args="-ts ${server_nodes} -tc ${client_nodes}"
 fi
 
-# ASAN-instrumented DAOS builds require libasan to be first in the library list.
-# Python is not ASAN-compiled but loads ASAN-instrumented DAOS libraries, so
-# preload libasan explicitly to prevent "ASan runtime does not come first" abort.
-export LD_PRELOAD=/usr/lib64/libasan.so.6
-
 # shellcheck disable=SC2086,SC2090,SC2048
 if ! python ./launch.py --mode ci ${launch_node_args} ${LAUNCH_OPT_ARGS} ${TEST_TAG_ARR[*]}; then
     rc=${PIPESTATUS[0]}

--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -114,6 +114,11 @@ if [ "${STAGE_NAME}" == "Functional Hardware 24" ]; then
     launch_node_args="-ts ${server_nodes} -tc ${client_nodes}"
 fi
 
+# ASAN-instrumented DAOS builds require libasan to be first in the library list.
+# Python is not ASAN-compiled but loads ASAN-instrumented DAOS libraries, so
+# preload libasan explicitly to prevent "ASan runtime does not come first" abort.
+export LD_PRELOAD=/usr/lib64/libasan.so.6
+
 # shellcheck disable=SC2086,SC2090,SC2048
 if ! python ./launch.py --mode ci ${launch_node_args} ${LAUNCH_OPT_ARGS} ${TEST_TAG_ARR[*]}; then
     rc=${PIPESTATUS[0]}

--- a/src/tests/ftest/util/launch_utils.py
+++ b/src/tests/ftest/util/launch_utils.py
@@ -462,17 +462,20 @@ class TestRunner():
             number, self.total_tests, test, repeat, self.total_repeats)
         start_time = int(time.time())
         # When running ASAN-instrumented DAOS binaries (SANITIZERS=address build),
-        # libasan must be the first library loaded in avocado worker processes.
-        # Workers import pydaos.raw which transitively loads ASAN-compiled libdaos.so;
-        # without LD_PRELOAD the dynamic linker initializes libasan too late and aborts.
-        # Pass these only to the avocado subprocess so SSH/clush helper commands that
-        # run before or after tests are not affected by the ASAN runtime.
+        # avocado worker processes import pydaos.raw which transitively loads
+        # ASAN-compiled libdaos.so.  Without any workaround, ASAN aborts with
+        # "ASan runtime does not come first in initial library list".
+        # LD_PRELOAD=libasan.so.6 fixes this but causes avocado's worker spawner
+        # to hang: ASAN's pthread_atfork/signal-handler interactions with
+        # avocado's process management block the main avocado process indefinitely.
+        # Instead, set verify_asan_link_order=0 so ASAN does not abort when it is
+        # loaded as a transitive dependency (not first).  Pass this only to the
+        # avocado subprocess; SSH/clush helper commands are unaffected since they
+        # do not load ASAN-compiled libraries.
         asan_extra_env = {}
-        libasan = "/usr/lib64/libasan.so.6"
-        if os.path.exists(libasan):
+        if os.path.exists("/usr/lib64/libasan.so.6"):
             asan_extra_env = {
-                "LD_PRELOAD": libasan,
-                "ASAN_OPTIONS": "detect_leaks=0",
+                "ASAN_OPTIONS": "detect_leaks=0:verify_asan_link_order=0",
             }
         result = run_local(logger, " ".join(command), capture_output=False,
                            extra_env=asan_extra_env or None)

--- a/src/tests/ftest/util/launch_utils.py
+++ b/src/tests/ftest/util/launch_utils.py
@@ -476,9 +476,19 @@ class TestRunner():
         # The avocado worker is not the DAOS-18859 reproduction target (the suspected
         # race is inside the daos CLI process itself, during pool connect), so under
         # TSan its reporting is silenced with report_bugs=0 to avoid noise unrelated to
-        # this investigation.  Whether TSan has an equivalent to ASAN's "runtime does not
-        # come first" abort here is untested; if it recurs this will need a follow-up
-        # iteration the same way the ASAN campaign did.
+        # this investigation.
+        #
+        # Under TSan, the late dlopen() of libdaos.so (transitively pulled in by the
+        # pydaos_shim C extension when pydaos.raw is imported) fails instead with
+        # "cannot allocate memory in static TLS block".  libtsan.so uses the
+        # initial-exec TLS model and reserves a large static TLS block (measured at
+        # ~255 KiB on Rocky Linux 9/glibc 2.34), far larger than glibc's default
+        # static TLS surplus reserved at process startup for later dlopen() calls
+        # (512 bytes).  Raising glibc's optional_static_tls tunable increases that
+        # reserved surplus so the late dlopen() succeeds, without loading any
+        # sanitizer runtime into the avocado process itself (unlike LD_PRELOAD,
+        # this cannot trigger the same pthread_atfork/fork-related hang seen with
+        # ASAN above).  1 MiB gives ample headroom above the measured requirement.
         sanitizer_extra_env = {}
         if os.path.exists("/usr/lib64/libasan.so.6"):
             sanitizer_extra_env = {
@@ -487,6 +497,7 @@ class TestRunner():
         elif list(Path("/usr/lib64").glob("libtsan.so*")):
             sanitizer_extra_env = {
                 "TSAN_OPTIONS": "report_bugs=0",
+                "GLIBC_TUNABLES": "glibc.rtld.optional_static_tls=1048576",
             }
         result = run_local(logger, " ".join(command), capture_output=False,
                            extra_env=sanitizer_extra_env or None)

--- a/src/tests/ftest/util/launch_utils.py
+++ b/src/tests/ftest/util/launch_utils.py
@@ -461,24 +461,35 @@ class TestRunner():
             "[Test %s/%s] Running the %s test on repetition %s/%s",
             number, self.total_tests, test, repeat, self.total_repeats)
         start_time = int(time.time())
-        # When running ASAN-instrumented DAOS binaries (SANITIZERS=address build),
-        # avocado worker processes import pydaos.raw which transitively loads
-        # ASAN-compiled libdaos.so.  Without any workaround, ASAN aborts with
-        # "ASan runtime does not come first in initial library list".
-        # LD_PRELOAD=libasan.so.6 fixes this but causes avocado's worker spawner
-        # to hang: ASAN's pthread_atfork/signal-handler interactions with
-        # avocado's process management block the main avocado process indefinitely.
-        # Instead, set verify_asan_link_order=0 so ASAN does not abort when it is
-        # loaded as a transitive dependency (not first).  Pass this only to the
-        # avocado subprocess; SSH/clush helper commands are unaffected since they
-        # do not load ASAN-compiled libraries.
-        asan_extra_env = {}
+        # When running sanitizer-instrumented DAOS binaries (SANITIZERS=address or
+        # SANITIZERS=thread build), avocado worker processes import pydaos.raw which
+        # transitively loads the sanitizer-compiled libdaos.so.  Without any workaround,
+        # ASAN aborts with "ASan runtime does not come first in initial library list".
+        # LD_PRELOAD=libasan.so.6 fixes this but causes avocado's worker spawner to hang:
+        # ASAN's pthread_atfork/signal-handler interactions with avocado's process
+        # management block the main avocado process indefinitely.  Instead, set
+        # verify_asan_link_order=0 so ASAN does not abort when it is loaded as a
+        # transitive dependency (not first).  Pass this only to the avocado subprocess;
+        # SSH/clush helper commands are unaffected since they do not load
+        # sanitizer-compiled libraries.
+        #
+        # The avocado worker is not the DAOS-18859 reproduction target (the suspected
+        # race is inside the daos CLI process itself, during pool connect), so under
+        # TSan its reporting is silenced with report_bugs=0 to avoid noise unrelated to
+        # this investigation.  Whether TSan has an equivalent to ASAN's "runtime does not
+        # come first" abort here is untested; if it recurs this will need a follow-up
+        # iteration the same way the ASAN campaign did.
+        sanitizer_extra_env = {}
         if os.path.exists("/usr/lib64/libasan.so.6"):
-            asan_extra_env = {
+            sanitizer_extra_env = {
                 "ASAN_OPTIONS": "detect_leaks=0:verify_asan_link_order=0",
             }
+        elif list(Path("/usr/lib64").glob("libtsan.so*")):
+            sanitizer_extra_env = {
+                "TSAN_OPTIONS": "report_bugs=0",
+            }
         result = run_local(logger, " ".join(command), capture_output=False,
-                           extra_env=asan_extra_env or None)
+                           extra_env=sanitizer_extra_env or None)
         end_time = int(time.time())
         return_code = result.output[0].returncode
         if return_code == 0:

--- a/src/tests/ftest/util/launch_utils.py
+++ b/src/tests/ftest/util/launch_utils.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2022-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -461,7 +461,21 @@ class TestRunner():
             "[Test %s/%s] Running the %s test on repetition %s/%s",
             number, self.total_tests, test, repeat, self.total_repeats)
         start_time = int(time.time())
-        result = run_local(logger, " ".join(command), capture_output=False)
+        # When running ASAN-instrumented DAOS binaries (SANITIZERS=address build),
+        # libasan must be the first library loaded in avocado worker processes.
+        # Workers import pydaos.raw which transitively loads ASAN-compiled libdaos.so;
+        # without LD_PRELOAD the dynamic linker initializes libasan too late and aborts.
+        # Pass these only to the avocado subprocess so SSH/clush helper commands that
+        # run before or after tests are not affected by the ASAN runtime.
+        asan_extra_env = {}
+        libasan = "/usr/lib64/libasan.so.6"
+        if os.path.exists(libasan):
+            asan_extra_env = {
+                "LD_PRELOAD": libasan,
+                "ASAN_OPTIONS": "detect_leaks=0",
+            }
+        result = run_local(logger, " ".join(command), capture_output=False,
+                           extra_env=asan_extra_env or None)
         end_time = int(time.time())
         return_code = result.output[0].returncode
         if return_code == 0:

--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2022-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -388,7 +388,8 @@ def get_clush_command(hosts, args=None, command="", command_env=None, command_su
     return " ".join(cmd_list)
 
 
-def run_local(log, command, verbose=True, timeout=None, stderr=False, capture_output=True):
+def run_local(log, command, verbose=True, timeout=None, stderr=False, capture_output=True,
+              extra_env=None):
     """Run the command on the local host.
 
     Args:
@@ -400,17 +401,23 @@ def run_local(log, command, verbose=True, timeout=None, stderr=False, capture_ou
         stderr (bool, optional): whether to enable stdout/stderr separation. Defaults to False.
         capture_output (bool, optional): whether to include stdout/stderr in the CommandResult.
             Defaults to True.
+        extra_env (dict, optional): additional environment variables to add to the subprocess
+            environment.  These are merged on top of os.environ without modifying it globally.
+            Defaults to None.
 
     Returns:
         CommandResult: groups of command results from the same hosts with the same return status
     """
     local_host = NodeSet(gethostname().split(".")[0])
+    proc_env = os.environ.copy()
+    if extra_env:
+        proc_env.update(extra_env)
     kwargs = {
         "encoding": "utf-8",
         "shell": True,
         "check": False,
         "timeout": timeout,
-        "env": os.environ.copy()
+        "env": proc_env
     }
     if capture_output:
         kwargs["stdout"] = subprocess.PIPE

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2020-2022 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -488,6 +488,7 @@ kv_put(daos_handle_t oh, daos_size_t size)
 			 * Max request in flight reached, wait for one i/o to
 			 * complete to reuse the slot
 			 */
+			evp = NULL;
 			while (1) {
 				rc = daos_eq_poll(eq, 1, DAOS_EQ_NOWAIT, 1, &evp);
 				if (rc > 0)
@@ -497,6 +498,11 @@ kv_put(daos_handle_t oh, daos_size_t size)
 					break;
 				}
 			}
+			/* Poll failure: evp is stale, do not dereference it */
+			if (rc < 0)
+				break;
+			/* Verify evp is valid to catch stale pointer bugs */
+			D_ASSERT(evp != NULL);
 
 			/** Check if completed operation failed */
 			if (evp->ev_error != DER_SUCCESS) {
@@ -551,8 +557,11 @@ kv_put(daos_handle_t oh, daos_size_t size)
 	num_events = daos_eq_query(eq, DAOS_EQR_ALL, 0, NULL);
 	while (1) {
 		eq_rc = daos_eq_poll(eq, 1, DAOS_EQ_NOWAIT, 1, &evp);
-		if (eq_rc > 0)
+		if (eq_rc > 0) {
 			completions += eq_rc;
+			if (rc == 0 && evp->ev_error != DER_SUCCESS)
+				rc = evp->ev_error;
+		}
 		if (eq_rc < 0) {
 			rc = eq_rc;
 			break;
@@ -628,6 +637,7 @@ kv_get(daos_handle_t oh, daos_size_t size)
 			 * Max request in flight reached, wait for one i/o to
 			 * complete to reuse the slot
 			 */
+			evp = NULL;
 			while (1) {
 				rc = daos_eq_poll(eq, 1, DAOS_EQ_NOWAIT, 1, &evp);
 				if (rc > 0)
@@ -637,6 +647,11 @@ kv_get(daos_handle_t oh, daos_size_t size)
 					break;
 				}
 			}
+			/* Poll failure: evp is stale, do not dereference it */
+			if (rc < 0)
+				break;
+			/* Verify evp is valid to catch stale pointer bugs */
+			D_ASSERT(evp != NULL);
 
 			/** Check if completed operation failed */
 			if (evp->ev_error != DER_SUCCESS) {

--- a/utils/docker/Dockerfile.el.8
+++ b/utils/docker/Dockerfile.el.8
@@ -154,11 +154,11 @@ ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
-# Build DAOS — always with SANITIZERS=address + BUILD_TYPE=debug on this branch (DAOS-18859 debugging)
+# Build DAOS — always with SANITIZERS=thread + BUILD_TYPE=debug on this branch (DAOS-18859 debugging)
 RUN [ "$DAOS_BUILD" != "yes" ] || {                                        \
         scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER     \
               FIRMWARE_MGMT=1 BUILD_TYPE=debug TARGET_TYPE=$DAOS_TARGET_TYPE \
-              SANITIZERS=address &&                                         \
+              SANITIZERS=thread &&                                          \
         ([ "$DAOS_KEEP_BUILD" != "no" ] || /bin/rm -rf build) &&           \
         go clean -cache &&                                                 \
         cp -r utils/config/examples /opt/daos;                             \

--- a/utils/docker/Dockerfile.el.8
+++ b/utils/docker/Dockerfile.el.8
@@ -1,6 +1,6 @@
 # Copyright 2018-2024 Intel Corporation
 # Copyright 2025 Google LLC
-# Copyright 2025 Hewlett Packard Enterprise Development LP
+# Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 # All rights reserved.
 #
 # 'recipe' for Docker to build an image of EL 8 based
@@ -154,10 +154,11 @@ ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
-# Build DAOS
+# Build DAOS — always with SANITIZERS=address + BUILD_TYPE=debug on this branch (DAOS-18859 debugging)
 RUN [ "$DAOS_BUILD" != "yes" ] || {                                        \
         scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER     \
-              FIRMWARE_MGMT=1 BUILD_TYPE=$DAOS_BUILD_TYPE TARGET_TYPE=$DAOS_TARGET_TYPE && \
+              FIRMWARE_MGMT=1 BUILD_TYPE=debug TARGET_TYPE=$DAOS_TARGET_TYPE \
+              SANITIZERS=address &&                                         \
         ([ "$DAOS_KEEP_BUILD" != "no" ] || /bin/rm -rf build) &&           \
         go clean -cache &&                                                 \
         cp -r utils/config/examples /opt/daos;                             \

--- a/utils/docker/Dockerfile.el.9
+++ b/utils/docker/Dockerfile.el.9
@@ -1,6 +1,6 @@
 # Copyright 2022-2024 Intel Corporation
 # Copyright 2025 Google LLC
-# Copyright 2025 Hewlett Packard Enterprise Development LP
+# Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 # All rights reserved.
 #
 # 'recipe' for Docker to build an image of EL 9 based
@@ -150,11 +150,11 @@ ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
-# Build DAOS
+# Build DAOS — always with SANITIZERS=address + BUILD_TYPE=debug on this branch (DAOS-18859 debugging)
 RUN [ "$DAOS_BUILD" != "yes" ] || {                                        \
         scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER     \
-              FIRMWARE_MGMT=1 BUILD_TYPE=$DAOS_BUILD_TYPE                  \
-	      TARGET_TYPE=$DAOS_TARGET_TYPE &&                             \
+              FIRMWARE_MGMT=1 BUILD_TYPE=debug                             \
+	      TARGET_TYPE=$DAOS_TARGET_TYPE SANITIZERS=address &&          \
         ([ "$DAOS_KEEP_BUILD" != "no" ] || /bin/rm -rf build) &&           \
         go clean -cache &&                                                 \
         cp -r utils/config/examples /opt/daos;                             \

--- a/utils/docker/Dockerfile.el.9
+++ b/utils/docker/Dockerfile.el.9
@@ -150,11 +150,11 @@ ARG JOBS=$DEPS_JOBS
 ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
-# Build DAOS — always with SANITIZERS=address + BUILD_TYPE=debug on this branch (DAOS-18859 debugging)
+# Build DAOS — always with SANITIZERS=thread + BUILD_TYPE=debug on this branch (DAOS-18859 debugging)
 RUN [ "$DAOS_BUILD" != "yes" ] || {                                        \
         scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER     \
               FIRMWARE_MGMT=1 BUILD_TYPE=debug                             \
-	      TARGET_TYPE=$DAOS_TARGET_TYPE SANITIZERS=address &&          \
+	      TARGET_TYPE=$DAOS_TARGET_TYPE SANITIZERS=thread &&           \
         ([ "$DAOS_KEEP_BUILD" != "no" ] || /bin/rm -rf build) &&           \
         go clean -cache &&                                                 \
         cp -r utils/config/examples /opt/daos;                             \

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -130,6 +130,7 @@ BuildRequires: libuuid-devel
 # Needed for debugging tasks
 %if (0%{?rhel} >= 8)
 BuildRequires: libasan
+BuildRequires: libtsan
 %endif
 %if (0%{?suse_version} > 0)
 BuildRequires: libasan8

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -54,6 +54,7 @@ dnf --nodocs install ${dnf_install_args} \
     librdmacm-devel \
     libtool \
     libtool-ltdl-devel \
+    libtsan \
     libunwind-devel \
     libuuid-devel \
     libyaml-devel \

--- a/utils/scripts/install-el9.sh
+++ b/utils/scripts/install-el9.sh
@@ -54,6 +54,7 @@ dnf --nodocs install ${dnf_install_args} \
     librdmacm-devel \
     libtool \
     libtool-ltdl-devel \
+    libtsan \
     libunwind-devel \
     libuuid-devel \
     libyaml-devel \


### PR DESCRIPTION
Add D_ERROR + fprintf(stderr) diagnostic messages in kv_put() and kv_get() that fire when daos_eq_poll() returns rc < 0 (poll error) and the code is about to dereference the stale evp pointer.

This commit does NOT fix the bug — it only makes it visible in CI logs. When triggered, the messages confirm the stale-evp condition occurred, helping correlate with subsequent SIGSEGV or ASAN errors.

Quick-Functional: true
Test-repeat: 5
Test-tag: PoolAutotestTest,test_pool_autotest

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
