### PR TITLE
DAOS-19005 test: Fix the dfuse/daos_build.py test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value='pipeline-lib@your_branch') _
+@Library(value='pipeline-lib@hendersp/DAOS-19005') _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]

--- a/ci/functional/test_main.sh
+++ b/ci/functional/test_main.sh
@@ -119,6 +119,7 @@ if "$hardware_ok"; then
            STAGE_NAME=\"${STAGE_NAME}\"               \
            DAOS_HTTPS_PROXY=\"${DAOS_HTTPS_PROXY:-}\" \
            DAOS_NO_PROXY=\"${DAOS_NO_PROXY:-}\"       \
+           TRUSTED_HOST=\"${TRUSTED_HOST:-}\"         \
            $(cat ci/functional/test_main_node.sh)"
     else
         ./ftest.sh "$test_tag" "$tnodes" "${FTEST_ARG:-}"

--- a/ci/functional/test_main_node.sh
+++ b/ci/functional/test_main_node.sh
@@ -15,7 +15,7 @@ export TEST_RPMS=true
 export REMOTE_ACCT=jenkins
 export WITH_VALGRIND="$WITH_VALGRIND"
 export STAGE_NAME="$STAGE_NAME"
-
 export DAOS_HTTPS_PROXY="${DAOS_HTTPS_PROXY:-}"
 export DAOS_NO_PROXY="${DAOS_NO_PROXY:-}"
+export TRUSTED_HOST="${TRUSTED_HOST:-}"
 /usr/lib/daos/TESTING/ftest/ftest.sh "$TEST_TAG" "$TNODES" "$FTEST_ARG"

--- a/ftest.sh
+++ b/ftest.sh
@@ -108,6 +108,7 @@ if ! clush "${CLUSH_ARGS[@]}" -B -l "${REMOTE_ACCT:-jenkins}" -R ssh -S \
      DAOS_FTEST_VENV=$DAOS_FTEST_VENV
      PYTHON_VERSION=${PYTHON_VERSION:-3.11}
      PREFIX=$PREFIX
+     TRUSTED_HOST=${TRUSTED_HOST:-}
      $(sed -e '1,/^$/d' "$SCRIPT_LOC"/setup_nodes.sh)"; then
     echo "Cluster setup (i.e. provisioning) failed"
     exit 1

--- a/src/tests/ftest/scripts/setup_nodes.sh
+++ b/src/tests/ftest/scripts/setup_nodes.sh
@@ -119,6 +119,15 @@ pip install ./pydaos
 rm -rf pydaos
 deactivate
 
+# Set up uv (for SPDK installer) for the daos_build.py test
+if [[ -n ${TRUSTED_HOST} ]]; then
+    sudo mkdir -p /etc/uv
+    cat <<EOF | sudo tee /etc/uv/uv.toml
+index-url = "${TRUSTED_HOST}/artifactory/api/pypi/pypi-proxy/simple"
+native-tls = true
+EOF
+fi
+
 rm -rf "${TEST_TAG_DIR:?}/"
 mkdir -p "$TEST_TAG_DIR/"
 if [ -z "$JENKINS_URL" ]; then


### PR DESCRIPTION
Support the updated spdk install by configuring a uv to be able to install pacakages from artifacttory.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-test-el8: false
Skip-func-test-leap15: false
Test-tag: DaosBuild DaosBuildVM

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
