### PR TITLE
DAOS-19022 container: hold sc_open_mutex on close

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1999,8 +1999,10 @@ cont_close_hdl(uuid_t cont_hdl_uuid)
 		DP_CONT(cont_child->sc_pool->spc_uuid, cont_child->sc_uuid), cont_child->sc_open,
 		DP_UUID(cont_hdl_uuid));
 
+	ABT_mutex_lock(hdl->sch_cont->sc_open_mutex);
 	D_ASSERT(cont_child->sc_open > 0);
 	cont_child->sc_open--;
+	ABT_mutex_unlock(hdl->sch_cont->sc_open_mutex);
 	if (cont_child->sc_open == 0)
 		dtx_cont_close(cont_child, false);
 


### PR DESCRIPTION
Hold sc_open_mutex in cont_close_hdl() to avoid race.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
