### PR TITLE
DAOS-623 ci: archive NLT inputs needed for offline debugging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -762,7 +762,10 @@ pipeline {
                     }
                     post {
                         always {
-                            unitTestPost artifacts: ['nlt_logs/'],
+                            unitTestPost artifacts: ['nlt_logs/', 'nlt_memcheck_logs/',
+                                                     'nlt-server-leaks.json',
+                                                     'nlt-junit.xml',
+                                                     'vm_test/nlt-errors.json'],
                                          testResults: 'nlt-junit.xml',
                                          always_script: 'ci/unit/test_nlt_post.sh',
                                          valgrind_stash: 'nlt-memcheck'
@@ -1035,7 +1038,7 @@ pipeline {
                             stash name: 'fault-inject-valgrind',
                                   includes: '*.memcheck.xml',
                                   allowEmpty: true
-                            archiveArtifacts artifacts: 'nlt_logs/fault-injection/',
+                            archiveArtifacts artifacts: 'nlt_logs/fault-injection/,nlt-errors.json,nlt-client-leaks.json,nlt-junit.xml',
                                              allowEmptyArchive: true
                             job_status_update()
                         }

--- a/ci/unit/test_nlt_post.sh
+++ b/ci/unit/test_nlt_post.sh
@@ -22,5 +22,13 @@ rsync -v -dpt -z -e "ssh $SSH_KEY_ARGS" jenkins@"$NODE":build/ \
       --filter="include nlt*.json" --filter="include dnt*.xml" \
       --filter="include nltir.xml" --filter="include nltr.json" \
       --filter="include nlt-junit.xml" --filter="exclude *" ./
+
+# Copy per-test valgrind memcheck XMLs into a dedicated directory so
+# they are archived as a logical group. The originals stay at the
+# workspace root so unitTestPost's valgrind_stash still picks them up
+# for the pipeline-end valgrindReportPublish panel.
+mkdir -p nlt_memcheck_logs
+cp dnt*.memcheck.xml nlt_memcheck_logs/ 2>/dev/null || true
+
 mkdir -p vm_test
 mv nlt-errors.json vm_test/


### PR DESCRIPTION
The NLT and Fault injection stages mark themselves UNSTABLE based on
recordIssues output, but the JSON files it parses aren't archived.

Add the recordIssues inputs to each stage's artifacts:
      - NLT: nlt-server-leaks.json, nlt-client-leaks.json, nlt-junit.xml,
        vm_test/nlt-errors.json (test_nlt_post.sh already rsyncs them
        back from the test VM)
      - Fault injection: nlt-errors.json, nlt-client-leaks.json,
        nlt-junit.xml

Also copy the per-test memcheck XMLs into nlt_memcheck_logs/ so
they're visible from the per-stage Jenkins UI rather than only from
the pipeline-end valgrindReportPublish tarball.

Together, these changes should make certain classes of failures
less mysterious.

Signed-off-by: Michael MacDonald <github@macdonald.cx>
