### PR TITLE
DAOS-18976 rebuild: migration fetch/enumerate should retry for network error

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -271,6 +271,17 @@ struct iter_obj_arg {
 	uint32_t		generation;
 };
 
+#define MIGR_RETRY_WAIT_WARN(tls, oid, rc, tried, duration)                                        \
+	do {                                                                                       \
+		tried++;                                                                           \
+		if (tried >= 4096)                                                                 \
+			tried = 2048;                                                              \
+		if ((tried & (tried - 1)) == 0)                                                    \
+			DL_WARN(rc, DF_RB ": retry " DF_UOID ", tried[%d] " DF_U64 " seconds ",    \
+				DP_RB_MPT(tls), DP_UOID(oid), tried, (duration));                  \
+		dss_sleep(1000);                                                                   \
+	} while (0)
+
 static int
 migrate_try_obj_insert(struct migrate_pool_tls *tls, uuid_t co_uuid, daos_unit_oid_t oid,
 		       daos_epoch_t epoch, daos_epoch_t punched_epoch, unsigned int shard,
@@ -778,6 +789,7 @@ mrone_obj_fetch_internal(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_
 	uint64_t              now;
 	int       rc;
 	int                   wait = MEM_NO_WAIT;
+	int                   tried = 0;
 
 	/* pass rebuild epoch by extra_arg */
 	if (flags & DIOF_FETCH_EPOCH_EC_AGG_BOUNDARY) {
@@ -789,7 +801,8 @@ mrone_obj_fetch_internal(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_
 retry:
 	rc = dsc_obj_fetch(oh, eph, &mrone->mo_dkey, iod_num, iods, sgls, NULL, flags, extra_arg,
 			   csum_iov_fetch);
-	if ((rc == -DER_TIMEDOUT || rc == -DER_FETCH_AGAIN || rc == -DER_NOMEM) &&
+	if ((rc == -DER_TIMEDOUT || rc == -DER_FETCH_AGAIN || rc == -DER_NOMEM ||
+	     daos_crt_network_error(rc)) &&
 	    tls->mpt_version + 1 >= tls->mpt_pool->spc_map_version) {
 		if (tls->mpt_fini) {
 			DL_ERROR(rc, DF_RB ": dsc_obj_fetch " DF_UOID "failed when mpt_fini",
@@ -799,19 +812,25 @@ retry:
 		/* If pool map does not change, then let's retry for timeout, instead of
 		 * fail out.
 		 */
+		now = daos_gettime_coarse();
+		if (then == 0)
+			then = now;
+
 		if (rc != -DER_NOMEM) {
-			DL_WARN(rc, DF_RB ": retry " DF_UOID, DP_RB_MPT(tls),
-				DP_UOID(mrone->mo_oid));
-			dss_sleep(1000);
-			D_GOTO(retry, rc);
+			if (rc == -DER_TIMEDOUT || rc == -DER_FETCH_AGAIN || now - then < 600) {
+				MIGR_RETRY_WAIT_WARN(tls, mrone->mo_oid, rc, tried, now - then);
+				D_GOTO(retry, rc);
+			}
+			/* waited for too long, return error and restart rebuild */
+			DL_ERROR(rc, DF_RB " waited for over 10 minutes due to network error",
+				 DP_RB_MRO(mrone));
+			return rc;
 		}
 
-		now = daos_gettime_coarse();
 		if (wait == MEM_NO_WAIT) {
 			wait = MEM_WAIT;
 			res->res_data.mem_waiting++;
 			res->res_data.mem_err++;
-			then = now;
 		}
 		/* sleep a few seconds before retry, give other layers a chance to
 		 * release resources.
@@ -3081,7 +3100,9 @@ migrate_obj_epoch(struct migrate_pool_tls *tls, struct iter_obj_arg *arg, daos_e
 	uint32_t		 minimum_nr;
 	uint32_t		 enum_flags;
 	uint32_t		 num;
-	int                       waited = 0;
+	uint64_t                  now;
+	uint64_t                  then  = 0;
+	int                       tried = 0;
 	int			 rc = 0;
 
 	D_DEBUG(DB_REBUILD, "migrate obj "DF_UOID" for shard %u eph "
@@ -3216,23 +3237,29 @@ migrate_obj_epoch(struct migrate_pool_tls *tls, struct iter_obj_arg *arg, daos_e
 			/* -DER_UPDATE_AGAIN means the remote target does not parse EC
 			 * aggregation yet, so let's retry.
 			 */
-			waited++;
+			now = daos_gettime_coarse();
+			if (then == 0)
+				then = now;
 			dss_sleep(5000);
 			D_DEBUG(DB_REBUILD, DF_UOID "retry %d secs with %d \n", DP_UOID(arg->oid),
-				waited * 5, rc);
+				(int)(now + 5 - then), rc);
 			rc = 0;
 			continue;
 		} else if (rc) {
 			/* To avoid reclaim and retry rebuild, let's retry until the pool map
 			 * being changed due to further failure.
 			 */
-			if (rc == -DER_TIMEDOUT &&
+			if ((rc == -DER_TIMEDOUT || daos_crt_network_error(rc)) &&
 			    tls->mpt_version + 1 >= tls->mpt_pool->spc_map_version) {
-				D_WARN(DF_UUID" retry "DF_UOID" "DF_RC"\n",
-				       DP_UUID(tls->mpt_pool_uuid), DP_UOID(arg->oid),
-				       DP_RC(rc));
-				rc = 0;
-				continue;
+				now = daos_gettime_coarse();
+				if (then == 0)
+					then = now;
+				if (rc == -DER_TIMEDOUT || now - then < 600) {
+					MIGR_RETRY_WAIT_WARN(tls, arg->oid, rc, tried, now - then);
+					rc = 0;
+					continue;
+				}
+				/* fall through and fail rebuild */
 			}
 
 			/* container might have been destroyed. Or there is

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -214,11 +214,16 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			D_WARN("leader change stable epoch from "DF_U64" to "
 			       DF_U64 "\n", rpt->rt_stable_epoch,
 			       dst_iv->riv_stable_epoch);
-		rpt->rt_global_done = dst_iv->riv_global_done;
-		rpt->rt_global_scan_done = dst_iv->riv_global_scan_done;
+
+		/* NB: IV refresh can arrive out of order, but rebuild can't revert global done */
+		if (!rpt->rt_global_done)
+			rpt->rt_global_done = dst_iv->riv_global_done;
+		if (!rpt->rt_global_scan_done)
+			rpt->rt_global_scan_done = dst_iv->riv_global_scan_done;
 		old_ver = rpt->rt_global_dtx_resync_version;
-		if (rpt->rt_global_dtx_resync_version < dst_iv->riv_global_dtx_resyc_version)
+		if (old_ver < dst_iv->riv_global_dtx_resyc_version)
 			rpt->rt_global_dtx_resync_version = dst_iv->riv_global_dtx_resyc_version;
+
 		if (old_ver < rpt->rt_rebuild_ver &&
 		    dst_iv->riv_global_dtx_resyc_version >= rpt->rt_rebuild_ver) {
 			D_INFO(DF_UUID " global/iv/rebuild_ver %u/%u/%u signal wait cond\n",


### PR DESCRIPTION
- There's a clear asymmetry between the scan (push) side and the pull (fetch) side:
   
   . Scan side (rebuild_objects_send_ult): Already retries ALL daos_crt_network_error()
     properly handles transient network errors when pushing OID lists to pullers.
    
   . Pull side (mrone_obj_fetch_internal): Does NOT retry network errors when fetching
     data from source
    
   . This patch makes them consistent and always retry for network error for both cases
    
- rebuild IV refresh can arrive out of order, make sure it doesn't revert global done flag

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
