### PR TITLE
DAOS-19029 control: Forward all check leader upcalls

### DIFF
--- a/src/control/common/proto/mgmt/mgmt.pb.go
+++ b/src/control/common/proto/mgmt/mgmt.pb.go
@@ -33,7 +33,7 @@ var File_mgmt_mgmt_proto protoreflect.FileDescriptor
 
 const file_mgmt_mgmt_proto_rawDesc = "" +
 	"\n" +
-	"\x0fmgmt/mgmt.proto\x12\x04mgmt\x1a\x12shared/event.proto\x1a\x19shared/check_engine.proto\x1a\x0fmgmt/pool.proto\x1a\x10mgmt/check.proto\x1a\x0fmgmt/cont.proto\x1a\x0emgmt/svc.proto\x1a\x0emgmt/acl.proto\x1a\x11mgmt/system.proto\x1a\rchk/chk.proto\x1a\x10chk/faults.proto2\xe5\x18\n" +
+	"\x0fmgmt/mgmt.proto\x12\x04mgmt\x1a\x12shared/event.proto\x1a\x19shared/check_engine.proto\x1a\x0fmgmt/pool.proto\x1a\x10mgmt/check.proto\x1a\x0fmgmt/cont.proto\x1a\x0emgmt/svc.proto\x1a\x0emgmt/acl.proto\x1a\x11mgmt/system.proto\x1a\rchk/chk.proto\x1a\x10chk/faults.proto2\x81\x1a\n" +
 	"\aMgmtSvc\x12'\n" +
 	"\x04Join\x12\r.mgmt.JoinReq\x1a\x0e.mgmt.JoinResp\"\x00\x12C\n" +
 	"\fClusterEvent\x12\x17.shared.ClusterEventReq\x1a\x18.shared.ClusterEventResp\"\x00\x12<\n" +
@@ -82,7 +82,9 @@ const file_mgmt_mgmt_proto_rawDesc = "" +
 	"\x14SystemCheckSetPolicy\x12\x17.mgmt.CheckSetPolicyReq\x1a\x0e.mgmt.DaosResp\"\x00\x12K\n" +
 	"\x14SystemCheckGetPolicy\x12\x17.mgmt.CheckGetPolicyReq\x1a\x18.mgmt.CheckGetPolicyResp\"\x00\x12<\n" +
 	"\x11SystemCheckRepair\x12\x11.mgmt.CheckActReq\x1a\x12.mgmt.CheckActResp\"\x00\x12L\n" +
-	"\x17SystemCheckEngineReport\x12\x16.shared.CheckReportReq\x1a\x17.shared.CheckReportResp\"\x00\x129\n" +
+	"\x17SystemCheckEngineReport\x12\x16.shared.CheckReportReq\x1a\x17.shared.CheckReportResp\"\x00\x12I\n" +
+	"\x12SystemCheckRegPool\x12\x17.shared.CheckRegPoolReq\x1a\x18.shared.CheckRegPoolResp\"\x00\x12O\n" +
+	"\x14SystemCheckDeregPool\x12\x19.shared.CheckDeregPoolReq\x1a\x1a.shared.CheckDeregPoolResp\"\x00\x129\n" +
 	"\rSystemSetAttr\x12\x16.mgmt.SystemSetAttrReq\x1a\x0e.mgmt.DaosResp\"\x00\x12B\n" +
 	"\rSystemGetAttr\x12\x16.mgmt.SystemGetAttrReq\x1a\x17.mgmt.SystemGetAttrResp\"\x00\x129\n" +
 	"\rSystemSetProp\x12\x16.mgmt.SystemSetPropReq\x1a\x0e.mgmt.DaosResp\"\x00\x12B\n" +
