### PR TITLE
DAOS-19061 test: Fix harness/core_files.py (#18425)

### DIFF
--- a/src/tests/ftest/harness/core_files.py
+++ b/src/tests/ftest/harness/core_files.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2021-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -87,6 +88,9 @@ class HarnessCoreFilesTest(TestWithServers):
         finally:
             # Display the journalctl log for the process that was sent the signal
             self.server_managers[0].manager.dump_logs(host)
+
+        # The rank in the errored state may transition to excluded state; allow either in tearDown
+        self.server_managers[0].update_expected_states(ranks, ["Joined", "Errored", "Excluded"])
 
         self.log.info("Test passed")
 


### PR DESCRIPTION
The killed rank may transition to the excluded state after detecing the errored state. Allow the tearDown rank state check to pass for either state.

Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
