### PR TITLE
DAOS-18905 build: fix in_list PATH check due to missing word-split

### DIFF
--- a/utils/sl/setup_local.sh
+++ b/utils/sl/setup_local.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # /*
 #  * (C) Copyright 2016-2023 Intel Corporation.
+#  * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 #  * (C) Copyright 2025 Google LLC
 #  *
 #  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -87,13 +88,15 @@ added="/ /usr /usr/local"
 old_path="${PATH//:/ }"
 echo OLD_PATH is "${old_path}"
 for item in $list; do
-    in_list "${!item}" "${added}"
+    # shellcheck disable=SC2086
+    in_list "${!item}" ${added}
     if [ $? -eq 1 ]; then
         continue
     fi
     export "${item?}"
     added+=" ${!item}"
-    in_list "${!item}/bin" "${old_path}"
+    # shellcheck disable=SC2086
+    in_list "${!item}/bin" ${old_path}
     if [ $? -eq 1 ]; then
         continue
     fi
@@ -102,7 +105,8 @@ for item in $list; do
     fi
 done
 
-in_list "${SL_PREFIX}/bin" "${old_path}"
+# shellcheck disable=SC2086
+in_list "${SL_PREFIX}/bin" ${old_path}
 # shellcheck disable=SC2181
 if [ $? -eq 0 ]; then
     PATH=$SL_PREFIX/bin:$PATH

--- a/utils/sl/setup_local.sh
+++ b/utils/sl/setup_local.sh
@@ -89,15 +89,13 @@ old_path="${PATH//:/ }"
 echo OLD_PATH is "${old_path}"
 for item in $list; do
     # shellcheck disable=SC2086
-    in_list "${!item}" ${added}
-    if [ $? -eq 1 ]; then
+    if ! in_list "${!item}" ${added}; then
         continue
     fi
     export "${item?}"
     added+=" ${!item}"
     # shellcheck disable=SC2086
-    in_list "${!item}/bin" ${old_path}
-    if [ $? -eq 1 ]; then
+    if ! in_list "${!item}/bin" ${old_path}; then
         continue
     fi
     if [ -d "${!item}/bin" ]; then
@@ -106,9 +104,7 @@ for item in $list; do
 done
 
 # shellcheck disable=SC2086
-in_list "${SL_PREFIX}/bin" ${old_path}
-# shellcheck disable=SC2181
-if [ $? -eq 0 ]; then
+if in_list "${SL_PREFIX}/bin" ${old_path}; then
     PATH=$SL_PREFIX/bin:$PATH
 fi
 export PATH


### PR DESCRIPTION
### Description

This PR fixes two related issues in `utils/sl/setup_local.sh`.

#### Commit 1 — word-split bug (`d51c4d1027`)

`setup_local.sh` uses the `in_list` helper to avoid prepending `$SL_PREFIX/bin` to `PATH` when it is already present. The guard was broken because `$old_path` (and `$added`) were **quoted** when passed to `in_list`, so the entire colon-to-space-converted PATH string was passed as a **single argument** instead of being word-split into individual directories. As a result `in_list` never found a match and `$SL_PREFIX/bin` was unconditionally prepended every time `setup_local.sh` was sourced — even in the same shell session.

The same quoting mistake affected both the per-prefix loop (`${added}`, `${old_path}`) and the final `SL_PREFIX/bin` check (`${old_path}`).

#### Commit 2 — latent `set -e` hazard (`16925e48ce`)

Once the word-split fix is in place, `in_list` correctly returns `1` for the "found" case. However, `in_list` was called as a standalone statement with its exit code checked afterward via `$?`. Scripts that source `setup_local.sh` under `set -e` (e.g. `utils/rpms/build_packages.sh`) abort immediately on that non-zero return before the `$?` check runs.

This was a latent design flaw independent of the quoting bug: `in_list` should always be called inside an `if` condition, not as a standalone statement with `$?` checked afterward. It surfaced here because fixing the quoting made `in_list` actually return `1` for the first time, triggering the abort in callers like `utils/rpms/build_packages.sh` — which is why the initial CI run on this PR showed build failures. The two commits are kept separate intentionally: the second independently documents the `set -e` hazard so it is findable in `git log` on its own. No explicit validation is needed — the CI passing on the second run is sufficient evidence.

### Validation

Both steps below must be run from the repo root (where `.build_vars.sh` lives after a successful build), as `setup_local.sh` looks for that file relative to `$PWD`.

**1. Without the fix** — check out the base branch before this patch (commit `05984ffd13`):

```bash
git checkout 05984ffd13
# Source three times and watch PATH grow by one entry each time:
for i in 1 2 3; do
    source utils/sl/setup_local.sh > /dev/null
    echo "source #$i: $(echo "$PATH" | tr ':' '\n' | grep -c install) install entries in PATH"
done
```

**2. With the fix** — check out the tip of this branch (commit `16925e48ce`):

```bash
git checkout 16925e48ce
# Reset PATH to remove any duplicates accumulated above, then repeat:
for i in 1 2 3; do
    source utils/sl/setup_local.sh > /dev/null
    echo "source #$i: $(echo "$PATH" | tr ':' '\n' | grep -c install) install entries in PATH"
done
```

Without the fix the install entry count grows by one on every source. With the fix it stays constant.

> **Note:** `.build_vars.sh` must exist in the repo root (generated by a successful build). Without it `setup_local.sh` exits early and PATH is not modified at all.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).