### PR TITLE
DAOS-19059 vos: cache vos object after DTX commit - b26

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1,7 +1,7 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2354,6 +2354,8 @@ vos_dtx_post_handle(struct vos_container *cont,
 	}
 
 	for (i = 0; i < count; i++) {
+		struct vos_dtx_act_ent *dae = NULL;
+
 		if (daes[i] == NULL)
 			continue;
 
@@ -2370,9 +2372,18 @@ vos_dtx_post_handle(struct vos_container *cont,
 		}
 
 		d_iov_set(&kiov, &DAE_XID(daes[i]), sizeof(DAE_XID(daes[i])));
-		rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
-				   &kiov, NULL);
+		/*
+		 * For abort case, set @args as NULL, then related vos object will be evicted from
+		 * cache via dbtree_delete().
+		 */
+		rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ, &kiov,
+				   abort ? NULL : &dae);
 		if (rc == 0 || rc == -DER_NONEXIST) {
+			if (dae != NULL) {
+				D_ASSERT(dae == daes[i]);
+				dtx_act_ent_cleanup(cont, dae, NULL, false, false);
+			}
+
 			dtx_evict_lid(cont, daes[i]);
 		} else {
 			/* The DTX entry has been committed or aborted, but we


### PR DESCRIPTION
It is unnecessary to evict the vos object from cache after related DTX committed; otherwise, other concurrent modification against the same object shard maybe required to retry.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
