### PR TITLE
DAOS-18945 container: bypass space check in flags tx update (#18365)

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1637,7 +1637,7 @@ cont_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 
 	container_flags |= CONTAINER_F_DESTROYING;
 	d_iov_set(&val, &container_flags, sizeof(container_flags));
-	rc = rdb_tx_update(tx, &cont->c_prop, &ds_cont_prop_ghce, &val);
+	rc = rdb_tx_update_critical(tx, &cont->c_prop, &ds_cont_prop_ghce, &val);
 
 out_prop:
 	daos_prop_free(prop);


### PR DESCRIPTION
When a pool's RDB has reached capacity usage to the point where further rdb_tx_update() can return -DER_NOSPACE, a container destroy operation (though epxecting to free RDB space) may itself encounter -DER_NOSPACE. It is possibly due to cont_destroy() first performing rdb_tx_update() before a second phase cont_destroy_post() performs (space-relieving) operations rdb_tx_delete() and rdb_tx_destroy_kvs().

With this change, convert the container_flags update in cont_destroy() to a "critical" tx update, bypassing RDB free space checks.

Features: container ObjectMetadata

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
