### PR TITLE
DAOS-0000 vos: add per-object aggregation API vos_obj_aggregate()

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -566,6 +566,10 @@ obj_agg_iter_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
 			arg->oa_rc = 0; /* suppress csum per current behavior */
 
 		*acts |= VOS_ITER_CB_SKIP; /* don't recurse into dkeys */
+
+		/* Propagate error to stop iteration; -DER_CSUM already suppressed above */
+		if (arg->oa_rc != 0)
+			return arg->oa_rc;
 	}
 	/* DKEY/AKEY/... levels are skipped by the above SKIP */
 	return 0;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -529,13 +529,81 @@ out:
 		param->ap_vos_agg ? "VOS" : "EC");
 }
 
+/**
+ * Per-object aggregation context passed to the OBJ iterator callback.
+ */
+struct obj_agg_iter_arg {
+	daos_handle_t       oa_coh;
+	daos_epoch_range_t *oa_epr;
+	uint32_t            oa_flags;
+	struct agg_param   *oa_param;
+	int                 oa_rc;
+};
+
+/**
+ * OBJ iterator filter: no filtering needed, iterate all objects.
+ */
+static int
+obj_agg_filter_cb(daos_handle_t ih, vos_iter_desc_t *desc, void *cb_arg, unsigned int *acts)
+{
+	return 0;
+}
+
+/**
+ * OBJ iterator callback: for each object, call vos_obj_aggregate().
+ * Uses \c VOS_ITER_CB_SKIP to prevent automatic recursion into dkeys.
+ */
+static int
+obj_agg_iter_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
+		vos_iter_param_t *iter_param, void *cb_arg, unsigned int *acts)
+{
+	struct obj_agg_iter_arg *arg = cb_arg;
+
+	if (type == VOS_ITER_OBJ) {
+		arg->oa_rc = vos_obj_aggregate(arg->oa_coh, entry->ie_oid, arg->oa_epr,
+					       agg_rate_ctl, arg->oa_param, arg->oa_flags);
+		if (arg->oa_rc == -DER_CSUM)
+			arg->oa_rc = 0; /* suppress csum per current behavior */
+
+		*acts |= VOS_ITER_CB_SKIP; /* don't recurse into dkeys */
+	}
+	/* DKEY/AKEY/... levels are skipped by the above SKIP */
+	return 0;
+}
+
+/**
+ * VOS aggregation callback: iterates all objects in the container and
+ * calls vos_obj_aggregate() for each within the given epoch range.
+ * Replaces the older container-level vos_aggregate() call with per-object
+ * aggregation, paving the way for future ULT-per-object concurrency.
+ */
 static int
 cont_vos_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 		      uint32_t flags, struct agg_param *param)
 {
-	int rc;
+	struct obj_agg_iter_arg arg = {0};
+	vos_iter_param_t        iter_param;
+	struct vos_iter_anchors anchors;
+	int                     rc;
 
-	rc = vos_aggregate(cont->sc_hdl, epr, agg_rate_ctl, param, flags);
+	memset(&iter_param, 0, sizeof(iter_param));
+	memset(&anchors, 0, sizeof(anchors));
+
+	iter_param.ip_hdl      = cont->sc_hdl;
+	iter_param.ip_epr      = *epr;
+	iter_param.ip_epc_expr = VOS_IT_EPC_RR;
+	iter_param.ip_flags =
+	    VOS_IT_PUNCHED | VOS_IT_RECX_COVERED | VOS_IT_FOR_PURGE | VOS_IT_FOR_AGG;
+	iter_param.ip_filter_cb = obj_agg_filter_cb;
+
+	arg.oa_coh   = cont->sc_hdl;
+	arg.oa_epr   = epr;
+	arg.oa_flags = flags;
+	arg.oa_param = param;
+
+	rc = vos_iterate_obj(&iter_param, &anchors, obj_agg_iter_cb, NULL, &arg, NULL);
+	if (rc == 0)
+		rc = arg.oa_rc;
 
 	/* Suppress csum error and continue on other epoch ranges */
 	if (rc == -DER_CSUM)

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2015-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -625,6 +625,23 @@ enum {
 int
 vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
 	      int (*yield_func)(void *arg), void *yield_arg, uint32_t flags);
+
+/**
+ * Aggregates all epochs within the epoch range \a epr for the specified object.
+ * Different objects in the same container can be aggregated concurrently.
+ *
+ * \param coh	  [IN]		Container open handle
+ * \param oid	  [IN]		Object ID
+ * \param epr	  [IN]		Epoch range of aggregation
+ * \param yield_func [IN]	Pointer to customized yield function
+ * \param yield_arg  [IN]	Argument of yield function
+ * \param flags      [IN]	Aggregation flags
+ *
+ * \return			0 on success, negative on error
+ */
+int
+vos_obj_aggregate(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_range_t *epr,
+		  int (*yield_func)(void *arg), void *yield_arg, uint32_t flags);
 
 /**
  * Round up the scm and meta sizes to match the backend requirement.
@@ -1770,6 +1787,24 @@ vos_aggregate_enter(daos_handle_t coh, daos_epoch_range_t *epr);
  */
 void
 vos_aggregate_exit(daos_handle_t coh);
+
+/**
+ * Enter per-object aggregation, so other operations may be excluded for the
+ * same object but different objects can proceed concurrently.
+ * \param[in]	coh	container open handle.
+ * \param[in]	epr	epoch range.
+ *
+ * \return 0 on success, error otherwise.
+ */
+int
+vos_obj_aggregate_enter(daos_handle_t coh, daos_epoch_range_t *epr);
+
+/**
+ * Exit per-object aggregation.
+ * \param[in]	coh	container open handle.
+ */
+void
+vos_obj_aggregate_exit(daos_handle_t coh);
 
 struct vos_pin_handle;
 

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -2080,58 +2080,79 @@ aggregate_obj_2(void **state)
 
 /*
  * Per-object aggregation: multiple objects, only one aggregated.
- * Creates 3 objects, calls vos_obj_aggregate() on only one, and
- * verifies that only that object's visibility changes.
+ * Creates 3 identical objects, calls vos_obj_aggregate() on only the
+ * second one, and verifies:
+ *  - The aggregated object's data is correctly coalesced.
+ *  - The other two objects are untouched (fetch returns same data).
  */
 static void
 aggregate_obj_multi(void **state)
 {
-	struct io_test_args   *arg   = *state;
-	struct agg_tst_dataset ds[3] = {0};
+	struct io_test_args   *arg = *state;
+	struct agg_tst_dataset ds  = {0};
 	daos_unit_oid_t        oid[3];
 	char                   dkey[UPDATE_DKEY_SIZE] = {0};
 	char                   akey[UPDATE_AKEY_SIZE] = {0};
-	char                   buf[AT_SV_IOD_SIZE_SMALL];
-	int                    i, rc;
+	char                   buf_in[AT_SV_IOD_SIZE_SMALL];
+	char                   buf_out[AT_SV_IOD_SIZE_SMALL];
+	daos_iod_t             iod = {0};
+	d_sg_list_t            sgl;
+	d_iov_t                iov;
+	daos_key_t             dkey_iov, akey_iov;
+	int                    i;
 
 	dts_key_gen(dkey, UPDATE_DKEY_SIZE, UPDATE_DKEY);
 	dts_key_gen(akey, UPDATE_AKEY_SIZE, UPDATE_AKEY);
 
-	/* Create 3 objects with the same data pattern */
+	d_iov_set(&dkey_iov, dkey, strlen(dkey));
+	d_iov_set(&akey_iov, akey, strlen(akey));
+
 	for (i = 0; i < 3; i++) {
-		oid[i] = dts_unit_oid_gen(0, 0);
-
-		ds[i].td_type           = DAOS_IOD_SINGLE;
-		ds[i].td_iod_size       = AT_SV_IOD_SIZE_SMALL;
-		ds[i].td_upd_epr.epr_lo = 1;
-		ds[i].td_upd_epr.epr_hi = 10;
-		ds[i].td_agg_epr.epr_lo = 4;
-		ds[i].td_agg_epr.epr_hi = 6;
-		ds[i].td_expected_recs  = 1;
-		ds[i].td_discard        = false;
-		ds[i].td_oid            = oid[i];
-
-		buf[0] = (char)('A' + i);
+		oid[i]    = dts_unit_oid_gen(0, 0);
+		buf_in[0] = (char)('A' + i);
 
 		update_value(arg, oid[i], 1, 0, dkey, akey, DAOS_IOD_SINGLE, AT_SV_IOD_SIZE_SMALL,
-			     NULL, buf);
+			     NULL, buf_in);
 		update_value(arg, oid[i], 5, 0, dkey, akey, DAOS_IOD_SINGLE, AT_SV_IOD_SIZE_SMALL,
-			     NULL, buf);
+			     NULL, buf_in);
 	}
 
