### PR TITLE
SRE-3751 cq: monitor Hadoop Maven dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,31 @@ updates:
       - daos-stack/actions-watchers
     commit-message:
       prefix: "Doc-only: true \n"
+
+  - package-ecosystem: maven
+    target-branch: master
+    directory: /src/client/java/hadoop-daos
+    schedule:
+      interval: weekly
+    groups:
+      java-packages:
+        patterns:
+          - "*"
+    reviewers:
+      - daos-stack/actions-watchers
+    commit-message:
+      prefix: "Doc-only: true \n"
+
+  - package-ecosystem: maven
+    target-branch: release/2.8
+    directory: /src/client/java/hadoop-daos
+    schedule:
+      interval: weekly
+    groups:
+      java-packages:
+        patterns:
+          - "*"
+    reviewers:
+      - daos-stack/actions-watchers
+    commit-message:
+      prefix: "Doc-only: true \n"


### PR DESCRIPTION
Monitor Hadoop Maven dependencies on active branches:
- master
- release 2.8

Should replace #18099 #18101 #18102
### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