@@ -94,90 +96,94 @@ const file_mgmt_mgmt_proto_rawDesc = "" +
 	".chk.Fault\x1a\x0e.mgmt.DaosResp\"\x00B:Z8github.com/daos-stack/daos/src/control/common/proto/mgmtb\x06proto3"
 
 var file_mgmt_mgmt_proto_goTypes = []any{
-	(*JoinReq)(nil),                 // 0: mgmt.JoinReq
-	(*shared.ClusterEventReq)(nil),  // 1: shared.ClusterEventReq
-	(*LeaderQueryReq)(nil),          // 2: mgmt.LeaderQueryReq
-	(*PoolCreateReq)(nil),           // 3: mgmt.PoolCreateReq
-	(*PoolDestroyReq)(nil),          // 4: mgmt.PoolDestroyReq
-	(*PoolEvictReq)(nil),            // 5: mgmt.PoolEvictReq
-	(*PoolExcludeReq)(nil),          // 6: mgmt.PoolExcludeReq
-	(*PoolDrainReq)(nil),            // 7: mgmt.PoolDrainReq
-	(*PoolExtendReq)(nil),           // 8: mgmt.PoolExtendReq
-	(*PoolReintReq)(nil),            // 9: mgmt.PoolReintReq
-	(*PoolQueryReq)(nil),            // 10: mgmt.PoolQueryReq
-	(*PoolQueryTargetReq)(nil),      // 11: mgmt.PoolQueryTargetReq
-	(*PoolSetPropReq)(nil),          // 12: mgmt.PoolSetPropReq
-	(*PoolGetPropReq)(nil),          // 13: mgmt.PoolGetPropReq
-	(*GetACLReq)(nil),               // 14: mgmt.GetACLReq
-	(*ModifyACLReq)(nil),            // 15: mgmt.ModifyACLReq
-	(*DeleteACLReq)(nil),            // 16: mgmt.DeleteACLReq
-	(*PoolUpgradeReq)(nil),          // 17: mgmt.PoolUpgradeReq
-	(*PoolRebuildStartReq)(nil),     // 18: mgmt.PoolRebuildStartReq
-	(*PoolRebuildStopReq)(nil),      // 19: mgmt.PoolRebuildStopReq
-	(*PoolSelfHealEvalReq)(nil),     // 20: mgmt.PoolSelfHealEvalReq
-	(*GetAttachInfoReq)(nil),        // 21: mgmt.GetAttachInfoReq
-	(*ListPoolsReq)(nil),            // 22: mgmt.ListPoolsReq
-	(*ListContReq)(nil),             // 23: mgmt.ListContReq
-	(*ContSetOwnerReq)(nil),         // 24: mgmt.ContSetOwnerReq
-	(*SystemQueryReq)(nil),          // 25: mgmt.SystemQueryReq
-	(*SystemStopReq)(nil),           // 26: mgmt.SystemStopReq
-	(*SystemStartReq)(nil),          // 27: mgmt.SystemStartReq
-	(*SystemExcludeReq)(nil),        // 28: mgmt.SystemExcludeReq
-	(*SystemDrainReq)(nil),          // 29: mgmt.SystemDrainReq
-	(*SystemRebuildManageReq)(nil),  // 30: mgmt.SystemRebuildManageReq
-	(*SystemSelfHealEvalReq)(nil),   // 31: mgmt.SystemSelfHealEvalReq
-	(*SystemEraseReq)(nil),          // 32: mgmt.SystemEraseReq
-	(*SystemCleanupReq)(nil),        // 33: mgmt.SystemCleanupReq
-	(*CheckEnableReq)(nil),          // 34: mgmt.CheckEnableReq
-	(*CheckDisableReq)(nil),         // 35: mgmt.CheckDisableReq
-	(*CheckStartReq)(nil),           // 36: mgmt.CheckStartReq
-	(*CheckStopReq)(nil),            // 37: mgmt.CheckStopReq
-	(*CheckQueryReq)(nil),           // 38: mgmt.CheckQueryReq
-	(*CheckSetPolicyReq)(nil),       // 39: mgmt.CheckSetPolicyReq
-	(*CheckGetPolicyReq)(nil),       // 40: mgmt.CheckGetPolicyReq
-	(*CheckActReq)(nil),             // 41: mgmt.CheckActReq
-	(*shared.CheckReportReq)(nil),   // 42: shared.CheckReportReq
-	(*SystemSetAttrReq)(nil),        // 43: mgmt.SystemSetAttrReq
-	(*SystemGetAttrReq)(nil),        // 44: mgmt.SystemGetAttrReq
-	(*SystemSetPropReq)(nil),        // 45: mgmt.SystemSetPropReq
-	(*SystemGetPropReq)(nil),        // 46: mgmt.SystemGetPropReq
-	(*chk.CheckReport)(nil),         // 47: chk.CheckReport
-	(*chk.Fault)(nil),               // 48: chk.Fault
-	(*JoinResp)(nil),                // 49: mgmt.JoinResp
-	(*shared.ClusterEventResp)(nil), // 50: shared.ClusterEventResp
-	(*LeaderQueryResp)(nil),         // 51: mgmt.LeaderQueryResp
-	(*PoolCreateResp)(nil),          // 52: mgmt.PoolCreateResp
-	(*PoolDestroyResp)(nil),         // 53: mgmt.PoolDestroyResp
-	(*PoolEvictResp)(nil),           // 54: mgmt.PoolEvictResp
-	(*PoolExcludeResp)(nil),         // 55: mgmt.PoolExcludeResp
-	(*PoolDrainResp)(nil),           // 56: mgmt.PoolDrainResp
-	(*PoolExtendResp)(nil),          // 57: mgmt.PoolExtendResp
-	(*PoolReintResp)(nil),           // 58: mgmt.PoolReintResp
-	(*PoolQueryResp)(nil),           // 59: mgmt.PoolQueryResp
-	(*PoolQueryTargetResp)(nil),     // 60: mgmt.PoolQueryTargetResp
-	(*PoolSetPropResp)(nil),         // 61: mgmt.PoolSetPropResp
-	(*PoolGetPropResp)(nil),         // 62: mgmt.PoolGetPropResp
-	(*ACLResp)(nil),                 // 63: mgmt.ACLResp
-	(*DaosResp)(nil),                // 64: mgmt.DaosResp
-	(*GetAttachInfoResp)(nil),       // 65: mgmt.GetAttachInfoResp
-	(*ListPoolsResp)(nil),           // 66: mgmt.ListPoolsResp
-	(*ListContResp)(nil),            // 67: mgmt.ListContResp
-	(*SystemQueryResp)(nil),         // 68: mgmt.SystemQueryResp
-	(*SystemStopResp)(nil),          // 69: mgmt.SystemStopResp
-	(*SystemStartResp)(nil),         // 70: mgmt.SystemStartResp
-	(*SystemExcludeResp)(nil),       // 71: mgmt.SystemExcludeResp
-	(*SystemDrainResp)(nil),         // 72: mgmt.SystemDrainResp
-	(*SystemRebuildManageResp)(nil), // 73: mgmt.SystemRebuildManageResp
-	(*SystemEraseResp)(nil),         // 74: mgmt.SystemEraseResp
-	(*SystemCleanupResp)(nil),       // 75: mgmt.SystemCleanupResp
-	(*CheckStartResp)(nil),          // 76: mgmt.CheckStartResp
-	(*CheckStopResp)(nil),           // 77: mgmt.CheckStopResp
-	(*CheckQueryResp)(nil),          // 78: mgmt.CheckQueryResp
-	(*CheckGetPolicyResp)(nil),      // 79: mgmt.CheckGetPolicyResp
-	(*CheckActResp)(nil),            // 80: mgmt.CheckActResp
-	(*shared.CheckReportResp)(nil),  // 81: shared.CheckReportResp
-	(*SystemGetAttrResp)(nil),       // 82: mgmt.SystemGetAttrResp
-	(*SystemGetPropResp)(nil),       // 83: mgmt.SystemGetPropResp
+	(*JoinReq)(nil),                   // 0: mgmt.JoinReq
+	(*shared.ClusterEventReq)(nil),    // 1: shared.ClusterEventReq
+	(*LeaderQueryReq)(nil),            // 2: mgmt.LeaderQueryReq
+	(*PoolCreateReq)(nil),             // 3: mgmt.PoolCreateReq
+	(*PoolDestroyReq)(nil),            // 4: mgmt.PoolDestroyReq
+	(*PoolEvictReq)(nil),              // 5: mgmt.PoolEvictReq
+	(*PoolExcludeReq)(nil),            // 6: mgmt.PoolExcludeReq
+	(*PoolDrainReq)(nil),              // 7: mgmt.PoolDrainReq
+	(*PoolExtendReq)(nil),             // 8: mgmt.PoolExtendReq
+	(*PoolReintReq)(nil),              // 9: mgmt.PoolReintReq
+	(*PoolQueryReq)(nil),              // 10: mgmt.PoolQueryReq
+	(*PoolQueryTargetReq)(nil),        // 11: mgmt.PoolQueryTargetReq
+	(*PoolSetPropReq)(nil),            // 12: mgmt.PoolSetPropReq
+	(*PoolGetPropReq)(nil),            // 13: mgmt.PoolGetPropReq
+	(*GetACLReq)(nil),                 // 14: mgmt.GetACLReq
+	(*ModifyACLReq)(nil),              // 15: mgmt.ModifyACLReq
+	(*DeleteACLReq)(nil),              // 16: mgmt.DeleteACLReq
+	(*PoolUpgradeReq)(nil),            // 17: mgmt.PoolUpgradeReq
+	(*PoolRebuildStartReq)(nil),       // 18: mgmt.PoolRebuildStartReq
+	(*PoolRebuildStopReq)(nil),        // 19: mgmt.PoolRebuildStopReq
+	(*PoolSelfHealEvalReq)(nil),       // 20: mgmt.PoolSelfHealEvalReq
+	(*GetAttachInfoReq)(nil),          // 21: mgmt.GetAttachInfoReq
+	(*ListPoolsReq)(nil),              // 22: mgmt.ListPoolsReq
+	(*ListContReq)(nil),               // 23: mgmt.ListContReq
+	(*ContSetOwnerReq)(nil),           // 24: mgmt.ContSetOwnerReq
+	(*SystemQueryReq)(nil),            // 25: mgmt.SystemQueryReq
+	(*SystemStopReq)(nil),             // 26: mgmt.SystemStopReq
+	(*SystemStartReq)(nil),            // 27: mgmt.SystemStartReq
+	(*SystemExcludeReq)(nil),          // 28: mgmt.SystemExcludeReq
+	(*SystemDrainReq)(nil),            // 29: mgmt.SystemDrainReq
+	(*SystemRebuildManageReq)(nil),    // 30: mgmt.SystemRebuildManageReq
+	(*SystemSelfHealEvalReq)(nil),     // 31: mgmt.SystemSelfHealEvalReq
+	(*SystemEraseReq)(nil),            // 32: mgmt.SystemEraseReq
+	(*SystemCleanupReq)(nil),          // 33: mgmt.SystemCleanupReq
+	(*CheckEnableReq)(nil),            // 34: mgmt.CheckEnableReq
+	(*CheckDisableReq)(nil),           // 35: mgmt.CheckDisableReq
+	(*CheckStartReq)(nil),             // 36: mgmt.CheckStartReq
+	(*CheckStopReq)(nil),              // 37: mgmt.CheckStopReq
+	(*CheckQueryReq)(nil),             // 38: mgmt.CheckQueryReq
+	(*CheckSetPolicyReq)(nil),         // 39: mgmt.CheckSetPolicyReq
+	(*CheckGetPolicyReq)(nil),         // 40: mgmt.CheckGetPolicyReq
+	(*CheckActReq)(nil),               // 41: mgmt.CheckActReq
+	(*shared.CheckReportReq)(nil),     // 42: shared.CheckReportReq
+	(*shared.CheckRegPoolReq)(nil),    // 43: shared.CheckRegPoolReq
+	(*shared.CheckDeregPoolReq)(nil),  // 44: shared.CheckDeregPoolReq
+	(*SystemSetAttrReq)(nil),          // 45: mgmt.SystemSetAttrReq
+	(*SystemGetAttrReq)(nil),          // 46: mgmt.SystemGetAttrReq
+	(*SystemSetPropReq)(nil),          // 47: mgmt.SystemSetPropReq
+	(*SystemGetPropReq)(nil),          // 48: mgmt.SystemGetPropReq
+	(*chk.CheckReport)(nil),           // 49: chk.CheckReport
+	(*chk.Fault)(nil),                 // 50: chk.Fault
+	(*JoinResp)(nil),                  // 51: mgmt.JoinResp
+	(*shared.ClusterEventResp)(nil),   // 52: shared.ClusterEventResp
+	(*LeaderQueryResp)(nil),           // 53: mgmt.LeaderQueryResp
+	(*PoolCreateResp)(nil),            // 54: mgmt.PoolCreateResp
+	(*PoolDestroyResp)(nil),           // 55: mgmt.PoolDestroyResp
+	(*PoolEvictResp)(nil),             // 56: mgmt.PoolEvictResp
+	(*PoolExcludeResp)(nil),           // 57: mgmt.PoolExcludeResp
+	(*PoolDrainResp)(nil),             // 58: mgmt.PoolDrainResp
+	(*PoolExtendResp)(nil),            // 59: mgmt.PoolExtendResp
+	(*PoolReintResp)(nil),             // 60: mgmt.PoolReintResp
+	(*PoolQueryResp)(nil),             // 61: mgmt.PoolQueryResp
+	(*PoolQueryTargetResp)(nil),       // 62: mgmt.PoolQueryTargetResp
+	(*PoolSetPropResp)(nil),           // 63: mgmt.PoolSetPropResp
+	(*PoolGetPropResp)(nil),           // 64: mgmt.PoolGetPropResp
+	(*ACLResp)(nil),                   // 65: mgmt.ACLResp
+	(*DaosResp)(nil),                  // 66: mgmt.DaosResp
+	(*GetAttachInfoResp)(nil),         // 67: mgmt.GetAttachInfoResp
+	(*ListPoolsResp)(nil),             // 68: mgmt.ListPoolsResp
+	(*ListContResp)(nil),              // 69: mgmt.ListContResp
+	(*SystemQueryResp)(nil),           // 70: mgmt.SystemQueryResp
+	(*SystemStopResp)(nil),            // 71: mgmt.SystemStopResp
+	(*SystemStartResp)(nil),           // 72: mgmt.SystemStartResp
+	(*SystemExcludeResp)(nil),         // 73: mgmt.SystemExcludeResp
+	(*SystemDrainResp)(nil),           // 74: mgmt.SystemDrainResp
+	(*SystemRebuildManageResp)(nil),   // 75: mgmt.SystemRebuildManageResp
+	(*SystemEraseResp)(nil),           // 76: mgmt.SystemEraseResp
+	(*SystemCleanupResp)(nil),         // 77: mgmt.SystemCleanupResp
+	(*CheckStartResp)(nil),            // 78: mgmt.CheckStartResp
+	(*CheckStopResp)(nil),             // 79: mgmt.CheckStopResp
+	(*CheckQueryResp)(nil),            // 80: mgmt.CheckQueryResp
+	(*CheckGetPolicyResp)(nil),        // 81: mgmt.CheckGetPolicyResp
+	(*CheckActResp)(nil),              // 82: mgmt.CheckActResp
+	(*shared.CheckReportResp)(nil),    // 83: shared.CheckReportResp
+	(*shared.CheckRegPoolResp)(nil),   // 84: shared.CheckRegPoolResp
+	(*shared.CheckDeregPoolResp)(nil), // 85: shared.CheckDeregPoolResp
+	(*SystemGetAttrResp)(nil),         // 86: mgmt.SystemGetAttrResp
+	(*SystemGetPropResp)(nil),         // 87: mgmt.SystemGetPropResp
 }
 var file_mgmt_mgmt_proto_depIdxs = []int32{
 	0,  // 0: mgmt.MgmtSvc.Join:input_type -> mgmt.JoinReq
@@ -224,66 +230,70 @@ var file_mgmt_mgmt_proto_depIdxs = []int32{
 	40, // 41: mgmt.MgmtSvc.SystemCheckGetPolicy:input_type -> mgmt.CheckGetPolicyReq
 	41, // 42: mgmt.MgmtSvc.SystemCheckRepair:input_type -> mgmt.CheckActReq
 	42, // 43: mgmt.MgmtSvc.SystemCheckEngineReport:input_type -> shared.CheckReportReq
-	43, // 44: mgmt.MgmtSvc.SystemSetAttr:input_type -> mgmt.SystemSetAttrReq
-	44, // 45: mgmt.MgmtSvc.SystemGetAttr:input_type -> mgmt.SystemGetAttrReq
-	45, // 46: mgmt.MgmtSvc.SystemSetProp:input_type -> mgmt.SystemSetPropReq
-	46, // 47: mgmt.MgmtSvc.SystemGetProp:input_type -> mgmt.SystemGetPropReq
-	47, // 48: mgmt.MgmtSvc.FaultInjectReport:input_type -> chk.CheckReport
-	48, // 49: mgmt.MgmtSvc.FaultInjectPoolFault:input_type -> chk.Fault
-	48, // 50: mgmt.MgmtSvc.FaultInjectMgmtPoolFault:input_type -> chk.Fault
-	49, // 51: mgmt.MgmtSvc.Join:output_type -> mgmt.JoinResp
-	50, // 52: mgmt.MgmtSvc.ClusterEvent:output_type -> shared.ClusterEventResp
-	51, // 53: mgmt.MgmtSvc.LeaderQuery:output_type -> mgmt.LeaderQueryResp
-	52, // 54: mgmt.MgmtSvc.PoolCreate:output_type -> mgmt.PoolCreateResp
-	53, // 55: mgmt.MgmtSvc.PoolDestroy:output_type -> mgmt.PoolDestroyResp
-	54, // 56: mgmt.MgmtSvc.PoolEvict:output_type -> mgmt.PoolEvictResp
-	55, // 57: mgmt.MgmtSvc.PoolExclude:output_type -> mgmt.PoolExcludeResp
-	56, // 58: mgmt.MgmtSvc.PoolDrain:output_type -> mgmt.PoolDrainResp
-	57, // 59: mgmt.MgmtSvc.PoolExtend:output_type -> mgmt.PoolExtendResp
-	58, // 60: mgmt.MgmtSvc.PoolReintegrate:output_type -> mgmt.PoolReintResp
-	59, // 61: mgmt.MgmtSvc.PoolQuery:output_type -> mgmt.PoolQueryResp
-	60, // 62: mgmt.MgmtSvc.PoolQueryTarget:output_type -> mgmt.PoolQueryTargetResp
-	61, // 63: mgmt.MgmtSvc.PoolSetProp:output_type -> mgmt.PoolSetPropResp
-	62, // 64: mgmt.MgmtSvc.PoolGetProp:output_type -> mgmt.PoolGetPropResp
-	63, // 65: mgmt.MgmtSvc.PoolGetACL:output_type -> mgmt.ACLResp
-	63, // 66: mgmt.MgmtSvc.PoolOverwriteACL:output_type -> mgmt.ACLResp
-	63, // 67: mgmt.MgmtSvc.PoolUpdateACL:output_type -> mgmt.ACLResp
-	63, // 68: mgmt.MgmtSvc.PoolDeleteACL:output_type -> mgmt.ACLResp
-	64, // 69: mgmt.MgmtSvc.PoolUpgrade:output_type -> mgmt.DaosResp
-	64, // 70: mgmt.MgmtSvc.PoolRebuildStart:output_type -> mgmt.DaosResp
-	64, // 71: mgmt.MgmtSvc.PoolRebuildStop:output_type -> mgmt.DaosResp
-	64, // 72: mgmt.MgmtSvc.PoolSelfHealEval:output_type -> mgmt.DaosResp
-	65, // 73: mgmt.MgmtSvc.GetAttachInfo:output_type -> mgmt.GetAttachInfoResp
-	66, // 74: mgmt.MgmtSvc.ListPools:output_type -> mgmt.ListPoolsResp
-	67, // 75: mgmt.MgmtSvc.ListContainers:output_type -> mgmt.ListContResp
-	64, // 76: mgmt.MgmtSvc.ContSetOwner:output_type -> mgmt.DaosResp
-	68, // 77: mgmt.MgmtSvc.SystemQuery:output_type -> mgmt.SystemQueryResp
-	69, // 78: mgmt.MgmtSvc.SystemStop:output_type -> mgmt.SystemStopResp
-	70, // 79: mgmt.MgmtSvc.SystemStart:output_type -> mgmt.SystemStartResp
-	71, // 80: mgmt.MgmtSvc.SystemExclude:output_type -> mgmt.SystemExcludeResp
-	72, // 81: mgmt.MgmtSvc.SystemDrain:output_type -> mgmt.SystemDrainResp
-	73, // 82: mgmt.MgmtSvc.SystemRebuildManage:output_type -> mgmt.SystemRebuildManageResp
-	64, // 83: mgmt.MgmtSvc.SystemSelfHealEval:output_type -> mgmt.DaosResp
-	74, // 84: mgmt.MgmtSvc.SystemErase:output_type -> mgmt.SystemEraseResp
-	75, // 85: mgmt.MgmtSvc.SystemCleanup:output_type -> mgmt.SystemCleanupResp
-	64, // 86: mgmt.MgmtSvc.SystemCheckEnable:output_type -> mgmt.DaosResp
-	64, // 87: mgmt.MgmtSvc.SystemCheckDisable:output_type -> mgmt.DaosResp
-	76, // 88: mgmt.MgmtSvc.SystemCheckStart:output_type -> mgmt.CheckStartResp
-	77, // 89: mgmt.MgmtSvc.SystemCheckStop:output_type -> mgmt.CheckStopResp
-	78, // 90: mgmt.MgmtSvc.SystemCheckQuery:output_type -> mgmt.CheckQueryResp
-	64, // 91: mgmt.MgmtSvc.SystemCheckSetPolicy:output_type -> mgmt.DaosResp
-	79, // 92: mgmt.MgmtSvc.SystemCheckGetPolicy:output_type -> mgmt.CheckGetPolicyResp
-	80, // 93: mgmt.MgmtSvc.SystemCheckRepair:output_type -> mgmt.CheckActResp
-	81, // 94: mgmt.MgmtSvc.SystemCheckEngineReport:output_type -> shared.CheckReportResp
-	64, // 95: mgmt.MgmtSvc.SystemSetAttr:output_type -> mgmt.DaosResp
-	82, // 96: mgmt.MgmtSvc.SystemGetAttr:output_type -> mgmt.SystemGetAttrResp
-	64, // 97: mgmt.MgmtSvc.SystemSetProp:output_type -> mgmt.DaosResp
-	83, // 98: mgmt.MgmtSvc.SystemGetProp:output_type -> mgmt.SystemGetPropResp
-	64, // 99: mgmt.MgmtSvc.FaultInjectReport:output_type -> mgmt.DaosResp
-	64, // 100: mgmt.MgmtSvc.FaultInjectPoolFault:output_type -> mgmt.DaosResp
-	64, // 101: mgmt.MgmtSvc.FaultInjectMgmtPoolFault:output_type -> mgmt.DaosResp
-	51, // [51:102] is the sub-list for method output_type
-	0,  // [0:51] is the sub-list for method input_type
+	43, // 44: mgmt.MgmtSvc.SystemCheckRegPool:input_type -> shared.CheckRegPoolReq
+	44, // 45: mgmt.MgmtSvc.SystemCheckDeregPool:input_type -> shared.CheckDeregPoolReq
+	45, // 46: mgmt.MgmtSvc.SystemSetAttr:input_type -> mgmt.SystemSetAttrReq
+	46, // 47: mgmt.MgmtSvc.SystemGetAttr:input_type -> mgmt.SystemGetAttrReq
+	47, // 48: mgmt.MgmtSvc.SystemSetProp:input_type -> mgmt.SystemSetPropReq
+	48, // 49: mgmt.MgmtSvc.SystemGetProp:input_type -> mgmt.SystemGetPropReq
+	49, // 50: mgmt.MgmtSvc.FaultInjectReport:input_type -> chk.CheckReport
+	50, // 51: mgmt.MgmtSvc.FaultInjectPoolFault:input_type -> chk.Fault
+	50, // 52: mgmt.MgmtSvc.FaultInjectMgmtPoolFault:input_type -> chk.Fault
+	51, // 53: mgmt.MgmtSvc.Join:output_type -> mgmt.JoinResp
+	52, // 54: mgmt.MgmtSvc.ClusterEvent:output_type -> shared.ClusterEventResp
+	53, // 55: mgmt.MgmtSvc.LeaderQuery:output_type -> mgmt.LeaderQueryResp
+	54, // 56: mgmt.MgmtSvc.PoolCreate:output_type -> mgmt.PoolCreateResp
+	55, // 57: mgmt.MgmtSvc.PoolDestroy:output_type -> mgmt.PoolDestroyResp
+	56, // 58: mgmt.MgmtSvc.PoolEvict:output_type -> mgmt.PoolEvictResp
+	57, // 59: mgmt.MgmtSvc.PoolExclude:output_type -> mgmt.PoolExcludeResp
+	58, // 60: mgmt.MgmtSvc.PoolDrain:output_type -> mgmt.PoolDrainResp
+	59, // 61: mgmt.MgmtSvc.PoolExtend:output_type -> mgmt.PoolExtendResp
+	60, // 62: mgmt.MgmtSvc.PoolReintegrate:output_type -> mgmt.PoolReintResp
+	61, // 63: mgmt.MgmtSvc.PoolQuery:output_type -> mgmt.PoolQueryResp
+	62, // 64: mgmt.MgmtSvc.PoolQueryTarget:output_type -> mgmt.PoolQueryTargetResp
+	63, // 65: mgmt.MgmtSvc.PoolSetProp:output_type -> mgmt.PoolSetPropResp
+	64, // 66: mgmt.MgmtSvc.PoolGetProp:output_type -> mgmt.PoolGetPropResp
+	65, // 67: mgmt.MgmtSvc.PoolGetACL:output_type -> mgmt.ACLResp
+	65, // 68: mgmt.MgmtSvc.PoolOverwriteACL:output_type -> mgmt.ACLResp
+	65, // 69: mgmt.MgmtSvc.PoolUpdateACL:output_type -> mgmt.ACLResp
+	65, // 70: mgmt.MgmtSvc.PoolDeleteACL:output_type -> mgmt.ACLResp
+	66, // 71: mgmt.MgmtSvc.PoolUpgrade:output_type -> mgmt.DaosResp
+	66, // 72: mgmt.MgmtSvc.PoolRebuildStart:output_type -> mgmt.DaosResp
+	66, // 73: mgmt.MgmtSvc.PoolRebuildStop:output_type -> mgmt.DaosResp
+	66, // 74: mgmt.MgmtSvc.PoolSelfHealEval:output_type -> mgmt.DaosResp
+	67, // 75: mgmt.MgmtSvc.GetAttachInfo:output_type -> mgmt.GetAttachInfoResp
+	68, // 76: mgmt.MgmtSvc.ListPools:output_type -> mgmt.ListPoolsResp
+	69, // 77: mgmt.MgmtSvc.ListContainers:output_type -> mgmt.ListContResp
+	66, // 78: mgmt.MgmtSvc.ContSetOwner:output_type -> mgmt.DaosResp
+	70, // 79: mgmt.MgmtSvc.SystemQuery:output_type -> mgmt.SystemQueryResp
+	71, // 80: mgmt.MgmtSvc.SystemStop:output_type -> mgmt.SystemStopResp
+	72, // 81: mgmt.MgmtSvc.SystemStart:output_type -> mgmt.SystemStartResp
+	73, // 82: mgmt.MgmtSvc.SystemExclude:output_type -> mgmt.SystemExcludeResp
+	74, // 83: mgmt.MgmtSvc.SystemDrain:output_type -> mgmt.SystemDrainResp
+	75, // 84: mgmt.MgmtSvc.SystemRebuildManage:output_type -> mgmt.SystemRebuildManageResp
+	66, // 85: mgmt.MgmtSvc.SystemSelfHealEval:output_type -> mgmt.DaosResp
+	76, // 86: mgmt.MgmtSvc.SystemErase:output_type -> mgmt.SystemEraseResp
+	77, // 87: mgmt.MgmtSvc.SystemCleanup:output_type -> mgmt.SystemCleanupResp
+	66, // 88: mgmt.MgmtSvc.SystemCheckEnable:output_type -> mgmt.DaosResp
+	66, // 89: mgmt.MgmtSvc.SystemCheckDisable:output_type -> mgmt.DaosResp
+	78, // 90: mgmt.MgmtSvc.SystemCheckStart:output_type -> mgmt.CheckStartResp
+	79, // 91: mgmt.MgmtSvc.SystemCheckStop:output_type -> mgmt.CheckStopResp
+	80, // 92: mgmt.MgmtSvc.SystemCheckQuery:output_type -> mgmt.CheckQueryResp
+	66, // 93: mgmt.MgmtSvc.SystemCheckSetPolicy:output_type -> mgmt.DaosResp
+	81, // 94: mgmt.MgmtSvc.SystemCheckGetPolicy:output_type -> mgmt.CheckGetPolicyResp
+	82, // 95: mgmt.MgmtSvc.SystemCheckRepair:output_type -> mgmt.CheckActResp
+	83, // 96: mgmt.MgmtSvc.SystemCheckEngineReport:output_type -> shared.CheckReportResp
+	84, // 97: mgmt.MgmtSvc.SystemCheckRegPool:output_type -> shared.CheckRegPoolResp
+	85, // 98: mgmt.MgmtSvc.SystemCheckDeregPool:output_type -> shared.CheckDeregPoolResp
+	66, // 99: mgmt.MgmtSvc.SystemSetAttr:output_type -> mgmt.DaosResp
+	86, // 100: mgmt.MgmtSvc.SystemGetAttr:output_type -> mgmt.SystemGetAttrResp
+	66, // 101: mgmt.MgmtSvc.SystemSetProp:output_type -> mgmt.DaosResp
+	87, // 102: mgmt.MgmtSvc.SystemGetProp:output_type -> mgmt.SystemGetPropResp
+	66, // 103: mgmt.MgmtSvc.FaultInjectReport:output_type -> mgmt.DaosResp
+	66, // 104: mgmt.MgmtSvc.FaultInjectPoolFault:output_type -> mgmt.DaosResp
+	66, // 105: mgmt.MgmtSvc.FaultInjectMgmtPoolFault:output_type -> mgmt.DaosResp
+	53, // [53:106] is the sub-list for method output_type
+	0,  // [0:53] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/src/control/common/proto/mgmt/mgmt_grpc.pb.go
+++ b/src/control/common/proto/mgmt/mgmt_grpc.pb.go
@@ -72,6 +72,8 @@ const (
 	MgmtSvc_SystemCheckGetPolicy_FullMethodName     = "/mgmt.MgmtSvc/SystemCheckGetPolicy"
 	MgmtSvc_SystemCheckRepair_FullMethodName        = "/mgmt.MgmtSvc/SystemCheckRepair"
 	MgmtSvc_SystemCheckEngineReport_FullMethodName  = "/mgmt.MgmtSvc/SystemCheckEngineReport"
+	MgmtSvc_SystemCheckRegPool_FullMethodName       = "/mgmt.MgmtSvc/SystemCheckRegPool"
+	MgmtSvc_SystemCheckDeregPool_FullMethodName     = "/mgmt.MgmtSvc/SystemCheckDeregPool"
 	MgmtSvc_SystemSetAttr_FullMethodName            = "/mgmt.MgmtSvc/SystemSetAttr"
 	MgmtSvc_SystemGetAttr_FullMethodName            = "/mgmt.MgmtSvc/SystemGetAttr"
 	MgmtSvc_SystemSetProp_FullMethodName            = "/mgmt.MgmtSvc/SystemSetProp"
@@ -181,6 +183,10 @@ type MgmtSvcClient interface {
 	SystemCheckRepair(ctx context.Context, in *CheckActReq, opts ...grpc.CallOption) (*CheckActResp, error)
 	// Report on checker results for an individual rank.
 	SystemCheckEngineReport(ctx context.Context, in *shared.CheckReportReq, opts ...grpc.CallOption) (*shared.CheckReportResp, error)
+	// Register a pool with the MS from the check leader.
+	SystemCheckRegPool(ctx context.Context, in *shared.CheckRegPoolReq, opts ...grpc.CallOption) (*shared.CheckRegPoolResp, error)
+	// De-register a pool with the MS from the check leader.
+	SystemCheckDeregPool(ctx context.Context, in *shared.CheckDeregPoolReq, opts ...grpc.CallOption) (*shared.CheckDeregPoolResp, error)
 	// Set a system attribute or attributes.
 	SystemSetAttr(ctx context.Context, in *SystemSetAttrReq, opts ...grpc.CallOption) (*DaosResp, error)
 	// Get a system attribute or attributes.
@@ -645,6 +651,26 @@ func (c *mgmtSvcClient) SystemCheckEngineReport(ctx context.Context, in *shared.
 	return out, nil
 }
 
+func (c *mgmtSvcClient) SystemCheckRegPool(ctx context.Context, in *shared.CheckRegPoolReq, opts ...grpc.CallOption) (*shared.CheckRegPoolResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(shared.CheckRegPoolResp)
+	err := c.cc.Invoke(ctx, MgmtSvc_SystemCheckRegPool_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *mgmtSvcClient) SystemCheckDeregPool(ctx context.Context, in *shared.CheckDeregPoolReq, opts ...grpc.CallOption) (*shared.CheckDeregPoolResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(shared.CheckDeregPoolResp)
+	err := c.cc.Invoke(ctx, MgmtSvc_SystemCheckDeregPool_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *mgmtSvcClient) SystemSetAttr(ctx context.Context, in *SystemSetAttrReq, opts ...grpc.CallOption) (*DaosResp, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(DaosResp)
@@ -815,6 +841,10 @@ type MgmtSvcServer interface {
 	SystemCheckRepair(context.Context, *CheckActReq) (*CheckActResp, error)
 	// Report on checker results for an individual rank.
 	SystemCheckEngineReport(context.Context, *shared.CheckReportReq) (*shared.CheckReportResp, error)
+	// Register a pool with the MS from the check leader.
+	SystemCheckRegPool(context.Context, *shared.CheckRegPoolReq) (*shared.CheckRegPoolResp, error)
+	// De-register a pool with the MS from the check leader.
+	SystemCheckDeregPool(context.Context, *shared.CheckDeregPoolReq) (*shared.CheckDeregPoolResp, error)
 	// Set a system attribute or attributes.
 	SystemSetAttr(context.Context, *SystemSetAttrReq) (*DaosResp, error)
 	// Get a system attribute or attributes.
@@ -970,6 +1000,12 @@ func (UnimplementedMgmtSvcServer) SystemCheckRepair(context.Context, *CheckActRe
 }
 func (UnimplementedMgmtSvcServer) SystemCheckEngineReport(context.Context, *shared.CheckReportReq) (*shared.CheckReportResp, error) {
 	return nil, status.Error(codes.Unimplemented, "method SystemCheckEngineReport not implemented")
+}
+func (UnimplementedMgmtSvcServer) SystemCheckRegPool(context.Context, *shared.CheckRegPoolReq) (*shared.CheckRegPoolResp, error) {
+	return nil, status.Error(codes.Unimplemented, "method SystemCheckRegPool not implemented")
+}
+func (UnimplementedMgmtSvcServer) SystemCheckDeregPool(context.Context, *shared.CheckDeregPoolReq) (*shared.CheckDeregPoolResp, error) {
+	return nil, status.Error(codes.Unimplemented, "method SystemCheckDeregPool not implemented")
 }
 func (UnimplementedMgmtSvcServer) SystemSetAttr(context.Context, *SystemSetAttrReq) (*DaosResp, error) {
 	return nil, status.Error(codes.Unimplemented, "method SystemSetAttr not implemented")
@@ -1805,6 +1841,42 @@ func _MgmtSvc_SystemCheckEngineReport_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MgmtSvc_SystemCheckRegPool_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(shared.CheckRegPoolReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MgmtSvcServer).SystemCheckRegPool(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MgmtSvc_SystemCheckRegPool_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MgmtSvcServer).SystemCheckRegPool(ctx, req.(*shared.CheckRegPoolReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MgmtSvc_SystemCheckDeregPool_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(shared.CheckDeregPoolReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MgmtSvcServer).SystemCheckDeregPool(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MgmtSvc_SystemCheckDeregPool_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MgmtSvcServer).SystemCheckDeregPool(ctx, req.(*shared.CheckDeregPoolReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _MgmtSvc_SystemSetAttr_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(SystemSetAttrReq)
 	if err := dec(in); err != nil {
@@ -2113,6 +2185,14 @@ var MgmtSvc_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SystemCheckEngineReport",
 			Handler:    _MgmtSvc_SystemCheckEngineReport_Handler,
+		},
+		{
+			MethodName: "SystemCheckRegPool",
+			Handler:    _MgmtSvc_SystemCheckRegPool_Handler,
+		},
+		{
+			MethodName: "SystemCheckDeregPool",
+			Handler:    _MgmtSvc_SystemCheckDeregPool_Handler,
 		},
 		{
 			MethodName: "SystemSetAttr",

--- a/src/control/lib/control/check.go
+++ b/src/control/lib/control/check.go
@@ -873,3 +873,97 @@ func SystemCheckEngineReport(ctx context.Context, rpcClient UnaryInvoker, req *S
 
 	return resp, nil
 }
+
+// SystemCheckRegPoolReq contains parameters to be passed to SystemCheckRegPool.
+type SystemCheckRegPoolReq struct {
+	unaryRequest
+	msRequest
+
+	sharedpb.CheckRegPoolReq
+}
+
+// SystemCheckRegPoolResp contains the response from the SystemCheckRegPool RPC.
+type SystemCheckRegPoolResp struct {
+	sharedpb.CheckRegPoolResp
+}
+
+// SystemCheckRegPool registers a pool with the management service for the checker.
+//
+// NB: This is an inter-server RPC.
+func SystemCheckRegPool(ctx context.Context, rpcClient UnaryInvoker, req *SystemCheckRegPoolReq) (*SystemCheckRegPoolResp, error) {
+	if req == nil {
+		return nil, errors.Errorf("nil %T", req)
+	}
+
+	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
+		return mgmtpb.NewMgmtSvcClient(conn).SystemCheckRegPool(ctx, &req.CheckRegPoolReq)
+	})
+
+	rpcClient.Debugf("DAOS system check register pool request: %s", pbutil.Debug(&req.CheckRegPoolReq))
+	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "gRPC call")
+	}
+
+	msResp, err := ur.getMSResponse()
+	if err != nil {
+		return nil, errors.Wrap(err, "checking MS response")
+	}
+
+	pbResp, ok := msResp.(*sharedpb.CheckRegPoolResp)
+	if !ok {
+		return nil, errors.Errorf("unexpected response type %T", msResp)
+	}
+
+	resp := new(SystemCheckRegPoolResp)
+	resp.CheckRegPoolResp = *pbResp
+
+	return resp, nil
+}
+
+// SystemCheckDeregPoolReq contains parameters to be passed to SystemCheckDeregPool.
+type SystemCheckDeregPoolReq struct {
+	unaryRequest
+	msRequest
+
+	sharedpb.CheckDeregPoolReq
+}
+
+// SystemCheckDeregPoolResp contains the response from the SystemCheckDeregPool RPC.
+type SystemCheckDeregPoolResp struct {
+	sharedpb.CheckDeregPoolResp
+}
+
+// SystemCheckDeregPool de-registers a pool with the management service for the checker.
+//
+// NB: This is an inter-server RPC.
+func SystemCheckDeregPool(ctx context.Context, rpcClient UnaryInvoker, req *SystemCheckDeregPoolReq) (*SystemCheckDeregPoolResp, error) {
+	if req == nil {
+		return nil, errors.Errorf("nil %T", req)
+	}
+
+	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
+		return mgmtpb.NewMgmtSvcClient(conn).SystemCheckDeregPool(ctx, &req.CheckDeregPoolReq)
+	})
+
+	rpcClient.Debugf("DAOS system check de-register pool request: %s", pbutil.Debug(&req.CheckDeregPoolReq))
+	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "gRPC call")
+	}
+
+	msResp, err := ur.getMSResponse()
+	if err != nil {
+		return nil, errors.Wrap(err, "checking MS response")
+	}
+
+	pbResp, ok := msResp.(*sharedpb.CheckDeregPoolResp)
+	if !ok {
+		return nil, errors.Errorf("unexpected response type %T", msResp)
+	}
+
+	resp := new(SystemCheckDeregPoolResp)
+	resp.CheckDeregPoolResp = *pbResp
+
+	return resp, nil
+}

--- a/src/control/lib/control/check_test.go
+++ b/src/control/lib/control/check_test.go
@@ -545,3 +545,175 @@ func TestControl_CheckEngineRepair(t *testing.T) {
 		})
 	}
 }
+
+func TestControl_SystemCheckRegPool(t *testing.T) {
+	for name, tc := range map[string]struct {
+		mic     *MockInvokerConfig
+		req     *SystemCheckRegPoolReq
+		expErr  error
+		expResp *SystemCheckRegPoolResp
+	}{
+		"nil req": {
+			expErr: errors.New("nil"),
+		},
+		"gRPC fails": {
+			mic: &MockInvokerConfig{
+				UnaryError: errors.New("MockInvoker error"),
+			},
+			req:    &SystemCheckRegPoolReq{},
+			expErr: errors.New("MockInvoker error"),
+		},
+		"MS error": {
+			mic: &MockInvokerConfig{
+				UnaryResponse: &UnaryResponse{
+					Responses: []*HostResponse{
+						{
+							Error: errors.New("MockInvoker response error"),
+						},
+					},
+				},
+			},
+			req:    &SystemCheckRegPoolReq{},
+			expErr: errors.New("MockInvoker response error"),
+		},
+		"daos error code": {
+			mic: &MockInvokerConfig{
+				UnaryResponse: &UnaryResponse{
+					Responses: []*HostResponse{{
+						Message: &sharedpb.CheckRegPoolResp{
+							Status: daos.MiscError.Int32(),
+						},
+					}},
+				},
+			},
+			req: &SystemCheckRegPoolReq{},
+			expResp: &SystemCheckRegPoolResp{
+				CheckRegPoolResp: sharedpb.CheckRegPoolResp{
+					Status: daos.MiscError.Int32(),
+				},
+			},
+		},
+		"bad MS response type": {
+			mic: &MockInvokerConfig{
+				UnaryResponse: &UnaryResponse{
+					Responses: []*HostResponse{
+						{
+							Message: &mgmtpb.CheckStartReq{
+								Sys: "something",
+							},
+						},
+					},
+				},
+			},
+			req:    &SystemCheckRegPoolReq{},
+			expErr: errors.New("unexpected response"),
+		},
+		"success": {
+			mic: &MockInvokerConfig{
+				UnaryResponse: &UnaryResponse{
+					Responses: []*HostResponse{{
+						Message: &sharedpb.CheckRegPoolResp{},
+					}},
+				},
+			},
+			req:     &SystemCheckRegPoolReq{},
+			expResp: &SystemCheckRegPoolResp{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := test.MustLogContext(t)
+
+			invoker := NewMockInvoker(logging.FromContext(ctx), tc.mic)
+			resp, err := SystemCheckRegPool(ctx, invoker, tc.req)
+
+			test.CmpErr(t, tc.expErr, err)
+			test.CmpAny(t, "response", tc.expResp, resp, cmpopts.IgnoreUnexported(sharedpb.CheckRegPoolResp{}))
+		})
+	}
+}
+
+func TestControl_SystemCheckDeregPool(t *testing.T) {
+	for name, tc := range map[string]struct {
+		mic     *MockInvokerConfig
+		req     *SystemCheckDeregPoolReq
+		expErr  error
+		expResp *SystemCheckDeregPoolResp
+	}{
+		"nil req": {
+			expErr: errors.New("nil"),
+		},
+		"gRPC fails": {
+			mic: &MockInvokerConfig{
+				UnaryError: errors.New("MockInvoker error"),
+			},
+			req:    &SystemCheckDeregPoolReq{},
+			expErr: errors.New("MockInvoker error"),
+		},
+		"MS error": {
+			mic: &MockInvokerConfig{
+				UnaryResponse: &UnaryResponse{
+					Responses: []*HostResponse{
+						{
+							Error: errors.New("MockInvoker response error"),
+						},
+					},
+				},
+			},
+			req:    &SystemCheckDeregPoolReq{},
+			expErr: errors.New("MockInvoker response error"),
+		},
+		"daos error code": {
+			mic: &MockInvokerConfig{
+				UnaryResponse: &UnaryResponse{
+					Responses: []*HostResponse{{
+						Message: &sharedpb.CheckDeregPoolResp{
+							Status: daos.MiscError.Int32(),
+						},
+					}},
+				},
+			},
+			req: &SystemCheckDeregPoolReq{},
+			expResp: &SystemCheckDeregPoolResp{
+				CheckDeregPoolResp: sharedpb.CheckDeregPoolResp{
+					Status: daos.MiscError.Int32(),
+				},
+			},
+		},
+		"bad MS response type": {
+			mic: &MockInvokerConfig{
+				UnaryResponse: &UnaryResponse{
+					Responses: []*HostResponse{
+						{
+							Message: &mgmtpb.CheckStartReq{
+								Sys: "something",
+							},
+						},
+					},
+				},
+			},
+			req:    &SystemCheckDeregPoolReq{},
+			expErr: errors.New("unexpected response"),
+		},
+		"success": {
+			mic: &MockInvokerConfig{
+				UnaryResponse: &UnaryResponse{
+					Responses: []*HostResponse{{
+						Message: &sharedpb.CheckDeregPoolResp{},
+					}},
+				},
+			},
+			req:     &SystemCheckDeregPoolReq{},
+			expResp: &SystemCheckDeregPoolResp{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := test.MustLogContext(t)
+
+			invoker := NewMockInvoker(logging.FromContext(ctx), tc.mic)
+			resp, err := SystemCheckDeregPool(ctx, invoker, tc.req)
+
+			test.CmpErr(t, tc.expErr, err)
+			test.CmpAny(t, "response", tc.expResp, resp, cmpopts.IgnoreUnexported(sharedpb.CheckDeregPoolResp{}))
+		})
+	}
+}

--- a/src/control/security/grpc_authorization.go
+++ b/src/control/security/grpc_authorization.go
@@ -89,6 +89,8 @@ var methodAuthorizations = map[string][]Component{
 	"/mgmt.MgmtSvc/SystemCheckGetPolicy":     {ComponentAdmin},
 	"/mgmt.MgmtSvc/SystemCheckRepair":        {ComponentAdmin},
 	"/mgmt.MgmtSvc/SystemCheckEngineReport":  {ComponentServer},
+	"/mgmt.MgmtSvc/SystemCheckRegPool":       {ComponentServer},
+	"/mgmt.MgmtSvc/SystemCheckDeregPool":     {ComponentServer},
 	"/mgmt.MgmtSvc/FaultInjectReport":        {ComponentAdmin},
 	"/mgmt.MgmtSvc/FaultInjectPoolFault":     {ComponentAdmin},
 	"/mgmt.MgmtSvc/FaultInjectMgmtPoolFault": {ComponentAdmin},

--- a/src/control/security/grpc_authorization_test.go
+++ b/src/control/security/grpc_authorization_test.go
@@ -106,6 +106,8 @@ func TestSecurity_ComponentHasAccess(t *testing.T) {
 		"/mgmt.MgmtSvc/SystemCheckGetPolicy":     {ComponentAdmin},
 		"/mgmt.MgmtSvc/SystemCheckRepair":        {ComponentAdmin},
 		"/mgmt.MgmtSvc/SystemCheckEngineReport":  {ComponentServer},
+		"/mgmt.MgmtSvc/SystemCheckRegPool":       {ComponentServer},
+		"/mgmt.MgmtSvc/SystemCheckDeregPool":     {ComponentServer},
 		"/mgmt.MgmtSvc/FaultInjectReport":        {ComponentAdmin},
 		"/mgmt.MgmtSvc/FaultInjectPoolFault":     {ComponentAdmin},
 		"/mgmt.MgmtSvc/FaultInjectMgmtPoolFault": {ComponentAdmin},

--- a/src/control/server/mgmt_check.go
+++ b/src/control/server/mgmt_check.go
@@ -723,3 +723,139 @@ func (svc *mgmtSvc) SystemCheckEngineReport(ctx context.Context, req *sharedpb.C
 	}
 	return new(sharedpb.CheckReportResp), nil
 }
+
+func raftErrToDaosErr(err error) error {
+	// Most of the errors returned by raft updates are logically impossible here. A sign of a
+	// developer error.
+	dErr := daos.MiscError
+	// Leadership change is the only thing that could really go wrong at this point.
+	if system.IsNotLeader(err) {
+		dErr = daos.TryAgain
+	}
+	return dErr
+}
+
+// SystemCheckRegPool registers a pool with the management service for the checker.
+//
+// NB: The final result of this function is delivered to the check leader as a dRPC response.
+//
+//	The daos.Status error codes make it possible to translate errors to meaningful error codes.
+func (svc *mgmtSvc) SystemCheckRegPool(parent context.Context, req *sharedpb.CheckRegPoolReq) (*sharedpb.CheckRegPoolResp, error) {
+	if req == nil {
+		return nil, errors.Wrapf(daos.InvalidInput, "nil %T", req)
+	}
+
+	if err := svc.checkLeaderRequest(wrapCheckerReq(req)); err != nil {
+		return nil, err
+	}
+
+	if err := svc.verifyCheckerReady(); err != nil {
+		return nil, err
+	}
+
+	poolUUID, err := uuid.Parse(req.Uuid)
+	if err != nil {
+		return nil, errors.Wrapf(daos.InvalidInput, "invalid pool UUID %q: %s", req.Uuid, err)
+	}
+
+	if !daos.LabelIsValid(req.Label) {
+		return nil, errors.Wrapf(daos.InvalidInput, "bad pool label %q", req.Label)
+	}
+
+	if len(req.Svcreps) == 0 {
+		return nil, errors.Wrapf(daos.InvalidInput, "request for pool %q has zero svcreps", req.Uuid)
+	}
+
+	lock, err := svc.sysdb.TakePoolLock(parent, poolUUID)
+	if err != nil {
+		return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to take pool lock: %s", err)
+	}
+	defer lock.Release()
+	ctx := lock.InContext(parent)
+
+	ps, err := svc.sysdb.FindPoolServiceByUUID(poolUUID)
+	if err == nil {
+		// We're updating an existing pool service.
+		if ps.PoolLabel != req.Label {
+			if _, err := svc.sysdb.FindPoolServiceByLabel(req.Label); err == nil {
+				return nil, errors.Wrapf(daos.Exists, "pool with label %q already exists", req.Label)
+			}
+		}
+		ps.PoolLabel = req.Label
+		ps.Replicas = ranklist.RanksFromUint32(req.Svcreps)
+
+		svc.log.Debugf("updating pool service from req: %+v", req)
+		if err := svc.sysdb.UpdatePoolService(ctx, ps); err != nil {
+			return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to update pool: %s", err.Error())
+		}
+
+		return &sharedpb.CheckRegPoolResp{}, nil
+	}
+
+	if !system.IsPoolNotFound(err) {
+		// Any error besides PoolNotFound is not expected.
+		return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to look up pool %s: %s", poolUUID, err.Error())
+	}
+
+	if _, err := svc.sysdb.FindPoolServiceByLabel(req.Label); err == nil {
+		return nil, errors.Wrapf(daos.Exists, "pool with label %q already exists", req.Label)
+	}
+
+	ps = &system.PoolService{
+		PoolUUID:  poolUUID,
+		PoolLabel: req.Label,
+		State:     system.PoolServiceStateReady,
+		Replicas:  ranklist.RanksFromUint32(req.Svcreps),
+	}
+
+	svc.log.Debugf("adding pool service from req: %+v", req)
+	if err := svc.sysdb.AddPoolService(ctx, ps); err != nil {
+		return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to add pool: %s", err.Error())
+	}
+	return &sharedpb.CheckRegPoolResp{}, nil
+}
+
+// SystemCheckDeregPool de-registers a pool with the management service for the checker.
+//
+// NB: The final result of this function is delivered to the check leader as a dRPC response.
+//
+//	The daos.Status error codes make it possible to translate errors to meaningful error codes.
+func (svc *mgmtSvc) SystemCheckDeregPool(parent context.Context, req *sharedpb.CheckDeregPoolReq) (*sharedpb.CheckDeregPoolResp, error) {
+	if req == nil {
+		return nil, errors.Wrapf(daos.InvalidInput, "nil %T", req)
+	}
+
+	if err := svc.checkLeaderRequest(wrapCheckerReq(req)); err != nil {
+		return nil, err
+	}
+
+	if err := svc.verifyCheckerReady(); err != nil {
+		return nil, err
+	}
+
+	poolUUID, err := uuid.Parse(req.Uuid)
+	if err != nil {
+		return nil, errors.Wrapf(daos.InvalidInput, "invalid pool UUID %q: %s", req.Uuid, err)
+	}
+
+	lock, err := svc.sysdb.TakePoolLock(parent, poolUUID)
+	if err != nil {
+		return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to take pool lock: %s", err)
+	}
+	defer lock.Release()
+	ctx := lock.InContext(parent)
+
+	if _, err := svc.sysdb.FindPoolServiceByUUID(poolUUID); err != nil {
+		if system.IsPoolNotFound(err) {
+			return nil, errors.Wrapf(daos.Nonexistent, "pool with uuid %q does not exist", req.Uuid)
+		}
+
+		return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to look up pool %s: %s", req.Uuid, err)
+	}
+
+	if err := svc.sysdb.RemovePoolService(ctx, poolUUID); err != nil {
+		return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to remove pool %s: %s", req.Uuid, err)
+	}
+
+	return &sharedpb.CheckDeregPoolResp{}, nil
+}

--- a/src/control/server/mgmt_check.go
+++ b/src/control/server/mgmt_check.go
@@ -724,17 +724,6 @@ func (svc *mgmtSvc) SystemCheckEngineReport(ctx context.Context, req *sharedpb.C
 	return new(sharedpb.CheckReportResp), nil
 }
 
-func raftErrToDaosErr(err error) error {
-	// Most of the errors returned by raft updates are logically impossible here. A sign of a
-	// developer error.
-	dErr := daos.MiscError
-	// Leadership change is the only thing that could really go wrong at this point.
-	if system.IsNotLeader(err) {
-		dErr = daos.TryAgain
-	}
-	return dErr
-}
-
 // SystemCheckRegPool registers a pool with the management service for the checker.
 //
 // NB: The final result of this function is delivered to the check leader as a dRPC response.
@@ -768,7 +757,7 @@ func (svc *mgmtSvc) SystemCheckRegPool(parent context.Context, req *sharedpb.Che
 
 	lock, err := svc.sysdb.TakePoolLock(parent, poolUUID)
 	if err != nil {
-		return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to take pool lock: %s", err)
+		return nil, errors.Wrapf(err, "failed to take pool lock")
 	}
 	defer lock.Release()
 	ctx := lock.InContext(parent)
@@ -786,7 +775,7 @@ func (svc *mgmtSvc) SystemCheckRegPool(parent context.Context, req *sharedpb.Che
 
 		svc.log.Debugf("updating pool service from req: %+v", req)
 		if err := svc.sysdb.UpdatePoolService(ctx, ps); err != nil {
-			return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to update pool: %s", err.Error())
+			return nil, errors.Wrapf(err, "failed to update pool")
 		}
 
 		return &sharedpb.CheckRegPoolResp{}, nil
@@ -794,7 +783,7 @@ func (svc *mgmtSvc) SystemCheckRegPool(parent context.Context, req *sharedpb.Che
 
 	if !system.IsPoolNotFound(err) {
 		// Any error besides PoolNotFound is not expected.
-		return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to look up pool %s: %s", poolUUID, err.Error())
+		return nil, errors.Wrapf(err, "failed to look up pool %s", poolUUID)
 	}
 
 	if _, err := svc.sysdb.FindPoolServiceByLabel(req.Label); err == nil {
@@ -810,7 +799,7 @@ func (svc *mgmtSvc) SystemCheckRegPool(parent context.Context, req *sharedpb.Che
 
 	svc.log.Debugf("adding pool service from req: %+v", req)
 	if err := svc.sysdb.AddPoolService(ctx, ps); err != nil {
-		return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to add pool: %s", err.Error())
+		return nil, errors.Wrapf(err, "failed to add pool")
 	}
 	return &sharedpb.CheckRegPoolResp{}, nil
 }
@@ -840,7 +829,7 @@ func (svc *mgmtSvc) SystemCheckDeregPool(parent context.Context, req *sharedpb.C
 
 	lock, err := svc.sysdb.TakePoolLock(parent, poolUUID)
 	if err != nil {
-		return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to take pool lock: %s", err)
+		return nil, errors.Wrapf(err, "failed to take pool lock")
 	}
 	defer lock.Release()
 	ctx := lock.InContext(parent)
@@ -850,11 +839,11 @@ func (svc *mgmtSvc) SystemCheckDeregPool(parent context.Context, req *sharedpb.C
 			return nil, errors.Wrapf(daos.Nonexistent, "pool with uuid %q does not exist", req.Uuid)
 		}
 
-		return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to look up pool %s: %s", req.Uuid, err)
+		return nil, errors.Wrapf(err, "failed to look up pool %s", req.Uuid)
 	}
 
 	if err := svc.sysdb.RemovePoolService(ctx, poolUUID); err != nil {
-		return nil, errors.Wrapf(raftErrToDaosErr(err), "failed to remove pool %s: %s", req.Uuid, err)
+		return nil, errors.Wrapf(err, "failed to remove pool %s", req.Uuid)
 	}
 
 	return &sharedpb.CheckDeregPoolResp{}, nil

--- a/src/control/server/mgmt_check_test.go
+++ b/src/control/server/mgmt_check_test.go
@@ -8,6 +8,7 @@
 package server
 
 import (
+	"context"
 	"net"
 	"sort"
 	"testing"
@@ -1166,6 +1167,22 @@ func TestServer_mgmtSvc_SystemCheckEngineReport(t *testing.T) {
 	}
 }
 
+func createMSMultiInCheckerMode(t *testing.T, log logging.Logger, nr int) *mgmtSvc {
+	svc := newTestMgmtSvc(t, log)
+	for i := 0; i < nr; i++ {
+		svc.sysdb.AddMember(&system.Member{
+			UUID: uuid.New(),
+			Rank: ranklist.Rank(i),
+			Addr: system.MockControlAddr(t, uint32(i)),
+		})
+	}
+	updateTestMemberState(t, svc, system.MemberStateCheckerStarted)
+	if err := svc.enableChecker(); err != nil {
+		t.Fatal(err)
+	}
+	return svc
+}
+
 func TestServer_mgmtSvc_SystemCheckRepair(t *testing.T) {
 	const testNumRanks = 5
 	const testSeq = 0x1234
@@ -1189,22 +1206,6 @@ func TestServer_mgmtSvc_SystemCheckRepair(t *testing.T) {
 		},
 	}
 
-	createMSMultiInCheckerMode := func(t *testing.T, log logging.Logger) *mgmtSvc {
-		svc := newTestMgmtSvc(t, log)
-		for i := 0; i < testNumRanks; i++ {
-			svc.sysdb.AddMember(&system.Member{
-				UUID: uuid.New(),
-				Rank: ranklist.Rank(i),
-				Addr: system.MockControlAddr(t, uint32(i)),
-			})
-		}
-		updateTestMemberState(t, svc, system.MemberStateCheckerStarted)
-		if err := svc.enableChecker(); err != nil {
-			t.Fatal(err)
-		}
-		return svc
-	}
-
 	for name, tc := range map[string]struct {
 		createMS     func(*testing.T, logging.Logger) *mgmtSvc
 		startFinding *checker.Finding
@@ -1220,7 +1221,7 @@ func TestServer_mgmtSvc_SystemCheckRepair(t *testing.T) {
 		},
 		"not leader": {
 			createMS: func(t *testing.T, l logging.Logger) *mgmtSvc {
-				svc := createMSMultiInCheckerMode(t, l)
+				svc := createMSMultiInCheckerMode(t, l, testNumRanks)
 				if err := svc.sysdb.ResignLeadership(errors.New("test")); err != nil {
 					t.Fatal(err)
 				}
@@ -1256,7 +1257,7 @@ func TestServer_mgmtSvc_SystemCheckRepair(t *testing.T) {
 		},
 		"finding has invalid rank": {
 			createMS: func(t *testing.T, l logging.Logger) *mgmtSvc {
-				return createMSMultiInCheckerMode(t, l)
+				return createMSMultiInCheckerMode(t, l, testNumRanks)
 			},
 			startFinding: &checker.Finding{
 				CheckReport: chkpb.CheckReport{
@@ -1307,7 +1308,7 @@ func TestServer_mgmtSvc_SystemCheckRepair(t *testing.T) {
 
 			if tc.createMS == nil {
 				tc.createMS = func(t *testing.T, l logging.Logger) *mgmtSvc {
-					return createMSMultiInCheckerMode(t, l)
+					return createMSMultiInCheckerMode(t, l, testNumRanks)
 				}
 			}
 			svc := tc.createMS(t, log)
@@ -1346,6 +1347,334 @@ func TestServer_mgmtSvc_SystemCheckRepair(t *testing.T) {
 			}
 
 			test.CmpAny(t, "updated finding", tc.expFinding, f, cmpopts.IgnoreUnexported(chkpb.CheckReport{}))
+		})
+	}
+}
+
+func addPS(t *testing.T, ctx context.Context, ms *mgmtSvc, ps *system.PoolService) *mgmtSvc {
+	lock, lockCtx := getPoolLockCtx(t, ctx, ms.sysdb, ps.PoolUUID)
+	if err := ms.sysdb.AddPoolService(lockCtx, ps); err != nil {
+		t.Fatal(err)
+	}
+	lock.Release()
+	return ms
+}
+
+func TestServer_mgmtSvc_SystemCheckRegPool(t *testing.T) {
+	testNumRanks := 5
+	testPoolUUID := uuid.New()
+	testPS := &system.PoolService{
+		PoolUUID:  testPoolUUID,
+		PoolLabel: "test_label",
+		State:     system.PoolServiceStateReady,
+		Replicas:  ranklist.RanksFromUint32([]uint32{3, 5, 6}),
+	}
+	validReq := &sharedpb.CheckRegPoolReq{
+		Seq:     0x1234,
+		Uuid:    testPoolUUID.String(),
+		Label:   "new_label",
+		Svcreps: []uint32{3, 5, 7},
+	}
+
+	for name, tc := range map[string]struct {
+		createMS  func(*testing.T, logging.Logger) *mgmtSvc
+		updateCtx func(*testing.T, context.Context, *mgmtSvc) (context.Context, func())
+		req       *sharedpb.CheckRegPoolReq
+		expErr    error
+		expResp   *sharedpb.CheckRegPoolResp
+		expPS     *system.PoolService
+	}{
+		"nil req": {
+			expErr: errors.New("nil"),
+		},
+		"not leader": {
+			createMS: func(t *testing.T, l logging.Logger) *mgmtSvc {
+				svc := createMSMultiInCheckerMode(t, l, testNumRanks)
+				if err := svc.sysdb.ResignLeadership(errors.New("test")); err != nil {
+					t.Fatal(err)
+				}
+
+				return svc
+			},
+			req:    validReq,
+			expErr: &system.ErrNotLeader{},
+		},
+		"not checker mode": {
+			createMS: func(t *testing.T, l logging.Logger) *mgmtSvc {
+				svc := newTestMgmtSvcMulti(t, l, testNumRanks, true)
+				return svc
+			},
+			req:    validReq,
+			expErr: checker.FaultCheckerNotEnabled,
+		},
+		"no pool UUID": {
+			req: &sharedpb.CheckRegPoolReq{
+				Seq:     validReq.Seq,
+				Label:   validReq.Label,
+				Svcreps: validReq.Svcreps,
+			},
+			expErr: daos.InvalidInput,
+		},
+		"invalid pool UUID": {
+			req: &sharedpb.CheckRegPoolReq{
+				Seq:     validReq.Seq,
+				Uuid:    "'Twas brillig and the slithy toves",
+				Label:   validReq.Label,
+				Svcreps: validReq.Svcreps,
+			},
+			expErr: daos.InvalidInput,
+		},
+		"invalid pool label": {
+			req: &sharedpb.CheckRegPoolReq{
+				Seq:     validReq.Seq,
+				Uuid:    validReq.Uuid,
+				Label:   "???????????",
+				Svcreps: validReq.Svcreps,
+			},
+			expErr: daos.InvalidInput,
+		},
+		"nil svc reps": {
+			req: &sharedpb.CheckRegPoolReq{
+				Seq:   validReq.Seq,
+				Uuid:  validReq.Uuid,
+				Label: validReq.Label,
+			},
+			expErr: daos.InvalidInput,
+		},
+		"empty svc reps": {
+			req: &sharedpb.CheckRegPoolReq{
+				Seq:     validReq.Seq,
+				Uuid:    validReq.Uuid,
+				Label:   validReq.Label,
+				Svcreps: []uint32{},
+			},
+			expErr: daos.InvalidInput,
+		},
+		"get pool lock fails": {
+			req: validReq,
+			updateCtx: func(t *testing.T, ctx context.Context, ms *mgmtSvc) (context.Context, func()) {
+				// Holding the lock for another pool UUID in the context will force a failure
+				lock, badCtx := getPoolLockCtx(t, ctx, ms.sysdb, uuid.New())
+				return badCtx, lock.Release
+			},
+			expErr: daos.MiscError,
+		},
+		"register existing pool svc": {
+			req:     validReq,
+			expResp: &sharedpb.CheckRegPoolResp{},
+			expPS: &system.PoolService{
+				PoolUUID:  testPS.PoolUUID,
+				PoolLabel: validReq.Label,
+				State:     system.PoolServiceStateReady,
+				Replicas:  ranklist.RanksFromUint32(validReq.Svcreps),
+			},
+		},
+		"existing pool wants existing label": {
+			createMS: func(t *testing.T, l logging.Logger) *mgmtSvc {
+				ms := createMSMultiInCheckerMode(t, l, testNumRanks)
+				psList := []*system.PoolService{
+					testPS,
+					{
+						PoolUUID:  uuid.New(),
+						PoolLabel: validReq.Label,
+					},
+				}
+
+				for _, ps := range psList {
+					ms = addPS(t, context.Background(), ms, ps)
+				}
+				return ms
+			},
+			req:    validReq,
+			expErr: daos.Exists,
+			expPS:  testPS, // unchanged
+		},
+		"register new pool svc": {
+			createMS: func(t *testing.T, l logging.Logger) *mgmtSvc {
+				return createMSMultiInCheckerMode(t, l, testNumRanks)
+			},
+			req:     validReq,
+			expResp: &sharedpb.CheckRegPoolResp{},
+			expPS: &system.PoolService{
+				PoolUUID:  testPS.PoolUUID,
+				PoolLabel: validReq.Label,
+				State:     system.PoolServiceStateReady,
+				Replicas:  ranklist.RanksFromUint32(validReq.Svcreps),
+			},
+		},
+		"new pool wants existing label": {
+			createMS: func(t *testing.T, l logging.Logger) *mgmtSvc {
+				ms := createMSMultiInCheckerMode(t, l, testNumRanks)
+				ps := &system.PoolService{
+					PoolUUID:  uuid.New(),
+					PoolLabel: validReq.Label,
+				}
+
+				return addPS(t, context.Background(), ms, ps)
+			},
+			req:    validReq,
+			expErr: daos.Exists,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := test.MustLogContext(t)
+			log := logging.FromContext(ctx)
+
+			if tc.createMS == nil {
+				tc.createMS = func(t *testing.T, l logging.Logger) *mgmtSvc {
+					ms := createMSMultiInCheckerMode(t, l, testNumRanks)
+					return addPS(t, ctx, ms, testPS)
+				}
+			}
+			svc := tc.createMS(t, log)
+
+			if tc.updateCtx != nil {
+				newCtx, cleanup := tc.updateCtx(t, ctx, svc)
+				defer cleanup()
+				ctx = newCtx
+			}
+
+			resp, err := svc.SystemCheckRegPool(ctx, tc.req)
+
+			test.CmpErr(t, tc.expErr, err)
+			test.CmpAny(t, "CheckRegPoolResp", tc.expResp, resp, cmpopts.IgnoreUnexported(sharedpb.CheckRegPoolResp{}))
+
+			// Check that the requested pool service was updated (or not)
+			if tc.expPS != nil {
+				finalPS, err := svc.sysdb.FindPoolServiceByUUID(tc.expPS.PoolUUID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				test.CmpAny(t, "checking pool service", tc.expPS, finalPS, cmpopts.IgnoreFields(system.PoolService{}, "LastUpdate"))
+			}
+		})
+	}
+}
+
+func TestServer_mgmtSvc_SystemCheckDeregPool(t *testing.T) {
+	testNumRanks := 5
+	testPoolUUID := uuid.New()
+	testPS := &system.PoolService{
+		PoolUUID:  testPoolUUID,
+		PoolLabel: "test_label",
+		State:     system.PoolServiceStateReady,
+		Replicas:  ranklist.RanksFromUint32([]uint32{3, 5, 6}),
+	}
+	validReq := &sharedpb.CheckDeregPoolReq{
+		Seq:  0x5678,
+		Uuid: testPoolUUID.String(),
+	}
+
+	for name, tc := range map[string]struct {
+		createMS      func(*testing.T, logging.Logger) *mgmtSvc
+		updateCtx     func(*testing.T, context.Context, *mgmtSvc) (context.Context, func())
+		req           *sharedpb.CheckDeregPoolReq
+		expErr        error
+		expResp       *sharedpb.CheckDeregPoolResp
+		expPSNotExist bool
+	}{
+		"nil req": {
+			expErr: errors.New("nil"),
+		},
+		"not leader": {
+			createMS: func(t *testing.T, l logging.Logger) *mgmtSvc {
+				svc := createMSMultiInCheckerMode(t, l, testNumRanks)
+				if err := svc.sysdb.ResignLeadership(errors.New("test")); err != nil {
+					t.Fatal(err)
+				}
+
+				return svc
+			},
+			req:           validReq,
+			expErr:        &system.ErrNotLeader{},
+			expPSNotExist: true, // wasn't created to begin with
+		},
+		"not checker mode": {
+			createMS: func(t *testing.T, l logging.Logger) *mgmtSvc {
+				svc := newTestMgmtSvcMulti(t, l, testNumRanks, true)
+				return svc
+			},
+			req:           validReq,
+			expErr:        checker.FaultCheckerNotEnabled,
+			expPSNotExist: true, // wasn't created to begin with
+		},
+		"no pool UUID": {
+			req: &sharedpb.CheckDeregPoolReq{
+				Seq: validReq.Seq,
+			},
+			expErr: daos.InvalidInput,
+		},
+		"invalid pool UUID": {
+			req: &sharedpb.CheckDeregPoolReq{
+				Seq:  validReq.Seq,
+				Uuid: "did gyre and gimbel in the wabe",
+			},
+			expErr: daos.InvalidInput,
+		},
+		"get pool lock fails": {
+			req: validReq,
+			updateCtx: func(t *testing.T, ctx context.Context, ms *mgmtSvc) (context.Context, func()) {
+				// Holding the lock for another pool UUID in the context will force a failure
+				lock, badCtx := getPoolLockCtx(t, ctx, ms.sysdb, uuid.New())
+				return badCtx, lock.Release
+			},
+			expErr: daos.MiscError,
+		},
+		"pool svc doesn't exist": {
+			req: &sharedpb.CheckDeregPoolReq{
+				Seq:  0x1234,
+				Uuid: uuid.NewString(), // some random UUID
+			},
+			expErr:        daos.Nonexistent,
+			expPSNotExist: true, // requested pool has no service created
+		},
+		"success": {
+			req:           validReq,
+			expResp:       &sharedpb.CheckDeregPoolResp{},
+			expPSNotExist: true, // requested pool svc existed and was removed
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := test.MustLogContext(t)
+			log := logging.FromContext(ctx)
+
+			if tc.createMS == nil {
+				tc.createMS = func(t *testing.T, l logging.Logger) *mgmtSvc {
+					ms := createMSMultiInCheckerMode(t, l, testNumRanks)
+					return addPS(t, ctx, ms, testPS)
+				}
+			}
+			svc := tc.createMS(t, log)
+
+			if tc.updateCtx != nil {
+				newCtx, cleanup := tc.updateCtx(t, ctx, svc)
+				defer cleanup()
+				ctx = newCtx
+			}
+
+			resp, err := svc.SystemCheckDeregPool(ctx, tc.req)
+
+			test.CmpErr(t, tc.expErr, err)
+			test.CmpAny(t, "CheckDeregPoolResp", tc.expResp, resp, cmpopts.IgnoreUnexported(sharedpb.CheckDeregPoolResp{}))
+
+			// can stop here for invalid inputs
+			if tc.req == nil {
+				return
+			}
+			testUUID, err := uuid.Parse(tc.req.Uuid)
+			if err != nil {
+				return
+			}
+
+			// Check that the requested pool service was removed (or not)
+			_, err = svc.sysdb.FindPoolServiceByUUID(testUUID)
+			if tc.expPSNotExist {
+				if !system.IsPoolNotFound(err) {
+					t.Fatalf("expected pool not found error, instead got: %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected no error, instead got: %v", err)
+			}
 		})
 	}
 }

--- a/src/control/server/mgmt_check_test.go
+++ b/src/control/server/mgmt_check_test.go
@@ -1457,7 +1457,7 @@ func TestServer_mgmtSvc_SystemCheckRegPool(t *testing.T) {
 				lock, badCtx := getPoolLockCtx(t, ctx, ms.sysdb, uuid.New())
 				return badCtx, lock.Release
 			},
-			expErr: daos.MiscError,
+			expErr: errors.New("failed to take pool lock"),
 		},
 		"register existing pool svc": {
 			req:     validReq,
@@ -1618,7 +1618,7 @@ func TestServer_mgmtSvc_SystemCheckDeregPool(t *testing.T) {
 				lock, badCtx := getPoolLockCtx(t, ctx, ms.sysdb, uuid.New())
 				return badCtx, lock.Release
 			},
-			expErr: daos.MiscError,
+			expErr: errors.New("failed to take pool lock"),
 		},
 		"pool svc doesn't exist": {
 			req: &sharedpb.CheckDeregPoolReq{

--- a/src/control/server/mgmt_drpc_checker.go
+++ b/src/control/server/mgmt_drpc_checker.go
@@ -10,7 +10,6 @@ package server
 import (
 	"context"
 
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
@@ -56,145 +55,67 @@ func (mod *srvModule) handleCheckerListPools(_ context.Context, reqb []byte) (ou
 	return
 }
 
-func (mod *srvModule) handleCheckerRegisterPool(parent context.Context, reqb []byte) (out []byte, outErr error) {
+func (mod *srvModule) handleCheckerRegisterPool(ctx context.Context, reqb []byte) (out []byte, outErr error) {
 	req := new(sharedpb.CheckRegPoolReq)
 	if err := proto.Unmarshal(reqb, req); err != nil {
 		return nil, drpc.UnmarshalingPayloadFailure()
 	}
 	mod.log.Debugf("handling CheckerRegisterPool: %+v", req)
 
-	resp := new(sharedpb.CheckRegPoolResp)
-	defer func() {
-		mod.log.Debugf("CheckerRegisterPool resp: %+v", resp)
-		out, outErr = proto.Marshal(resp)
-	}()
+	// Forward the report to the MS
+	msReq := &control.SystemCheckRegPoolReq{
+		CheckRegPoolReq: *req,
+	}
+	msReq.SetHostList(mod.msReplicas)
 
-	poolUUID, err := uuid.Parse(req.Uuid)
+	mod.log.Debugf("forwarding check register pool req to MS: %+v", msReq)
+	resp, err := control.SystemCheckRegPool(ctx, mod.rpcClient, msReq)
+
+	var drpcResp *sharedpb.CheckRegPoolResp
 	if err != nil {
-		mod.log.Errorf("invalid pool UUID %q: %s", req.Uuid, err)
-		resp.Status = int32(daos.InvalidInput)
-		return
-	}
-	if !daos.LabelIsValid(req.Label) {
-		mod.log.Errorf("bad pool label %q", req.Label)
-		resp.Status = int32(daos.InvalidInput)
-		return
-	}
-	if len(req.Svcreps) == 0 {
-		mod.log.Errorf("pool %q has zero svcreps", req.Uuid)
-		resp.Status = int32(daos.InvalidInput)
-		return
-	}
-
-	lock, err := mod.poolDB.TakePoolLock(parent, poolUUID)
-	if err != nil {
-		mod.log.Errorf("failed to take pool lock: %s", err)
-		resp.Status = int32(daos.MiscError)
-		return
-	}
-	defer lock.Release()
-	ctx := lock.InContext(parent)
-
-	ps, err := mod.poolDB.FindPoolServiceByUUID(poolUUID)
-	if err == nil {
-		// We're updating an existing pool service.
-		if ps.PoolLabel != req.Label {
-			if _, err := mod.poolDB.FindPoolServiceByLabel(req.Label); err == nil {
-				mod.log.Errorf("pool with label %q already exists", req.Label)
-				resp.Status = int32(daos.Exists)
-				return
-			}
+		mod.log.Errorf("SystemCheckRegPool failed: %s", err)
+		drpcResp = &sharedpb.CheckRegPoolResp{
+			Status: grpcErrToDaosStatus(err).Int32(),
 		}
-		ps.PoolLabel = req.Label
-		ps.Replicas = ranklist.RanksFromUint32(req.Svcreps)
-
-		mod.log.Debugf("updating pool service from req: %+v", req)
-		if err := mod.poolDB.UpdatePoolService(ctx, ps); err != nil {
-			mod.log.Errorf("failed to update pool: %s", err)
-			resp.Status = int32(daos.MiscError)
-			return
-		}
-
-		return
-	} else if !system.IsPoolNotFound(err) {
-		mod.log.Errorf("failed to find pool: %s", err)
-		resp.Status = int32(daos.MiscError)
-		return
+	} else {
+		drpcResp = &resp.CheckRegPoolResp
 	}
 
-	if _, err := mod.poolDB.FindPoolServiceByLabel(req.Label); err == nil {
-		mod.log.Errorf("pool with label %q already exists", req.Label)
-		resp.Status = int32(daos.Exists)
-		return
-	}
-
-	ps = &system.PoolService{
-		PoolUUID:  poolUUID,
-		PoolLabel: req.Label,
-		State:     system.PoolServiceStateReady,
-		Replicas:  ranklist.RanksFromUint32(req.Svcreps),
-	}
-
-	mod.log.Debugf("adding pool service from req: %+v", req)
-	if err := mod.poolDB.AddPoolService(ctx, ps); err != nil {
-		mod.log.Errorf("failed to register pool: %s", err)
-		resp.Status = int32(daos.MiscError)
-		return
-	}
-
-	return
+	mod.log.Debugf("CheckerRegPool resp: %+v", drpcResp)
+	return proto.Marshal(drpcResp)
 }
 
-func (mod *srvModule) handleCheckerDeregisterPool(parent context.Context, reqb []byte) (out []byte, outErr error) {
+func (mod *srvModule) handleCheckerDeregisterPool(ctx context.Context, reqb []byte) (out []byte, outErr error) {
 	req := new(sharedpb.CheckDeregPoolReq)
 	if err := proto.Unmarshal(reqb, req); err != nil {
 		return nil, drpc.UnmarshalingPayloadFailure()
 	}
 	mod.log.Debugf("handling CheckerDeregisterPool: %+v", req)
 
-	resp := new(sharedpb.CheckDeregPoolResp)
-	defer func() {
-		mod.log.Debugf("CheckerDeregisterPool resp: %+v", resp)
-		out, outErr = proto.Marshal(resp)
-	}()
-
-	poolUUID, err := uuid.Parse(req.Uuid)
-	if err != nil {
-		mod.log.Errorf("invalid pool UUID %q: %s", req.Uuid, err)
-		resp.Status = int32(daos.InvalidInput)
-		return
+	// Forward the report to the MS
+	msReq := &control.SystemCheckDeregPoolReq{
+		CheckDeregPoolReq: *req,
 	}
+	msReq.SetHostList(mod.msReplicas)
 
-	lock, err := mod.poolDB.TakePoolLock(parent, poolUUID)
+	mod.log.Debugf("forwarding check deregister pool req to MS: %+v", msReq)
+	resp, err := control.SystemCheckDeregPool(ctx, mod.rpcClient, msReq)
+
+	var drpcResp *sharedpb.CheckDeregPoolResp
 	if err != nil {
-		mod.log.Errorf("failed to take pool lock: %s", err)
-		resp.Status = int32(daos.MiscError)
-		return
-	}
-	defer lock.Release()
-	ctx := lock.InContext(parent)
-
-	if _, err := mod.poolDB.FindPoolServiceByUUID(poolUUID); err != nil {
-		if system.IsPoolNotFound(err) {
-			mod.log.Errorf("pool with uuid %q does not exist", req.Uuid)
-			resp.Status = int32(daos.Nonexistent)
-		} else {
-			mod.log.Errorf("failed to check pool uuid: %s", err)
-			resp.Status = int32(daos.MiscError)
+		mod.log.Errorf("SystemCheckDeregPool failed: %s", err)
+		drpcResp = &sharedpb.CheckDeregPoolResp{
+			Status: grpcErrToDaosStatus(err).Int32(),
 		}
-		return
+	} else {
+		drpcResp = &resp.CheckDeregPoolResp
 	}
 
-	if err := mod.poolDB.RemovePoolService(ctx, poolUUID); err != nil {
-		mod.log.Errorf("failed to remove pool: %s", err)
-		resp.Status = int32(daos.MiscError)
-		return
-	}
-
-	return
+	mod.log.Debugf("CheckerDeregPool resp: %+v", drpcResp)
+	return proto.Marshal(drpcResp)
 }
 
-func chkReportErrToDaosStatus(err error) daos.Status {
+func grpcErrToDaosStatus(err error) daos.Status {
 	err = errors.Cause(err) // Fully unwrap before attempting comparisons
 
 	if status, ok := err.(daos.Status); ok {
@@ -211,6 +132,7 @@ func chkReportErrToDaosStatus(err error) daos.Status {
 		fault.IsFaultCode(err, code.SystemCheckerInvalidMemberStates):
 		return daos.NotApplicable
 	default:
+		// The dreaded DER_MISC error. Who knows what happened? We don't!
 		return daos.MiscError
 	}
 }
@@ -235,7 +157,7 @@ func (mod *srvModule) handleCheckerReport(ctx context.Context, reqb []byte) (out
 	if err != nil {
 		mod.log.Errorf("SystemCheckEngineReport failed: %s", err)
 		drpcResp = &sharedpb.CheckReportResp{
-			Status: chkReportErrToDaosStatus(err).Int32(),
+			Status: grpcErrToDaosStatus(err).Int32(),
 		}
 	} else {
 		drpcResp = &resp.CheckReportResp

--- a/src/control/server/mgmt_drpc_checker_test.go
+++ b/src/control/server/mgmt_drpc_checker_test.go
@@ -110,202 +110,175 @@ func TestSrvModule_HandleCheckerListPools(t *testing.T) {
 	}
 }
 
-func TestSrvModule_HandleCheckerRegisterPool(t *testing.T) {
-	existingPool := &system.PoolService{
-		PoolUUID:  uuid.New(),
-		PoolLabel: "test-pool",
-		Replicas:  []ranklist.Rank{0, 1, 2},
-	}
-	otherPool := &system.PoolService{
-		PoolUUID:  uuid.New(),
-		PoolLabel: "test-pool2",
-		Replicas:  []ranklist.Rank{0, 1, 2},
-	}
-	makeReqBytes := func(id, label string, replicas []ranklist.Rank) []byte {
-		req := &sharedpb.CheckRegPoolReq{
-			Uuid:    id,
-			Label:   label,
-			Svcreps: ranklist.RanksToUint32(replicas),
-		}
+func TestServer_srvModule_handleCheckerRegisterPool(t *testing.T) {
+	bytesFromReq := func(t *testing.T, req *sharedpb.CheckRegPoolReq) []byte {
 		b, err := proto.Marshal(req)
 		if err != nil {
 			t.Fatal(err)
 		}
 		return b
 	}
-	newUUID := uuid.New().String()
+
+	validReq := &sharedpb.CheckRegPoolReq{
+		Seq:     0x1234,
+		Uuid:    uuid.NewString(),
+		Svcreps: []uint32{1, 2},
+	}
 
 	for name, tc := range map[string]struct {
-		req        []byte
-		notReplica bool
-		expResp    *sharedpb.CheckRegPoolResp
-		expErr     error
+		mic      *control.MockInvokerConfig
+		reqBytes []byte
+		expErr   error
+		expResp  *sharedpb.CheckRegPoolResp
 	}{
 		"bad payload": {
-			req:    []byte{'b', 'a', 'd'},
-			expErr: drpc.UnmarshalingPayloadFailure(),
+			reqBytes: []byte{'b', 'a', 'd'},
+			expErr:   drpc.UnmarshalingPayloadFailure(),
 		},
-		"bad uuid": {
-			req:     makeReqBytes("ow", "new", []ranklist.Rank{0}),
-			expResp: &sharedpb.CheckRegPoolResp{Status: int32(daos.InvalidInput)},
+		"gRPC failure to resp status": {
+			mic: &control.MockInvokerConfig{
+				UnaryError: errors.New("MockInvoker error"),
+			},
+			reqBytes: bytesFromReq(t, validReq),
+			expResp: &sharedpb.CheckRegPoolResp{
+				Status: daos.MiscError.Int32(),
+			},
 		},
-		"bad label": {
-			req:     makeReqBytes(newUUID, newUUID, []ranklist.Rank{0}),
-			expResp: &sharedpb.CheckRegPoolResp{Status: int32(daos.InvalidInput)},
+		"daos status error in resp": {
+			mic: &control.MockInvokerConfig{
+				UnaryResponse: &control.UnaryResponse{
+					Responses: []*control.HostResponse{{
+						Message: &sharedpb.CheckRegPoolResp{
+							Status: daos.MiscError.Int32(),
+						},
+					}},
+				},
+			},
+			reqBytes: bytesFromReq(t, validReq),
+			expResp: &sharedpb.CheckRegPoolResp{
+				Status: daos.MiscError.Int32(),
+			},
 		},
-		"empty label": {
-			req:     makeReqBytes(newUUID, "", []ranklist.Rank{0}),
-			expResp: &sharedpb.CheckRegPoolResp{Status: int32(daos.InvalidInput)},
-		},
-		"zero svcreps": {
-			req:     makeReqBytes(newUUID, "new", []ranklist.Rank{}),
-			expResp: &sharedpb.CheckRegPoolResp{Status: int32(daos.InvalidInput)},
-		},
-		"not replica on update": {
-			req:        makeReqBytes(existingPool.PoolUUID.String(), "new-label", []ranklist.Rank{1}),
-			notReplica: true,
-			expResp:    &sharedpb.CheckRegPoolResp{Status: int32(daos.MiscError)},
-		},
-		"not replica on add": {
-			req:        makeReqBytes(newUUID, "new", []ranklist.Rank{0}),
-			notReplica: true,
-			expResp:    &sharedpb.CheckRegPoolResp{Status: int32(daos.MiscError)},
-		},
-		"duplicate label on update": {
-			req:     makeReqBytes(existingPool.PoolUUID.String(), otherPool.PoolLabel, []ranklist.Rank{0}),
-			expResp: &sharedpb.CheckRegPoolResp{Status: int32(daos.Exists)},
-		},
-		"duplicate label on add": {
-			req:     makeReqBytes(newUUID, existingPool.PoolLabel, []ranklist.Rank{0}),
-			expResp: &sharedpb.CheckRegPoolResp{Status: int32(daos.Exists)},
-		},
-		"successful update": {
-			req:     makeReqBytes(existingPool.PoolUUID.String(), "new-label", []ranklist.Rank{1}),
-			expResp: &sharedpb.CheckRegPoolResp{},
-		},
-		"successful add": {
-			req:     makeReqBytes(newUUID, "new", []ranklist.Rank{0}),
-			expResp: &sharedpb.CheckRegPoolResp{},
+		"success": {
+			mic: &control.MockInvokerConfig{
+				UnaryResponse: &control.UnaryResponse{
+					Responses: []*control.HostResponse{{
+						Message: &sharedpb.CheckRegPoolResp{},
+					}},
+				},
+			},
+			reqBytes: bytesFromReq(t, validReq),
+			expResp:  &sharedpb.CheckRegPoolResp{},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
-			defer test.ShowBufferOnFailure(t, buf)
-
-			parent, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := test.MustLogContext(t)
+			log := logging.FromContext(ctx)
 
 			mod := mockSrvModule(t, log, 1)
-			if tc.notReplica {
-				mod.poolDB = raft.MockDatabaseWithCfg(t, log, &raft.DatabaseConfig{})
-			} else {
-				lock, ctx := getPoolLockCtx(t, parent, mod.poolDB, existingPool.PoolUUID)
-				if err := mod.poolDB.AddPoolService(ctx, existingPool); err != nil {
-					t.Fatal(err)
-				}
-				lock.Release()
-				lock, ctx = getPoolLockCtx(t, parent, mod.poolDB, otherPool.PoolUUID)
-				if err := mod.poolDB.AddPoolService(ctx, otherPool); err != nil {
-					t.Fatal(err)
-				}
-				lock.Release()
+			if tc.mic != nil {
+				mod.rpcClient = control.NewMockInvoker(log, tc.mic)
 			}
 
-			gotMsg, gotErr := mod.handleCheckerRegisterPool(parent, tc.req)
-			test.CmpErr(t, tc.expErr, gotErr)
+			respBytes, err := mod.handleCheckerRegisterPool(ctx, tc.reqBytes)
+
+			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
 			}
 
-			gotResp := new(sharedpb.CheckRegPoolResp)
-			if err := proto.Unmarshal(gotMsg, gotResp); err != nil {
+			resp := new(sharedpb.CheckRegPoolResp)
+			if err := proto.Unmarshal(respBytes, resp); err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(tc.expResp, gotResp, protocmp.Transform()); diff != "" {
-				t.Fatalf("unexpected response (-want +got):\n%s", diff)
-			}
+
+			test.CmpAny(t, "CheckRegPoolResp", tc.expResp, resp, cmpopts.IgnoreUnexported(sharedpb.CheckRegPoolResp{}))
 		})
 	}
 }
 
-func TestSrvModule_HandleCheckerDeregisterPool(t *testing.T) {
-	existingPool := &system.PoolService{
-		PoolUUID:  uuid.New(),
-		PoolLabel: "test-pool",
-		Replicas:  []ranklist.Rank{0, 1, 2},
-	}
-	makeReqBytes := func(id string) []byte {
-		req := &sharedpb.CheckDeregPoolReq{
-			Uuid: id,
-		}
+func TestServer_srvModule_handleCheckerDeregisterPool(t *testing.T) {
+	bytesFromReq := func(t *testing.T, req *sharedpb.CheckDeregPoolReq) []byte {
 		b, err := proto.Marshal(req)
 		if err != nil {
 			t.Fatal(err)
 		}
 		return b
 	}
-	unkUUID := uuid.New().String()
+
+	validReq := &sharedpb.CheckDeregPoolReq{
+		Seq:  0x1234,
+		Uuid: uuid.NewString(),
+	}
 
 	for name, tc := range map[string]struct {
-		req        []byte
-		notReplica bool
-		expResp    *sharedpb.CheckDeregPoolResp
-		expErr     error
+		mic      *control.MockInvokerConfig
+		reqBytes []byte
+		expErr   error
+		expResp  *sharedpb.CheckDeregPoolResp
 	}{
 		"bad payload": {
-			req:    []byte{'b', 'a', 'd'},
-			expErr: drpc.UnmarshalingPayloadFailure(),
+			reqBytes: []byte{'b', 'a', 'd'},
+			expErr:   drpc.UnmarshalingPayloadFailure(),
 		},
-		"not replica": {
-			req:        makeReqBytes(existingPool.PoolUUID.String()),
-			notReplica: true,
-			expResp:    &sharedpb.CheckDeregPoolResp{Status: int32(daos.MiscError)},
+		"gRPC failure to resp status": {
+			mic: &control.MockInvokerConfig{
+				UnaryError: errors.New("MockInvoker error"),
+			},
+			reqBytes: bytesFromReq(t, validReq),
+			expResp: &sharedpb.CheckDeregPoolResp{
+				Status: daos.MiscError.Int32(),
+			},
 		},
-		"bad uuid": {
-			req:     makeReqBytes("ow"),
-			expResp: &sharedpb.CheckDeregPoolResp{Status: int32(daos.InvalidInput)},
-		},
-		"unknown uuid": {
-			req:     makeReqBytes(unkUUID),
-			expResp: &sharedpb.CheckDeregPoolResp{Status: int32(daos.Nonexistent)},
+		"daos status error in resp": {
+			mic: &control.MockInvokerConfig{
+				UnaryResponse: &control.UnaryResponse{
+					Responses: []*control.HostResponse{{
+						Message: &sharedpb.CheckDeregPoolResp{
+							Status: daos.MiscError.Int32(),
+						},
+					}},
+				},
+			},
+			reqBytes: bytesFromReq(t, validReq),
+			expResp: &sharedpb.CheckDeregPoolResp{
+				Status: daos.MiscError.Int32(),
+			},
 		},
 		"success": {
-			req:     makeReqBytes(existingPool.PoolUUID.String()),
-			expResp: &sharedpb.CheckDeregPoolResp{},
+			mic: &control.MockInvokerConfig{
+				UnaryResponse: &control.UnaryResponse{
+					Responses: []*control.HostResponse{{
+						Message: &sharedpb.CheckDeregPoolResp{},
+					}},
+				},
+			},
+			reqBytes: bytesFromReq(t, validReq),
+			expResp:  &sharedpb.CheckDeregPoolResp{},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
-			defer test.ShowBufferOnFailure(t, buf)
-
-			parent, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := test.MustLogContext(t)
+			log := logging.FromContext(ctx)
 
 			mod := mockSrvModule(t, log, 1)
-			if tc.notReplica {
-				mod.poolDB = raft.MockDatabaseWithCfg(t, log, &raft.DatabaseConfig{})
-			} else {
-				lock, ctx := getPoolLockCtx(t, parent, mod.poolDB, existingPool.PoolUUID)
-				if err := mod.poolDB.AddPoolService(ctx, existingPool); err != nil {
-					t.Fatal(err)
-				}
-				lock.Release()
+			if tc.mic != nil {
+				mod.rpcClient = control.NewMockInvoker(log, tc.mic)
 			}
 
-			ctx := context.Background()
-			gotMsg, gotErr := mod.handleCheckerDeregisterPool(ctx, tc.req)
-			test.CmpErr(t, tc.expErr, gotErr)
+			respBytes, err := mod.handleCheckerDeregisterPool(ctx, tc.reqBytes)
+
+			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
 			}
 
-			gotResp := new(sharedpb.CheckDeregPoolResp)
-			if err := proto.Unmarshal(gotMsg, gotResp); err != nil {
+			resp := new(sharedpb.CheckDeregPoolResp)
+			if err := proto.Unmarshal(respBytes, resp); err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(tc.expResp, gotResp, protocmp.Transform()); diff != "" {
-				t.Fatalf("unexpected response (-want +got):\n%s", diff)
-			}
+
+			test.CmpAny(t, "CheckDeregPoolResp", tc.expResp, resp, cmpopts.IgnoreUnexported(sharedpb.CheckDeregPoolResp{}))
 		})
 	}
 }
@@ -443,7 +416,7 @@ func TestServer_srvModule_chkReportErrToDaosStatus(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			result := chkReportErrToDaosStatus(tc.in)
+			result := grpcErrToDaosStatus(tc.in)
 
 			test.CmpErr(t, tc.expResult, result)
 		})

--- a/src/proto/mgmt/mgmt.proto
+++ b/src/proto/mgmt/mgmt.proto
@@ -117,6 +117,10 @@ service MgmtSvc {
 	rpc SystemCheckRepair(CheckActReq) returns (CheckActResp) {}
 	// Report on checker results for an individual rank.
 	rpc SystemCheckEngineReport(shared.CheckReportReq) returns (shared.CheckReportResp) {}
+	// Register a pool with the MS from the check leader.
+	rpc SystemCheckRegPool(shared.CheckRegPoolReq) returns (shared.CheckRegPoolResp) {}
+	// De-register a pool with the MS from the check leader.
+	rpc SystemCheckDeregPool(shared.CheckDeregPoolReq) returns (shared.CheckDeregPoolResp) {}
 	// Set a system attribute or attributes.
 	rpc SystemSetAttr(SystemSetAttrReq) returns (DaosResp) {}
 	// Get a system attribute or attributes.


### PR DESCRIPTION
In preparation for tracking the check leader separately from the MS leader, check leader upcalls (from the check leader to the MS) must be explicitly forwarded to the MS leader.

- Add control API endpoints for forwarded dRPCs
- Add forwarding for register and deregister pool

Features: recovery

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