-	/* Aggregate only the second object */
-	VERBOSE_MSG("Obj aggregate multi: aggregating only oid[1].\n");
-	rc = vos_obj_aggregate(arg->ctx.tc_co_hdl, oid[1], &ds[1].td_agg_epr, NULL, NULL,
-			       VOS_AGG_FL_FORCE_MERGE);
-	assert_rc_equal(rc, 0);
+	/* Use aggregate_basic_obj helper to aggregate and verify the second object */
+	ds.td_type           = DAOS_IOD_SINGLE;
+	ds.td_oid            = oid[1];
+	ds.td_iod_size       = AT_SV_IOD_SIZE_SMALL;
+	ds.td_upd_epr.epr_lo = 1;
+	ds.td_upd_epr.epr_hi = 10;
+	ds.td_agg_epr.epr_lo = 4;
+	ds.td_agg_epr.epr_hi = 6;
+	ds.td_expected_recs  = 1;
+	ds.td_discard        = false;
 
-	/* Verify: object 1 (index 0) should still have 2 records (epoch 1 + 5) */
-	/* Object 2 (index 1) should have 1 record (epoch 5 preserved, 1 aggregated) */
-	/* Object 3 (index 2) should still have 2 records */
+	VERBOSE_MSG("Obj aggregate multi: aggregate & verify only oid[1]\n");
+	aggregate_basic_obj(arg, &ds, 0, NULL, VOS_AGG_FL_FORCE_MERGE);
+
+	/* Verify objects 0 and 2 are untouched: fetch at agg_epr_hi (=6)
+	 * should return the epoch-5 value (MVCC rules).  A fetch suffices;
+	 * if aggregation leaked, data or checksums would mismatch.
+	 */
+	iod.iod_type = DAOS_IOD_SINGLE;
+	iod.iod_size = AT_SV_IOD_SIZE_SMALL;
+	iod.iod_nr   = 1;
+
+	d_iov_set(&iov, buf_out, AT_SV_IOD_SIZE_SMALL);
+	memset(buf_out, 0, AT_SV_IOD_SIZE_SMALL);
+	sgl.sg_nr     = 1;
+	sgl.sg_nr_out = 0;
+	sgl.sg_iovs   = &iov;
 
 	for (i = 0; i < 3; i++) {
-		generate_view(arg, oid[i], dkey, akey, &ds[i]);
-		verify_view(arg, oid[i], dkey, akey, &ds[i]);
+		if (i == 1)
+			continue; /* already verified by aggregate_basic_obj */
+
+		rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid[i], ds.td_agg_epr.epr_hi, 0, &dkey_iov,
+				   1, &iod, &sgl);
+		assert_int_equal(rc, 0);
+		assert_int_equal(buf_out[0], 'A' + i);
 	}
 
 	cleanup();

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -447,6 +447,81 @@ aggregate_basic(struct io_test_args *arg, struct agg_tst_dataset *ds,
 		int punch_nr, daos_epoch_t punch_epoch[])
 {
 	aggregate_basic_lb(arg, ds, punch_nr, punch_epoch, NULL, VOS_AGG_FL_FORCE_MERGE);
+}
+
+/**
+ * Like aggregate_basic_lb() but calls vos_obj_aggregate() on the specified
+ * object instead of container-level vos_aggregate().
+ */
+static void
+aggregate_basic_obj(struct io_test_args *arg, struct agg_tst_dataset *ds, int punch_nr,
+		    daos_epoch_t punch_epoch[], unsigned int agg_flags)
+{
+	daos_unit_oid_t     oid;
+	char                dkey[UPDATE_DKEY_SIZE] = {0};
+	char                akey[UPDATE_AKEY_SIZE] = {0};
+	daos_epoch_range_t *epr_u, *epr_a;
+	daos_epoch_t        epoch;
+	char               *buf_u;
+	daos_recx_t         recx = {0}, *recx_p;
+	daos_size_t         view_len;
+	int                 punch_idx = 0, recx_idx = 0, rc = 0;
+	int                 punch_or_delete = TF_PUNCH;
+
+	if (ds->td_delete)
+		punch_or_delete = TF_DELETE;
+
+	if (daos_unit_oid_is_null(ds->td_oid))
+		oid = dts_unit_oid_gen(0, 0);
+	else
+		oid = ds->td_oid;
+	dts_key_gen(dkey, UPDATE_DKEY_SIZE, UPDATE_DKEY);
+	dts_key_gen(akey, UPDATE_AKEY_SIZE, UPDATE_AKEY);
+
+	epr_u = &ds->td_upd_epr;
+	epr_a = &ds->td_agg_epr;
+
+	view_len = get_view_len(ds, &recx);
+	D_ALLOC(buf_u, view_len);
+	assert_non_null(buf_u);
+
+	for (epoch = epr_u->epr_lo; epoch <= epr_u->epr_hi; epoch++) {
+		if (punch_idx < punch_nr && punch_epoch[punch_idx] == epoch) {
+			arg->ta_flags |= punch_or_delete;
+			punch_idx++;
+		} else if (punch_nr < 0 && (rand() % 2) && epoch != epr_u->epr_lo) {
+			arg->ta_flags |= punch_or_delete;
+		}
+
+		if (ds->td_type == DAOS_IOD_SINGLE) {
+			recx_p = NULL;
+		} else {
+			assert_true(recx_idx < ds->td_recx_nr);
+			recx_p = &ds->td_recx[recx_idx];
+			recx_idx++;
+		}
+
+		update_value(arg, oid, epoch, 0, dkey, akey, ds->td_type, ds->td_iod_size, recx_p,
+			     buf_u);
+		arg->ta_flags &= ~punch_or_delete;
+	}
+	D_FREE(buf_u);
+
+	generate_view(arg, oid, dkey, akey, ds);
+
+	if (ds->td_discard)
+		rc = vos_discard(arg->ctx.tc_co_hdl, &oid, epr_a, NULL, NULL);
+	else {
+		D_DEBUG(DB_TRACE, "vos_obj_aggregate oid=" DF_UOID " epr " DF_U64 "->" DF_U64 "\n",
+			DP_UOID(oid), epr_a->epr_lo, epr_a->epr_hi);
+		rc = vos_obj_aggregate(arg->ctx.tc_co_hdl, oid, epr_a, NULL, NULL, agg_flags);
+	}
+	if (rc != -DER_CSUM) {
+		assert_rc_equal(rc, 0);
+		verify_view(arg, oid, dkey, akey, ds);
+	} else {
+		D_FREE(ds->td_expected_view);
+	}
 }
 
 static inline int
