### PR TITLE
DAOS-19132 rdb: Fix destination ranks in log messages

### DIFF
--- a/src/rdb/rdb_rpc.c
+++ b/src/rdb/rdb_rpc.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2017-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -351,24 +351,18 @@ rdb_recvd(void *arg)
 static void
 rdb_raft_rpc_cb(const struct crt_cb_info *cb_info)
 {
-	struct rdb_raft_rpc    *rrpc = cb_info->cci_arg;
-	struct rdb	       *db = rrpc->drc_db;
-	crt_opcode_t		opc = opc_get(cb_info->cci_rpc->cr_opc);
-	d_rank_t		dstrank;
-	int			rc;
+	struct rdb_raft_rpc *rrpc = cb_info->cci_arg;
+	struct rdb          *db   = rrpc->drc_db;
+	crt_opcode_t         opc  = opc_get(cb_info->cci_rpc->cr_opc);
+	int                  rc   = cb_info->cci_rc;
 
-	rc = crt_req_dst_rank_get(rrpc->drc_rpc, &dstrank);
-	D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
-
-	rc = cb_info->cci_rc;
-	D_DEBUG(DB_MD, DF_DB": opc=%u rank=%u rtt=%f\n", DP_DB(db), opc,
-		dstrank, ABT_get_wtime() - rrpc->drc_sent);
+	D_DEBUG(DB_MD, DF_DB ": opc=%u rank=%u rtt=%f\n", DP_DB(db), opc,
+		rrpc->drc_rpc->cr_ep.ep_rank, ABT_get_wtime() - rrpc->drc_sent);
 	ABT_mutex_lock(db->d_mutex);
 	if (rc != 0 || db->d_stop) {
 		if (rc != -DER_CANCELED)
-			D_ERROR(DF_DB": RPC %x to rank %u failed: "DF_RC"\n",
-				DP_DB(rrpc->drc_db), opc,
-				dstrank, DP_RC(rc));
+			DL_INFO(rc, DF_DB ": RPC %x to rank %u failed", DP_DB(rrpc->drc_db), opc,
+				rrpc->drc_rpc->cr_ep.ep_rank);
 		/*
 		 * Drop this RPC, assuming that raft will make a new one. If we
 		 * are stopping, rdb_recvd() might have already stopped. Hence,
@@ -433,14 +427,8 @@ rdb_abort_raft_rpcs(struct rdb *db)
 		d_list_del_init(&rrpc->drc_entry);
 		rc = crt_req_abort(rrpc->drc_rpc);
 		if (rc != 0) {
-			d_rank_t	dstrank;
-			int		rc2;
-
-			rc2 = crt_req_dst_rank_get(rrpc->drc_rpc, &dstrank);
-			D_ASSERTF(rc2 == 0, ""DF_RC"\n", DP_RC(rc2));
-			D_ERROR(DF_DB": failed to abort %x to rank %u: "
-				""DF_RC"\n", DP_DB(rrpc->drc_db),
-				rrpc->drc_rpc->cr_opc, dstrank, DP_RC(rc));
+			DL_ERROR(rc, DF_DB ": failed to abort %x to rank %u", DP_DB(rrpc->drc_db),
+				 rrpc->drc_rpc->cr_opc, rrpc->drc_rpc->cr_ep.ep_rank);
 			return rc;
 		}
 	}


### PR DESCRIPTION
Rajesh observed log messages like these:

    crt_rpc_complete_and_unlock(0x7efc3df4a620) [opc=0x7040000
      (DAOS_RDB_MODULE:) rpcid=0x3637ab4c00003653 rank:tag=102:0]
      failed, DER_OOG(-1019): 'Out of group or member list'
    rdb_raft_rpc_cb() 14673705[207]: RPC 0 to rank 0 failed:
      DER_OOG(-1019): 'Out of group or member list'

Apparently, rdb_raft_rpc_cb should log 'to rank 102' instead of 'to rank 0'. The issue is that depending on when the error happens the destination rank in the request header may have yet to be initialized. This patch returns to use cr_ep.ep_rank for request senders.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
