### PR TITLE
DAOS-18990 pool: Fix "data redundancy" in queries (#18314)

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4181,16 +4181,38 @@ bulk_cb(const struct crt_bulk_cb_info *cb_info)
 static int
 pool_query_set_rebuild_status_degraded(struct pool_svc *svc, struct daos_rebuild_status *rebuild_st)
 {
-	unsigned int down_tgts = 0;
-	int          rc;
+	struct pool_target *tgts       = NULL;
+	unsigned int        tgts_count = 0;
+	bool                degraded   = false;
+	int                 rc;
+	int                 i;
 
+	/* Infer the data redundancy status from the pool map. */
 	ABT_rwlock_rdlock(svc->ps_pool->sp_lock);
-	rc = pool_map_find_down_tgts(svc->ps_pool->sp_map, NULL /* tgt_pp */, &down_tgts);
-	ABT_rwlock_unlock(svc->ps_pool->sp_lock);
-	if (rc != 0)
+	rc = pool_map_find_tgts_by_state(svc->ps_pool->sp_map, PO_COMP_ST_DOWN | PO_COMP_ST_UP,
+					 &tgts, &tgts_count);
+	if (rc != 0) {
+		ABT_rwlock_unlock(svc->ps_pool->sp_lock);
 		return rc;
+	}
+	for (i = 0; i < tgts_count; i++) {
+		if (tgts[i].ta_comp.co_status == PO_COMP_ST_DOWN ||
+		    (tgts[i].ta_comp.co_status == PO_COMP_ST_UP &&
+		     tgts[i].ta_comp.co_flags & PO_COMPF_DOWN2UP)) {
+			/*
+			 * Any DOWN targets are not yet rebuilt, and any UP
+			 * targets with the DOWN2UP flag are neither rebuilt
+			 * nor fully reintegrated, hence degraded data
+			 * redundancy.
+			 */
+			degraded = true;
+			break;
+		}
+	}
+	D_FREE(tgts);
+	ABT_rwlock_unlock(svc->ps_pool->sp_lock);
 
-	if (down_tgts > 0)
+	if (degraded)
 		rebuild_st->rs_flags |= DAOS_RSF_DEGRADED;
 	else
 		rebuild_st->rs_flags &= ~DAOS_RSF_DEGRADED;


### PR DESCRIPTION
See the Jira ticket for the problem. This patch checks UP+DOWN2UP targets in addition to DOWN ones when inferring data redundancy status for pool queries.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
