### PR TITLE
DAOS-18930 test: remove hardcoded ib0 from mem_ratio (#18162)

### DIFF
--- a/src/tests/ftest/pool/mem_ratio.yaml
+++ b/src/tests/ftest/pool/mem_ratio.yaml
@@ -12,14 +12,12 @@ server_config:
     0:
       pinned_numa_node: 0
       nr_xs_helpers: 1
-      fabric_iface: ib0
       fabric_iface_port: 31317
       log_file: daos_server0.log
       storage: auto
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
-      fabric_iface: ib1
       fabric_iface_port: 31417
       log_file: daos_server1.log
       storage: auto


### PR DESCRIPTION
Remove hardcoded ib0/ib1 from mem_ratio.yaml.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
