### PR TITLE
DAOS-19018 kv: fix reference leak in daos_kv2objhandle()

### DIFF
--- a/src/client/kv/dc_kv.c
+++ b/src/client/kv/dc_kv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -94,12 +95,19 @@ kv_hdl2ptr(daos_handle_t oh)
 
 daos_handle_t daos_kv2objhandle(daos_handle_t kv_oh)
 {
-	struct dc_kv *dk = kv_hdl2ptr(kv_oh);
+	struct dc_kv *dk;
+	daos_handle_t oh;
 
-	if (dk)
-		return dk->daos_oh;
+	dk = kv_hdl2ptr(kv_oh);
+	if (dk == NULL) {
+		oh = DAOS_HDL_INVAL;
+		goto out;
+	}
+	oh = dk->daos_oh;
+	kv_decref(dk);
 
-	return DAOS_HDL_INVAL;
+out:
+	return oh;
 }
 
 static void

--- a/src/tests/suite/daos_kv.c
+++ b/src/tests/suite/daos_kv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -10,6 +11,7 @@
  */
 #include <daos.h>
 #include <daos_kv.h>
+#include <daos/kv.h>
 #include "daos_test.h"
 
 #if D_HAS_WARNING(4, "-Wframe-larger-than")
@@ -352,15 +354,58 @@ kv_cond_ops(void **state)
 	print_message("all good\n");
 } /* End simple_put_get */
 
+static void
+kv_obj_handle(void **state)
+{
+	test_arg_t   *arg = *state;
+	daos_obj_id_t oid;
+	daos_handle_t kv_oh;
+	daos_handle_t oh;
+	int           rc;
+	int           i;
+
+	/** invalid handle must return DAOS_HDL_INVAL */
+	print_message("Getting obj handle from invalid KV handle\n");
+	oh = daos_kv2objhandle(DAOS_HDL_INVAL);
+	assert_true(daos_handle_is_inval(oh));
+
+	oid = daos_test_oid_gen(arg->coh, OC_SX, type, 0, arg->myrank);
+	rc  = daos_kv_open(arg->coh, oid, DAOS_OO_RW, &kv_oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	/** valid handle must return a valid object handle */
+	print_message("Getting obj handle from valid KV handle\n");
+	oh = daos_kv2objhandle(kv_oh);
+	assert_true(daos_handle_is_valid(oh));
+
+	/**
+	 * Call multiple times: each call must release the lookup reference so
+	 * no reference leak accumulates (regression for DAOS-19018).
+	 * When built with ASAN/LeakSanitizer, any leaked dc_kv reference will
+	 * be reported here.
+	 */
+	print_message("Calling daos_kv2objhandle() repeatedly\n");
+	for (i = 0; i < 10; i++) {
+		oh = daos_kv2objhandle(kv_oh);
+		assert_true(daos_handle_is_valid(oh));
+	}
+
+	/** KV must be closeable after repeated calls */
+	print_message("Closing KV handle\n");
+	rc = daos_kv_close(kv_oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	print_message("all good\n");
+}
+
 static const struct CMUnitTest kv_tests[] = {
-	{"KV: Object Put/GET (blocking)",
-	 simple_put_get, async_disable, NULL},
-	{"KV: Object Put/GET with daos_ofeat_t flag(blocking)",
-	 simple_put_get_old, async_disable, NULL},
-	{"KV: Object Put/GET (non-blocking)",
-	 simple_put_get, async_enable, NULL},
-	{"KV: Object Conditional Ops (blocking)",
-	 kv_cond_ops, async_disable, NULL},
+    {"KV: Object Put/GET (blocking)", simple_put_get, async_disable, NULL},
+    {"KV: Object Put/GET with daos_ofeat_t flag(blocking)", simple_put_get_old, async_disable,
+     NULL},
+    {"KV: Object Put/GET (non-blocking)", simple_put_get, async_enable, NULL},
+    {"KV: Object Conditional Ops (blocking)", kv_cond_ops, async_disable, NULL},
+    {"KV: daos_kv2objhandle() correctness and reference leak (DAOS-19018)", kv_obj_handle,
+     async_disable, NULL},
 };
 
 int


### PR DESCRIPTION
### Description

`kv_hdl2ptr()` increments the `dc_kv` reference count via `daos_hhash_link_lookup(). daos_kv2objhandle()` was returning without calling `kv_decref()`, leaking one reference per call. Add the missing `kv_decref()` after copying the object handle.

Also add a regression test in the `DAOS_KV_API` suite that calls `daos_kv2objhandle()` with both invalid and valid handles, exercises the function repeatedly to surface any leak under ASAN/LeakSanitizer, and verifies the KV handle can be cleanly closed afterwards.

### Dependency

This PR depends on [PR #18423](https://github.com/daos-stack/daos/pull/18423) (DAOS-19017: fix `d_aligned_alloc` size constraint violation). Without that fix, ASAN aborts immediately on the misaligned allocation, which prevents it from reaching the leak-detection phase. PR #18423 must be merged first for the ASAN/LeakSanitizer validation below to be reproducible.

### Validation

Both runs used `daos_test -K` with filter `kv_obj_handle`, built with `SANITIZERS=address`.

**Without the fix** — LeakSanitizer detects the `dc_kv` leak:

```
==2573095==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 in calloc
    #1 in d_calloc src/gurt/misc.c:126
    #2 in kv_alloc src/client/kv/dc_kv.c:60
    #3 in open_handle_cb src/client/kv/dc_kv.c:130
    ...
    #16 in kv_obj_handle src/tests/suite/daos_kv.c:373

SUMMARY: AddressSanitizer: 17019 byte(s) leaked in 54 allocation(s).
```

**With the fix** — no `kv_alloc` leak, 80 bytes and 1 allocation fewer:

```
SUMMARY: AddressSanitizer: 16939 byte(s) leaked in 53 allocation(s).
```

The remaining leaks in both runs (openmpi, isal, hwloc) are pre-existing third-party leaks unrelated to this change.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
