### PR TITLE
DAOS-18991 test: use mpi4py from system install (#18362)

### DIFF
--- a/requirements-ftest.txt
+++ b/requirements-ftest.txt
@@ -5,4 +5,3 @@ clustershell
 paramiko
 distro
 torch
-mpi4py

--- a/src/tests/ftest/util/mpiio_utils.py
+++ b/src/tests/ftest/util/mpiio_utils.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2019-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -31,6 +32,10 @@ class Mpi4pyCommand(ExecutableCommand):
             path (str): path to the macsio command.
         """
         super().__init__("/run/mpi4py/*", "test_io_daos.py", path)
+
+        # Do not run with python directly as this executable comes from the system install,
+        # not from the current python environment.
+        self._python = None
 
 
 class RomioCommand(ExecutableCommand):


### PR DESCRIPTION
Use mpi4py from the system install instead of from the virtual environment, because MPI linkage is incorrect in the virtual environment.

Test-tag: LlnlMpi4py llnlmpi4pyhdf5 mpi4py
Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
