### PR TITLE
DAOS-19001 vos: set dth_need_validation when evict active DTX - b28

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -29,18 +29,19 @@
 #define DTX_UMOFF_TYPES		(DTX_UMOFF_ILOG | DTX_UMOFF_SVT | DTX_UMOFF_EVT)
 #define DTX_INDEX_INVAL		(int32_t)(-1)
 
-#define dtx_evict_lid(cont, dae)							\
-	do {										\
-		if (dae->dae_dth != NULL && dae->dae_dth->dth_ent != NULL) {		\
-			D_ASSERT(dae->dae_dth->dth_ent == dae);				\
-			dae->dae_dth->dth_ent = NULL;					\
-		}									\
-		D_DEBUG(DB_IO, "Evicting DTX "DF_DTI": lid=%x\n",			\
-			DP_DTI(&DAE_XID(dae)), DAE_LID(dae));				\
-		d_list_del_init(&dae->dae_link);					\
-		lrua_evictx(cont->vc_dtx_array,						\
-			    (DAE_LID(dae) & DTX_LID_SOLO_MASK) - DTX_LID_RESERVED,	\
-			    DAE_EPOCH(dae));						\
+#define dtx_evict_lid(cont, dae)                                                                   \
+	do {                                                                                       \
+		if (dae->dae_dth != NULL && dae->dae_dth->dth_ent != NULL) {                       \
+			D_ASSERT(dae->dae_dth->dth_ent == dae);                                    \
+			dae->dae_dth->dth_need_validation = 1;                                     \
+			dae->dae_dth->dth_ent             = NULL;                                  \
+		}                                                                                  \
+		D_DEBUG(DB_IO, "Evicting DTX " DF_DTI ": lid = %x\n", DP_DTI(&DAE_XID(dae)),       \
+			DAE_LID(dae));                                                             \
+		d_list_del_init(&dae->dae_link);                                                   \
+		lrua_evictx(cont->vc_dtx_array,                                                    \
+			    (DAE_LID(dae) & DTX_LID_SOLO_MASK) - DTX_LID_RESERVED,                 \
+			    DAE_EPOCH(dae));                                                       \
 	} while (0)
 
 bool vos_skip_old_partial_dtx;


### PR DESCRIPTION
There is race condition between IO RPC handler and DTX resync that may commit or abort the DTX when related DTX leader waiting for non-leader participants. To properly handle such case, anytime when an active DTX entry is evicted from the cache, in spite of it is for commit or abort, we need to set dtx_handle::dth_need_validation to notify the DTX owner about the event.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
