### PR TITLE
DAOS-18976 rebuild: abort scan sooner when rebuild is interrupted

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -3379,7 +3379,8 @@ ds_migrate_stop(struct ds_pool *pool, unsigned int version, unsigned int generat
 	atomic_fetch_sub(&pool->sp_rebuilding, arg.tls_stopped);
 	ABT_mutex_free(&arg.stop_lock);
 
-	D_INFO(DF_UUID" migrate stopped\n", DP_UUID(pool->sp_uuid));
+	D_INFO(DF_UUID " ver %d, gen %d migrate stopped\n", DP_UUID(pool->sp_uuid), version,
+	       generation);
 }
 
 static int

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -129,7 +129,7 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 		    !daos_crt_network_error(rc)))
 			break;
 
-		if (rpt->rt_abort || rpt->rt_finishing) {
+		if (rpt->rt_abort || rpt->rt_finishing || rpt->rt_global_done) {
 			rc = -DER_SHUTDOWN;
 			DL_INFO(rc, DF_RB ": give up ds_object_migrate_send, shutdown rebuild",
 				DP_RB_RPT(rpt));
@@ -728,8 +728,9 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 	int				i;
 	int				rc = 0;
 
-	if (rpt->rt_abort || arg->cont_child->sc_stopping) {
-		D_DEBUG(DB_REBUILD, "rebuild is aborted\n");
+	if (rpt->rt_abort || rpt->rt_finishing || rpt->rt_global_done ||
+	    arg->cont_child->sc_stopping) {
+		D_DEBUG(DB_REBUILD, DF_RB "rebuild is aborted\n", DP_RB_RPT(rpt));
 		return 1;
 	}
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -2349,8 +2349,7 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 	struct rebuild_pool_tls	*pool_tls;
 	int			 rc;
 
-	D_INFO("finishing rebuild for "DF_UUID", map_ver=%u refcount %u\n",
-	       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver, rpt->rt_refcount);
+	D_INFO(DF_RB "finishing rebuild, refcount %u\n", DP_RB_RPT(rpt), rpt->rt_refcount);
 
 	D_ASSERT(atomic_load(&rpt->rt_pool->sp_rebuilding) > 0);
 	atomic_fetch_sub(&rpt->rt_pool->sp_rebuilding, 1);
@@ -2420,8 +2419,7 @@ rebuild_tgt_status_check_ult(void *arg)
 		rc = rebuild_tgt_query(rpt, &status);
 		ABT_mutex_free(&status.lock);
 		if (rc || status.status != 0) {
-			D_ERROR(DF_UUID" rebuild failed: "DF_RC"\n",
-				DP_UUID(rpt->rt_pool_uuid),
+			D_ERROR(DF_RB " rebuild failed: " DF_RC "\n", DP_RB_RPT(rpt),
 				DP_RC(rc == 0 ? status.status : rc));
 			if (status.status == 0)
 				status.status = rc;
@@ -2530,14 +2528,13 @@ rebuild_tgt_status_check_ult(void *arg)
 		}
 
 		if (check_cnt % log_cnt_intv == 0 || rpt->rt_global_done || rpt->rt_abort) {
-			D_INFO(DF_UUID " ver %d gen %u obj " DF_U64 "/" DF_U64 " rec " DF_U64
-				       " size " DF_U64 " scan done %d pull done %d scan gl done %d"
-				       " gl done %d status %d abort %s\n",
-			       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver,
-			       rpt->rt_pool->sp_rebuild_gen, iv.riv_toberb_obj_count,
-			       iv.riv_obj_count, iv.riv_rec_count, iv.riv_size, rpt->rt_scan_done,
-			       iv.riv_pull_done, rpt->rt_global_scan_done, rpt->rt_global_done,
-			       iv.riv_status, rpt->rt_abort ? "yes" : "no");
+			D_INFO(DF_RB " obj " DF_U64 "/" DF_U64 " rec " DF_U64 " size " DF_U64
+				     " scan done %d pull done %d scan gl done %d"
+				     " gl done %d status %d abort %s\n",
+			       DP_RB_RPT(rpt), iv.riv_toberb_obj_count, iv.riv_obj_count,
+			       iv.riv_rec_count, iv.riv_size, rpt->rt_scan_done, iv.riv_pull_done,
+			       rpt->rt_global_scan_done, rpt->rt_global_done, iv.riv_status,
+			       rpt->rt_abort ? "yes" : "no");
 			log_cnt_intv = min(log_cnt_intv * 2, (uint64_t)RBLD_LOG_INTV_CNT);
 		}
 		check_cnt++;


### PR DESCRIPTION
- abort scan sooner if rebuild is interrupted

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
