### PR TITLE
DAOS-18976 rebuild: refine rebuild gen handling

### DIFF
--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -193,8 +193,8 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 
 	if (ref_rc != 0) {
 		rc = ref_rc;
-		DL_WARN(rc, DF_UUID "bypass refresh, IV class id %d.",
-			DP_UUID(entry->ns->iv_pool_uuid), key->class_id);
+		DL_WARN(rc, DF_RB ", IV ns pool " DF_UUID "bypass refresh, IV class id %d.",
+			DP_RB_RPT(rpt), DP_UUID(entry->ns->iv_pool_uuid), key->class_id);
 		goto out;
 	}
 

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -142,8 +142,11 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 
 		if (rpt->rt_abort || rpt->rt_finishing || rpt->rt_global_done) {
 			rc = -DER_SHUTDOWN;
-			DL_INFO(rc, DF_RB ": give up ds_object_migrate_send, shutdown rebuild",
-				DP_RB_RPT(rpt));
+			DL_INFO(rc,
+				DF_RB ": rt_abort %d rf_finishing %d rt_global_done %d, "
+				      "give up ds_object_migrate_send, shutdown rebuild",
+				DP_RB_RPT(rpt), rpt->rt_abort, rpt->rt_finishing,
+				rpt->rt_global_done);
 			break;
 		}
 
@@ -1342,6 +1345,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 			rpt->rt_re_report = 1;
 
 			rpt->rt_leader_rank = rsi->rsi_master_rank;
+			rpt->rt_rebuild_gen = rsi->rsi_rebuild_gen;
 
 			/* If this is the old leader, then also stop the rebuild tracking ULT. */
 			rebuild_leader_abort(rsi->rsi_pool_uuid, rsi->rsi_rebuild_ver, -1,

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1813,7 +1813,8 @@ rebuild_leader_start(struct ds_pool *pool, struct rebuild_task *task,
 	 */
 	ds_rebuild_running_query_adv(pool->sp_uuid, -1, &version, NULL, &generation,
 				     &rebuild_leader_rank, &rebuild_leader_term);
-	if ((version < task->dst_map_ver) ||
+	if (task->dst_rebuild_op == RB_OP_RECLAIM || task->dst_rebuild_op == RB_OP_FAIL_RECLAIM ||
+	    (version < task->dst_map_ver) ||
 	    (version == task->dst_map_ver && leader_rank == rebuild_leader_rank &&
 	     leader_term == rebuild_leader_term))
 		generation = ++pool->sp_rebuild_gen;
@@ -2283,6 +2284,8 @@ iv_stop:
 	/* NB: even if there are failures, the leader should notify other engines to abort rebuild
 	 */
 	if (rgt && rgt->rgt_init_scan) {
+		struct rebuild_tgt_pool_tracker *local_rpt;
+
 		if (myrank != pool->sp_iv_ns->iv_master_rank) {
 			/* If master has been changed, then let's skip
 			 * iv sync, and the new leader will take over
@@ -2294,6 +2297,14 @@ iv_stop:
 		}
 
 		rebuild_leader_status_notify(rgt, pool, task->dst_rebuild_op, myrank);
+
+		local_rpt = rpt_lookup(pool->sp_uuid, task->dst_rebuild_op, rgt->rgt_rebuild_ver,
+				       rgt->rgt_rebuild_gen);
+		if (local_rpt) {
+			local_rpt->rt_abort = 1;
+			D_INFO(DF_RB " set rt_abort", DP_RB_RPT(local_rpt));
+			rpt_put(local_rpt);
+		}
 	}
 
 try_reschedule:
@@ -3089,8 +3100,12 @@ rebuild_tgt_status_check_ult(void *arg)
 				/* Already finished rebuild, cannot find rebuild status on leader
 				 * (see crt_iv_hdlr_xx()). Abort the rebuild
 				 */
-				if (rc == -DER_NONEXIST && !status.rebuilding)
+				if (rc == -DER_NONEXIST && !status.rebuilding) {
+					D_INFO(DF_RB ", rc %d, status.rebuilding %d, "
+						     "set rt_global_done",
+					       DP_RB_RPT(rpt), rc, status.rebuilding);
 					rpt->rt_global_done = 1;
+				}
 
 				if (ns->iv_stop) {
 					D_DEBUG(DB_REBUILD, "abort rebuild " DF_RB "\n",


### PR DESCRIPTION
1. For RECLAIM/FAIL_RECLAIM always bump the rebuild gen.
2. abort local rpt when rgt done. Some log refinning

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
