### PR TITLE
DAOS-18866 vos: unconditional punch fix (#18219)

### DIFF
--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -494,6 +494,16 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	if (rc != 0)
 		goto reset;
 
+	if (!(hold_flags & VOS_OBJ_CREATE) && (obj->obj_df == NULL)) {
+		rc = vos_ilog_ts_add(ts_set, NULL, &oid, sizeof(oid));
+		D_ASSERT(rc == 0);
+
+		rc = -DER_NONEXIST;
+		vos_obj_release(obj, 0, true);
+		obj = NULL;
+		goto reset;
+	}
+
 	rc = vos_tx_begin(dth, vos_cont2umm(cont), cont->vc_pool->vp_sysdb, obj);
 	if (rc != 0)
 		goto reset;

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -545,6 +545,8 @@ vos_obj_incarnate(struct vos_object *obj, daos_epoch_range_t *epr, daos_epoch_t 
 		if (rc == 0) {
 			obj->obj_sync_epoch = obj->obj_df->vo_sync;
 		} else if (rc == -DER_NONEXIST) {
+			if (!(flags & VOS_OBJ_CREATE))
+				return -DER_NONEXIST;
 			rc = vos_oi_alloc(cont, obj->obj_id, epr->epr_hi, &obj->obj_df, ts_set);
 			if (rc) {
 				DL_ERROR(rc, DF_CONT ": Failed to allocate OI " DF_UOID ".",


### PR DESCRIPTION
Return DER_NONEXIST error when object doesn't exist for unconditional puch case. This patch also fixed vos_obj_incarnate() to return DER_NONEXIST error when CREATE flag isn't present.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