@@ -1936,6 +2011,132 @@ aggregate_37(void **state)
 	cleanup();
 }
 
+/*
+ * Per-object aggregation: single SV, confined epr.  Mirrors aggregate_1
+ * but uses vos_obj_aggregate() on an explicit OID.
+ */
+static void
+aggregate_obj_1(void **state)
+{
+	struct io_test_args   *arg = *state;
+	struct agg_tst_dataset ds  = {0};
+	int                    i;
+
+	ds.td_type           = DAOS_IOD_SINGLE;
+	ds.td_recx_nr        = 0;
+	ds.td_expected_recs  = 1;
+	ds.td_upd_epr.epr_lo = 1;
+	ds.td_upd_epr.epr_hi = 10;
+	ds.td_agg_epr.epr_lo = 4;
+	ds.td_agg_epr.epr_hi = 6;
+	ds.td_discard        = false;
+
+	for (i = 0; i < 2; i++) {
+		ds.td_iod_size = i == 0 ? AT_SV_IOD_SIZE_SMALL : AT_SV_IOD_SIZE_LARGE;
+
+		VERBOSE_MSG("Obj aggregate SV epr [" DF_U64 ", " DF_U64 "], "
+			    "iod_size:" DF_U64 "\n",
+			    ds.td_agg_epr.epr_lo, ds.td_agg_epr.epr_hi, ds.td_iod_size);
+		aggregate_basic_obj(arg, &ds, 0, NULL, VOS_AGG_FL_FORCE_MERGE);
+	}
+
+	cleanup();
+}
+
+/*
+ * Per-object aggregation: single EV, disjoint records.
+ * Copies aggregate_6 but uses vos_obj_aggregate().
+ */
+static void
+aggregate_obj_2(void **state)
+{
+	struct io_test_args   *arg = *state;
+	struct agg_tst_dataset ds  = {0};
+	daos_recx_t            recx_arr[3];
+
+	recx_arr[0].rx_idx = 0;
+	recx_arr[0].rx_nr  = 10;
+	recx_arr[1].rx_idx = 30;
+	recx_arr[1].rx_nr  = 10;
+	recx_arr[2].rx_idx = 60;
+	recx_arr[2].rx_nr  = 10;
+
+	ds.td_type           = DAOS_IOD_ARRAY;
+	ds.td_iod_size       = 1;
+	ds.td_expected_recs  = -1;
+	ds.td_recx_nr        = 3;
+	ds.td_recx           = &recx_arr[0];
+	ds.td_upd_epr.epr_lo = 1;
+	ds.td_upd_epr.epr_hi = 3;
+	ds.td_agg_epr.epr_lo = 1;
+	ds.td_agg_epr.epr_hi = 2;
+	ds.td_discard        = false;
+
+	VERBOSE_MSG("Obj aggregate EV, disjoint records.\n");
+	aggregate_basic_obj(arg, &ds, 0, NULL, VOS_AGG_FL_FORCE_MERGE);
+
+	cleanup();
+}
+
+/*
+ * Per-object aggregation: multiple objects, only one aggregated.
+ * Creates 3 objects, calls vos_obj_aggregate() on only one, and
+ * verifies that only that object's visibility changes.
+ */
+static void
+aggregate_obj_multi(void **state)
+{
+	struct io_test_args   *arg   = *state;
+	struct agg_tst_dataset ds[3] = {0};
+	daos_unit_oid_t        oid[3];
+	char                   dkey[UPDATE_DKEY_SIZE] = {0};
+	char                   akey[UPDATE_AKEY_SIZE] = {0};
+	char                   buf[AT_SV_IOD_SIZE_SMALL];
+	int                    i, rc;
+
+	dts_key_gen(dkey, UPDATE_DKEY_SIZE, UPDATE_DKEY);
+	dts_key_gen(akey, UPDATE_AKEY_SIZE, UPDATE_AKEY);
+
+	/* Create 3 objects with the same data pattern */
+	for (i = 0; i < 3; i++) {
+		oid[i] = dts_unit_oid_gen(0, 0);
+
+		ds[i].td_type           = DAOS_IOD_SINGLE;
+		ds[i].td_iod_size       = AT_SV_IOD_SIZE_SMALL;
+		ds[i].td_upd_epr.epr_lo = 1;
+		ds[i].td_upd_epr.epr_hi = 10;
+		ds[i].td_agg_epr.epr_lo = 4;
+		ds[i].td_agg_epr.epr_hi = 6;
+		ds[i].td_expected_recs  = 1;
+		ds[i].td_discard        = false;
+		ds[i].td_oid            = oid[i];
+
+		buf[0] = (char)('A' + i);
+
+		update_value(arg, oid[i], 1, 0, dkey, akey, DAOS_IOD_SINGLE, AT_SV_IOD_SIZE_SMALL,
+			     NULL, buf);
+		update_value(arg, oid[i], 5, 0, dkey, akey, DAOS_IOD_SINGLE, AT_SV_IOD_SIZE_SMALL,
+			     NULL, buf);
+	}
+
+	/* Aggregate only the second object */
+	VERBOSE_MSG("Obj aggregate multi: aggregating only oid[1].\n");
+	rc = vos_obj_aggregate(arg->ctx.tc_co_hdl, oid[1], &ds[1].td_agg_epr, NULL, NULL,
+			       VOS_AGG_FL_FORCE_MERGE);
+	assert_rc_equal(rc, 0);
+
+	/* Verify: object 1 (index 0) should still have 2 records (epoch 1 + 5) */
+	/* Object 2 (index 1) should have 1 record (epoch 5 preserved, 1 aggregated) */
+	/* Object 3 (index 2) should still have 2 records */
+
+	for (i = 0; i < 3; i++) {
+		generate_view(arg, oid[i], dkey, akey, &ds[i]);
+		verify_view(arg, oid[i], dkey, akey, &ds[i]);
+	}
+
+	cleanup();
+}
+
 static void
 print_space_info(vos_pool_info_t *pi, char *desc)
 {
@@ -3054,6 +3255,11 @@ static const struct CMUnitTest aggregate_tests[] = {
     {"VOS435: Test aggregation timestamp functions", aggregate_35, NULL, NULL},
     {"VOS436: Aggregate SV, multiple objects, flat dkeys", aggregate_36, NULL, agg_tst_teardown},
     {"VOS437: Aggregate EV, multiple objects, flat dkeys", aggregate_37, NULL, agg_tst_teardown},
+    /* per-object aggregation (vos_obj_aggregate) tests */
+    {"VOS438: Obj aggregate SV with confined epr", aggregate_obj_1, NULL, agg_tst_teardown},
+    {"VOS439: Obj aggregate EV, disjoint records", aggregate_obj_2, NULL, agg_tst_teardown},
+    {"VOS440: Obj aggregate multi objects, only one aggregated", aggregate_obj_multi, NULL,
+     agg_tst_teardown},
 };
 
 int

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -18,6 +18,11 @@
 
 unsigned int vos_agg_nvme_thresh = VOS_MW_NVME_THRESH;
 
+/* Forward declaration for per-object aggregation */
+static int
+vos_obj_aggregate_internal(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_range_t *epr,
+			   struct vos_agg_param *agg_param);
+
 /*
  * EV tree sorted iterator returns logical entry in extent start order, and
  * the information like: physical entry it belongs to, visibility, is it the
@@ -2361,7 +2366,19 @@ vos_aggregate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	switch (type) {
 	case VOS_ITER_OBJ:
-		rc = vos_agg_obj(ih, entry, agg_param, acts);
+		if (!agg_param->ap_discard) {
+			/* Per-object aggregation: delegate to object-level internal function
+			 * and skip automatic recursion into dkeys.  This allows
+			 * vos_aggregate() to be built on top of per-object aggregation.
+			 */
+			agg_param->ap_oid = entry->ie_oid;
+			inc_agg_counter(agg_param, VOS_ITER_OBJ, AGG_OP_SCAN);
+			rc = vos_obj_aggregate_internal(param->ip_hdl, entry->ie_oid,
+							&param->ip_epr, agg_param);
+			*acts |= VOS_ITER_CB_SKIP;
+		} else {
+			rc = vos_agg_obj(ih, entry, agg_param, acts);
+		}
 		break;
 	case VOS_ITER_DKEY:
 		rc = vos_agg_dkey(ih, entry, agg_param, acts);
