### PR TITLE
DAOS-19031 cart: Fix test_ep_cred_client race condition (#18439)

### DIFF
--- a/src/tests/ftest/cart/test_ep_cred_client.c
+++ b/src/tests/ftest/cart/test_ep_cred_client.c
@@ -37,8 +37,10 @@ static void
 rpc_handle_ping_front_q(const struct crt_cb_info *info)
 {
 	DBG_PRINT("Response from front queued rpc\n");
-	D_ASSERTF(info->cci_rc == 0, "rpc response failed. rc: %d\n",
-		  info->cci_rc);
+	D_ASSERTF(info->cci_rc == 0, "rpc response failed. rc: %d\n", info->cci_rc);
+
+	/* sent_count == resp_count means rpc didn't get queued in the front */
+	D_ASSERTF(sent_count != resp_count, "Send count matches response count\n");
 	sem_post(&test.tg_queue_front_token);
 }
 
@@ -130,8 +132,6 @@ test_run()
 		D_ASSERTF(rc == 0, "crt_req_send() failed. rc: %d\n", rc);
 
 		crtu_sem_timedwait(&test.tg_queue_front_token, 61, __LINE__);
-		D_ASSERTF(sent_count != resp_count,
-			"Send count matches response count\n");
 	}
 
 	DBG_PRINT("Waiting for responses to %d rpcs\n",


### PR DESCRIPTION
Fix test race condition where status was checked outside of the completion callback.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
