### PR TITLE
DAOS-19088 ci: pin mercury-devel to the latest 15.5 version

### DIFF
--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -135,7 +135,7 @@ Requires: openssl
 # of mercury, at which time the autoprov shared library version should
 # suffice
 Requires: mercury-libfabric >= %{mercury_version}
-Requires: mercury-libfabric <= %{mercury_version_max}
+
 
 
 %description
@@ -167,7 +167,6 @@ Requires: libpmemobj >= 2.1.3-2
 %endif
 Requires: libfabric >= %{libfabric_version}
 Requires: mercury-libfabric >= %{mercury_version}
-Requires: mercury-libfabric <= %{mercury_version_max}
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 Requires: numactl
@@ -189,7 +188,6 @@ This package contains DAOS administrative tools (e.g. dmg).
 Summary: The DAOS client
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: mercury-libfabric >= %{mercury_version}
-Requires: mercury-libfabric <= %{mercury_version_max}
 Requires: libfabric >= %{libfabric_version}
 %if (0%{?suse_version} >= 1500)
 Requires: libfabric1 >= %{libfabric_version}

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -11,6 +11,7 @@
 %global daos_build_args client test
 %endif
 %global mercury_version   2.4.1
+%global mercury_version_max   2.4.1-2
 %global libfabric_version 1.20
 %global argobots_version 1.2-3
 %global __python %{__python3}
@@ -37,6 +38,7 @@ BuildRequires: scons >= 2.4
 %endif
 BuildRequires: libfabric-devel >= %{libfabric_version}
 BuildRequires: mercury-devel >= %{mercury_version}
+BuildRequires: mercury-devel <= %{mercury_version_max}
 BuildRequires: gcc-c++
 %if (0%{?rhel} >= 8)
 %global openmpi openmpi
@@ -133,6 +135,7 @@ Requires: openssl
 # of mercury, at which time the autoprov shared library version should
 # suffice
 Requires: mercury-libfabric >= %{mercury_version}
+Requires: mercury-libfabric <= %{mercury_version_max}
 
 
 %description
@@ -164,6 +167,7 @@ Requires: libpmemobj >= 2.1.3-2
 %endif
 Requires: libfabric >= %{libfabric_version}
 Requires: mercury-libfabric >= %{mercury_version}
+Requires: mercury-libfabric <= %{mercury_version_max}
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 Requires: numactl
@@ -185,6 +189,7 @@ This package contains DAOS administrative tools (e.g. dmg).
 Summary: The DAOS client
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: mercury-libfabric >= %{mercury_version}
+Requires: mercury-libfabric <= %{mercury_version_max}
 Requires: libfabric >= %{libfabric_version}
 %if (0%{?suse_version} >= 1500)
 Requires: libfabric1 >= %{libfabric_version}


### PR DESCRIPTION
The latest available leap 15.5 `mercury-devel` RPM has version 2.4.1-2.
This version must be used for proper DAOS build on leap 15.5.


### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