@@ -2535,6 +2552,7 @@ enum {
 	AGG_MODE_AGGREGATE,
 	AGG_MODE_DISCARD,
 	AGG_MODE_OBJ_DISCARD,
+	AGG_MODE_OBJ_AGGREGATE,
 };
 
 static int
@@ -2620,6 +2638,22 @@ aggregate_enter(struct vos_container *cont, int agg_mode, daos_epoch_range_t *ep
 
 		cont->vc_obj_discard_count++;
 		break;
+	case AGG_MODE_OBJ_AGGREGATE:
+		/**
+		 * Per-object aggregation: allows concurrent per-object aggregation
+		 * within the same container, and may overlap with container-level
+		 * aggregation. Conflicts only with container-level discard.
+		 */
+		if (cont->vc_in_discard) {
+			D_ERROR(DF_CONT ": In discard epr[" DF_U64 ", " DF_U64 "], "
+					"cannot do obj aggregate\n",
+				DP_CONT(cont->vc_pool->vp_id, cont->vc_id),
+				cont->vc_epr_discard.epr_lo, cont->vc_epr_discard.epr_hi);
+			return -DER_BUSY;
+		}
+
+		cont->vc_obj_aggregate_count++;
+		break;
 	}
 
 	rc = vos_flush_wal_header(cont->vc_pool);
