### PR TITLE
DAOS-18991 test: add mpich to requirements-ftest.txt

### DIFF
--- a/requirements-ftest.txt
+++ b/requirements-ftest.txt
@@ -6,3 +6,4 @@ paramiko
 distro
 torch
 mpi4py
+mpich


### PR DESCRIPTION
Add mpich to requirements-ftest.txt so mpi4py can work with mpich.

Test-tag: LlnlMpi4py IorSmall mpich
Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
