### PR TITLE
DAOS-18827 build: fix missing libisal2 dep in deb packages (#18057)

### DIFF
--- a/utils/rpms/daos.sh
+++ b/utils/rpms/daos.sh
@@ -71,6 +71,7 @@ install_list+=("${tmp}${sysconfdir}/daos/certs=${sysconfdir}/daos")
 EXTRA_OPTS+=("--rpm-attr" "0755,root,root:${sysconfdir}/daos/certs")
 
 DEPENDS=( "mercury >= ${mercury_version}" )
+DEPENDS+=( "${isal_lib} >= ${isal_version}" )
 DEPENDS+=( "${isal_crypto_lib} >= ${isal_crypto_version}" )
 build_package "daos"
 
@@ -431,8 +432,7 @@ DEPENDS+=("${openmpi_lib}")
 list_files files "${SL_PREFIX}/lib64/libdpar_mpi.so"
 clean_bin "${files[@]}"
 append_install_list "${files[@]}"
-# Don't do autoreq, we know we need OpenMPI so add it explicitly
-build_package "daos-client-tests-openmpi" "noautoreq"
+build_package "daos-client-tests-openmpi"
 
 #shim packages
 PACKAGE_TYPE="empty"

--- a/utils/rpms/fpm_common.sh
+++ b/utils/rpms/fpm_common.sh
@@ -155,9 +155,6 @@ create_opts() {
 
 build_package() {
   name="$1"; shift
-  if [ "${1-}" != "noautoreq" ]; then
-    EXTRA_OPTS+=("--rpm-autoreq")
-  fi
 
   output_type="${OUTPUT_TYPE:-rpm}"
   EXTRA_OPTS+=("--rpm-autoprov")


### PR DESCRIPTION
The --rpm-autoreq FPM option is RPM-only and silently no-ops when building Debian packages, causing the daos package to miss the libisal2 (libisal.so.2) dependency in .deb output. Remove the option and the associated noautoreq escape hatch in favour of uniform explicit dependency declarations across both packaging formats.
Add the missing isal_lib dependency to the daos package.

Skip-test: true
Skip-unit-test: true
Skip-unit-tests: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
