### PR TITLE
DAOS-18509 test: remove 'rd_fac:0,space_rb:0'

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -161,6 +161,7 @@ const (
 	ServerPoolHasContainers
 	ServerPoolMemRatioNoRoles
 	ServerBadFaultDomainLabels
+	ServerPoolTooFewFaultDomains
 	ServerJoinReplaceEnabledPoolRank
 	ServerRankAdminExcluded
 	ServerTransparentHugepageEnabled

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -173,6 +173,15 @@ var FaultPoolMemRatioNoRoles = serverFault(
 	"pool create request contains MD-on-SSD parameters but MD-on-SSD has not been enabled",
 	"either remove MD-on-SSD-specific options from the command request or set bdev_roles in "+
 		"server config file to enable MD-on-SSD")
+
+func FaultPoolTooFewFaultDomains(rdFac int, numDomains int) *fault.Fault {
+	return serverFault(
+		code.ServerPoolTooFewFaultDomains,
+		fmt.Sprintf("pool redundancy factor %d requires at least %d fault domains but only %d are available",
+			rdFac, rdFac+1, numDomains),
+		"retry the request with a lower redundancy factor or add more fault domains",
+	)
+}
 
 func FaultBadFaultDomainLabels(faultPath, addr string, reqLabels, systemLabels []string) *fault.Fault {
 	return serverFault(

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -415,10 +415,13 @@ func (svc *mgmtSvc) poolCreate(parent context.Context, req *mgmtpb.PoolCreateReq
 	}
 
 	// Check if the requested redundancy factor can be met with the number of supplied fault domains.
+	domainNr, err := svc.membership.DomainNr(req.Ranks...)
+	if err != nil {
+		return nil, err
+	}
 	for _, prop := range req.GetProperties() {
 		if prop.GetNumber() == uint32(daos.PoolPropertyRedunFac) {
 			rdFac := int(prop.GetNumval())
-			domainNr := svc.membership.DomainNr()
 			if rdFac+1 > domainNr {
 				return nil, FaultPoolTooFewFaultDomains(rdFac, domainNr)
 			}

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -418,6 +418,18 @@ func (svc *mgmtSvc) poolCreate(parent context.Context, req *mgmtpb.PoolCreateReq
 	req.FaultDomains, err = svc.membership.CompressedFaultDomainTree(req.Ranks...)
 	if err != nil {
 		return nil, err
+	}
+
+	// Check if the requested redundancy factor can be met with the number of supplied fault domains.
+	for _, prop := range req.GetProperties() {
+		if prop.GetNumber() == uint32(daos.PoolPropertyRedunFac) {
+			rdFac := int(prop.GetNumval())
+			domainNr := len(req.FaultDomains)
+			if rdFac+1 > domainNr {
+				return nil, FaultPoolTooFewFaultDomains(rdFac, domainNr)
+			}
+			break
+		}
 	}
 
 	if err := svc.calculateCreateStorage(req); err != nil {

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -414,22 +414,23 @@ func (svc *mgmtSvc) poolCreate(parent context.Context, req *mgmtpb.PoolCreateReq
 		return nil, FaultPoolInvalidServiceReps(maxSvcReps)
 	}
 
-	// IO engine needs the fault domain tree for placement purposes
-	req.FaultDomains, err = svc.membership.CompressedFaultDomainTree(req.Ranks...)
-	if err != nil {
-		return nil, err
-	}
-
 	// Check if the requested redundancy factor can be met with the number of supplied fault domains.
 	for _, prop := range req.GetProperties() {
 		if prop.GetNumber() == uint32(daos.PoolPropertyRedunFac) {
 			rdFac := int(prop.GetNumval())
-			domainNr := len(req.FaultDomains)
+			domainNr := svc.membership.DomainNr()
 			if rdFac+1 > domainNr {
 				return nil, FaultPoolTooFewFaultDomains(rdFac, domainNr)
 			}
 			break
 		}
+	}
+
+	// IO engine needs the fault domain tree for placement purposes
+	svc.log.Debugf("req.Ranks: %v", req.Ranks)
+	req.FaultDomains, err = svc.membership.CompressedFaultDomainTree(req.Ranks...)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := svc.calculateCreateStorage(req); err != nil {

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -427,7 +427,6 @@ func (svc *mgmtSvc) poolCreate(parent context.Context, req *mgmtpb.PoolCreateReq
 	}
 
 	// IO engine needs the fault domain tree for placement purposes
-	svc.log.Debugf("req.Ranks: %v", req.Ranks)
 	req.FaultDomains, err = svc.membership.CompressedFaultDomainTree(req.Ranks...)
 	if err != nil {
 		return nil, err

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -129,7 +129,7 @@ func testPoolRedunFacProp() []*mgmtpb.PoolProperty {
 		{
 			Number: daos.PoolPropertyRedunFac,
 			Value: &mgmtpb.PoolProperty_Numval{
-				Numval: 2,
+				Numval: 1,
 			},
 		},
 	}
@@ -660,7 +660,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 				Ranks:      []uint32{0},
 				Properties: testPoolRedunFacProp(),
 			},
-			expErr: FaultPoolTooFewFaultDomains(2, 1),
+			expErr: FaultPoolTooFewFaultDomains(1, 2),
 		},
 		"successful creation with rd_fac": {
 			targetCount: 2,

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -660,7 +660,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 				Ranks:      []uint32{0},
 				Properties: testPoolRedunFacProp(),
 			},
-			expErr: FaultPoolTooFewFaultDomains(1, 2),
+			expErr: FaultPoolTooFewFaultDomains(1, 1),
 		},
 		"successful creation with rd_fac": {
 			targetCount: 2,

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -113,6 +113,23 @@ func testPoolLabelProp() []*mgmtpb.PoolProperty {
 			Number: daos.PoolPropertyLabel,
 			Value: &mgmtpb.PoolProperty_Strval{
 				Strval: "test",
+			},
+		},
+	}
+}
+
+func testPoolRedunFacProp() []*mgmtpb.PoolProperty {
+	return []*mgmtpb.PoolProperty{
+		{
+			Number: daos.PoolPropertyLabel,
+			Value: &mgmtpb.PoolProperty_Strval{
+				Strval: "test",
+			},
+		},
+		{
+			Number: daos.PoolPropertyRedunFac,
+			Value: &mgmtpb.PoolProperty_Numval{
+				Numval: 2,
 			},
 		},
 	}
@@ -634,6 +651,33 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 				TierBytes: []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 			},
 			expErr: FaultPoolNoLabel,
+		},
+		"failed creation too few fault domains": {
+			targetCount: 1,
+			req: &mgmtpb.PoolCreateReq{
+				Uuid:       test.MockUUID(1),
+				TierBytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
+				Ranks:      []uint32{0},
+				Properties: testPoolRedunFacProp(),
+			},
+			expErr: FaultPoolTooFewFaultDomains(2, 1),
+		},
+		"successful creation with rd_fac": {
+			targetCount: 2,
+			req: &mgmtpb.PoolCreateReq{
+				Uuid:       test.MockUUID(1),
+				TierBytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
+				Ranks:      []uint32{0, 1},
+				Properties: testPoolRedunFacProp(),
+			},
+			drpcRet: &mgmtpb.PoolCreateResp{
+				TierBytes: []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
+				TgtRanks:  []uint32{0, 1},
+			},
+			expResp: &mgmtpb.PoolCreateResp{
+				TierBytes: []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
+				TgtRanks:  []uint32{0, 1},
+			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -785,6 +785,11 @@ func (m *Membership) CompressedFaultDomainTree(ranks ...uint32) ([]uint32, error
 	return append([]uint32{md}, compressTree(subtree)...), nil
 }
 
+// DomainNr returns the number of fault domains in the subtree of the domain
+// tree specified by the given ranks.
+// If no ranks are provided, the entire tree is considered.
+//
+// Note: Do not confuse fault domains with the FaultDomain struct.
 func (m *Membership) DomainNr(ranks ...uint32) (int, error) {
 	tree := m.db.FaultDomainTree()
 	if tree == nil {

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -785,6 +785,10 @@ func (m *Membership) CompressedFaultDomainTree(ranks ...uint32) ([]uint32, error
 	return append([]uint32{md}, compressTree(subtree)...), nil
 }
 
+func (m *Membership) DomainNr() int {
+	return len(m.db.FaultDomainTree().Domains())
+}
+
 const (
 	DomTreeMetadataHasFaultDom uint32 = (1 << iota)
 	DomTreeMetadataHasPerfDom

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -785,8 +785,18 @@ func (m *Membership) CompressedFaultDomainTree(ranks ...uint32) ([]uint32, error
 	return append([]uint32{md}, compressTree(subtree)...), nil
 }
 
-func (m *Membership) DomainNr() int {
-	return len(m.db.FaultDomainTree().Domains())
+func (m *Membership) DomainNr(ranks ...uint32) (int, error) {
+	tree := m.db.FaultDomainTree()
+	if tree == nil {
+		return 0, errors.New("uninitialized fault domain tree")
+	}
+
+	subtree, err := getFaultDomainSubtree(tree, ranks...)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(subtree.Domains()), nil
 }
 
 const (

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -796,6 +796,21 @@ func (m *Membership) DomainNr(ranks ...uint32) (int, error) {
 		return 0, err
 	}
 
+	// TODO DAOS-6353: Properly detect when fault and perf domain are requested.
+	// Currently any depth greater than the minimum must indicate a performance domain.
+	minDepth := 2 // domain + rank
+	if tree.Depth() > minDepth {
+		// Loop over the children of the root and sum up the number their children.
+		sum := 0
+		for _, child := range subtree.Children {
+			sum += len(child.Children)
+		}
+		return sum, nil
+	} else {
+		// There are no perf domains, so all children of the root are fault domains.
+		return len(subtree.Children), nil
+	}
+
 	return len(subtree.Domains()), nil
 }
 

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -799,7 +799,7 @@ func (m *Membership) DomainNr(ranks ...uint32) (int, error) {
 	// TODO DAOS-6353: Properly detect when fault and perf domain are requested.
 	// Currently any depth greater than the minimum must indicate a performance domain.
 	minDepth := 2 // domain + rank
-	if tree.Depth() > minDepth {
+	if subtree.Depth() > minDepth {
 		// Loop over the children of the root and sum up the number their children.
 		sum := 0
 		for _, child := range subtree.Children {
@@ -807,11 +807,9 @@ func (m *Membership) DomainNr(ranks ...uint32) (int, error) {
 		}
 		return sum, nil
 	} else {
-		// There are no perf domains, so all children of the root are fault domains.
+		// There are no perf domains, so the children of the root are fault domains.
 		return len(subtree.Children), nil
 	}
-
-	return len(subtree.Domains()), nil
 }
 
 const (

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -1299,13 +1299,15 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 	}
 
 	for name, tc := range map[string]struct {
-		tree       *FaultDomainTree
-		inputRanks []uint32
-		expResult  []uint32
-		expErr     error
+		tree        *FaultDomainTree
+		inputRanks  []uint32
+		expResult   []uint32
+		expErr      error
+		expDomainNr int
 	}{
 		"nil tree": {
-			expErr: errors.New("uninitialized fault domain tree"),
+			expErr:      errors.New("uninitialized fault domain tree"),
+			expDomainNr: 0,
 		},
 		"root only": {
 			tree: NewFaultDomainTree(),
@@ -1315,6 +1317,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				ExpFaultDomainID(0),
 				0,
 			},
+			expDomainNr: 0,
 		},
 		"single branch, no rank leaves": {
 			tree: NewFaultDomainTree(
@@ -1335,6 +1338,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				ExpFaultDomainID(3),
 				0,
 			},
+			expDomainNr: 1,
 		},
 		"multi branch, no rank leaves": {
 			tree: NewFaultDomainTree(
@@ -1374,6 +1378,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				ExpFaultDomainID(8),
 				0,
 			},
+			expDomainNr: 5,
 		},
 		"single branch with rank leaves": {
 			tree: NewFaultDomainTree(
@@ -1395,6 +1400,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				1,
 				5,
 			},
+			expDomainNr: 1,
 		},
 		"multi branch with rank leaves": {
 			tree: NewFaultDomainTree(
@@ -1442,6 +1448,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				4,
 				5,
 			},
+			expDomainNr: 6,
 		},
 		"intermediate domain has name like rank": {
 			tree: NewFaultDomainTree(
@@ -1463,6 +1470,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				1,
 				1, // rank
 			},
+			expDomainNr: 1,
 		},
 		"request one rank with node only": {
 			tree: NewFaultDomainTree(
@@ -1485,6 +1493,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				// ranks
 				4,
 			},
+			expDomainNr: 6,
 		},
 		"request one rank": {
 			tree: NewFaultDomainTree(
@@ -1510,6 +1519,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				// ranks
 				4,
 			},
+			expDomainNr: 6,
 		},
 		"request multiple ranks": {
 			tree: NewFaultDomainTree(
@@ -1550,6 +1560,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				4,
 				5,
 			},
+			expDomainNr: 6,
 		},
 		"request nonexistent rank": {
 			tree: NewFaultDomainTree(
@@ -1560,8 +1571,9 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				rankDomain("/rack1/pdu3", 4),
 				rankDomain("/rack2/pdu4", 5),
 			),
-			inputRanks: []uint32{4, 0, 5, 3, 100},
-			expErr:     errors.New("rank 100 not found"),
+			inputRanks:  []uint32{4, 0, 5, 3, 100},
+			expErr:      errors.New("rank 100 not found"),
+			expDomainNr: 6,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -1574,6 +1586,9 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 			result, err := membership.CompressedFaultDomainTree(tc.inputRanks...)
 
 			test.CmpErr(t, tc.expErr, err)
+
+			domainNr := membership.DomainNr()
+			test.AssertEqual(t, tc.expDomainNr, domainNr, "unexpected domain number")
 
 			if diff := cmp.Diff(tc.expResult, result); diff != "" {
 				t.Fatalf("(-want, +got): %s", diff)

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -1306,8 +1306,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 		expDomainNr int
 	}{
 		"nil tree": {
-			expErr:      errors.New("uninitialized fault domain tree"),
-			expDomainNr: 0,
+			expErr: errors.New("uninitialized fault domain tree"),
 		},
 		"root only": {
 			tree: NewFaultDomainTree(),
@@ -1571,9 +1570,8 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				rankDomain("/rack1/pdu3", 4),
 				rankDomain("/rack2/pdu4", 5),
 			),
-			inputRanks:  []uint32{4, 0, 5, 3, 100},
-			expErr:      errors.New("rank 100 not found"),
-			expDomainNr: 0,
+			inputRanks: []uint32{4, 0, 5, 3, 100},
+			expErr:     errors.New("rank 100 not found"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -1582,16 +1582,14 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 			membership := NewMembership(log, db)
 
 			result, err := membership.CompressedFaultDomainTree(tc.inputRanks...)
-
 			test.CmpErr(t, tc.expErr, err)
-
-			domainNr, err := membership.DomainNr(tc.inputRanks...)
-			test.CmpErr(t, tc.expErr, err)
-			test.AssertEqual(t, tc.expDomainNr, domainNr, "unexpected domain number")
-
 			if diff := cmp.Diff(tc.expResult, result); diff != "" {
 				t.Fatalf("(-want, +got): %s", diff)
 			}
+
+			domainNr, err := membership.DomainNr(log, tc.inputRanks...)
+			test.CmpErr(t, tc.expErr, err)
+			test.AssertEqual(t, tc.expDomainNr, domainNr, "unexpected domain number")
 		})
 	}
 }

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -1493,7 +1493,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				// ranks
 				4,
 			},
-			expDomainNr: 6,
+			expDomainNr: 1,
 		},
 		"request one rank": {
 			tree: NewFaultDomainTree(
@@ -1519,7 +1519,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				// ranks
 				4,
 			},
-			expDomainNr: 6,
+			expDomainNr: 1,
 		},
 		"request multiple ranks": {
 			tree: NewFaultDomainTree(
@@ -1560,7 +1560,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				4,
 				5,
 			},
-			expDomainNr: 6,
+			expDomainNr: 4,
 		},
 		"request nonexistent rank": {
 			tree: NewFaultDomainTree(
@@ -1573,7 +1573,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 			),
 			inputRanks:  []uint32{4, 0, 5, 3, 100},
 			expErr:      errors.New("rank 100 not found"),
-			expDomainNr: 6,
+			expDomainNr: 0,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -1587,7 +1587,8 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 
 			test.CmpErr(t, tc.expErr, err)
 
-			domainNr := membership.DomainNr()
+			domainNr, err := membership.DomainNr(tc.inputRanks...)
+			test.CmpErr(t, tc.expErr, err)
 			test.AssertEqual(t, tc.expDomainNr, domainNr, "unexpected domain number")
 
 			if diff := cmp.Diff(tc.expResult, result); diff != "" {

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -1339,46 +1339,6 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 			},
 			expDomainNr: 1,
 		},
-		"multi branch, no rank leaves": {
-			tree: NewFaultDomainTree(
-				MustCreateFaultDomainFromString("/rack0/pdu0"),
-				MustCreateFaultDomainFromString("/rack0/pdu1"),
-				MustCreateFaultDomainFromString("/rack1/pdu2"),
-				MustCreateFaultDomainFromString("/rack1/pdu3"),
-				MustCreateFaultDomainFromString("/rack2/pdu4"),
-			),
-			expResult: []uint32{
-				0, // metadata
-				2, // root
-				ExpFaultDomainID(0),
-				3,
-				1, // rack0
-				ExpFaultDomainID(1),
-				2,
-				1, // rack1
-				ExpFaultDomainID(4),
-				2,
-				1, // rack2
-				ExpFaultDomainID(7),
-				1,
-				0, // pdu0
-				ExpFaultDomainID(2),
-				0,
-				0, // pdu1
-				ExpFaultDomainID(3),
-				0,
-				0, // pdu2
-				ExpFaultDomainID(5),
-				0,
-				0, // pdu3
-				ExpFaultDomainID(6),
-				0,
-				0, // pdu4
-				ExpFaultDomainID(8),
-				0,
-			},
-			expDomainNr: 5,
-		},
 		"single branch with rank leaves": {
 			tree: NewFaultDomainTree(
 				rankDomain("/one/two/three", 5),
@@ -1447,7 +1407,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				4,
 				5,
 			},
-			expDomainNr: 6,
+			expDomainNr: 5,
 		},
 		"intermediate domain has name like rank": {
 			tree: NewFaultDomainTree(
@@ -1559,7 +1519,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				4,
 				5,
 			},
-			expDomainNr: 4,
+			expDomainNr: 3,
 		},
 		"request nonexistent rank": {
 			tree: NewFaultDomainTree(
@@ -1587,7 +1547,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				t.Fatalf("(-want, +got): %s", diff)
 			}
 
-			domainNr, err := membership.DomainNr(log, tc.inputRanks...)
+			domainNr, err := membership.DomainNr(tc.inputRanks...)
 			test.CmpErr(t, tc.expErr, err)
 			test.AssertEqual(t, tc.expDomainNr, domainNr, "unexpected domain number")
 		})

--- a/src/tests/ftest/performance/ior_easy.yaml
+++ b/src/tests/ftest/performance/ior_easy.yaml
@@ -24,7 +24,7 @@ server_config:
 
 pool:
   size: 95%
-  properties: rd_fac:0,space_rb:0,ec_cell_sz:1MiB
+  properties: rd_fac:3,space_rb:0,ec_cell_sz:1MiB
 
 container:
   type: POSIX


### PR DESCRIPTION
Test-tag: test_performance_ior_easy_dfs_sx

Skip-unit-tests:true
Skip-NLT: true
Skip-unit-test-memcheck: true
Skip-func-vm: true
Skip-fault-injection-test: true
Skip-test-rpms: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
