### PR TITLE
DAOS-19226 cart: primary group incorrectly initialized on clients

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1471,14 +1471,12 @@ crt_primary_grp_init(crt_group_id_t grpid)
 {
 	struct crt_grp_gdata	*grp_gdata;
 	struct crt_grp_priv	*grp_priv = NULL;
-	crt_group_id_t		 pri_grpid;
-	bool			 is_service;
+	crt_group_id_t           pri_grpid;
 	int			 rc = 0;
 
 	grp_gdata = crt_gdata.cg_grp;
 	D_ASSERT(grp_gdata != NULL);
 
-	is_service = crt_is_service();
 	pri_grpid = (grpid != NULL) ? grpid : CRT_DEFAULT_GRPID;
 
 	rc = crt_grp_priv_create(&grp_priv, pri_grpid, true);
@@ -1488,13 +1486,8 @@ crt_primary_grp_init(crt_group_id_t grpid)
 	}
 	D_ASSERT(grp_priv != NULL);
 
-	if (is_service) {
-		grp_priv->gp_self = CRT_NO_RANK;
-		grp_priv->gp_size = 0;
-	} else {
-		grp_priv->gp_size = 1;
-		grp_priv->gp_self = 0;
-	}
+	grp_priv->gp_self = CRT_NO_RANK;
+	grp_priv->gp_size = 0;
 
 	rc = grp_priv_init_membs(grp_priv, grp_priv->gp_size);
 	if (rc != 0) {

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1180,6 +1180,10 @@ crt_req_is_self(struct crt_rpc_priv *rpc_priv)
 	bool			 same_rank;
 
 	D_ASSERT(rpc_priv != NULL);
+
+	if (!crt_is_service())
+		return false;
+
 	grp_priv_self = crt_grp_pub2priv(NULL);
 	tgt_ep = &rpc_priv->crp_pub.cr_ep;
 	same_group = (tgt_ep->ep_grp == NULL) ||

--- a/src/tests/ftest/cart/test_ep_cred_client.c
+++ b/src/tests/ftest/cart/test_ep_cred_client.c
@@ -82,9 +82,6 @@ test_run()
 	rc = sem_init(&test.tg_queue_front_token, 0, 0);
 	D_ASSERTF(rc == 0, "sem_init() failed.\n");
 
-	rc = crt_group_rank(NULL, &test.tg_my_rank);
-	D_ASSERTF(rc == 0, "crt_group_rank() failed. rc: %d\n", rc);
-
 	rc = crt_proto_register(&my_proto_fmt_0);
 	D_ASSERTF(rc == 0, "registration failed with rc: %d\n", rc);
 

--- a/src/tests/ftest/cart/test_multisend_client.c
+++ b/src/tests/ftest/cart/test_multisend_client.c
@@ -96,9 +96,6 @@ test_run()
 	rc = sem_init(&test.tg_token_to_proceed, 0, 0);
 	D_ASSERTF(rc == 0, "sem_init() failed.\n");
 
-	rc = crt_group_rank(NULL, &test.tg_my_rank);
-	D_ASSERTF(rc == 0, "crt_group_rank() failed. rc: %d\n", rc);
-
 	rc = crt_proto_register(&my_proto_fmt);
 	D_ASSERTF(rc == 0, "crt_proto_register() failed. rc: %d\n", rc);
 

--- a/src/tests/ftest/cart/test_no_timeout.c
+++ b/src/tests/ftest/cart/test_no_timeout.c
@@ -91,9 +91,6 @@ test_run(void)
 	rc = sem_init(&test_g.t_token_to_proceed, 0, 0);
 	D_ASSERTF(rc == 0, "sem_init() failed.\n");
 
-	rc = crt_group_rank(NULL, &test_g.t_my_rank);
-	D_ASSERTF(rc == 0, "crt_group_rank() failed. rc: %d\n", rc);
-
 	/* register RPCs */
 	rc = crt_proto_register(&my_proto_fmt_test_group1);
 	D_ASSERTF(rc == 0, "crt_proto_register() failed. rc: %d\n", rc);

--- a/src/tests/ftest/cart/test_proto_client.c
+++ b/src/tests/ftest/cart/test_proto_client.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2018-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -86,9 +86,6 @@ test_run()
 
 	rc = sem_init(&test.tg_token_to_proceed, 0, 0);
 	D_ASSERTF(rc == 0, "sem_init() failed.\n");
-
-	rc = crt_group_rank(NULL, &test.tg_my_rank);
-	D_ASSERTF(rc == 0, "crt_group_rank() failed. rc: %d\n", rc);
 
 	switch (test.tg_num_proto) {
 	case 4:

--- a/src/tests/ftest/cart/test_rpc_error.c
+++ b/src/tests/ftest/cart/test_rpc_error.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -204,8 +205,10 @@ rpc_err_init(void)
 	rc = crt_init(rpc_err.re_local_group_name, flag);
 	D_ASSERTF(rc == 0, "crt_init() failed, rc: %d\n", rc);
 
-	rc = crt_group_rank(NULL, &rpc_err.re_my_rank);
-	D_ASSERTF(rc == 0, "crt_group_rank() failed, rc: %d\n", rc);
+	if (rpc_err.re_is_service) {
+		rc = crt_group_rank(NULL, &rpc_err.re_my_rank);
+		D_ASSERTF(rc == 0, "crt_group_rank() failed, rc: %d\n", rc);
+	}
 
 	rc = crt_context_create(&rpc_err.re_crt_ctx);
 	D_ASSERTF(rc == 0, "crt_context_create() failed. rc: %d\n", rc);


### PR DESCRIPTION
- Primary group on clients was incorrectly initialized to size of 1 with self rank set to 0, instead of size of 0 and self rank set to CRT_NO_RANK.

- Added extra check in crt_grp_is_self() to return false for clients at all times.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
