### PR TITLE
DAOS-18890 pil4dfs: fix use-after-free of shared struct file_obj

### DIFF
--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2022-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -508,6 +508,11 @@ remove_dot_and_cleanup(char szPath[], int len);
 
 /* reference count of fake fd duplicated by real fd with dup2() */
 static int                dup_ref_count[MAX_OPENED_FILE];
+/* whether the direct fake fd of a slot is still open. Together with dup_ref_count[] it
+ * tells when a slot can be cleared, independent of the shared struct file_obj reference
+ * count (the same struct file_obj may be referenced by multiple fake fd slots).
+ */
+static bool               fd_direct_open[MAX_OPENED_FILE];
 struct file_obj          *d_file_list[MAX_OPENED_FILE];
 static struct dir_obj    *dir_list[MAX_OPENED_DIR];
 static struct mmap_obj    mmap_list[MAX_MMAP_BLOCK];
@@ -1536,6 +1541,7 @@ find_next_available_fd(struct file_obj *obj, int *new_fd)
 		d_file_list[idx] = new_obj;
 	}
 	dup_ref_count[idx] = 0;
+	fd_direct_open[idx] = true;
 	if (next_free_fd > last_fd)
 		last_fd = next_free_fd;
 	next_free_fd = -1;
@@ -1672,10 +1678,18 @@ free_fd(int idx, bool closing_dup_fd)
 
 	if (closing_dup_fd)
 		dup_ref_count[idx]--;
+	else
+		/* the direct fake fd of this slot is being closed */
+		fd_direct_open[idx] = false;
 	d_file_list[idx]->ref_count--;
 	if (d_file_list[idx]->ref_count == 0)
 		saved_obj = d_file_list[idx];
-	if ((dup_ref_count[idx] > 0) || (closing_dup_fd && (d_file_list[idx]->ref_count > 0))) {
+	/* Keep this slot while it still has references of its own: either the direct fake fd
+	 * is still open, or it still has dup2() references via low fds. ref_count must not be
+	 * used to decide whether to clear this slot, since it is shared when the same struct
+	 * file_obj is referenced by multiple fake fd slots (e.g. dup()/fcntl(F_DUPFD)).
+	 */
+	if (fd_direct_open[idx] || (dup_ref_count[idx] > 0)) {
 		D_MUTEX_UNLOCK(&lock_fd);
 		return;
 	}


### PR DESCRIPTION
free_fd() decided whether to clear a d_file_list[] slot using the object-wide ref_count instead of the slot's own references. When a struct file_obj was shared across multiple fake-fd slots (via dup() or fcntl(F_DUPFD)) and one slot's own references were exhausted while another slot still held the object, the slot was left dangling, pointing at memory that was later freed. close_all_fd() then dereferenced it at exit, corrupting the heap during teardown.

Track each slot's direct fake fd open state (fd_direct_open[]) so a slot is cleared based on its own references (direct fd + dup_ref_count), while the object is freed only when the shared ref_count reaches zero.

Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
