### PR TITLE
DAOS-19151 rebuild: skip orphan container in rebuild puller

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -3765,7 +3765,8 @@ cont_fetch_start_ult(void *arg)
 	rc = ds_cont_fetch_snaps(fetch_arg->pool->sp_iv_ns, fetch_arg->cont_uuid,
 				 &fetch_arg->snapshots, &fetch_arg->snap_cnt);
 	if (rc) {
-		D_ERROR("ds_cont_fetch_snaps failed: " DF_RC "\n", DP_RC(rc));
+		DL_ERROR(rc, DF_CONT ": ds_cont_fetch_snaps failed",
+			 DP_CONT(fetch_arg->pool_uuid, fetch_arg->cont_uuid));
 		return rc;
 	}
 
@@ -3820,9 +3821,16 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 	rc = dss_ult_execute(cont_fetch_start_ult, &fetch_arg, NULL, NULL, DSS_XS_SYS, 0,
 			     MIGRATE_STACK_SIZE);
 	if (rc) {
-		DL_ERROR(rc, DF_RB ": ds_pool_lookup failed", DP_RB_MPT(tls));
-		if (rc == -DER_SHUTDOWN)
-			rc = 0;
+		DL_ERROR(rc, DF_RB ": cont_fetch_start_ult failed", DP_RB_MPT(tls));
+		if (rc == -DER_CONT_NONEXIST) {
+			DL_ERROR(rc, DF_RB ": " DF_CONT " skip orphan container", DP_RB_MPT(tls),
+				 DP_CONT(tls->mpt_pool_uuid, cont_uuid));
+			D_GOTO(cont_done, rc = 0);
+		}
+		if (rc == -DER_SHUTDOWN) {
+			tls->mpt_fini = 1;
+			DL_ERROR(rc, DF_RB ": set mpt_fini", DP_RB_MPT(tls));
+		}
 		D_GOTO(free, rc);
 	}
 
@@ -3853,6 +3861,7 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 		}
 	}
 
+cont_done:
 	D_DEBUG(DB_REBUILD, DF_RB ": iter cont " DF_UUID "/%" PRIx64 " finish.\n", DP_RB_MPT(tls),
 		DP_UUID(cont_uuid), ih.cookie);
 


### PR DESCRIPTION
At rebuild puller side, the migrate_cont_iter_cb() -> cont_fetch_start_ult() -> ds_cont_fetch_snaps() possibly get -2050/-DER_CONT_NONEXIST for orphan container case. In that case skip the container and continue rebuild task.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
