### PR TITLE
DAOS-18541 cart: flush RMA puts in Mercury na_ucx to ensure remote co…

### DIFF
--- a/deps/patches/mercury/0004_na_ucx_rma_remote_completion.patch
+++ b/deps/patches/mercury/0004_na_ucx_rma_remote_completion.patch
@@ -1,0 +1,126 @@
+diff --git a/src/na/na_ucx.c b/src/na/na_ucx.c
+index 96501b2..f01f36e 100644
+--- a/src/na/na_ucx.c
++++ b/src/na/na_ucx.c
+@@ -579,6 +579,24 @@ na_ucp_get(ucp_ep_h ep, void *buf, size_t buf_size, uint64_t remote_addr,
+ static void
+ na_ucp_rma_cb(void *request, ucs_status_t status, void *user_data);
+ 
++/**
++ * Whether RMA puts must be flushed to guarantee remote completion.
++ */
++static bool
++na_ucp_rma_flush_enabled(void);
++
++/**
++ * Flush an endpoint to guarantee remote completion of a prior RMA put.
++ */
++static na_return_t
++na_ucp_flush(ucp_ep_h ep, void *request);
++
++/**
++ * RMA flush callback.
++ */
++static void
++na_ucp_flush_cb(void *request, ucs_status_t status, void *user_data);
++
+ /*---------------------------------------------------------------------------*/
+ /* NA UCX helpers                                                            */
+ /*---------------------------------------------------------------------------*/
+@@ -2477,6 +2495,96 @@ na_ucp_rma_cb(void *request, ucs_status_t status, void NA_UNUSED *user_data)
+         NA_GOTO_SUBSYS_ERROR(rma, done, cb_ret, na_ucs_status_to_na(status),
+             "na_ucp_rma_cb() failed (%s)", ucs_status_string(status));
+ 
++done:
++    /* Local completion of a put only means the source buffer can be reused, it
++     * does not guarantee the data is visible in the remote process memory.
++     * Flush the endpoint to force remote completion and defer the NA completion
++     * until the flush completes. Gets are unaffected: local completion of a get
++     * means the data has already been delivered into the local buffer. */
++    if (cb_ret == NA_SUCCESS &&
++        na_ucx_op_id->completion_data.callback_info.type == NA_CB_PUT &&
++        na_ucx_op_id->addr != NULL && na_ucx_op_id->addr->ucp_ep != NULL &&
++        na_ucp_rma_flush_enabled()) {
++        cb_ret = na_ucp_flush(na_ucx_op_id->addr->ucp_ep, na_ucx_op_id);
++        if (cb_ret == NA_SUCCESS)
++            return; /* Completion deferred to na_ucp_flush_cb() */
++    }
++
++    na_ucx_complete(na_ucx_op_id, cb_ret);
++}
++
++/*---------------------------------------------------------------------------*/
++static bool
++na_ucp_rma_flush_enabled(void)
++{
++    static int enabled = -1;
++
++    /* Lazily cache the env lookup; benign race as all threads compute the same
++     * value. Set NA_UCX_RMA_FLUSH=0 to restore local-completion behavior. */
++    if (enabled == -1) {
++        const char *env = getenv("NA_UCX_RMA_FLUSH");
++
++        enabled = (env != NULL &&
++                      (env[0] == '0' || env[0] == 'n' || env[0] == 'N'))
++                      ? 0
++                      : 1;
++    }
++
++    return enabled != 0;
++}
++
++/*---------------------------------------------------------------------------*/
++static na_return_t
++na_ucp_flush(ucp_ep_h ep, void *request)
++{
++    const ucp_request_param_t flush_params = {
++        .op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_REQUEST,
++        .cb = {.send = na_ucp_flush_cb},
++        .request = request};
++    ucs_status_ptr_t status_ptr;
++    na_return_t ret;
++
++    /* Reuse the op ID as the flush request: the put has completed by now and
++     * UCX allows posting new operations from within completion callbacks. */
++    status_ptr = ucp_ep_flush_nbx(ep, &flush_params);
++    if (status_ptr == NULL) {
++        /* Check for immediate completion */
++        NA_LOG_SUBSYS_DEBUG(rma, "ucp_ep_flush_nbx() completed immediately");
++
++        /* Directly execute callback */
++        na_ucp_flush_cb(request, UCS_OK, NULL);
++    } else
++        NA_CHECK_SUBSYS_ERROR(rma, UCS_PTR_IS_ERR(status_ptr), error, ret,
++            na_ucs_status_to_na(UCS_PTR_STATUS(status_ptr)),
++            "ucp_ep_flush_nbx() failed (%s)",
++            ucs_status_string(UCS_PTR_STATUS(status_ptr)));
++
++    NA_LOG_SUBSYS_DEBUG(rma, "ucp_ep_flush_nbx() was posted");
++
++    return NA_SUCCESS;
++
++error:
++    return ret;
++}
++
++/*---------------------------------------------------------------------------*/
++static void
++na_ucp_flush_cb(void *request, ucs_status_t status, void NA_UNUSED *user_data)
++{
++    struct na_ucx_op_id *na_ucx_op_id = (struct na_ucx_op_id *) request;
++    na_return_t cb_ret;
++
++    NA_LOG_SUBSYS_DEBUG(
++        rma, "ucp_ep_flush_nbx() completed (%s)", ucs_status_string(status));
++
++    if (status == UCS_OK)
++        NA_GOTO_DONE(done, cb_ret, NA_SUCCESS);
++    if (status == UCS_ERR_CANCELED)
++        NA_GOTO_DONE(done, cb_ret, NA_CANCELED);
++    else
++        NA_GOTO_SUBSYS_ERROR(rma, done, cb_ret, na_ucs_status_to_na(status),
++            "na_ucp_flush_cb() failed (%s)", ucs_status_string(status));
++
+ done:
+     na_ucx_complete(na_ucx_op_id, cb_ret);
+ }

