### PR TITLE
SRE-3827 test: assume fault injection is enabled by default (#18465)

### DIFF
--- a/src/tests/ftest/util/launch_utils.py
+++ b/src/tests/ftest/util/launch_utils.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2022-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -45,6 +45,10 @@ def fault_injection_enabled(logger):
         bool: whether or not fault injection is enabled
     """
     logger.debug("-" * 80)
+    logger.debug("Checking if 'fault_status' utility is available:")
+    if not run_local(logger, "which fault_status").passed:
+        logger.debug("  Missing 'fault_status' command; assuming fault injection is enabled")
+        return True
     logger.debug("Checking for fault injection enablement via 'fault_status':")
     if run_local(logger, "fault_status").passed:
         logger.debug("  Fault injection is enabled")


### PR DESCRIPTION
If the fault_status executable is not available (e.g. on a light agent where DAOS is not installed) we cannot rule out there are tests to run. It does not change the behaviour when fault_status is available so no more tests will get run but less stages will get skipped without good reason when the test scope is restricted allowing to run a single fault injection test if necessary.

Fault injection test below picked arbitrarily.

Test-tag: test_daos_pipeline

Skip-unit-tests:true
Skip-NLT: true
Skip-unit-test-memcheck: true
Skip-func-vm: true
Skip-fault-injection-test: true
Skip-test-rpms: true

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
