### PR TITLE
DAOS-18992 test: bump torch to 2.12.0 (#18302)

### DIFF
--- a/utils/cq/requirements.txt
+++ b/utils/cq/requirements.txt
@@ -9,4 +9,4 @@ yamllint==1.38.0
 codespell==2.4.2
 # Used by ci/jira_query.py which pip installs it standalone.
 jira
-torch>=2.11.0
+torch>=2.12.0


### PR DESCRIPTION
Updates `torch` to 2.12.0

Test-tag: pytorch
Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
