### PR TITLE
DAOS-18954 test: Enable nvme/enospace.py test for release-2.6

### DIFF
--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -695,7 +695,8 @@ class NvmeEnospace(ServerFillUp, TestWithTelemetry):
         self.run_enospace_with_bg_job(self.client_log)
 
         # Read the same container which was written at the beginning.
-        self.nvme_local_cont.uuid = baseline_cont_uuid
+        # self.nvme_local_cont.uuid = baseline_cont_uuid
+        self.ior_cmd.dfs_cont.update(baseline_cont_uuid)
         self.start_ior_load(storage='SCM', operation='Auto_Read', percent=1)
         max_mib_latest = float(self.ior_matrix[0][int(IorMetrics.MAX_MIB)])
         self.log.info("IOR Latest Read MiB %s", max_mib_latest)

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -695,7 +695,7 @@ class NvmeEnospace(ServerFillUp, TestWithTelemetry):
         self.run_enospace_with_bg_job(self.client_log)
 
         # Read the same container which was written at the beginning.
-        self.container.uuid = baseline_cont_uuid
+        self.nvme_local_cont.uuid = baseline_cont_uuid
         self.start_ior_load(storage='SCM', operation='Auto_Read', percent=1)
         max_mib_latest = float(self.ior_matrix[0][int(IorMetrics.MAX_MIB)])
         self.log.info("IOR Latest Read MiB %s", max_mib_latest)

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -1,6 +1,6 @@
 '''
   (C) Copyright 2020-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -8,7 +8,6 @@ import os
 import threading
 import time
 
-from apricot import skipForTicket
 from avocado.core.exceptions import TestFail
 from daos_utils import DaosCommand
 from exception_utils import CommandFailure
@@ -667,7 +666,6 @@ class NvmeEnospace(ServerFillUp, TestWithTelemetry):
         self.log_step("Run one more sanity IOR to fill 1%")
         self.start_ior_load(storage='SCM', operation="Auto_Write", percent=1)
 
-    @skipForTicket("DAOS-8896")
     def test_performance_storage_full(self):
         """Jira ID: DAOS-4756.
 

--- a/src/tests/ftest/nvme/enospace.yaml
+++ b/src/tests/ftest/nvme/enospace.yaml
@@ -13,12 +13,12 @@ server_config:
     0:
       pinned_numa_node: 0
       nr_xs_helpers: 1
-      targets: 1
+      targets: 4
       storage: auto
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
-      targets: 1
+      targets: 4
       storage: auto
   transport_config:
     allow_insecure: true

--- a/src/tests/ftest/nvme/enospace.yaml
+++ b/src/tests/ftest/nvme/enospace.yaml
@@ -13,12 +13,12 @@ server_config:
     0:
       pinned_numa_node: 0
       nr_xs_helpers: 1
-      targets: 4
+      targets: 1
       storage: auto
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
-      targets: 4
+      targets: 1
       storage: auto
   transport_config:
     allow_insecure: true


### PR DESCRIPTION
Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: NvmeEnospace
Required-githooks: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
