### PR TITLE
DAOS-19151 container: refine some logs in IV and EC agg path

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1485,7 +1485,8 @@ crt_hdlr_iv_fetch_aux(void *arg)
 			D_GOTO(reply_direct, rc);
 		}
 	} else {
-		D_ERROR("ERROR happened: "DF_RC"\n", DP_RC(rc));
+		DL_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_CONT_NONEXIST || rc == -DER_NONEXIST,
+			  DB_TRACE, DLOG_ERR, rc, "ERROR happened.");
 		D_GOTO(reply_direct, rc);
 	}
 

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -486,7 +486,8 @@ again:
 				/* convert to more specific errno */
 				if (rc == -DER_NONEXIST)
 					rc = -DER_CONT_NONEXIST;
-				DL_CDEBUG(rc == -DER_NOTLEADER, DLOG_INFO, DLOG_ERR, rc,
+				DL_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_CONT_NONEXIST,
+					  DLOG_INFO, DLOG_ERR, rc,
 					  DF_CONT " create IV_CONT_PROP iv entry failed",
 					  DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
 			} else if (class_id == IV_CONT_CAPA) {

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -2148,6 +2148,7 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 	uint64_t                         cur_ts;
 	int				 i;
 	int                              warn_slug_ranks = 8; /* 8 ranks at most */
+	int                              cont_num        = 0;
 	int				 rc = 0;
 
 	rc = map_ranks_failed(pool->sp_map, &fail_ranks);
@@ -2158,6 +2159,7 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 
 	ABT_mutex_lock(svc->cs_cont_ephs_mutex);
 	d_list_for_each_entry_safe(eph_ldr, tmp, &svc->cs_cont_ephs_leader_list, cte_list) {
+		cont_num++;
 		if (eph_ldr->cte_deleted) {
 			d_list_del(&eph_ldr->cte_list);
 			D_FREE(eph_ldr->cte_server_ephs);
@@ -2216,8 +2218,11 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 
 		if (min_ec_agg_eph == eph_ldr->cte_current_ec_agg_eph &&
 		    min_stable_eph == eph_ldr->cte_current_stable_eph &&
-		    eph_ldr->cte_current_ec_agg_eph != 0)
+		    eph_ldr->cte_current_ec_agg_eph != 0) {
+			if (cont_num % 10 == 0)
+				dss_sleep(0);
 			continue;
+		}
 
 		/**
 		 * NB: during extending or reintegration, the new
@@ -6364,7 +6369,8 @@ ds_cont_get_prop(uuid_t pool_uuid, uuid_t cont_uuid, daos_prop_t **prop_out)
 	ABT_rwlock_rdlock(svc->cs_lock);
 	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
 	if (rc != 0) {
-		DL_ERROR(rc, DF_CONT " cont_lookup failed", DP_CONT(pool_uuid, cont_uuid));
+		DL_CDEBUG(rc == -DER_NONEXIST, DLOG_INFO, DLOG_ERR, rc,
+			  DF_CONT " cont_lookup failed", DP_CONT(pool_uuid, cont_uuid));
 		D_GOTO(out_lock, rc);
 	}
 

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -692,7 +692,8 @@ ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 	ABT_rwlock_rdlock(svc->cs_lock);
 	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
 	if (rc != 0) {
-		DL_ERROR(rc, DF_CONT " cont_lookup failed", DP_CONT(pool_uuid, cont_uuid));
+		DL_CDEBUG(rc == -DER_NONEXIST, DLOG_INFO, DLOG_ERR, rc,
+			  DF_CONT " cont_lookup failed", DP_CONT(pool_uuid, cont_uuid));
 		D_GOTO(out_lock, rc);
 	}
 

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -2775,6 +2775,7 @@ ds_cont_eph_report(struct ds_pool *pool)
 	struct cont_track_eph	*ec_eph;
 	struct cont_track_eph	*tmp;
 	int                      rc, ret, *failed_tgts = NULL;
+	int                      cont_num = 0;
 	unsigned int             failed_tgts_nr;
 
 	D_ASSERT(pool != NULL && pool->sp_map != NULL);
@@ -2789,6 +2790,7 @@ ds_cont_eph_report(struct ds_pool *pool)
 		daos_epoch_t min_stable_eph;
 		int          i;
 
+		cont_num++;
 		if (dss_ult_exiting(pool->sp_ec_ephs_req))
 			break;
 
@@ -2820,8 +2822,11 @@ ds_cont_eph_report(struct ds_pool *pool)
 
 		if (min_ec_agg_eph <= ec_eph->cte_last_ec_agg_epoch &&
 		    min_stable_eph <= ec_eph->cte_last_stable_epoch &&
-		    pool->sp_reclaim == DAOS_RECLAIM_DISABLED)
+		    pool->sp_reclaim == DAOS_RECLAIM_DISABLED) {
+			if (cont_num % 10 == 0)
+				dss_sleep(0);
 			continue;
+		}
 
 		/* if aggregation enabled, make sure to report ec_agg_eph at the start phase
 		 * when min_ec_agg_eph and cte_last_ec_agg_epoch are both zero.
@@ -2845,6 +2850,8 @@ ds_cont_eph_report(struct ds_pool *pool)
 					min_ec_agg_eph, ec_eph->cte_last_ec_agg_epoch,
 					min_stable_eph, ec_eph->cte_last_stable_epoch,
 					DP_UUID(ec_eph->cte_cont_uuid));
+			if (cont_num % 10 == 0)
+				dss_sleep(0);
 			continue;
 		}
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1341,13 +1341,14 @@ agg_peer_check_avail(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 	int                    rc;
 
 	if (ds_pool_is_rebuilding(agg_param->ap_cont->sc_pool->spc_pool)) {
+		rc = -DER_OP_CANCELED;
 		/* We currently pause EC aggregation for rebuild, so just cancel the
 		 * aggregation for the current stripe. It means the following peer status
 		 * check may not be checked at all, but let's keep the code because it could
 		 * be useful in the future.
 		 */
-		D_ERROR(DF_UOID " pauses EC aggregation for rebuild\n", DP_UOID(entry->ae_oid));
-		return -DER_OP_CANCELED;
+		DL_ERROR(rc, DF_UOID " pauses EC aggregation for rebuild", DP_UOID(entry->ae_oid));
+		return rc;
 	}
 
 	rc = pool_map_find_failed_tgts(agg_param->ap_pool_info.api_pool->sp_map, &targets,
@@ -1939,9 +1940,9 @@ agg_process_stripe(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 	/* avoid race between EC aggregation and rebuild scanner */
 	agg_param->ap_cont->sc_ec_agg_updates++;
 	if (ds_pool_is_rebuilding(agg_param->ap_cont->sc_pool->spc_pool)) {
-		D_DEBUG(DB_EPC, DF_UOID " abort as rebuild started\n", DP_UOID(entry->ae_oid));
+		rc = -DER_OP_CANCELED;
+		DL_INFO(rc, DF_UOID " abort as rebuild started", DP_UOID(entry->ae_oid));
 		update_vos = false;
-		rc         = -1;
 		goto out;
 	}
 
@@ -2581,11 +2582,12 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	 * (see obj_inflight_io_check()).
 	 */
 	if (ds_pool_is_rebuilding(agg_param->ap_pool_info.api_pool)) {
-		D_INFO(DF_CONT " abort as rebuild started, sp_rebuilding %d\n",
-		       DP_CONT(agg_param->ap_pool_info.api_pool_uuid,
-			       agg_param->ap_pool_info.api_cont_uuid),
-		       atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding));
-		return -1;
+		rc = -DER_OP_CANCELED;
+		DL_INFO(rc, DF_CONT " abort as rebuild started, sp_rebuilding %d.",
+			DP_CONT(agg_param->ap_pool_info.api_pool_uuid,
+				agg_param->ap_pool_info.api_cont_uuid),
+			atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding));
+		return rc;
 	}
 
 	switch (type) {
@@ -2609,9 +2611,9 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	}
 
 	if (rc < 0) {
-		D_ERROR(DF_UUID " EC aggregation (rebuilding %d) failed: " DF_RC "\n",
-			DP_UUID(agg_param->ap_pool_info.api_pool->sp_uuid),
-			atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding), DP_RC(rc));
+		DL_ERROR(rc, DF_UUID " EC aggregation (rebuilding %d) failed",
+			 DP_UUID(agg_param->ap_pool_info.api_pool->sp_uuid),
+			 atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding));
 		return rc;
 	}
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -43,6 +43,7 @@
 		case -DER_BUSY:                                                                    \
 		case -DER_EXIST:                                                                   \
 		case -DER_NONEXIST:                                                                \
+		case -DER_OP_CANCELED:                                                             \
 			__is_err = false;                                                          \
 			break;                                                                     \
 		}                                                                                  \
@@ -62,6 +63,7 @@
 		case -DER_BUSY:                                                                    \
 		case -DER_EXIST:                                                                   \
 		case -DER_NONEXIST:                                                                \
+		case -DER_OP_CANCELED:                                                             \
 			__is_err = false;                                                          \
 			break;                                                                     \
 		}                                                                                  \


### PR DESCRIPTION
1. lower the log level when container IV hit -DER_CONT_NONEXIST
2. refine err code returned when abort EC agg

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
