### PR TITLE
DAOS-18827 build: Update Ubuntu base image to 24.04 (#18044)

### DIFF
--- a/.github/workflows/landing-builds.yml
+++ b/.github/workflows/landing-builds.yml
@@ -249,7 +249,7 @@ jobs:
             with: rockylinux/rockylinux:8
           - distro: ubuntu
             base: ubuntu
-            with: ubuntu:22.04
+            with: ubuntu:24.04
     env:
       DEPS_JOBS: 10
       BASE_DISTRO: ${{ matrix.with }}

--- a/ci/parse_ci_envs.sh
+++ b/ci/parse_ci_envs.sh
@@ -53,6 +53,11 @@ if [ -n "${STAGE_NAME:?}" ]; then
       : "${TARGET:=ubuntu22}"
       : "${REPO_SPEC:=ubuntu-22.04}"
       ;;
+    *Ubuntu\ 24.04*|*ubuntu2404*)
+      : "${CHROOT_NAME:="not_applicable"}"
+      : "${TARGET:=ubuntu24}"
+      : "${REPO_SPEC:=ubuntu-24.04}"
+      ;;
   esac
 fi
 export CHROOT_NAME

--- a/src/control/provider/system/distribution_test.go
+++ b/src/control/provider/system/distribution_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2022 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -93,6 +94,19 @@ func TestSystem_getDistribution(t *testing.T) {
 				Name: "Ubuntu",
 				Version: DistributionVersion{
 					Major: 22,
+					Minor: 4,
+				},
+			},
+		},
+		"ubuntu-24.04": {
+			fileMap: map[string]string{
+				"/etc/os-release": "distros/ubuntu24.04-os-rel",
+			},
+			expDist: Distribution{
+				ID:   "ubuntu",
+				Name: "Ubuntu",
+				Version: DistributionVersion{
+					Major: 24,
 					Minor: 4,
 				},
 			},

--- a/src/control/provider/system/distros/ubuntu24.04-os-rel
+++ b/src/control/provider/system/distros/ubuntu24.04-os-rel
@@ -1,0 +1,12 @@
+NAME="Ubuntu"
+VERSION="24.04.2 LTS (Noble Numbat)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 24.04.2 LTS"
+VERSION_ID="24.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+UBUNTU_CODENAME=noble
+VERSION_CODENAME=noble

--- a/utils/docker/Dockerfile.ubuntu
+++ b/utils/docker/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 # Copyright 2018-2024 Intel Corporation
 # Copyright 2025 Google LLC
-# Copyright 2025 Hewlett Packard Enterprise Development LP
+# Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 # All rights reserved.
 #
 # 'recipe' for Docker to build an image of Ubuntu-based environment for building the DAOS project.
@@ -9,7 +9,7 @@
 #
 
 # Pull base image
-ARG BASE_DISTRO=ubuntu:22.04
+ARG BASE_DISTRO=ubuntu:24.04
 FROM $BASE_DISTRO
 LABEL maintainer="daos@daos.groups.io"
 # Needed for later use of BASE_DISTRO


### PR DESCRIPTION
### Description

Backport of the PR https://github.com/daos-stack/daos/pull/18044

The Dockerfile.ubuntu was updated to change the BASE_DISTRO argument from ubuntu:22.04 to ubuntu:24.04.
This ensures that our Docker builds leverage the latest Ubuntu LTS release, providing improved security, updated packages, and better long-term support.


### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
