### PR TITLE
DAOS-18971 test: increase pool_space_metrics pool size

### DIFF
--- a/src/tests/ftest/telemetry/pool_space_metrics.yaml
+++ b/src/tests/ftest/telemetry/pool_space_metrics.yaml
@@ -22,7 +22,7 @@ server_config:
       storage: auto
 
 pool_scm:
-  scm_size: 1G
+  scm_size: 5G
   nvme_size: 0
 
 pool_scm_nvme:
@@ -30,7 +30,6 @@ pool_scm_nvme:
 
 container:
   type: POSIX
-  control_method: daos
   properties: rd_fac:0
   oclass: SX
 


### PR DESCRIPTION
Increase the pool size in pool_space_metrics.yaml since space pressure is causing lower performance.

Test-tag: TelemetryPoolSpaceMetrics
Test-repeat: 3

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
