### PR TITLE
DAOS-19133 common: Adjust engin logs severity names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -721,7 +721,7 @@ pipeline {
                                      inst_repos: daosRepos(),
                                      test_script: 'ci/unit/test_nlt.sh' +
                                                   ' --system-ram-reserved 4' +
-                                                  ' --max-log-size 1950MiB' +
+                                                  ' --max-log-size 2000MiB' +
                                                   ' --dfuse-dir /localhome/jenkins/' +
                                                   ' --log-usage-save nltir.xml' +
                                                   ' --log-usage-export nltr.json' +

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -457,7 +457,7 @@ pipeline {
                     agent {
                         dockerfile {
                             filename 'utils/docker/Dockerfile.code_scanning'
-                            label 'docker_runner'
+                            label 'fox-119_docker_1'
                             additionalBuildArgs dockerBuildArgs(add_repos: false) +
                                                 ' --build-arg POINT_RELEASE=.7' +
                                                 " --build-arg PYTHON_VERSION=${env.PYTHON_VERSION}"
@@ -497,7 +497,7 @@ pipeline {
                     agent {
                         dockerfile {
                             filename 'utils/docker/Dockerfile.el.8'
-                            label 'docker_runner'
+                            label 'fox-119_docker_1'
                             additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
                                                                 deps_build: false,
                                                                 parallel_build: true) +
@@ -551,7 +551,7 @@ pipeline {
                     agent {
                         dockerfile {
                             filename 'utils/docker/Dockerfile.el.9'
-                            label 'docker_runner'
+                            label 'fox-119_docker_1'
                             additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
                                                                 deps_build: false,
                                                                 parallel_build: true) +
@@ -605,7 +605,7 @@ pipeline {
                     agent {
                         dockerfile {
                             filename 'utils/docker/Dockerfile.leap.15'
-                            label 'docker_runner'
+                            label 'fox-119_docker_1'
                             additionalBuildArgs dockerBuildArgs(repo_type: 'stable',
                                                                 parallel_build: true,
                                                                 deps_build: false) +

--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -145,9 +145,9 @@ level of logging on a per-subsystem basis as well
 ("D_LOG_MASK=DEBUG,MEM=ERR").
 
 -   Log Levels:
-    debug, dbug, info, note, warn, error, err, crit, alrt, fatal, emrg, emit
+    debug, dbug, info, note, warn, error, err, crit, alrt, fatal, emit
 
-Note: debug == dbug, error == err and fatal == emrg.
+Note: debug == dbug and error == err.
 
 ### Debug Masks/Streams:
 

--- a/src/cart/README.env
+++ b/src/cart/README.env
@@ -69,7 +69,7 @@ This file lists the environment variables used in CaRT.
 
  . D_LOG_FLUSH
    Specifies priority level for flushing of messages into the log file.
-   Can be set to one of the following "DBUG,INFO,NOTE,WARN,ERR,CRIT,ALRT,EMRG,EMIT"
+   Can be set to one of the following "DBUG,INFO,NOTE,WARN,ERR,CRIT,ALRT,EMIT"
    If not set will default to "WARN".
 
  . DD_STDERR

--- a/src/control/cmd/ddb/main.go
+++ b/src/control/cmd/ddb/main.go
@@ -219,8 +219,8 @@ func strToLogLevels(level string) (logging.LogLevel, engine.LogLevel, error) {
 		return logging.LogLevelError, engine.LogLevelCrit, nil
 	case "ALRT":
 		return logging.LogLevelError, engine.LogLevelAlrt, nil
-	case "FATAL", "EMRG":
-		return logging.LogLevelError, engine.LogLevelEmrg, nil
+	case "FATAL":
+		return logging.LogLevelError, engine.LogLevelFatal, nil
 	case "EMIT":
 		return logging.LogLevelError, engine.LogLevelEmit, nil
 	default:

--- a/src/control/cmd/ddb/manpage.go
+++ b/src/control/cmd/ddb/manpage.go
@@ -98,7 +98,7 @@ The Go CLI and the C engine use separate logging systems with different log leve
 The \fI--debug=<log level>\fR option sets the log level for both systems to the closest matching
 levels. The available log levels are: \fBTRACE\fR, \fBDEBUG\fR (or \fBDBUG\fR), \fBINFO\fR,
 \fBNOTICE\fR (or \fBNOTE\fR), \fBWARN\fR, \fBERROR\fR (or \fBERR\fR), \fBCRIT\fR, \fBALRT\fR,
-\fBFATAL\fR (or \fBEMRG\fR), and \fBEMIT\fR. The default log level is \fBERROR\fR.
+\fBFATAL\fR, and \fBEMIT\fR. The default log level is \fBERROR\fR.
 
 Logs can be redirected to a file using the \fI--log_dir=<path>\fR option. Note that \fBERROR\fR
 and above are always printed to the console, even when \fI--log_dir\fR is set.`

--- a/src/control/server/engine/utils.go
+++ b/src/control/server/engine/utils.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2023 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -65,7 +66,7 @@ const (
 	LogLevelErr
 	LogLevelCrit
 	LogLevelAlrt
-	LogLevelEmrg
+	LogLevelFatal
 	LogLevelEmit
 )
 
@@ -85,8 +86,8 @@ func (ll LogLevel) String() string {
 		return "CRIT"
 	case LogLevelAlrt:
 		return "ALRT"
-	case LogLevelEmrg:
-		return "EMRG"
+	case LogLevelFatal:
+		return "FATAL"
 	case LogLevelEmit:
 		return "EMIT"
 	default:
@@ -111,8 +112,8 @@ func StrToLogLevel(s string) LogLevel {
 		return LogLevelCrit
 	case "ALRT":
 		return LogLevelAlrt
-	case "FATAL", "EMRG":
-		return LogLevelEmrg
+	case "FATAL":
+		return LogLevelFatal
 	case "EMIT":
 		return LogLevelEmit
 	default:
@@ -123,7 +124,7 @@ func StrToLogLevel(s string) LogLevel {
 var (
 	validLogLevels = []string{
 		"DEBUG", "DBUG", "INFO", "NOTE", "WARN", "ERROR", "ERR", "CRIT", "ALRT", "FATAL",
-		"EMRG", "EMIT",
+		"EMIT",
 	}
 	validLogStreams = []string{
 		"ALL",                                                     // Select all streams

--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -115,8 +115,8 @@ static const char *clog_pristr(int);
 static int clog_setnfac(int);
 
 /* static arrays for converting between pri's and strings */
-static const char * const norm[] = { "DBUG", "INFO", "NOTE", "WARN", "ERR ",
-				     "CRIT", "ALRT", "EMRG", "EMIT"};
+static const char *const norm[] = { "DEBUG", "INFO ", "NOTE ", "WARN ", "ERROR",
+				  "CRIT ", "ALRT ", "FATAL", "EMIT "};
 /**
  * clog_pristr: convert priority to 4 byte symbolic name.
  *

--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -663,7 +663,7 @@ void d_vlog(int flags, const char *fmt, va_list ap)
 
 	hlen_pt1 = hlen;	/* save part 1 length */
 	if (hlen < sizeof(buf) && mst.oflags & DLOG_FLV_FAC)
-		hlen += snprintf(buf + hlen, sizeof(buf) - hlen, "%-4s ", facstr);
+		hlen += snprintf(buf + hlen, sizeof(buf) - hlen, "%-6s ", facstr);
 	/*
 	 * we expect there is still room (i.e. at least one byte) for a
 	 * message, so this overflow check should never happen, but let's

--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -663,7 +663,7 @@ void d_vlog(int flags, const char *fmt, va_list ap)
 
 	hlen_pt1 = hlen;	/* save part 1 length */
 	if (hlen < sizeof(buf) && mst.oflags & DLOG_FLV_FAC)
-		hlen += snprintf(buf + hlen, sizeof(buf) - hlen, "%-6s ", facstr);
+		hlen += snprintf(buf + hlen, sizeof(buf) - hlen, "%-4s ", facstr);
 	/*
 	 * we expect there is still room (i.e. at least one byte) for a
 	 * message, so this overflow check should never happen, but let's

--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -28,13 +28,12 @@ class InvalidLogFile(Exception):
 LOG_LEVELS = {
     'EMIT': 1,
     'FATAL': 2,
-    'EMRG': 3,
-    'CRIT': 4,
-    'ERROR': 5,
-    'WARN': 6,
-    'NOTE': 7,
-    'INFO': 8,
-    'DEBUG': 9}
+    'CRIT': 3,
+    'ERROR': 4,
+    'WARN': 5,
+    'NOTE': 6,
+    'INFO': 7,
+    'DEBUG': 8}
 
 # Make a reverse lookup from log level to name.
 LOG_NAMES = {}

--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -71,6 +71,10 @@ class LogLine():
 
     # pylint: disable=too-many-public-methods
 
+    # Match a log tag with pid/tid/uid ('TAG[pid/tid/uid]').
+    # Assumes DLOG_FLV_TAG and DLOG_FLV_LOGPID are set.
+    _pid_tag_re = re.compile(r'.+\[\d+/\d+/\d+\]')
+
     @staticmethod
     def is_valid(line):
         """Return True if a valid CaRT log line is recognized."""
@@ -86,26 +90,28 @@ class LogLine():
             and len(fields[1]) == 10 and fields[1][4] == '/' and fields[1][7] == '/'
             # Valid time: hh:mm:ss.micros
             and len(fields[2]) == 15 and fields[2][2] == ':' and fields[2][8] == '.'
+            # Assuming DLOG_FLV_TAG and DLOG_FLV_LOGPID are set: TAG[pid/tid/uid]
+            and LogLine._pid_tag_re.fullmatch(fields[4])
             # pylint: enable=too-many-boolean-expressions
         )
 
     # Match an address range, a region in memory.
-    re_region = re.compile(r"(0|0x[0-9a-f]{1,16})-(0x[0-9a-f]{1,16})")
+    _re_region = re.compile(r"(0|0x[0-9a-f]{1,16})-(0x[0-9a-f]{1,16})")
     # Match a pointer, with optional ')', '.' or ',' suffix.
-    re_pointer = re.compile(r"0x[0-9a-f]{1,16}((\)|\.|\,)?)")
+    _re_pointer = re.compile(r"0x[0-9a-f]{1,16}((\)|\.|\,)?)")
     # Match a pid marker
-    re_pid = re.compile(r"pid=(\d+)")
+    _re_pid = re.compile(r"pid=(\d+)")
 
     # Match a truncated uuid from DF_UUID
-    re_uuid = re.compile(r"[0-9a-f]{8}(:|\,?)")
+    _re_uuid = re.compile(r"[0-9a-f]{8}(:|\,?)")
     # Match a truncated uuid[rank] from DF_DB
-    re_uuid_rank = re.compile(r"[0-9,a-f]{8}\[\d+\](:?)")
+    _re_uuid_rank = re.compile(r"[0-9,a-f]{8}\[\d+\](:?)")
     # Match from DF_UIOD
-    re_uiod = re.compile(r"\d{1,20}\.\d{1,20}.(\d{1,10})")
+    _re_uiod = re.compile(r"\d{1,20}\.\d{1,20}.(\d{1,10})")
     # Match a RPCID from RPC_TRACE macro.
-    re_rpcid = re.compile(r"rpcid=0x[0-9a-f]{1,16}")
+    _re_rpcid = re.compile(r"rpcid=0x[0-9a-f]{1,16}")
     # Match DF_CONT
-    re_cont = re.compile(r"[0-9a-f]{8}/[0-9a-f]{8}(:?)")
+    _re_cont = re.compile(r"[0-9a-f]{8}/[0-9a-f]{8}(:?)")
 
     def __init__(self, line):
         # The format of log lines depends on the flags (DLOG_FLV_*) passed during initialization.
@@ -209,36 +215,36 @@ class LogLine():
         for entry in self._fields[2:]:
             field = None
 
-            r = self.re_region.fullmatch(entry)
+            r = self._re_region.fullmatch(entry)
             if r:
                 field = '0x...-0x...'
 
             if not field:
-                r = self.re_pointer.fullmatch(entry)
+                r = self._re_pointer.fullmatch(entry)
                 if r:
                     field = '0x...{}'.format(r.group(1))
             if not field:
-                r = self.re_pid.fullmatch(entry)
+                r = self._re_pid.fullmatch(entry)
                 if r:
                     field = 'pid=<pid>'
             if not field:
-                r = self.re_uuid.fullmatch(entry)
+                r = self._re_uuid.fullmatch(entry)
                 if r:
                     field = 'uuid{}'.format(r.group(1))
             if not field:
-                r = self.re_uuid_rank.fullmatch(entry)
+                r = self._re_uuid_rank.fullmatch(entry)
                 if r:
                     field = 'uuid/rank{}'.format(r.group(1))
             if not field:
-                r = self.re_uiod.fullmatch(entry)
+                r = self._re_uiod.fullmatch(entry)
                 if r:
                     field = 'uoid.{}'.format(r.group(1))
             if not field:
-                r = self.re_rpcid.fullmatch(entry)
+                r = self._re_rpcid.fullmatch(entry)
                 if r:
                     field = 'rpcid=<rpcid>'
             if not field:
-                r = self.re_cont.fullmatch(entry)
+                r = self._re_cont.fullmatch(entry)
                 if r:
                     field = 'pool/cont{}'.format(r.group(1))
             if field:

--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -30,11 +30,11 @@ LOG_LEVELS = {
     'FATAL': 2,
     'EMRG': 3,
     'CRIT': 4,
-    'ERR': 5,
+    'ERROR': 5,
     'WARN': 6,
     'NOTE': 7,
     'INFO': 8,
-    'DBUG': 9}
+    'DEBUG': 9}
 
 # Make a reverse lookup from log level to name.
 LOG_NAMES = {}

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -446,7 +446,7 @@ class LogTest():
                     if show:
                         # Allow WARNING or ERROR messages, but anything higher like assert should
                         # trigger a failure.
-                        if line.level < cart_logparse.LOG_LEVELS['ERR']:
+                        if line.level < cart_logparse.LOG_LEVELS['ERROR']:
                             show_line(line, 'HIGH', 'error in strict mode')
                         else:
                             show_line(line, 'NORMAL', 'warning in strict mode')

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -545,7 +545,7 @@ def get_errors_count(log, hostlist, file_glob):
     """
     # Get the Client side Error from client_log file.
     cmd = "cat {} | sed -n -E -e ".format(get_log_file(file_glob))
-    cmd += r"'/^ERR[[:space:]].+[[:space:]]DER_[^(]+\([^)]+\).+$/"
+    cmd += r"'/^ERROR[[:space:]].+[[:space:]]DER_[^(]+\([^)]+\).+$/"
     cmd += r"s/^.+[[:space:]]DER_[^(]+\((-[[:digit:]]+)\).+$/\1/p'"
     result = run_remote(log, hostlist, cmd, verbose=False)
     errors_count = {}

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -424,7 +424,7 @@
 #  # Mask specifies minimum level of message significance to pass to logger.
 #  # Currently supported values:
 #  #   DEBUG, DBUG (alias for DEBUG), INFO, NOTE, WARN, ERROR, ERR (alias for ERROR), CRIT, ALRT,
-#  #   FATAL, EMRG, EMIT
+#  #   FATAL, EMIT
 #  #
 #  # default: ERR
 #  log_mask: INFO
@@ -595,7 +595,7 @@
 #  # Mask specifies minimum level of message significance to pass to logger.
 #  # Currently supported values:
 #  #   DEBUG, DBUG (alias for DEBUG), INFO, NOTE, WARN, ERROR, ERR (alias for ERROR), CRIT, ALRT,
-#  #   FATAL, EMRG, EMIT
+#  #   FATAL, EMIT
 #  #
 #  # default: ERR
 #  log_mask: INFO


### PR DESCRIPTION
Adjust severity names in engine logs to follow ones defined for server
- DBUG → DEBUG
- ERR → ERROR
- EMRG → FATAL

Support for redundant `EMRG` messages has been removed, as they are no longer used anywhere following their unification with the `FATAL` type.

    
The minimum length of the facility field should has been increased to 6  to cover all existing facility names.
This will make sure the start of the log line message stays in the same place, no matter where it comes from.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
