### PR TITLE
DAOS-19104 test: Add some FAULT_INJECTION_REQUIREDs

### DIFF
--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -392,6 +392,8 @@ co_properties(void **state)
 	char			*exp_owner_grp;
 	char			 str[37];
 
+	FAULT_INJECTION_REQUIRED();
+
 	print_message("create container with properties, and query/verify.\n");
 	rc = test_setup((void **)&arg, SETUP_POOL_CONNECT, arg0->multi_rank,
 			SMALL_POOL_SIZE, 0, NULL);
@@ -1041,6 +1043,8 @@ co_acl(void **state)
 	char			*user;
 	d_string_t		 name_to_remove = "friendlyuser@";
 	uint8_t			 type_to_remove = DAOS_ACL_USER;
+
+	FAULT_INJECTION_REQUIRED();
 
 	print_message("create container with access props, and verify.\n");
 	rc = test_setup((void **)&arg, SETUP_POOL_CONNECT, arg0->multi_rank,
@@ -2613,6 +2617,8 @@ co_rf_simple(void **state)
 	daos_recx_t		 recx;
 	int			 rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	/* needs 3 alive nodes after excluding 3 */
 	if (!test_runable(arg0, 6))
 		skip();
@@ -2845,6 +2851,8 @@ delet_container_during_aggregation(void **state)
 	int		 i;
 	int		 rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	/* Prepare records */
 	oid = daos_test_oid_gen(arg->coh, OC_SX, 0, 0, arg->myrank);
 
@@ -3024,6 +3032,8 @@ co_redun_lvl(void **state)
 	int			 nrank_per_node, ndom;
 	d_rank_t		 ranks[3];
 	int			 i, rc;
+
+	FAULT_INJECTION_REQUIRED();
 
 	if (!test_runable(arg0, 8))
 		skip();
@@ -3848,6 +3858,8 @@ co_op_dup_timing(void **state)
 	double             t_fp_loop[NUM_FP];
 	int                rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	/* Create a separate pool with svc_ops_entry_age property (dummy workload duration). */
 	prop = daos_prop_alloc(3);
 	/* label - set arg->pool_label to use daos_pool_connect() */
@@ -4048,6 +4060,8 @@ co_open_destroying(void **state)
 	uuid_t        uuid;
 	daos_handle_t coh;
 	int           rc;
+
+	FAULT_INJECTION_REQUIRED();
 
 	par_barrier(PAR_COMM_WORLD);
 

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -505,6 +505,8 @@ pool_properties(void **state)
 	char			*expected_owner;
 	char			*expected_group;
 
+	FAULT_INJECTION_REQUIRED();
+
 	par_barrier(PAR_COMM_WORLD);
 
 	print_message("create pool with properties, and query it to verify.\n");
@@ -2298,12 +2300,16 @@ pool_map_refreshes_setup(void **state)
 static void
 pool_map_refreshes(void **state)
 {
+	FAULT_INJECTION_REQUIRED();
+
 	pool_map_refreshes_common(state, false /* fall_back */);
 }
 
 static void
 pool_map_refreshes_fallback(void **state)
 {
+	FAULT_INJECTION_REQUIRED();
+
 	pool_map_refreshes_common(state, true /* fall_back */);
 }
 


### PR DESCRIPTION
Add some missing FAULT_INJECTION_REQUIREDs to daos_container.c and daos_pool.c.

faults-enabled: false
Test-tag: test_daos_pool test_daos_container
Skip-unit-tests: true
Skip-unit-test: true
Skip-nlt: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