--- a/utils/build.config
+++ b/utils/build.config
@@ -27,6 +27,6 @@ ucx=https://github.com/openucx/ucx.git
 
 [patch_versions]
 spdk=0001_3428322b812fe31cc3e1d0308a7f5bd4b06b9886.diff,0002_spdk_rwf_nowait.patch,0003_external_isal.patch
-mercury=0001_dep_versions.patch,0002_ofi_counters.patch,0003_ofi_auth_key.patch
+mercury=0001_dep_versions.patch,0002_ofi_counters.patch,0003_ofi_auth_key.patch,0004_na_ucx_rma_remote_completion.patch
 pmdk=https://github.com/daos-stack/pmdk/commit/bb048d67ccd07609f86a5e8b3c6ad54414d593ee.diff,https://github.com/daos-stack/pmdk/commit/69925cf455ef672c4cbdbdb13bef7ae581e67045.diff,https://github.com/daos-stack/pmdk/commit/6805ed4f8d1a4e4c6070bf8b68f0dffef08b9c99.diff
 argobots=0001_411e5b344642ebc82190fd8b125db512e5b449d1.diff,0002_bb0c908abfac4bfe37852eee621930634183c6aa.diff


### PR DESCRIPTION
…mpletion

 The ucx+dc_x data path completes a bulk fetch (server-side RDMA put) on
 the put's local completion. For ucp_put_nbx, local completion only means
 the source buffer can be reused, not that the data is visible in the
 remote process memory. The server then replies and the client verifies
 the checksum against a destination buffer that is still empty or holds
 stale (reused) bytes, producing a calculated checksum of 0 and a
 spurious DER_CSUM (-2021). The window widens under congestion/timeouts,
 matching the observed rebuild checksum bursts.

 Patch Mercury na_ucx so that, on a put's local completion, the endpoint
 is flushed via ucp_ep_flush_nbx() to force remote completion, deferring
 the NA completion to the flush callback. Gets are unaffected since their
 local completion already implies data delivery. The behavior can be
 disabled with NA_UCX_RMA_FLUSH=0 for comparison.

 Add deps/patches/mercury/0004_na_ucx_rma_remote_completion.patch and
 register it in utils/build.config.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