@@ -2657,6 +2691,10 @@ aggregate_exit(struct vos_container *cont, int agg_mode)
 	case AGG_MODE_OBJ_DISCARD:
 		D_ASSERT(cont->vc_obj_discard_count > 0);
 		cont->vc_obj_discard_count--;
+		break;
+	case AGG_MODE_OBJ_AGGREGATE:
+		D_ASSERT(cont->vc_obj_aggregate_count > 0);
+		cont->vc_obj_aggregate_count--;
 		break;
 	}
 }
@@ -2813,6 +2851,144 @@ free_agg_data:
 		if (vam && vam->vam_fail_count)
 			d_tm_inc_counter(vam->vam_fail_count, 1);
 	}
+	umem_heap_gc(&cont->vc_pool->vp_umm);
+
+	return rc;
+}
+
+/**
+ * Aggregate a single object within a container without acquiring container-level
+ * locks.  The caller is responsible for locking (via aggregate_enter/exit or
+ * via vos_obj_aggregate which wraps this).
+ *
+ * \param[in] coh	Container open handle
+ * \param[in] oid	Object ID to aggregate
+ * \param[in] epr	Epoch range for aggregation
+ * \param[in] agg_param	Initialized aggregation parameters (credits, yield, umm, etc.)
+ *
+ * \return		0 on success, negative on error
+ */
+static int
+vos_obj_aggregate_internal(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_range_t *epr,
+			   struct vos_agg_param *agg_param)
+{
+	struct vos_container   *cont = vos_hdl2cont(coh);
+	vos_iter_param_t        iter_param;
+	struct vos_iter_anchors anchors;
+	int                     rc;
+
+	D_DEBUG(DB_EPC, DF_CONT ": Object " DF_UOID " aggregation epr " DF_X64 "-" DF_X64 "\n",
+		DP_CONT(cont->vc_pool->vp_id, cont->vc_id), DP_UOID(oid), epr->epr_lo, epr->epr_hi);
+
+	memset(&iter_param, 0, sizeof(iter_param));
+	memset(&anchors, 0, sizeof(anchors));
+
+	/* Set iteration parameters: start at DKEY level for the given object */
+	iter_param.ip_hdl      = coh;
+	iter_param.ip_oid      = oid;
+	iter_param.ip_epr      = *epr;
+	iter_param.ip_epc_expr = VOS_IT_EPC_RR;
+	iter_param.ip_flags =
+	    VOS_IT_PUNCHED | VOS_IT_RECX_COVERED | VOS_IT_FOR_PURGE | VOS_IT_FOR_AGG;
+	iter_param.ip_filter_cb  = vos_agg_filter;
+	iter_param.ip_filter_arg = agg_param;
+
+	/* Save current object ID so callbacks can reference it */
+	agg_param->ap_oid = oid;
+
+	rc = vos_iterate(&iter_param, VOS_ITER_DKEY, true, &anchors, vos_aggregate_pre_cb,
+			 vos_aggregate_post_cb, agg_param, NULL);
+
+	return rc;
+}
+
+int
+vos_obj_aggregate_enter(daos_handle_t coh, daos_epoch_range_t *epr)
+{
+	return aggregate_enter(vos_hdl2cont(coh), AGG_MODE_OBJ_AGGREGATE, epr);
+}
+
+void
+vos_obj_aggregate_exit(daos_handle_t coh)
+{
+	aggregate_exit(vos_hdl2cont(coh), AGG_MODE_OBJ_AGGREGATE);
+}
+
+/**
+ * Aggregate epochs within a specified epoch range for a single object.
+ * Multiple objects in the same container can be aggregated concurrently
+ * by calling this function from different threads.
+ *
+ * \param coh	  [IN]		Container open handle
+ * \param oid	  [IN]		Object ID
+ * \param epr	  [IN]		Epoch range of aggregation
+ * \param yield_func [IN]	Pointer to customized yield function
+ * \param yield_arg  [IN]	Argument of yield function
+ * \param flags      [IN]	Aggregation flags
+ *
+ * \return			0 on success, negative on error
+ */
+int
+vos_obj_aggregate(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_range_t *epr,
+		  int (*yield_func)(void *arg), void *yield_arg, uint32_t flags)
+{
+	struct vos_container *cont = vos_hdl2cont(coh);
+	struct vos_agg_param  agg_param;
+	uint64_t              feats;
+	daos_epoch_t          agg_write;
+	bool                  has_agg_write;
+	int                   rc;
+	bool                  run_agg = false;
+
+	D_DEBUG(DB_TRACE, DF_CONT ": obj " DF_UOID " epr: %lu -> %lu\n",
+		DP_CONT(cont->vc_pool->vp_id, cont->vc_id), DP_UOID(oid), epr->epr_lo, epr->epr_hi);
+	D_ASSERT(epr != NULL);
+	D_ASSERTF(epr->epr_lo < epr->epr_hi && epr->epr_hi != DAOS_EPOCH_MAX,
+		  "epr_lo:" DF_U64 ", epr_hi:" DF_U64 "\n", epr->epr_lo, epr->epr_hi);
+
+	rc = aggregate_enter(cont, AGG_MODE_OBJ_AGGREGATE, epr);
+	if (rc)
+		return rc;
+
+	memset(&agg_param, 0, sizeof(agg_param));
+
+	if (flags & VOS_AGG_FL_FORCE_SCAN)
+		agg_param.ap_filter_epoch = epr->epr_lo;
+	else
+		agg_param.ap_filter_epoch = cont->vc_cont_df->cd_hae;
+
+	feats         = dbtree_feats_get(&cont->vc_cont_df->cd_obj_root);
+	has_agg_write = vos_feats_agg_time_get(feats, &agg_write);
+	if (has_agg_write && agg_write <= agg_param.ap_filter_epoch)
+		goto exit;
+
+	agg_param.ap_umm        = &cont->vc_pool->vp_umm;
+	agg_param.ap_coh        = coh;
+	agg_param.ap_discard    = 0;
+	agg_param.ap_yield_func = yield_func;
+	agg_param.ap_yield_arg  = yield_arg;
+	agg_param.ap_flags      = flags;
+	credits_set(cont->vc_pool, &agg_param.ap_credits, true);
+	merge_window_init(&agg_param.ap_window);
+	run_agg = true;
+
+	rc = vos_obj_aggregate_internal(coh, oid, epr, &agg_param);
+
+	if (rc != 0 || agg_param.ap_nospc_err) {
+		close_merge_window(&agg_param.ap_window, rc);
+	} else if (agg_param.ap_csum_err) {
+		rc = -DER_CSUM;
+		close_merge_window(&agg_param.ap_window, rc);
+	} else if (agg_param.ap_in_progress) {
+		/* Don't error out — just skip HAE update */
+	}
+
+exit:
+	aggregate_exit(cont, AGG_MODE_OBJ_AGGREGATE);
+
+	if (run_agg && merge_window_status(&agg_param.ap_window) != MW_CLOSED)
+		D_ASSERTF(false, "Per-object merge window resource leaked.\n");
+
 	umem_heap_gc(&cont->vc_pool->vp_umm);
 
 	return rc;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -449,6 +449,7 @@ struct vos_container {
 	/* Various flags */
 	uint32_t vc_in_aggregation : 1, vc_in_discard : 1, vc_cmt_dtx_indexed : 1, vc_dtx_reset : 1;
 	unsigned int		vc_obj_discard_count;
+	unsigned int            vc_obj_aggregate_count;
 	unsigned int		vc_open_count;
 	/* The latest pool map version that DTX resync has been done. */
 	uint32_t                vc_dtx_resync_ver;


### PR DESCRIPTION
Restructure VOS aggregation from container-centric to object-centric:

1. Add vos_obj_aggregate(coh, oid, epr, ...) public API for per-object aggregation. Objects in the same container can be aggregated concurrently via the new AGG_MODE_OBJ_AGGREGATE locking mode (reference count).

2. Extract vos_obj_aggregate_internal() as the shared per-object implementation without container-level locking. Existing vos_aggregate() now iterates objects and calls this internal function per object via VOS_ITER_CB_SKIP.

3. Refactor srv_target.c to use vos_obj_aggregate() explicitly: cont_vos_aggregate_cb() now iterates container objects with vos_iterate_obj() and calls vos_obj_aggregate() for each. This prepares for future ULT-per-object parallel aggregation.

4. Add vos_obj_aggregate_enter/exit() public wrappers.

5. Add struct vos_container.vc_obj_aggregate_count for per-object concurrency tracking.

6. Add unit tests (VOS438-VOS440) covering per-object aggregation SV, EV, and multi-object isolation.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
