### PR TITLE
DAOS-19028 test: DO NOT LAND test_rebuild_29 repro attempt

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -3436,8 +3436,17 @@ crt_group_primary_modify(crt_group_t *grp, crt_context_t *ctxs, int num_ctxs, d_
 	for (i = 0; i < n_idx_to_check; i++) {
 		uint32_t	idx = idx_to_check[i];
 		uint64_t	incarnation = incarnations[idx];
+		const char     *uri         = "<none>";
 
 		rank = ranks->rl_ranks[idx];
+		if (uris != NULL && uris[idx] != NULL)
+			uri = uris[idx];
+
+		D_DEBUG(DB_ALL,
+			"group replace existing rank: rank=%u incoming_inc=%lu incoming_uri=%s "
+			"note=swim_check_only_uri_cache_not_explicitly_refreshed\n",
+			rank, (unsigned long)incarnation, uri);
+
 		rc = crt_swim_rank_check(grp_priv, rank, incarnation);
 		if (rc != 0)
 			D_ERROR("Failed to check SWIM state of rank %u: "DF_RC"\n", rank,

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -82,6 +82,39 @@ pool_create_rpc_timeout(crt_rpc_t *tc_req, size_t scm_size)
 	return max(timeout, default_timeout);
 }
 
+static void
+warn_pool_create_timeout_missing_uri(uuid_t pool_uuid, d_rank_list_t *rank_list)
+{
+	int i;
+	int missing = 0;
+
+	if (rank_list == NULL || rank_list->rl_nr == 0)
+		return;
+
+	for (i = 0; i < rank_list->rl_nr; i++) {
+		d_rank_t rank = rank_list->rl_ranks[i];
+		char    *uri  = NULL;
+		int      rc;
+
+		rc = crt_rank_uri_get(NULL /* grp */, rank, 0 /* tag */, &uri);
+		if (rc != 0 || uri == NULL || uri[0] == '\0') {
+			D_WARN(
+			    DF_UUID
+			    ": MGMT_TGT_CREATE timeout: missing target URI rank=%u lookup_rc=" DF_RC
+			    "\n",
+			    DP_UUID(pool_uuid), rank, DP_RC(rc));
+			missing++;
+		}
+
+		D_FREE(uri);
+	}
+
+	if (missing > 0) {
+		D_WARN(DF_UUID ": MGMT_TGT_CREATE timeout: missing URI targets=%d/%u\n",
+		       DP_UUID(pool_uuid), missing, rank_list->rl_nr);
+	}
+}
+
 static int
 ds_mgmt_tgt_pool_create_ranks(uuid_t pool_uuid, char *tgt_dev, d_rank_list_t *rank_list,
 			      size_t scm_size, size_t nvme_size)
@@ -122,6 +155,8 @@ ds_mgmt_tgt_pool_create_ranks(uuid_t pool_uuid, char *tgt_dev, d_rank_list_t *ra
 	if (rc == 0 && DAOS_FAIL_CHECK(DAOS_POOL_CREATE_FAIL_CORPC))
 		rc = -DER_TIMEDOUT;
 	if (rc != 0) {
+		if (rc == -DER_TIMEDOUT)
+			warn_pool_create_timeout_missing_uri(pool_uuid, rank_list);
 		D_ERROR(DF_UUID": dss_rpc_send MGMT_TGT_CREATE: rc="DF_RC"\n",
 			DP_UUID(pool_uuid), DP_RC(rc));
 		D_GOTO(decref, rc);
@@ -130,6 +165,8 @@ ds_mgmt_tgt_pool_create_ranks(uuid_t pool_uuid, char *tgt_dev, d_rank_list_t *ra
 	tc_out = crt_reply_get(tc_req);
 	rc = tc_out->tc_rc;
 	if (rc != 0) {
+		if (rc == -DER_TIMEDOUT)
+			warn_pool_create_timeout_missing_uri(pool_uuid, rank_list);
 		D_ERROR(DF_UUID": failed to create targets: rc="DF_RC"\n",
 			DP_UUID(tc_in->tc_pool_uuid), DP_RC(rc));
 		D_GOTO(decref, rc);

--- a/src/mgmt/srv_system.c
+++ b/src/mgmt/srv_system.c
@@ -141,6 +141,20 @@ free_server_list(struct server_entry *list, int len)
 	D_FREE(list);
 }
 
+static bool
+map_update_verbose_enabled(void)
+{
+	static bool initialized;
+	static bool enabled;
+
+	if (!initialized) {
+		d_getenv_bool("DAOS_MAP_UPDATE_VERBOSE", &enabled);
+		initialized = true;
+	}
+
+	return enabled;
+}
+
 static struct server_entry *
 dup_server_list(struct server_entry *in, int in_len)
 {
@@ -224,18 +238,24 @@ map_update_bcast(crt_context_t ctx, struct mgmt_svc *svc, uint32_t map_version,
 	crt_rpc_t		       *rpc;
 	int                             i;
 	int				rc;
+	bool                            verbose;
 
+	verbose = map_update_verbose_enabled();
 	D_DEBUG(DB_MGMT, "enter: version=%u nservers=%d\n", map_version,
 		nservers);
-	for (i = 0; i < nservers; i++) {
-		const char *uri = "<none>";
+	if (verbose) {
+		for (i = 0; i < nservers; i++) {
+			const char *uri = "<none>";
 
-		if (servers[i].se_uri != NULL)
-			uri = servers[i].se_uri;
+			if (servers[i].se_uri != NULL)
+				uri = servers[i].se_uri;
 
-		D_DEBUG(DB_MGMT, "map[%d/%d]: rank=%u inc=%lu uri=%s flags=%u nctxs=%u\n", i + 1,
-			nservers, servers[i].se_rank, (unsigned long)servers[i].se_incarnation, uri,
-			(unsigned int)servers[i].se_flags, (unsigned int)servers[i].se_nctxs);
+			D_DEBUG(DB_MGMT, "map[%d/%d]: rank=%u inc=%lu uri=%s flags=%u nctxs=%u\n",
+				i + 1, nservers, servers[i].se_rank,
+				(unsigned long)servers[i].se_incarnation, uri,
+				(unsigned int)servers[i].se_flags,
+				(unsigned int)servers[i].se_nctxs);
+		}
 	}
 
 	opc = DAOS_RPC_OPCODE(MGMT_TGT_MAP_UPDATE, DAOS_MGMT_MODULE,
@@ -266,13 +286,8 @@ map_update_bcast(crt_context_t ctx, struct mgmt_svc *svc, uint32_t map_version,
 out_rpc:
 	crt_req_decref(rpc);
 out:
-	if (rc != 0) {
-		D_WARN("map update bcast failed for version=%u nservers=%d: " DF_RC "\n",
-		       map_version, nservers, DP_RC(rc));
-	}
-
-	D_DEBUG(DB_MGMT, "leave: version=%u nservers=%d: "DF_RC"\n",
-		map_version, nservers, DP_RC(rc));
+	DL_CDEBUG(rc, DLOG_WARN, DB_MGMT, rc, "map update bcast: version=%u nservers=%d",
+		  map_version, nservers);
 	return rc;
 }
 

--- a/src/mgmt/srv_system.c
+++ b/src/mgmt/srv_system.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -221,10 +222,21 @@ map_update_bcast(crt_context_t ctx, struct mgmt_svc *svc, uint32_t map_version,
 	struct mgmt_tgt_map_update_out *out;
 	crt_opcode_t			opc;
 	crt_rpc_t		       *rpc;
+	int                             i;
 	int				rc;
 
 	D_DEBUG(DB_MGMT, "enter: version=%u nservers=%d\n", map_version,
 		nservers);
+	for (i = 0; i < nservers; i++) {
+		const char *uri = "<none>";
+
+		if (servers[i].se_uri != NULL)
+			uri = servers[i].se_uri;
+
+		D_DEBUG(DB_MGMT, "map[%d/%d]: rank=%u inc=%lu uri=%s flags=%u nctxs=%u\n", i + 1,
+			nservers, servers[i].se_rank, (unsigned long)servers[i].se_incarnation, uri,
+			(unsigned int)servers[i].se_flags, (unsigned int)servers[i].se_nctxs);
+	}
 
 	opc = DAOS_RPC_OPCODE(MGMT_TGT_MAP_UPDATE, DAOS_MGMT_MODULE,
 			      DAOS_MGMT_VERSION);
@@ -254,6 +266,11 @@ map_update_bcast(crt_context_t ctx, struct mgmt_svc *svc, uint32_t map_version,
 out_rpc:
 	crt_req_decref(rpc);
 out:
+	if (rc != 0) {
+		D_WARN("map update bcast failed for version=%u nservers=%d: " DF_RC "\n",
+		       map_version, nservers, DP_RC(rc));
+	}
+
 	D_DEBUG(DB_MGMT, "leave: version=%u nservers=%d: "DF_RC"\n",
 		map_version, nservers, DP_RC(rc));
 	return rc;

--- a/src/mgmt/srv_system.c
+++ b/src/mgmt/srv_system.c
@@ -155,6 +155,28 @@ map_update_verbose_enabled(void)
 	return enabled;
 }
 
+static void
+warn_map_update_timeout_missing_uri(uint32_t map_version, int nservers,
+				    struct server_entry servers[])
+{
+	int i;
+	int missing = 0;
+
+	for (i = 0; i < nservers; i++) {
+		if (servers[i].se_uri == NULL || servers[i].se_uri[0] == '\0') {
+			D_WARN("MGMT_TGT_MAP_UPDATE timeout: missing target URI rank=%u map_ver=%u "
+			       "idx=%d/%d\n",
+			       servers[i].se_rank, map_version, i + 1, nservers);
+			missing++;
+		}
+	}
+
+	if (missing > 0) {
+		D_WARN("MGMT_TGT_MAP_UPDATE timeout: missing URI targets=%d/%d map_ver=%u\n",
+		       missing, nservers, map_version);
+	}
+}
+
 static struct server_entry *
 dup_server_list(struct server_entry *in, int in_len)
 {
@@ -276,8 +298,11 @@ map_update_bcast(crt_context_t ctx, struct mgmt_svc *svc, uint32_t map_version,
 	in->tm_map_version = map_version;
 
 	rc = dss_rpc_send(rpc);
-	if (rc != 0)
+	if (rc != 0) {
+		if (rc == -DER_TIMEDOUT)
+			warn_map_update_timeout_missing_uri(map_version, nservers, servers);
 		goto out_rpc;
+	}
 
 	out = crt_reply_get(rpc);
 	if (out->tm_rc != 0)

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -1540,6 +1540,39 @@ int
 ds_mgmt_tgt_map_update_pre_forward(crt_rpc_t *rpc, void *arg)
 {
 	struct mgmt_tgt_map_update_in  *in = crt_req_get(rpc);
+	d_rank_t                        self_rank = dss_self_rank();
+	uint64_t                        self_inc  = 0;
+	uint64_t                        map_inc   = 0;
+	const char                     *map_uri   = "<none>";
+	char                           *self_uri  = NULL;
+	int                             self_inc_rc;
+	int                             self_uri_rc;
+	bool                            map_has_self = false;
+	uint32_t                        i;
+
+	for (i = 0; i < in->tm_servers.ca_count; i++) {
+		if (in->tm_servers.ca_arrays[i].se_rank == self_rank) {
+			map_has_self = true;
+			map_inc      = in->tm_servers.ca_arrays[i].se_incarnation;
+			if (in->tm_servers.ca_arrays[i].se_uri != NULL)
+				map_uri = in->tm_servers.ca_arrays[i].se_uri;
+			break;
+		}
+	}
+
+	self_inc_rc = crt_self_incarnation_get(&self_inc);
+	self_uri_rc = crt_self_uri_get(0 /* tag */, &self_uri);
+
+	D_DEBUG(DB_MGMT,
+		"map update recv: version=%u self_rank=%u self_inc=%lu self_uri=%s "
+		"map_has_self=%d map_inc=%lu map_uri=%s nservers=" DF_U64
+		" self_inc_rc=%d self_uri_rc=%d\n",
+		in->tm_map_version, self_rank, (unsigned long)self_inc,
+		self_uri_rc == 0 ? self_uri : "<unavailable>", map_has_self, (unsigned long)map_inc,
+		map_uri, in->tm_servers.ca_count, self_inc_rc, self_uri_rc);
+
+	if (self_uri_rc == 0)
+		D_FREE(self_uri);
 
 	return ds_mgmt_group_update(in->tm_servers.ca_arrays, in->tm_servers.ca_count,
 				    in->tm_map_version);

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -15,6 +15,7 @@
 #include <sys/sysinfo.h>
 #include <ftw.h>
 #include <dirent.h>
+#include <string.h>
 
 #include <daos_srv/vos.h>
 #include <daos_srv/pool.h>
@@ -1548,6 +1549,10 @@ ds_mgmt_tgt_map_update_pre_forward(crt_rpc_t *rpc, void *arg)
 	int                             self_inc_rc;
 	int                             self_uri_rc;
 	bool                            map_has_self = false;
+	bool                            inc_mismatch = false;
+	bool                            uri_mismatch = false;
+	bool                            warn;
+	const char                     *warn_prefix;
 	uint32_t                        i;
 
 	for (i = 0; i < in->tm_servers.ca_count; i++) {
@@ -1563,13 +1568,21 @@ ds_mgmt_tgt_map_update_pre_forward(crt_rpc_t *rpc, void *arg)
 	self_inc_rc = crt_self_incarnation_get(&self_inc);
 	self_uri_rc = crt_self_uri_get(0 /* tag */, &self_uri);
 
-	D_DEBUG(DB_MGMT,
-		"map update recv: version=%u self_rank=%u self_inc=%lu self_uri=%s "
-		"map_has_self=%d map_inc=%lu map_uri=%s nservers=" DF_U64
-		" self_inc_rc=%d self_uri_rc=%d\n",
-		in->tm_map_version, self_rank, (unsigned long)self_inc,
-		self_uri_rc == 0 ? self_uri : "<unavailable>", map_has_self, (unsigned long)map_inc,
-		map_uri, in->tm_servers.ca_count, self_inc_rc, self_uri_rc);
+	if (map_has_self && self_inc_rc == 0)
+		inc_mismatch = self_inc != map_inc;
+	if (map_has_self && self_uri_rc == 0 && map_uri != NULL)
+		uri_mismatch = strcmp(self_uri, map_uri) != 0;
+
+	warn        = !map_has_self || inc_mismatch || uri_mismatch;
+	warn_prefix = warn ? "MISMATCH " : "";
+	D_CDEBUG(warn, DLOG_WARN, DB_MGMT,
+		 "%smap update recv: version=%u self_rank=%u self_inc=%lu self_uri=%s "
+		 "map_has_self=%d map_inc=%lu map_uri=%s nservers=" DF_U64
+		 " self_inc_rc=%d self_uri_rc=%d\n",
+		 warn_prefix, in->tm_map_version, self_rank, (unsigned long)self_inc,
+		 self_uri_rc == 0 ? self_uri : "<unavailable>", map_has_self,
+		 (unsigned long)map_inc, map_uri, in->tm_servers.ca_count, self_inc_rc,
+		 self_uri_rc);
 
 	if (self_uri_rc == 0)
 		D_FREE(self_uri);
@@ -1604,6 +1617,17 @@ ds_mgmt_tgt_map_update_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 {
 	struct mgmt_tgt_map_update_out *out_source = crt_reply_get(source);
 	struct mgmt_tgt_map_update_out *out_result = crt_reply_get(result);
+	d_rank_t                        src_rank   = CRT_NO_RANK;
+	int                             rc;
+
+	rc = crt_req_src_rank_get(source, &src_rank);
+	if (rc != 0)
+		src_rank = CRT_NO_RANK;
+
+	if (out_source->tm_rc != 0) {
+		D_WARN("map update aggregate member error: src_rank=%u tm_rc=%d\n", src_rank,
+		       out_source->tm_rc);
+	}
 
 	out_result->tm_rc += out_source->tm_rc;
 	return 0;

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -1537,6 +1537,20 @@ ds_mgmt_tgt_mark_hdlr(crt_rpc_t *rpc)
 	crt_reply_send(rpc);
 }
 
+static bool
+map_update_verbose_enabled(void)
+{
+	static bool initialized;
+	static bool enabled;
+
+	if (!initialized) {
+		d_getenv_bool("DAOS_MAP_UPDATE_VERBOSE", &enabled);
+		initialized = true;
+	}
+
+	return enabled;
+}
+
 int
 ds_mgmt_tgt_map_update_pre_forward(crt_rpc_t *rpc, void *arg)
 {
@@ -1552,8 +1566,11 @@ ds_mgmt_tgt_map_update_pre_forward(crt_rpc_t *rpc, void *arg)
 	bool                            inc_mismatch = false;
 	bool                            uri_mismatch = false;
 	bool                            warn;
+	bool                            verbose;
 	const char                     *warn_prefix;
 	uint32_t                        i;
+
+	verbose = map_update_verbose_enabled();
 
 	for (i = 0; i < in->tm_servers.ca_count; i++) {
 		if (in->tm_servers.ca_arrays[i].se_rank == self_rank) {
@@ -1562,6 +1579,24 @@ ds_mgmt_tgt_map_update_pre_forward(crt_rpc_t *rpc, void *arg)
 			if (in->tm_servers.ca_arrays[i].se_uri != NULL)
 				map_uri = in->tm_servers.ca_arrays[i].se_uri;
 			break;
+		}
+	}
+
+	if (verbose) {
+		for (i = 0; i < in->tm_servers.ca_count; i++) {
+			const char *uri = "<none>";
+
+			if (in->tm_servers.ca_arrays[i].se_uri != NULL)
+				uri = in->tm_servers.ca_arrays[i].se_uri;
+
+			D_DEBUG(
+			    DB_MGMT,
+			    "pre_forward map[%u/%u]: rank=%u inc=%lu uri=%s flags=%u nctxs=%u\n",
+			    i + 1, (unsigned int)in->tm_servers.ca_count,
+			    (unsigned int)in->tm_servers.ca_arrays[i].se_rank,
+			    (unsigned long)in->tm_servers.ca_arrays[i].se_incarnation, uri,
+			    (unsigned int)in->tm_servers.ca_arrays[i].se_flags,
+			    (unsigned int)in->tm_servers.ca_arrays[i].se_nctxs);
 		}
 	}
 

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -50,6 +50,7 @@ server_config:
         - D_LOG_FILE_APPEND_RANK=1
         - D_LOG_FLUSH=DEBUG
         - FI_LOG_LEVEL=warn
+        - DAOS_MAP_UPDATE_VERBOSE=1
         - D_LOG_STDERR_IN_LOG=1
       storage: auto
     1:
@@ -63,6 +64,7 @@ server_config:
         - D_LOG_FILE_APPEND_RANK=1
         - D_LOG_FLUSH=DEBUG
         - FI_LOG_LEVEL=warn
+        - DAOS_MAP_UPDATE_VERBOSE=1
         - D_LOG_STDERR_IN_LOG=1
       storage: auto
   transport_config:

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -34,7 +34,7 @@ from util.storage_utils import StorageException
 from util.yaml_utils import YamlException
 
 DEFAULT_LOGS_THRESHOLD = "2150M"    # 2.1G
-MAX_CI_REPETITIONS = 10
+MAX_CI_REPETITIONS = 20
 
 
 class LaunchError(Exception):

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -34,7 +34,7 @@ from util.storage_utils import StorageException
 from util.yaml_utils import YamlException
 
 DEFAULT_LOGS_THRESHOLD = "2150M"    # 2.1G
-MAX_CI_REPETITIONS = 20
+MAX_CI_REPETITIONS = 30
 
 
 class LaunchError(Exception):

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1327,6 +1327,7 @@ rebuild_kill_PS_leader_during_rebuild(void **state)
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	oids[OBJ_NR];
 	d_rank_t	leader;
+	d_rank_t         non_leader;
 	int		i;
 
 	if (!test_runable(arg, 7) || arg->pool.alive_svc->rl_nr < 5) {
@@ -1341,25 +1342,44 @@ rebuild_kill_PS_leader_during_rebuild(void **state)
 		oids[i] = dts_oid_set_rank(oids[i], 6);
 	}
 	rebuild_io(arg, oids, OBJ_NR);
+	non_leader = leader != 6 ? 6 : 5;
+	print_message("REBUILD29: leader=%u non_leader=%u pre_rs_version=%u pre_pool_ver=%u\n",
+		      leader, non_leader, arg->pool.pool_info.pi_rebuild_st.rs_version,
+		      arg->pool.pool_info.pi_map_ver);
 
-	/* kill non-leader rank */
-	if (leader != 6)
-		daos_kill_server(arg, arg->pool.pool_uuid, arg->group,
-				 arg->pool.alive_svc, 6);
-	else
-		daos_kill_server(arg, arg->pool.pool_uuid, arg->group,
-				 arg->pool.alive_svc, 5);
-	/* hang the rebuild */
+	/* Set scan hang before the first kill so fail-loc RPC itself does not race with exclusion.
+	 */
 	if (arg->myrank == 0) {
+		print_message(
+		    "REBUILD29: setting DAOS_REBUILD_TGT_SCAN_HANG before non-leader kill\n");
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      DAOS_REBUILD_TGT_SCAN_HANG, 0, NULL);
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_VALUE, 5,
 				      0, NULL);
 	}
-	sleep(2);
+	par_barrier(PAR_COMM_WORLD);
+
+	/* kill non-leader rank */
+	print_message("REBUILD29: killing non-leader rank=%u to trigger first rebuild\n",
+		      non_leader);
+	daos_kill_server(arg, arg->pool.pool_uuid, arg->group, arg->pool.alive_svc, non_leader);
+
+	/* Wait for the first rebuild to start instead of relying on a fixed sleep. */
+	if (arg->myrank == 0) {
+		print_message("REBUILD29: waiting for first rebuild start after non-leader kill\n");
+		test_rebuild_wait_to_start_next(&arg, 1);
+		print_message("REBUILD29: first rebuild started: rs_version=%u state=%d errno=%d\n",
+			      arg->pool.pool_info.pi_rebuild_st.rs_version,
+			      arg->pool.pool_info.pi_rebuild_st.rs_state,
+			      arg->pool.pool_info.pi_rebuild_st.rs_errno);
+	}
+	par_barrier(PAR_COMM_WORLD);
+
+	print_message("REBUILD29: killing PS leader rank=%u during active first rebuild\n", leader);
 	rebuild_single_pool_rank(arg, leader, true);
 
 	sleep(5);
+	print_message("REBUILD29: reintegrating prior leader rank=%u\n", leader);
 	reintegrate_single_pool_rank(arg, leader, true);
 }
 


### PR DESCRIPTION
Logging for MGMT_TGT_MAP_UPDATE and MGMT_TGT_CREATE timeouts,
and test improvements

src/mgmt/srv_system.c:
- map_update_bcast(): per-rank map-member dump if environment variable
  DAOS_MAP_UPDATE_VERBOSE is nonzero/true.
- Add warn_map_update_timeout_missing_uri(): on -DER_TIMEDOUT from
  MGMT_TGT_MAP_UPDATE, emit a warning for every rank whose URI is
  URI is NULL/empty in the map payload, plus a summary count.

src/mgmt/srv_target.c:
- ds_mgmt_tgt_map_update_pre_forward(): log every entry in the incoming
  map (rank / incarnation / URI / flags / nctxs) if environment
  variable DAOS_MAP_UPDATE_VERBOSE is nonzero. Warn on mismatches.

src/mgmt/srv_pool.c:
- Add warn_pool_create_timeout_missing_uri(): on DER_TIMEDOUT from the
  MGMT_TGT_CREATE corpc (both at send time and at reply time), look up
  each target rank's URI via crt_rank_uri_get() and emit a D_WARN for
  any rank whose URI is not resolvable.

src/cart/crt_group.c:
- crt_group_primary_modify(): when replacing an existing rank entry,
  log the incoming incarnation and URI with a note indicating that the
  SWIM check uses only the URI cache and does not explicitly refresh it.

src/tests/ftest/daos_test/suite.yaml:
- Set DAOS_MAP_UPDATE_VERBOSE=1 on all engine env blocks for the
  daos_test suite so the verbose map-member dump is active during
  ftest runs (REBUILD29 and related tests).

src/tests/ftest/launch.py:
- Increase MAX_CI_REPETITIONS to 30 to allow longer repeat
  runs of REBUILD29 in CI.

src/tests/suite/daos_rebuild.c (REBUILD29):
- Set DAOS_REBUILD_TGT_SCAN_HANG fault injection *before* killing the
  non-leader engine, eliminating the race where the daos_debug_set_params
  RPC itself can time out because the exclusion has already disrupted
  communication with the target engine.
- Replace the hard-coded sleep(2) synchronization with an explicit call
  to test_rebuild_wait_to_start_next() so that PS-leader kill is
  guaranteed to occur during the active first rebuild scan, not before
  it begins or after it completes.

Test-tag: test_rebuild_29
Test-repeat: 30
Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-test-rpms: true
Test-provider-hw-medium: ofi+tcp

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
