### PR TITLE
SRE-3351 ci: fix the quick-functional pragmas

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -489,7 +489,7 @@ pipeline {
                 expression { !skip_build_stage() }
             }
             parallel {
-                stage('Build on EL 8') {
+                stage('Build RPM on EL 8') {
                     when {
                         beforeAgent true
                         expression { !skip_build_stage('el8') }
@@ -543,7 +543,7 @@ pipeline {
                         }
                     }
                 }
-                stage('Build on EL 9') {
+                stage('Build RPM on EL 9') {
                     when {
                         beforeAgent true
                         expression { !skip_build_stage('el9') }
@@ -597,7 +597,7 @@ pipeline {
                         }
                     }
                 }
-                stage('Build on Leap 15') {
+                stage('Build RPM on Leap 15') {
                     when {
                         beforeAgent true
                         expression { !skip_build_stage('leap15') }


### PR DESCRIPTION
After renaming the stages, the pragma behaves as before. I'm not changing the logic, just the name.

Signed-off-by: Oksana Salyk <oksana.salyk@hpe.com>

Quick-Functional: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
