### PR TITLE
DAOS-18995 control: Incorrect value printed for percentage tier-ratio

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -191,20 +191,20 @@ type poolCreateCmd struct {
 	} `positional-args:"yes"`
 }
 
-func ratio2Percentage(log logging.Logger, scm, nvme float64) (p float64) {
+func ratio2Percentage(log logging.Logger, tier1, tier2 float64) (p float64) {
 	p = 100.00
 	min := storage.MinScmToNVMeRatio * p
 
-	if nvme > 0 {
-		p *= scm / nvme
+	if tier2 > 0 {
+		p *= tier1 / (tier1 + tier2)
 		if p < min {
-			log.Noticef("SCM:NVMe ratio is less than %0.2f%%, DAOS performance "+
+			log.Noticef("storage tier ratio is less than %0.2f%%, DAOS performance "+
 				"will suffer!", min)
 		}
 		return
 	}
 
-	log.Notice("Creating DAOS pool without NVME storage")
+	log.Notice("Creating DAOS pool with only a single tier of storage")
 	return
 }
 
@@ -261,7 +261,8 @@ func (cmd *poolCreateCmd) storageAutoTotal(req *control.PoolCreateReq) error {
 
 	scmPercentage := ratio2Percentage(cmd.Logger, req.TierRatio[0], req.TierRatio[1])
 	msg := fmt.Sprintf("Creating DAOS pool with automatic storage allocation: "+
-		"%s total, %0.2f%% ratio", humanize.Bytes(req.TotalBytes), scmPercentage)
+		"%s total, %0.2f%% storage tier ratio", humanize.Bytes(req.TotalBytes),
+		scmPercentage)
 	if req.NumRanks > 0 {
 		msg += fmt.Sprintf(" with %d ranks", req.NumRanks)
 	}
@@ -282,7 +283,7 @@ func (cmd *poolCreateCmd) storageManualMdOnSsd(req *control.PoolCreateReq) error
 	}
 
 	msg := fmt.Sprintf("Creating DAOS pool in MD-on-SSD mode with manual per-engine storage "+
-		"allocation: %s metadata, %s data (%0.2f%% storage ratio) and %0.2f%% "+
+		"allocation: %s metadata, %s data (%0.2f%% storage tier ratio) and %0.2f%% "+
 		"memory-file:meta-blob size ratio", humanize.Bytes(metaBytes),
 		humanize.Bytes(dataBytes), 100.00*(float64(metaBytes)/float64(dataBytes)),
 		100.00*req.MemRatio)
@@ -311,7 +312,7 @@ func (cmd *poolCreateCmd) storageManual(req *control.PoolCreateReq) error {
 	req.TierBytes = []uint64{scmBytes, nvmeBytes}
 
 	msg := fmt.Sprintf("Creating DAOS pool with manual per-engine storage allocation:"+
-		" %s SCM, %s NVMe (%0.2f%% ratio)", humanize.Bytes(scmBytes),
+		" %s SCM, %s NVMe (%0.2f%% storage tier ratio)", humanize.Bytes(scmBytes),
 		humanize.Bytes(nvmeBytes),
 		ratio2Percentage(cmd.Logger, float64(scmBytes), float64(nvmeBytes)))
 	cmd.Info(msg)


### PR DESCRIPTION
Correct percentage value printed.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
