### PR TITLE
DAOS-19103 test: call FI macro in rebuild tests

### DIFF
--- a/src/tests/suite/daos_rebuild_interactive.c
+++ b/src/tests/suite/daos_rebuild_interactive.c
@@ -224,6 +224,8 @@ int_rebuild_many_objects_with_failure(void **state)
 	int            rc;
 	int            i;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (!test_runable(arg, 6))
 		return;
 

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -1373,6 +1373,8 @@ rebuild_many_objects_with_failure(void **state)
 	int		rc;
 	int		i;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (!test_runable(arg, 6))
 		return;
 
@@ -1463,6 +1465,8 @@ rebuild_object_with_csum_error(void **state)
 	daos_size_t      block_size    = 200L * MB;
 	daos_size_t	io_count = block_size / transfer_size;
 	uint32_t	iterations = 2;
+
+	FAULT_INJECTION_REQUIRED();
 
 	if (!test_runable(arg, 3)) {
 		skip();
@@ -1749,6 +1753,8 @@ rebuild_with_dfs_inflight_append(void **state)
 	daos_obj_id_t	oid;
 	struct rebuild_cb_arg cb_arg;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (!test_runable(arg, 6))
 		return;
 
@@ -1809,6 +1815,8 @@ rebuild_with_dfs_inflight_punch(void **state)
 	struct rebuild_cb_arg cb_arg;
 	struct stat	st;
 	int		rc;
+
+	FAULT_INJECTION_REQUIRED();
 
 	if (!test_runable(arg, 6))
 		return;
@@ -1893,6 +1901,8 @@ rebuild_with_dfs_inflight_append_punch(void **state)
 	struct rebuild_cb_arg cb_arg;
 	struct stat	st;
 	int		rc;
+
+	FAULT_INJECTION_REQUIRED();
 
 	if (!test_runable(arg, 6))
 		return;


### PR DESCRIPTION
This change covers DAOS-19103 and DAOS-19104 fixes needed
for the relevant interactive and simple rebuild test cases.

Add FAULT_INJECTION_REQUIRED() in tests requiring fault injection
enabled, to skip cleanly (instead of hange) when run with a daos
release build.

faults-enabled:  false
Test-tag: test_daos_rebuild_simple  test_daos_rebuild_interactive
Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-test-rpms: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
