### PR TITLE
DAOS-19116 object: do not log IO RPC DER_TIMEDOUT as ERROR

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -787,14 +787,14 @@ dc_rw_cb(tse_task_t *task, void *arg)
 		 * If any failure happens inside Cart, let's reset failure to
 		 * TIMEDOUT, so the upper layer can retry.
 		 */
-		D_ERROR(DF_UOID
-			" (%s) RPC %p (%d) to %d/%d, flags %lx/%x, task %p failed, %s, TX " DF_DTI
-			": " DF_RC "\n",
-			DP_UOID(orw->orw_oid), is_ec_obj ? "EC" : "non-EC", rw_args->rpc, opc,
-			rw_args->rpc->cr_ep.ep_rank, rw_args->rpc->cr_ep.ep_tag,
-			(unsigned long)orw->orw_api_flags, orw->orw_flags, task,
-			orw->orw_bulks.ca_arrays || orw->orw_bulks.ca_count ? "DMA" : "non-DMA",
-			DP_DTI(&orw->orw_dti), DP_RC(ret));
+		DL_CDEBUG(ret != -DER_TIMEDOUT, DLOG_ERR, DB_IO, ret,
+			  DF_UOID " (%s) RPC %p (%d) "
+				  " to %d/%d, flags %lx/%x, task %p failed, %s, TX " DF_DTI,
+			  DP_UOID(orw->orw_oid), is_ec_obj ? "EC" : "non-EC", rw_args->rpc, opc,
+			  rw_args->rpc->cr_ep.ep_rank, rw_args->rpc->cr_ep.ep_tag,
+			  (unsigned long)orw->orw_api_flags, orw->orw_flags, task,
+			  orw->orw_bulks.ca_arrays || orw->orw_bulks.ca_count ? "DMA" : "non-DMA",
+			  DP_DTI(&orw->orw_dti));
 
 		D_GOTO(out, ret);
 	}


### PR DESCRIPTION
DAOS client logic will resend IO request if hit DER_TIMEDOUT. That is invisible to the application and not fatal. Logging it as ERROR is confused and may fill the log file under some bad case, such as server overloaded for very long time.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
