### PR TITLE
DAOS-19172 vos: set filter_cb for scrubber

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1684,6 +1684,7 @@ struct scrub_ctx {
 	sc_sleep_fn_t		 sc_sleep_fn;
 	sc_yield_fn_t		 sc_yield_fn;
 	void			*sc_sched_arg;
+	uint32_t                 sc_filter_credits;
 
 	enum scrub_status        sc_status;
 	uint8_t                  sc_cont_loaded : 1, /* Have all the containers been loaded */

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -1121,7 +1121,7 @@ vos_iterate_obj(vos_iter_param_t *param, struct vos_iter_anchors *anchors, vos_i
 		return vos_iterate_internal(param, VOS_ITER_OBJ, true, false, anchors, pre_cb,
 					    post_cb, arg, dth);
 
-	/* The caller must provide a filter callback and call the oi_bkt_iter_skip() properly */
+	/* The caller must provide a filter callback and call the vos_bkt_iter_skip() properly */
 	D_ASSERT(param->ip_filter_cb != NULL && param->ip_bkt_iter == NULL);
 
 	bkt_iter = bkt_iter_alloc(cont->vc_pool);

--- a/src/vos/vos_pool_scrub.c
+++ b/src/vos/vos_pool_scrub.c
@@ -726,6 +726,31 @@ obj_iter_scrub_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	return 0;
 }
 
+/* Yield if scrubber consecutively skips too many objects */
+#define SCRUB_FILTER_CREDITS 64
+
+static int
+sc_obj_filter_cb(daos_handle_t ih, vos_iter_desc_t *desc, void *cb_arg, unsigned int *acts)
+{
+	struct scrub_ctx *ctx = cb_arg;
+
+	if (desc->id_type == VOS_ITER_OBJ) {
+		if (vos_bkt_iter_skip(ih, desc)) {
+			*acts |= VOS_ITER_CB_SKIP;
+
+			D_ASSERT(ctx->sc_filter_credits > 0);
+			if (--ctx->sc_filter_credits == 0) {
+				ctx->sc_filter_credits = SCRUB_FILTER_CREDITS;
+				sc_sleep(ctx, 0);
+			}
+		} else {
+			ctx->sc_filter_credits = SCRUB_FILTER_CREDITS;
+		}
+	}
+
+	return 0;
+}
+
 static int
 sc_scrub_cont(struct scrub_ctx *ctx)
 {
@@ -737,10 +762,15 @@ sc_scrub_cont(struct scrub_ctx *ctx)
 	if (!daos_csummer_initialized(sc_csummer(ctx)))
 		return 0;
 
+	ctx->sc_filter_credits = SCRUB_FILTER_CREDITS;
+
 	param.ip_hdl = sc_cont_hdl(ctx);
 	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
 	param.ip_epr.epr_lo = 0;
 	param.ip_epc_expr = VOS_IT_EPC_RE;
+	param.ip_filter_cb  = sc_obj_filter_cb;
+	param.ip_filter_arg = ctx;
+
 	/*
 	 * FIXME: Improve iteration by only iterating over visible
 	 * recxs (set param.ip_flags = VOS_IT_RECX_VISIBLE). Will have to be


### PR DESCRIPTION
Properly set the filter callback for scrubber, which is required for the vos_iterate_obj() in md-on-ssd phase2 mode.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
