### PR TITLE
DAOS-18991 test: Remove python3-mpi4py-tests requirement

### DIFF
--- a/src/tests/ftest/scripts/setup_nodes.sh
+++ b/src/tests/ftest/scripts/setup_nodes.sh
@@ -106,7 +106,6 @@ cat <<EOF > "${DAOS_FTEST_VENV}"/pip.conf
 [global]
     progress_bar = off
     no_color = true
-    quiet = 1
 EOF
 
 pip install --upgrade pip

--- a/utils/rpms/daos.changelog
+++ b/utils/rpms/daos.changelog
@@ -1,4 +1,7 @@
 %changelog
+* Fri May 22 2026 Phillip Henderson <phillip.henderson@intel.com> 2.9.100-5
+- Move mpi4py requirement for daos-client-tests; covered by requirements-ftest.txt
+
 * Mon May 04 2026 Cedric Koch-Hofer <cedric.koch-hofer@hpe.com> 2.9.100-4
 - Add gperftools-devel as a build dependency of daos-devel
 

--- a/utils/rpms/daos.sh
+++ b/utils/rpms/daos.sh
@@ -469,7 +469,6 @@ DEPENDS+=("hdf5-vol-daos-mpich-tests")
 DEPENDS+=("MACSio-mpich")
 DEPENDS+=("simul-mpich")
 DEPENDS+=("romio-tests")
-DEPENDS+=("python3-mpi4py-tests >= 3.1.6")
 build_package "daos-tests"
 
 build_package "daos-client-tests-mpich"

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -24,7 +24,7 @@
 
 Name:          daos
 Version:       2.9.100
-Release:       4%{?relval}%{?dist}
+Release:       5%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent


### PR DESCRIPTION
Remove python3-mpi4py-tests to avoid conflict with pip install of mpi4py

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: LlnlMpi4py

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
