### PR TITLE
DAOS-19214 dfs: add progressive layout support in the IO paths

### DIFF
--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -1282,6 +1282,7 @@ set_short_read_cb(tse_task_t *task, void *data)
 	/** adjust the read_nr based on the array size */
 	args->iod->arr_nr_short_read = 0;
 	args->iod->arr_nr_read = 0;
+	args->iod->arr_array_size    = params->array_size;
 
 	for (i = 0; i < args->iod->arr_nr; i++) {
 		daos_off_t idx = args->iod->arr_rgs[i].rg_idx;
@@ -1404,6 +1405,7 @@ next:
 	if (nr_short_recs == 0) {
 		/** memset all holes to 0 */
 		params->array_size = UINT64_MAX;
+		args->iod->arr_array_size = params->array_size;
 		rc = process_iomap(params, args);
 		D_GOTO(out, rc);
 	}

--- a/src/client/dfs/common.c
+++ b/src/client/dfs/common.c
@@ -594,13 +594,13 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name, siz
 		}
 
 		if (obj) {
-			rc = file_stat(dfs, obj->oh, obj->f.tail_oh, obj->f.has_tail, th,
-				       &array_stbuf);
+			rc = file_stat(dfs, obj->oh, obj->f.tail_oh, obj->f.has_tail,
+				       obj->f.split_off, th, &array_stbuf);
 			if (rc)
 				return rc;
 		} else {
 			rc = file_stat_by_oid(dfs, entry.oid, entry.tail_oid, has_tail,
-					      entry.chunk_size, th, &array_stbuf);
+					      entry.split_off, entry.chunk_size, th, &array_stbuf);
 			if (rc)
 				return rc;
 		}

--- a/src/client/dfs/dfs-progressive-layout.md
+++ b/src/client/dfs/dfs-progressive-layout.md
@@ -248,20 +248,86 @@ On creation, tail_state is set to active.
 tail_state is initialized as active at file creation and remains active for the lifetime of the file.
 It is informational only in this design and does not gate routing, size query, or unlink behavior. In the future, we can explore an efficient way to track the state of the tail(s) to improve metadata efficiency of accessing the tail oid.
 
+## Range Classification and Validation
+
+Both the single-range (read/write) and multi-range (readx/writex) entry points classify the
+request against split_off before routing. For progressive-layout files (has_tail) only:
+
+1. Validate every range first: if any range wraps (rg_idx + rg_len < rg_idx) the call returns
+   EINVAL before any routing or arithmetic. This guards the idx + len computations used by
+   classification and SGL splitting against integer overflow.
+2. Classify the set of ranges into one of three dispositions:
+   - HEAD: every range lies fully below split_off → route to the head object unchanged.
+   - TAIL: every range lies at or above split_off → route to the tail object with each
+     rg_idx translated by -split_off.
+   - SPLIT: the set contains a mix of head-only and tail-only ranges (or a range that itself
+     crosses split_off) → split the request into a head part and a tail part.
+
+Non progressive-layout files (has_tail == false) bypass this entirely and pass straight to the
+single underlying array object, preserving existing behavior.
+
 ## Read Path Changes
 
-Given logical request [off, off+len):
+A logical read maps onto one or both array objects per the classification above. The subtlety is
+that each array object only knows its OWN size: the head object cannot tell whether the logical
+file continues into the tail. This matters for short reads and holes.
 
-1. If range is fully below split, read head.
-3. If fully above split, read tail using translated offset off - split_off.
-4. If crossing split, split the read SGL and issue two reads asynchronously, wait for completion (if blocking), and return combined bytes. If the call is non-blocking, we need to track both fetch operations as part of completion.
+### Hole and short-read semantics (POSIX)
+
+A byte-array read fills interior holes (offsets below the object's size that were never written)
+with zeros and counts them as read, but for offsets at or beyond the object's size it returns a
+short count and leaves the caller's buffer bytes UNTOUCHED (never pre-zeroed). For a
+progressive-layout file the logical EOF is split_off + tail_extent, so a region the head object
+reports as short can be one of two things:
+
+- An interior hole of the logical file (the tail holds data): it must read back as zeros and be
+  counted as read.
+- The genuine end of file (the tail is empty): the short count is correct and the buffer past it
+  is left untouched per POSIX.
+
+To resolve this without a redundant size query, the array read returns the size it already used to
+resolve its own short reads in `daos_array_iod_t.arr_array_size` (the real array size when a short
+read was possible, or UINT64_MAX otherwise). DFS reuses that value instead of issuing its own head
+size query.
+
+### Head-only read
+
+1. Issue the head read.
+2. If it returned the full requested length, finalize immediately (no extra query).
+3. If it short-read, query the tail SIZE:
+   - tail size == 0: genuine EOF. Keep the short count; leave the buffer past it untouched.
+   - tail size > 0: interior hole. Zero each requested range's untouched gap in place (placed
+     per range using the head size reported via arr_array_size, since ranges may be unsorted and
+     the gap need not be at the physical end of the SGL) and count the full requested length.
+
+The tail size query is only issued on a short read, so the common full-data read pays nothing
+extra. The synchronous path does this inline; the asynchronous path expresses it as a two-task
+chain (head read → tail get_size, the latter bound to the user event) where the tail get_size body
+only runs when the head actually short-read.
+
+### Cross-split (straddle) read
+
+The request is split into a head part and a tail part that are issued concurrently and tracked by a
+parent task; the user event (or a private event when blocking) completes only after both finish.
+The combined read size is the sum of the two parts' returned bytes, with the same head-hole
+correction as above: when the head part short-reads at its own EOF but the tail part reports a
+non-zero size (gated on the tail part's arr_array_size, NOT on whether the requested tail subrange
+happened to return bytes — a multi-range readx may target a tail range that is itself beyond EOF),
+the head region is interior to the logical file, so its untouched gaps are zeroed per range (using
+the head part's reported size) and the head's full requested length is counted. Because both array
+reads report their sizes, no separate size queries are needed on the straddle path either.
 
 ## Write Path Changes
 
 Given logical request [off, off+len):
 
-1. Route lower segment to head, upper segment to tail (split SGL similar to reads). Writes to the 2 array objects can be done asynchronously.
-2. Wait for all the update operations to complete if the write is blocking. If the call is non-blocking, we need to track both updates as part of completion.
+1. Route lower segment to head, upper segment to tail (split SGL similar to reads). Writes to the
+   two array objects are issued concurrently.
+2. Wait for all the update operations to complete if the write is blocking. If the call is
+   non-blocking, both updates are tracked by a parent task as part of completion.
+
+Writes need no hole or size-query handling: holes are a read-side concern, and a write never
+short-completes the way a read does at EOF.
 
 ## Truncate and Punch Semantics
 
@@ -314,3 +380,12 @@ Unit and integration coverage should include:
 6. Punch ranges below, above, and across split.
 7. Rename and unlink for promoted files.
 8. Mount compatibility checks between v3 and v4 clients and containers.
+9. Hole and short-read handling, sync and async, single-range and multi-range (readx):
+  - Head-only read whose range ends in a hole while the tail holds data (interior hole → zeros
+    read back and counted) versus an empty tail (genuine EOF → short count, buffer untouched).
+  - Straddle readx with unsorted head ranges (an all-hole head range preceding a data head
+    range) to verify per-range zero placement rather than a trailing-zero of the SGL.
+  - Straddle readx whose tail range is itself beyond EOF while the file still extends into the
+    tail elsewhere, verifying the head hole is still zeroed and counted (gate on tail size, not
+    on the tail subrange's returned bytes).
+  - Range-overflow guard: a wrapping range returns EINVAL.

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -489,11 +489,12 @@ int
 entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name, size_t len,
 	   struct dfs_obj *obj, bool get_size, struct stat *stbuf, uint64_t *obj_hlc);
 int
-file_stat(dfs_t *dfs, daos_handle_t head_oh, daos_handle_t tail_oh, bool has_tail, daos_handle_t th,
-	  daos_array_stbuf_t *stbuf);
+file_stat(dfs_t *dfs, daos_handle_t head_oh, daos_handle_t tail_oh, bool has_tail,
+	  daos_size_t split_off, daos_handle_t th, daos_array_stbuf_t *stbuf);
 int
 file_stat_by_oid(dfs_t *dfs, daos_obj_id_t head_oid, daos_obj_id_t tail_oid, bool has_tail,
-		 daos_size_t chunk_size, daos_handle_t th, daos_array_stbuf_t *stbuf);
+		 daos_size_t split_off, daos_size_t chunk_size, daos_handle_t th,
+		 daos_array_stbuf_t *stbuf);
 int
 file_truncate_zero(dfs_obj_t *obj, daos_handle_t th);
 int

--- a/src/client/dfs/file.c
+++ b/src/client/dfs/file.c
@@ -15,8 +15,8 @@
 #include "dfs_internal.h"
 
 int
-file_stat(dfs_t *dfs, daos_handle_t head_oh, daos_handle_t tail_oh, bool has_tail, daos_handle_t th,
-	  daos_array_stbuf_t *stbuf)
+file_stat(dfs_t *dfs, daos_handle_t head_oh, daos_handle_t tail_oh, bool has_tail,
+	  daos_size_t split_off, daos_handle_t th, daos_array_stbuf_t *stbuf)
 {
 	daos_array_stbuf_t tail_stbuf = {0};
 	int                rc;
@@ -37,12 +37,13 @@ file_stat(dfs_t *dfs, daos_handle_t head_oh, daos_handle_t tail_oh, bool has_tai
 
 	/*
 	 * The head holds logical bytes [0, split_off) and the tail holds [split_off, EOF) indexed
-	 * from 0, so the logical size is the sum of both extents. This is correct while the head is
-	 * densely filled up to split_off whenever the tail is non-empty.
-	 * TODO: once the PL IO path lands, account for sparse files written only past split_off
-	 * (where the head extent is shorter than split_off) using split_off explicitly.
+	 * from 0. When the tail has data the logical size is split_off + the tail extent (the head
+	 * is logically full up to split_off); otherwise it is the head extent. Using split_off
+	 * explicitly keeps the size correct for sparse files written only past split_off, where the
+	 * head extent is shorter than split_off.
 	 */
-	stbuf->st_size += tail_stbuf.st_size;
+	if (tail_stbuf.st_size > 0)
+		stbuf->st_size = split_off + tail_stbuf.st_size;
 	if (tail_stbuf.st_max_epoch > stbuf->st_max_epoch)
 		stbuf->st_max_epoch = tail_stbuf.st_max_epoch;
 
@@ -51,7 +52,8 @@ file_stat(dfs_t *dfs, daos_handle_t head_oh, daos_handle_t tail_oh, bool has_tai
 
 int
 file_stat_by_oid(dfs_t *dfs, daos_obj_id_t head_oid, daos_obj_id_t tail_oid, bool has_tail,
-		 daos_size_t chunk_size, daos_handle_t th, daos_array_stbuf_t *stbuf)
+		 daos_size_t split_off, daos_size_t chunk_size, daos_handle_t th,
+		 daos_array_stbuf_t *stbuf)
 {
 	daos_handle_t head_oh = DAOS_HDL_INVAL;
 	daos_handle_t tail_oh = DAOS_HDL_INVAL;
@@ -80,7 +82,7 @@ file_stat_by_oid(dfs_t *dfs, daos_obj_id_t head_oid, daos_obj_id_t tail_oid, boo
 		}
 	}
 
-	rc = file_stat(dfs, head_oh, tail_oh, has_tail, th, stbuf);
+	rc = file_stat(dfs, head_oh, tail_oh, has_tail, split_off, th, stbuf);
 out:
 	if (daos_handle_is_valid(tail_oh)) {
 		int rc2 = daos_array_close(tail_oh, NULL);
@@ -240,7 +242,8 @@ dfs_get_size(dfs_t *dfs, dfs_obj_t *obj, daos_size_t *size)
 	if (size == NULL)
 		return EINVAL;
 
-	rc = file_stat(dfs, obj->oh, obj->f.tail_oh, obj->f.has_tail, dfs->th, &stbuf);
+	rc = file_stat(dfs, obj->oh, obj->f.tail_oh, obj->f.has_tail, obj->f.split_off, dfs->th,
+		       &stbuf);
 	if (rc)
 		return rc;
 

--- a/src/client/dfs/io.c
+++ b/src/client/dfs/io.c
@@ -38,37 +38,42 @@ dfs_update_file_metrics(dfs_t *dfs, daos_size_t read_bytes, daos_size_t write_by
 
 /** A head or tail portion of a logical array IO after splitting at split_off. */
 struct dfs_io_part {
-	daos_handle_t    oh;
-	daos_array_iod_t iod;
-	d_sg_list_t      sgl;
-	bool             active;
+	daos_handle_t    dip_oh;
+	daos_array_iod_t dip_iod;
+	d_sg_list_t      dip_sgl;
+	bool             dip_active;
 };
 
+/* Append each contiguous chunk that daos_sgl_processor() yields as an iov in dst_iovs. */
+struct sgl_append_ctx {
+	d_iov_t  *dst_iovs;
+	uint32_t *dst_nr;
+};
+
+static int
+sgl_append_iov_cb(uint8_t *buf, size_t len, void *args)
+{
+	struct sgl_append_ctx *ctx = args;
+
+	d_iov_set(&ctx->dst_iovs[*ctx->dst_nr], buf, len);
+	(*ctx->dst_nr)++;
+	return 0;
+}
+
 /*
- * Append \a need bytes from \a src starting at the running cursor (\a cur_iov, \a cur_off) as a set
- * of iovs into \a dst_iovs, advancing the cursor. The cursor walks the source sgl byte stream so
- * that successive calls carve out consecutive byte slices that map to consecutive array ranges.
+ * Append \a need bytes from \a src starting at the running cursor \a idx as a set of iovs into \a
+ * dst_iovs, advancing the cursor. The cursor walks the source sgl byte stream (by iov_len) so that
+ * successive calls carve out consecutive byte slices that map to consecutive array ranges.
+ * daos_sgl_processor() stops at the end of the sgl, so a \a need larger than the bytes remaining in
+ * \a src cannot walk past sg_nr.
  */
 static void
-sgl_copy_bytes(d_sg_list_t *src, uint32_t *cur_iov, daos_size_t *cur_off, daos_size_t need,
-	       d_iov_t *dst_iovs, uint32_t *dst_nr)
+sgl_copy_bytes(d_sg_list_t *src, struct daos_sgl_idx *idx, daos_size_t need, d_iov_t *dst_iovs,
+	       uint32_t *dst_nr)
 {
-	while (need > 0) {
-		d_iov_t    *siov  = &src->sg_iovs[*cur_iov];
-		daos_size_t avail = siov->iov_len - *cur_off;
-		daos_size_t take  = avail < need ? avail : need;
+	struct sgl_append_ctx ctx = {.dst_iovs = dst_iovs, .dst_nr = dst_nr};
 
-		if (take > 0) {
-			d_iov_set(&dst_iovs[*dst_nr], (char *)siov->iov_buf + *cur_off, take);
-			(*dst_nr)++;
-			*cur_off += take;
-			need -= take;
-		}
-		if (*cur_off == siov->iov_len) {
-			(*cur_iov)++;
-			*cur_off = 0;
-		}
-	}
+	daos_sgl_processor(src, false, idx, need, sgl_append_iov_cb, &ctx);
 }
 
 /* Zero a [off, off+len) byte window within the logical SGL stream (walking iov capacities). */
@@ -166,8 +171,8 @@ dfs_pl_head_short_read(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_range_
 static void
 dfs_io_part_free(struct dfs_io_part *part)
 {
-	D_FREE(part->iod.arr_rgs);
-	D_FREE(part->sgl.sg_iovs);
+	D_FREE(part->dip_iod.arr_rgs);
+	D_FREE(part->dip_sgl.sg_iovs);
 }
 
 /*
@@ -180,20 +185,19 @@ static int
 dfs_io_build_parts(dfs_obj_t *obj, daos_range_t *rgs, uint32_t rg_nr, d_sg_list_t *sgl,
 		   struct dfs_io_part *head, struct dfs_io_part *tail)
 {
-	daos_size_t split   = obj->f.split_off;
-	uint32_t    cur_iov = 0;
-	daos_size_t cur_off = 0;
-	uint32_t    i;
-	int         rc = 0;
+	daos_size_t         split = obj->f.split_off;
+	struct daos_sgl_idx cur   = {0};
+	uint32_t            i;
+	int                 rc = 0;
 
 	memset(head, 0, sizeof(*head));
 	memset(tail, 0, sizeof(*tail));
-	head->oh = obj->oh;
-	tail->oh = obj->f.tail_oh;
+	head->dip_oh = obj->oh;
+	tail->dip_oh = obj->f.tail_oh;
 
-	D_ALLOC_ARRAY(head->iod.arr_rgs, rg_nr);
-	D_ALLOC_ARRAY(tail->iod.arr_rgs, rg_nr);
-	if (head->iod.arr_rgs == NULL || tail->iod.arr_rgs == NULL)
+	D_ALLOC_ARRAY(head->dip_iod.arr_rgs, rg_nr);
+	D_ALLOC_ARRAY(tail->dip_iod.arr_rgs, rg_nr);
+	if (head->dip_iod.arr_rgs == NULL || tail->dip_iod.arr_rgs == NULL)
 		D_GOTO(err, rc = -DER_NOMEM);
 
 	if (sgl != NULL) {
@@ -203,9 +207,9 @@ dfs_io_build_parts(dfs_obj_t *obj, daos_range_t *rgs, uint32_t rg_nr, d_sg_list_
 		 */
 		uint32_t max_iovs = sgl->sg_nr + 2 * rg_nr;
 
-		D_ALLOC_ARRAY(head->sgl.sg_iovs, max_iovs);
-		D_ALLOC_ARRAY(tail->sgl.sg_iovs, max_iovs);
-		if (head->sgl.sg_iovs == NULL || tail->sgl.sg_iovs == NULL)
+		D_ALLOC_ARRAY(head->dip_sgl.sg_iovs, max_iovs);
+		D_ALLOC_ARRAY(tail->dip_sgl.sg_iovs, max_iovs);
+		if (head->dip_sgl.sg_iovs == NULL || tail->dip_sgl.sg_iovs == NULL)
 			D_GOTO(err, rc = -DER_NOMEM);
 	}
 
@@ -223,28 +227,28 @@ dfs_io_build_parts(dfs_obj_t *obj, daos_range_t *rgs, uint32_t rg_nr, d_sg_list_
 			hlen = (end < split ? end : split) - idx;
 
 		if (hlen > 0) {
-			daos_range_t *r = &head->iod.arr_rgs[head->iod.arr_nr++];
+			daos_range_t *r = &head->dip_iod.arr_rgs[head->dip_iod.arr_nr++];
 
 			r->rg_idx = idx;
 			r->rg_len = hlen;
 			if (sgl != NULL)
-				sgl_copy_bytes(sgl, &cur_iov, &cur_off, hlen, head->sgl.sg_iovs,
-					       &head->sgl.sg_nr);
+				sgl_copy_bytes(sgl, &cur, hlen, head->dip_sgl.sg_iovs,
+					       &head->dip_sgl.sg_nr);
 		}
 		if (len - hlen > 0) {
-			daos_range_t *r    = &tail->iod.arr_rgs[tail->iod.arr_nr++];
+			daos_range_t *r    = &tail->dip_iod.arr_rgs[tail->dip_iod.arr_nr++];
 			daos_size_t   tidx = (idx > split ? idx : split) - split;
 
 			r->rg_idx = tidx;
 			r->rg_len = len - hlen;
 			if (sgl != NULL)
-				sgl_copy_bytes(sgl, &cur_iov, &cur_off, len - hlen,
-					       tail->sgl.sg_iovs, &tail->sgl.sg_nr);
+				sgl_copy_bytes(sgl, &cur, len - hlen, tail->dip_sgl.sg_iovs,
+					       &tail->dip_sgl.sg_nr);
 		}
 	}
 
-	head->active = head->iod.arr_nr > 0;
-	tail->active = tail->iod.arr_nr > 0;
+	head->dip_active = head->dip_iod.arr_nr > 0;
+	tail->dip_active = tail->dip_iod.arr_nr > 0;
 	return 0;
 
 err:
@@ -287,7 +291,8 @@ dfs_io_split_cb(tse_task_t *task, void *data)
 		DFS_OP_STAT_INCR(args->dfs, DOS_WRITE);
 		dfs_update_file_metrics(args->dfs, 0, args->buf_size);
 	} else {
-		daos_size_t nr_read = args->head.iod.arr_nr_read + args->tail.iod.arr_nr_read;
+		daos_size_t nr_read =
+		    args->head.dip_iod.arr_nr_read + args->tail.dip_iod.arr_nr_read;
 
 		/*
 		 * arr_nr_read from an array read excludes only the trailing short-read (records
@@ -305,15 +310,17 @@ dfs_io_split_cb(tse_task_t *task, void *data)
 		 * the head's reported size -- the head ranges may be unsorted, so the untouched gap
 		 * need not be at the tail of the head SGL.
 		 */
-		if (args->head.active && args->tail.active && args->tail.iod.arr_array_size > 0) {
+		if (args->head.dip_active && args->tail.dip_active &&
+		    args->tail.dip_iod.arr_array_size > 0) {
 			daos_size_t head_len = 0;
 			uint32_t    i;
 
-			for (i = 0; i < args->head.iod.arr_nr; i++)
-				head_len += args->head.iod.arr_rgs[i].rg_len;
-			sgl_zero_head_holes(&args->head.sgl, args->head.iod.arr_rgs,
-					    args->head.iod.arr_nr, args->head.iod.arr_array_size);
-			nr_read = head_len + args->tail.iod.arr_nr_read;
+			for (i = 0; i < args->head.dip_iod.arr_nr; i++)
+				head_len += args->head.dip_iod.arr_rgs[i].rg_len;
+			sgl_zero_head_holes(&args->head.dip_sgl, args->head.dip_iod.arr_rgs,
+					    args->head.dip_iod.arr_nr,
+					    args->head.dip_iod.arr_array_size);
+			nr_read = head_len + args->tail.dip_iod.arr_nr_read;
 		}
 
 		DFS_OP_STAT_INCR(args->dfs, DOS_READ);
@@ -359,7 +366,7 @@ dfs_io_split_task(tse_task_t *task)
 		tse_task_t         *io_task;
 		daos_array_io_t    *io_arg;
 
-		if (!part->active)
+		if (!part->dip_active)
 			continue;
 
 		rc = dc_task_create(io_func, sched, NULL, &io_task);
@@ -367,10 +374,10 @@ dfs_io_split_task(tse_task_t *task)
 			D_GOTO(err, rc);
 
 		io_arg      = dc_task_get_args(io_task);
-		io_arg->oh  = part->oh;
+		io_arg->oh  = part->dip_oh;
 		io_arg->th  = args->write ? DAOS_TX_NONE : args->dfs->th;
-		io_arg->iod = &part->iod;
-		io_arg->sgl = &part->sgl;
+		io_arg->iod = &part->dip_iod;
+		io_arg->sgl = &part->dip_sgl;
 
 		rc = tse_task_register_deps(task, 1, &io_task);
 		if (rc != 0) {

--- a/src/client/dfs/io.c
+++ b/src/client/dfs/io.c
@@ -28,11 +28,476 @@ dfs_update_file_metrics(dfs_t *dfs, daos_size_t read_bytes, daos_size_t write_by
 		d_tm_inc_gauge(dfs->metrics->dm_write_bytes, write_bytes);
 }
 
+/*
+ * Progressive layout (PL) splits a file's logical byte range across two array objects: the head
+ * array holds logical bytes [0, split_off) and the tail array holds logical bytes [split_off, EOF)
+ * reindexed to start at 0 (tail index == logical_off - split_off). The helpers below route a
+ * logical IO to the proper array object(s) based on obj->f.split_off. Non-PL files (has_tail ==
+ * false) never reach these helpers and keep their original single-object behavior.
+ */
+
+/** A head or tail portion of a logical array IO after splitting at split_off. */
+struct dfs_io_part {
+	daos_handle_t    oh;
+	daos_array_iod_t iod;
+	d_sg_list_t      sgl;
+	bool             active;
+};
+
+/*
+ * Append \a need bytes from \a src starting at the running cursor (\a cur_iov, \a cur_off) as a set
+ * of iovs into \a dst_iovs, advancing the cursor. The cursor walks the source sgl byte stream so
+ * that successive calls carve out consecutive byte slices that map to consecutive array ranges.
+ */
+static void
+sgl_copy_bytes(d_sg_list_t *src, uint32_t *cur_iov, daos_size_t *cur_off, daos_size_t need,
+	       d_iov_t *dst_iovs, uint32_t *dst_nr)
+{
+	while (need > 0) {
+		d_iov_t    *siov  = &src->sg_iovs[*cur_iov];
+		daos_size_t avail = siov->iov_len - *cur_off;
+		daos_size_t take  = avail < need ? avail : need;
+
+		if (take > 0) {
+			d_iov_set(&dst_iovs[*dst_nr], (char *)siov->iov_buf + *cur_off, take);
+			(*dst_nr)++;
+			*cur_off += take;
+			need -= take;
+		}
+		if (*cur_off == siov->iov_len) {
+			(*cur_iov)++;
+			*cur_off = 0;
+		}
+	}
+}
+
+/* Zero a [off, off+len) byte window within the logical SGL stream (walking iov capacities). */
+static void
+sgl_zero_range(d_sg_list_t *sgl, daos_size_t off, daos_size_t len)
+{
+	uint32_t i;
+
+	for (i = 0; i < sgl->sg_nr && len > 0; i++) {
+		d_iov_t    *iov = &sgl->sg_iovs[i];
+		daos_size_t cap = iov->iov_buf_len;
+		daos_size_t n;
+
+		if (off >= cap) {
+			off -= cap;
+			continue;
+		}
+		n = cap - off;
+		if (n > len)
+			n = len;
+		memset((char *)iov->iov_buf + off, 0, n);
+		len -= n;
+		off = 0;
+	}
+}
+
+/*
+ * Zero the SGL bytes that correspond to interior holes of a head-only read. For each requested
+ * range the bytes at or beyond the head array's own EOF (\a head_size) were left untouched by the
+ * fetch; when the tail holds data those bytes are interior holes of the logical file and must read
+ * back as zeros. Ranges map into the SGL byte stream in iod order (a cursor advances by each range
+ * length), so the per-range hole is zeroed at its own position regardless of how the ranges are
+ * sorted. The bytes before head_size were already data- or zero-filled by the array fetch.
+ */
+static void
+sgl_zero_head_holes(d_sg_list_t *sgl, daos_range_t *rgs, uint32_t rg_nr, daos_size_t head_size)
+{
+	daos_size_t cursor = 0;
+	uint32_t    j;
+
+	for (j = 0; j < rg_nr; j++) {
+		daos_size_t idx = rgs[j].rg_idx;
+		daos_size_t len = rgs[j].rg_len;
+		daos_size_t hole_at;
+
+		if (idx >= head_size)
+			hole_at = 0; /* whole range is past the head EOF */
+		else if (idx + len > head_size)
+			hole_at = head_size - idx; /* range straddles the head EOF */
+		else
+			hole_at = len; /* range is fully within the head data */
+
+		if (len > hole_at)
+			sgl_zero_range(sgl, cursor + hole_at, len - hole_at);
+		cursor += len;
+	}
+}
+
+/*
+ * Resolve a short read of the head array of a progressive-layout file. The head array reports a
+ * short read (and leaves the buffer untouched) for any bytes past its OWN EOF, but it has no
+ * knowledge of the tail. If the tail holds data, the logical file extends beyond split_off, so the
+ * head's short region is an interior hole of the logical file rather than the file's EOF: the bytes
+ * the head left untouched must read back as zeros and be counted as read. If the tail is empty the
+ * short region is the genuine EOF: per POSIX the buffer past EOF is left untouched and the short
+ * count stands. Only call this when the head actually short-fetched (nr_read < buf_size); the
+ * tail-size lookup is then off the common (full-data) path.
+ *
+ * Zeros are placed per range using the head array size (\a head_size, which the head read already
+ * reported via arr_array_size), so unsorted/non-contiguous dfs_readx() ranges (whose holes need not
+ * be at the tail of the SGL) are handled correctly. Only the tail-size lookup is needed here, and
+ * only for interior holes (tail has data), not for reads at EOF.
+ */
+static int
+dfs_pl_head_short_read(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_range_t *rgs,
+		       uint32_t rg_nr, daos_size_t buf_size, daos_size_t head_size,
+		       daos_size_t *nr_read)
+{
+	daos_size_t tail_size = 0;
+	int         rc;
+
+	rc = daos_array_get_size(obj->f.tail_oh, dfs->th, &tail_size, NULL);
+	if (rc)
+		return rc;
+	if (tail_size == 0)
+		/* genuine EOF: leave the buffer past EOF untouched (POSIX), keep the short count */
+		return 0;
+
+	/* logical file continues into the tail: the head's untouched gaps are interior holes */
+	sgl_zero_head_holes(sgl, rgs, rg_nr, head_size);
+	*nr_read = buf_size;
+	return 0;
+}
+
+static void
+dfs_io_part_free(struct dfs_io_part *part)
+{
+	D_FREE(part->iod.arr_rgs);
+	D_FREE(part->sgl.sg_iovs);
+}
+
+/*
+ * Split the logical array ranges (and, when \a sgl is not NULL, the matching sgl byte stream) at
+ * obj->f.split_off into a head portion (logical [0, split_off), routed to obj->oh) and a tail
+ * portion (logical [split_off, EOF) reindexed to start at 0, routed to obj->f.tail_oh). The
+ * produced ranges/iovs are allocated and must be released with dfs_io_part_free().
+ */
+static int
+dfs_io_build_parts(dfs_obj_t *obj, daos_range_t *rgs, uint32_t rg_nr, d_sg_list_t *sgl,
+		   struct dfs_io_part *head, struct dfs_io_part *tail)
+{
+	daos_size_t split   = obj->f.split_off;
+	uint32_t    cur_iov = 0;
+	daos_size_t cur_off = 0;
+	uint32_t    i;
+	int         rc = 0;
+
+	memset(head, 0, sizeof(*head));
+	memset(tail, 0, sizeof(*tail));
+	head->oh = obj->oh;
+	tail->oh = obj->f.tail_oh;
+
+	D_ALLOC_ARRAY(head->iod.arr_rgs, rg_nr);
+	D_ALLOC_ARRAY(tail->iod.arr_rgs, rg_nr);
+	if (head->iod.arr_rgs == NULL || tail->iod.arr_rgs == NULL)
+		D_GOTO(err, rc = -DER_NOMEM);
+
+	if (sgl != NULL) {
+		/*
+		 * Each range can split at most one source iov, so head and tail together never need
+		 * more than sg_nr + 2 * rg_nr iovs; size each side to that safe upper bound.
+		 */
+		uint32_t max_iovs = sgl->sg_nr + 2 * rg_nr;
+
+		D_ALLOC_ARRAY(head->sgl.sg_iovs, max_iovs);
+		D_ALLOC_ARRAY(tail->sgl.sg_iovs, max_iovs);
+		if (head->sgl.sg_iovs == NULL || tail->sgl.sg_iovs == NULL)
+			D_GOTO(err, rc = -DER_NOMEM);
+	}
+
+	for (i = 0; i < rg_nr; i++) {
+		daos_size_t idx = rgs[i].rg_idx;
+		daos_size_t len = rgs[i].rg_len;
+		daos_size_t end = idx + len;
+		daos_size_t hlen;
+
+		if (len == 0)
+			continue;
+
+		hlen = 0;
+		if (idx < split)
+			hlen = (end < split ? end : split) - idx;
+
+		if (hlen > 0) {
+			daos_range_t *r = &head->iod.arr_rgs[head->iod.arr_nr++];
+
+			r->rg_idx = idx;
+			r->rg_len = hlen;
+			if (sgl != NULL)
+				sgl_copy_bytes(sgl, &cur_iov, &cur_off, hlen, head->sgl.sg_iovs,
+					       &head->sgl.sg_nr);
+		}
+		if (len - hlen > 0) {
+			daos_range_t *r    = &tail->iod.arr_rgs[tail->iod.arr_nr++];
+			daos_size_t   tidx = (idx > split ? idx : split) - split;
+
+			r->rg_idx = tidx;
+			r->rg_len = len - hlen;
+			if (sgl != NULL)
+				sgl_copy_bytes(sgl, &cur_iov, &cur_off, len - hlen,
+					       tail->sgl.sg_iovs, &tail->sgl.sg_nr);
+		}
+	}
+
+	head->active = head->iod.arr_nr > 0;
+	tail->active = tail->iod.arr_nr > 0;
+	return 0;
+
+err:
+	dfs_io_part_free(head);
+	dfs_io_part_free(tail);
+	return rc;
+}
+
+/*
+ * Tracking context for a logical IO that straddles split_off and is therefore issued as two
+ * concurrent array operations (head + tail). It lives until both sub-tasks complete and is freed
+ * by the parent task's completion callback (dfs_io_split_cb).
+ */
+struct dfs_io_split_args {
+	dfs_t             *dfs;
+	daos_size_t       *read_size;
+	daos_size_t        buf_size;
+	bool               write;
+	struct dfs_io_part head;
+	struct dfs_io_part tail;
+};
+
+/*
+ * Completion callback on the parent task. It runs once both the head and tail sub-tasks have
+ * completed, aggregates their results, updates stats/metrics, and releases the tracking context.
+ */
+static int
+dfs_io_split_cb(tse_task_t *task, void *data)
+{
+	struct dfs_io_split_args *args = *((struct dfs_io_split_args **)data);
+	int                       rc   = task->dt_result;
+
+	if (rc != 0) {
+		D_ERROR("Failed to %s split array object: " DF_RC "\n",
+			args->write ? "write to" : "read from", DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	if (args->write) {
+		DFS_OP_STAT_INCR(args->dfs, DOS_WRITE);
+		dfs_update_file_metrics(args->dfs, 0, args->buf_size);
+	} else {
+		daos_size_t nr_read = args->head.iod.arr_nr_read + args->tail.iod.arr_nr_read;
+
+		/*
+		 * arr_nr_read from an array read excludes only the trailing short-read (records
+		 * past that object's local EOF); interior holes are counted and zero-filled. The
+		 * head object has no knowledge of the tail object, so when a head range ends in a
+		 * hole it is reported as a (trailing) short-read even though the logical file
+		 * continues into the tail. The head region is within the logical EOF whenever the
+		 * file extends into the tail -- i.e. when the tail array SIZE is non-zero -- which
+		 * is NOT the same as the requested tail subrange returning data: a multi-range
+		 * readx may target a tail range that is itself beyond EOF (arr_nr_read == 0) while
+		 * the file still extends into the tail elsewhere. Both array reads report the size
+		 * each used to resolve its own short reads (arr_array_size), so gate on the tail's
+		 * reported size, count the head's full requested length, and zero the bytes the
+		 * head read left untouched past its own EOF. Place those zeros per head range using
+		 * the head's reported size -- the head ranges may be unsorted, so the untouched gap
+		 * need not be at the tail of the head SGL.
+		 */
+		if (args->head.active && args->tail.active && args->tail.iod.arr_array_size > 0) {
+			daos_size_t head_len = 0;
+			uint32_t    i;
+
+			for (i = 0; i < args->head.iod.arr_nr; i++)
+				head_len += args->head.iod.arr_rgs[i].rg_len;
+			sgl_zero_head_holes(&args->head.sgl, args->head.iod.arr_rgs,
+					    args->head.iod.arr_nr, args->head.iod.arr_array_size);
+			nr_read = head_len + args->tail.iod.arr_nr_read;
+		}
+
+		DFS_OP_STAT_INCR(args->dfs, DOS_READ);
+		if (args->read_size != NULL)
+			*args->read_size = nr_read;
+		dfs_update_file_metrics(args->dfs, nr_read, 0);
+	}
+out:
+	dfs_io_part_free(&args->head);
+	dfs_io_part_free(&args->tail);
+	D_FREE(args);
+	return rc;
+}
+
+/*
+ * Parent task body. It spawns one array sub-task per active part (head and tail) on the parent's
+ * scheduler, registers each as a dependency of the parent so the parent only completes after both
+ * sub-tasks complete, and schedules the sub-tasks to run concurrently.
+ */
+static int
+dfs_io_split_task(tse_task_t *task)
+{
+	struct dfs_io_split_args *args  = daos_task_get_priv(task);
+	tse_sched_t              *sched = tse_task2sched(task);
+	struct dfs_io_part       *parts[2];
+	tse_task_func_t           io_func;
+	d_list_t                  io_list;
+	bool                      cb_registered = false;
+	int                       i, rc;
+
+	D_INIT_LIST_HEAD(&io_list);
+	parts[0] = &args->head;
+	parts[1] = &args->tail;
+	io_func  = args->write ? dc_array_write : dc_array_read;
+
+	rc = tse_task_register_comp_cb(task, dfs_io_split_cb, &args, sizeof(args));
+	if (rc != 0)
+		D_GOTO(err, rc);
+	cb_registered = true;
+
+	for (i = 0; i < 2; i++) {
+		struct dfs_io_part *part = parts[i];
+		tse_task_t         *io_task;
+		daos_array_io_t    *io_arg;
+
+		if (!part->active)
+			continue;
+
+		rc = dc_task_create(io_func, sched, NULL, &io_task);
+		if (rc != 0)
+			D_GOTO(err, rc);
+
+		io_arg      = dc_task_get_args(io_task);
+		io_arg->oh  = part->oh;
+		io_arg->th  = args->write ? DAOS_TX_NONE : args->dfs->th;
+		io_arg->iod = &part->iod;
+		io_arg->sgl = &part->sgl;
+
+		rc = tse_task_register_deps(task, 1, &io_task);
+		if (rc != 0) {
+			tse_task_complete(io_task, rc);
+			D_GOTO(err, rc);
+		}
+		tse_task_list_add(io_task, &io_list);
+	}
+
+	tse_task_list_sched(&io_list, true);
+	return 0;
+
+err:
+	tse_task_list_abort(&io_list, rc);
+	if (!cb_registered) {
+		dfs_io_part_free(&args->head);
+		dfs_io_part_free(&args->tail);
+		D_FREE(args);
+	}
+	tse_task_complete(task, rc);
+	return rc;
+}
+
+/*
+ * Issue a logical IO that straddles split_off by splitting it into a head and a tail array
+ * operation that run concurrently. A parent task (bound to \a ev, or to a private event when \a ev
+ * is NULL) tracks both sub-tasks and completes the event only after both finish. On the
+ * asynchronous path this returns once the operations are submitted; on the synchronous path (no
+ * user event) it blocks until both sub-tasks complete before returning. Returns an errno.
+ */
+static int
+dfs_io_split(dfs_t *dfs, dfs_obj_t *obj, daos_range_t *rgs, uint32_t rg_nr, d_sg_list_t *sgl,
+	     bool write, daos_size_t buf_size, daos_size_t *read_size, daos_event_t *ev)
+{
+	struct dfs_io_split_args *args;
+	tse_task_t               *task = NULL;
+	int                       rc;
+
+	D_ALLOC_PTR(args);
+	if (args == NULL)
+		return ENOMEM;
+
+	args->dfs       = dfs;
+	args->read_size = read_size;
+	args->buf_size  = buf_size;
+	args->write     = write;
+
+	rc = dfs_io_build_parts(obj, rgs, rg_nr, sgl, &args->head, &args->tail);
+	if (rc != 0) {
+		D_FREE(args);
+		return daos_der2errno(rc);
+	}
+
+	if (ev != NULL)
+		daos_event_errno_rc(ev);
+
+	rc = dc_task_create(dfs_io_split_task, NULL, ev, &task);
+	if (rc != 0) {
+		dfs_io_part_free(&args->head);
+		dfs_io_part_free(&args->tail);
+		D_FREE(args);
+		return daos_der2errno(rc);
+	}
+
+	daos_task_set_priv(task, args);
+
+	/*
+	 * dc_task_schedule() runs the parent body instantly. For the asynchronous case it returns
+	 * after the sub-tasks are submitted and the user event tracks their completion; for the
+	 * synchronous case (private event) it blocks until both sub-tasks complete before
+	 * returning.
+	 */
+	rc = dc_task_schedule(task, true);
+	return daos_der2errno(rc);
+}
+
+enum dfs_io_loc {
+	DFS_IO_HEAD,
+	DFS_IO_TAIL,
+	DFS_IO_SPLIT,
+};
+
+/** Classify where a set of logical ranges land relative to split_off. */
+static enum dfs_io_loc
+classify_ranges(daos_range_t *rgs, uint32_t rg_nr, daos_size_t split)
+{
+	bool     head = false;
+	bool     tail = false;
+	uint32_t i;
+
+	for (i = 0; i < rg_nr; i++) {
+		if (rgs[i].rg_len == 0)
+			continue;
+		if (rgs[i].rg_idx < split)
+			head = true;
+		if (rgs[i].rg_idx + rgs[i].rg_len > split)
+			tail = true;
+		if (head && tail)
+			return DFS_IO_SPLIT;
+	}
+	return tail ? DFS_IO_TAIL : DFS_IO_HEAD;
+}
+
+/*
+ * Reject ranges whose [rg_idx, rg_idx + rg_len) span wraps past the 64-bit offset space. Such input
+ * is invalid and would make the PL split classification (classify_ranges) and the head/tail length
+ * math (dfs_io_build_parts) operate on wrapped offsets, misrouting the IO. dfs_punch() applies the
+ * same guard to offset + len.
+ */
+static bool
+pl_ranges_valid(daos_range_t *rgs, uint32_t rg_nr)
+{
+	uint32_t i;
+
+	for (i = 0; i < rg_nr; i++) {
+		if (rgs[i].rg_idx + rgs[i].rg_len < rgs[i].rg_idx)
+			return false;
+	}
+	return true;
+}
+
 struct dfs_read_params {
 	dfs_t           *dfs;
 	daos_size_t     *read_size;
 	daos_array_iod_t arr_iod;
 	daos_range_t     rg;
+	daos_range_t    *rgs_owned;
 };
 
 static int
@@ -53,13 +518,22 @@ read_cb(tse_task_t *task, void *data)
 	dfs_update_file_metrics(params->dfs, params->arr_iod.arr_nr_read, 0);
 	*params->read_size = params->arr_iod.arr_nr_read;
 out:
+	D_FREE(params->rgs_owned);
 	D_FREE(params);
 	return rc;
 }
 
+/*
+ * Asynchronous read of one array object (\a oh) over \a rg_nr ranges. When \a own_rgs is true, \a
+ * rgs is a heap buffer whose ownership is transferred here and freed once the read completes (used
+ * for the reindexed PL tail ranges). When \a own_rgs is false, the ranges are not owned: a single
+ * range is copied into the params (so a stack range may be passed), while multiple ranges are
+ * referenced in place and the caller must keep them alive until completion (e.g. the user-supplied
+ * dfs_readx ranges). This avoids an extra allocation/copy on the common read paths.
+ */
 static int
-dfs_read_int(dfs_t *dfs, dfs_obj_t *obj, daos_off_t off, dfs_iod_t *iod, d_sg_list_t *sgl,
-	     daos_size_t buf_size, daos_size_t *read_size, daos_event_t *ev)
+dfs_read_int(dfs_t *dfs, daos_handle_t oh, daos_range_t *rgs, uint32_t rg_nr, bool own_rgs,
+	     d_sg_list_t *sgl, daos_size_t *read_size, daos_event_t *ev)
 {
 	tse_task_t             *task = NULL;
 	daos_array_io_t        *args;
@@ -70,29 +544,34 @@ dfs_read_int(dfs_t *dfs, dfs_obj_t *obj, daos_off_t off, dfs_iod_t *iod, d_sg_li
 	daos_event_errno_rc(ev);
 
 	rc = dc_task_create(dc_array_read, NULL, ev, &task);
-	if (rc != 0)
+	if (rc != 0) {
+		if (own_rgs)
+			D_FREE(rgs);
 		return daos_der2errno(rc);
+	}
 
 	D_ALLOC_PTR(params);
 	if (params == NULL)
 		D_GOTO(err_task, rc = -DER_NOMEM);
 
-	params->dfs       = dfs;
-	params->read_size = read_size;
-
-	/** set array location */
-	if (iod == NULL) {
-		params->arr_iod.arr_nr  = 1;
-		params->rg.rg_len       = buf_size;
-		params->rg.rg_idx       = off;
+	params->dfs            = dfs;
+	params->read_size      = read_size;
+	params->arr_iod.arr_nr = rg_nr;
+	if (own_rgs) {
+		/** take ownership of the caller's heap ranges; freed by read_cb at completion */
+		params->rgs_owned       = rgs;
+		params->arr_iod.arr_rgs = rgs;
+	} else if (rg_nr == 1) {
+		/** copy the single (possibly stack) range into the embedded storage */
+		params->rg              = rgs[0];
 		params->arr_iod.arr_rgs = &params->rg;
 	} else {
-		params->arr_iod.arr_nr  = iod->iod_nr;
-		params->arr_iod.arr_rgs = iod->iod_rgs;
+		/** reference the caller-owned ranges in place; they persist for the async op */
+		params->arr_iod.arr_rgs = rgs;
 	}
 
 	args      = dc_task_get_args(task);
-	args->oh  = obj->oh;
+	args->oh  = oh;
 	args->th  = dfs->th;
 	args->sgl = sgl;
 	args->iod = &params->arr_iod;
@@ -113,7 +592,208 @@ dfs_read_int(dfs_t *dfs, dfs_obj_t *obj, daos_off_t off, dfs_iod_t *iod, d_sg_li
 err_params:
 	D_FREE(params);
 err_task:
+	/** read_cb was never registered, so free the owned ranges (if any) here */
+	if (own_rgs)
+		D_FREE(rgs);
 	tse_task_complete(task, rc);
+	/** the event is completed with the proper rc */
+	return 0;
+}
+
+/*
+ * Async head-only read of a progressive-layout file. The head array can only short-read against its
+ * OWN EOF; it cannot know the tail holds data. So a short head read may actually be an interior
+ * hole of the logical file (tail non-empty) that must read back as zeros and be counted, or it may
+ * be the genuine EOF (tail empty) where the buffer past EOF must be left untouched (POSIX). This
+ * issues the head read, then conditionally a tail get_size to tell an interior hole from EOF; the
+ * head size needed to place the per-range zeros is the one the read already reported via
+ * arr_array_size, so no separate head get_size is required. The tail get_size is gated on an actual
+ * short read, so a full-data read pays nothing. The two tasks form a linear chain:
+ *   read_task (head read) -> size_task (tail get_size, user-facing).
+ */
+struct dfs_pl_head_read_params {
+	dfs_t           *dfs;
+	dfs_obj_t       *obj;
+	d_sg_list_t     *sgl;
+	daos_size_t     *read_size;
+	daos_size_t      buf_size;
+	daos_size_t      tail_size;
+	daos_array_iod_t arr_iod; /* head read iod; arr_nr_read/arr_array_size filled by the read */
+	daos_range_t     rg;      /* embedded storage for the single-range case */
+	daos_range_t    *rgs_owned; /* heap ranges whose ownership was transferred here, if any */
+};
+
+/* Record the read count, bump stats/metrics, and release the params. */
+static void
+pl_head_read_finalize(struct dfs_pl_head_read_params *p, daos_size_t nr_read)
+{
+	*p->read_size = nr_read;
+	DFS_OP_STAT_INCR(p->dfs, DOS_READ);
+	dfs_update_file_metrics(p->dfs, nr_read, 0);
+}
+
+/* Completion cb on the tail get_size; only registered for a possible short read. */
+static int
+pl_head_size_comp_cb(tse_task_t *task, void *data)
+{
+	struct dfs_pl_head_read_params *p  = daos_task_get_priv(task);
+	int                             rc = task->dt_result;
+
+	if (rc != 0) {
+		D_ERROR("Failed to get tail size: " DF_RC "\n", DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	if (p->tail_size == 0) {
+		/* genuine EOF: leave the buffer past EOF untouched (POSIX), keep the short count */
+		pl_head_read_finalize(p, p->arr_iod.arr_nr_read);
+	} else {
+		/*
+		 * The tail holds data, so every byte the head left untouched past its own EOF is an
+		 * interior hole of the logical file. Zero each range's hole in place using the head
+		 * array size the read already reported (ranges may be unsorted, so a hole can map
+		 * anywhere in the SGL) and count the full requested length as read.
+		 */
+		sgl_zero_head_holes(p->sgl, p->arr_iod.arr_rgs, p->arr_iod.arr_nr,
+				    p->arr_iod.arr_array_size);
+		pl_head_read_finalize(p, p->buf_size);
+	}
+out:
+	D_FREE(p->rgs_owned);
+	D_FREE(p);
+	return rc;
+}
+
+/*
+ * Prep cb on the user-facing tail get_size task, gated behind the head read. It resolves a short
+ * head read: a full read finalizes here and short-circuits the tail get_size body; a short read
+ * arms the tail get_size so pl_head_size_comp_cb can tell an interior hole (tail has data, zero the
+ * gaps) from the genuine EOF (tail empty, leave the buffer untouched per POSIX). The head array
+ * size needed to place the zeros was already reported by the read (arr_array_size), so no separate
+ * head get_size is issued.
+ */
+static int
+pl_head_size_prep_cb(tse_task_t *task, void *data)
+{
+	struct dfs_pl_head_read_params *p = daos_task_get_priv(task);
+	daos_array_get_size_t          *args;
+	int                             rc = task->dt_result;
+
+	if (rc != 0) {
+		D_ERROR("Failed to read from head array object: " DF_RC "\n", DP_RC(rc));
+		D_GOTO(done, rc);
+	}
+
+	if (p->arr_iod.arr_nr_read >= p->buf_size) {
+		/* head satisfied the whole read; skip the tail lookup */
+		pl_head_read_finalize(p, p->arr_iod.arr_nr_read);
+		D_GOTO(done, rc = 0);
+	}
+
+	/* short head read: look up the tail size so the comp cb can classify the gap */
+	rc = tse_task_register_comp_cb(task, pl_head_size_comp_cb, NULL, 0);
+	if (rc != 0)
+		D_GOTO(done, rc);
+	args       = daos_task_get_args(task);
+	args->oh   = p->obj->f.tail_oh;
+	args->th   = p->dfs->th;
+	args->size = &p->tail_size;
+	return 0;
+
+done:
+	D_FREE(p->rgs_owned);
+	D_FREE(p);
+	tse_task_complete(task, rc);
+	return rc;
+}
+
+static int
+dfs_pl_head_read_int(dfs_t *dfs, dfs_obj_t *obj, daos_range_t *rgs, uint32_t rg_nr, bool own_rgs,
+		     d_sg_list_t *sgl, daos_size_t buf_size, daos_size_t *read_size,
+		     daos_event_t *ev)
+{
+	tse_task_t                     *size_task = NULL;
+	tse_task_t                     *read_task = NULL;
+	daos_array_io_t                *rargs;
+	struct dfs_pl_head_read_params *params;
+	tse_sched_t                    *sched;
+	int                             rc;
+
+	D_ASSERT(ev);
+	daos_event_errno_rc(ev);
+
+	/*
+	 * size_task is the user-facing task (bound to ev); it doubles as the conditional tail
+	 * get_size used to classify a short head read. Its body only runs when the prep cb leaves
+	 * it armed (the head short-read; the tail size then tells an interior hole from EOF).
+	 */
+	rc = dc_task_create(dc_array_get_size, NULL, ev, &size_task);
+	if (rc != 0) {
+		if (own_rgs)
+			D_FREE(rgs);
+		return daos_der2errno(rc);
+	}
+	sched = tse_task2sched(size_task);
+
+	D_ALLOC_PTR(params);
+	if (params == NULL)
+		D_GOTO(err_size, rc = -DER_NOMEM);
+	params->dfs            = dfs;
+	params->obj            = obj;
+	params->sgl            = sgl;
+	params->read_size      = read_size;
+	params->buf_size       = buf_size;
+	params->arr_iod.arr_nr = rg_nr;
+	if (own_rgs) {
+		/** take ownership of the caller's heap ranges; freed by the cbs at completion */
+		params->rgs_owned       = rgs;
+		params->arr_iod.arr_rgs = rgs;
+	} else if (rg_nr == 1) {
+		/** copy the single (possibly stack) range into the embedded storage */
+		params->rg              = rgs[0];
+		params->arr_iod.arr_rgs = &params->rg;
+	} else {
+		/** reference the caller-owned ranges in place; they persist for the async op */
+		params->arr_iod.arr_rgs = rgs;
+	}
+
+	/** child sub-task: the actual head array read */
+	rc = dc_task_create(dc_array_read, sched, NULL, &read_task);
+	if (rc != 0)
+		D_GOTO(err_params, rc);
+	rargs      = dc_task_get_args(read_task);
+	rargs->oh  = obj->oh;
+	rargs->th  = dfs->th;
+	rargs->sgl = sgl;
+	rargs->iod = &params->arr_iod;
+
+	/** chain the tasks: read -> tail get_size (user-facing) */
+	rc = tse_task_register_deps(size_task, 1, &read_task);
+	if (rc != 0)
+		D_GOTO(err_read, rc);
+
+	daos_task_set_priv(size_task, params);
+	rc = tse_task_register_cbs(size_task, pl_head_size_prep_cb, NULL, 0, NULL, NULL, 0);
+	if (rc != 0)
+		D_GOTO(err_read, rc);
+
+	/*
+	 * Schedule the parent before the child (the size_task waits on its dep). dc_task_schedule()
+	 * completes a task even on error, driving the registered cbs (which free params), so the rc
+	 * is handled through the normal completion path and can be ignored here.
+	 */
+	dc_task_schedule(size_task, true);
+	dc_task_schedule(read_task, true);
+	return 0;
+
+err_read:
+	tse_task_complete(read_task, rc);
+err_params:
+	D_FREE(params);
+err_size:
+	if (own_rgs)
+		D_FREE(rgs);
+	tse_task_complete(size_task, rc);
 	/** the event is completed with the proper rc */
 	return 0;
 }
@@ -122,8 +802,11 @@ int
 dfs_read(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off, daos_size_t *read_size,
 	 daos_event_t *ev)
 {
-	daos_size_t buf_size;
-	int         i, rc;
+	daos_handle_t oh;
+	daos_off_t    aoff;
+	daos_size_t   buf_size;
+	bool          pl_head = false;
+	int           i, rc;
 
 	if (dfs == NULL || !dfs->mounted)
 		return EINVAL;
@@ -151,6 +834,27 @@ dfs_read(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off, daos_size
 
 	D_DEBUG(DB_TRACE, "DFS Read: Off %" PRIu64 ", Len %zu\n", off, buf_size);
 
+	oh   = obj->oh;
+	aoff = off;
+	if (obj->f.has_tail) {
+		daos_range_t    rg = {.rg_idx = off, .rg_len = buf_size};
+		enum dfs_io_loc loc;
+
+		if (!pl_ranges_valid(&rg, 1))
+			return EINVAL;
+		loc = classify_ranges(&rg, 1, obj->f.split_off);
+
+		if (loc == DFS_IO_SPLIT)
+			return dfs_io_split(dfs, obj, &rg, 1, sgl, false, 0, read_size, ev);
+		if (loc == DFS_IO_TAIL) {
+			oh   = obj->f.tail_oh;
+			aoff = off - obj->f.split_off;
+		} else {
+			/** head-only read of a PL file: may need tail-aware hole handling */
+			pl_head = true;
+		}
+	}
+
 	if (ev == NULL) {
 		daos_array_iod_t iod;
 		daos_range_t     rg;
@@ -158,13 +862,26 @@ dfs_read(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off, daos_size
 		/** set array location */
 		iod.arr_nr  = 1;
 		rg.rg_len   = buf_size;
-		rg.rg_idx   = off;
+		rg.rg_idx   = aoff;
 		iod.arr_rgs = &rg;
 
-		rc = daos_array_read(obj->oh, dfs->th, &iod, sgl, NULL);
+		rc = daos_array_read(oh, dfs->th, &iod, sgl, NULL);
 		if (rc) {
 			D_ERROR("daos_array_read() failed, " DF_RC "\n", DP_RC(rc));
 			return daos_der2errno(rc);
+		}
+
+		/*
+		 * A short head read past the head's own EOF is an interior hole of the logical file
+		 * when the tail has data; zero the gap and count it as read.
+		 */
+		if (pl_head && iod.arr_nr_read < buf_size) {
+			rc = dfs_pl_head_short_read(dfs, obj, sgl, &rg, 1, buf_size,
+						    iod.arr_array_size, &iod.arr_nr_read);
+			if (rc) {
+				D_ERROR("tail size lookup failed, " DF_RC "\n", DP_RC(rc));
+				return daos_der2errno(rc);
+			}
 		}
 
 		DFS_OP_STAT_INCR(dfs, DOS_READ);
@@ -173,14 +890,26 @@ dfs_read(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off, daos_size
 		return 0;
 	}
 
-	return dfs_read_int(dfs, obj, off, NULL, sgl, buf_size, read_size, ev);
+	{
+		daos_range_t rg = {.rg_idx = aoff, .rg_len = buf_size};
+
+		if (pl_head)
+			return dfs_pl_head_read_int(dfs, obj, &rg, 1, false, sgl, buf_size,
+						    read_size, ev);
+		return dfs_read_int(dfs, oh, &rg, 1, false, sgl, read_size, ev);
+	}
 }
 
 int
 dfs_readx(dfs_t *dfs, dfs_obj_t *obj, dfs_iod_t *iod, d_sg_list_t *sgl, daos_size_t *read_size,
 	  daos_event_t *ev)
 {
-	int rc;
+	daos_handle_t oh        = DAOS_HDL_INVAL;
+	daos_range_t *rgs       = NULL;
+	uint32_t      rg_nr     = 0;
+	bool          rgs_alloc = false;
+	bool          pl_head   = false;
+	int           rc;
 
 	if (dfs == NULL || !dfs->mounted)
 		return EINVAL;
@@ -205,26 +934,93 @@ dfs_readx(dfs_t *dfs, dfs_obj_t *obj, dfs_iod_t *iod, d_sg_list_t *sgl, daos_siz
 		return 0;
 	}
 
+	oh    = obj->oh;
+	rgs   = iod->iod_rgs;
+	rg_nr = iod->iod_nr;
+	if (obj->f.has_tail) {
+		enum dfs_io_loc loc;
+
+		if (!pl_ranges_valid(iod->iod_rgs, iod->iod_nr))
+			return EINVAL;
+		loc = classify_ranges(iod->iod_rgs, iod->iod_nr, obj->f.split_off);
+
+		if (loc == DFS_IO_SPLIT)
+			return dfs_io_split(dfs, obj, iod->iod_rgs, iod->iod_nr, sgl, false, 0,
+					    read_size, ev);
+		if (loc == DFS_IO_TAIL) {
+			uint32_t j;
+
+			D_ALLOC_ARRAY(rgs, iod->iod_nr);
+			if (rgs == NULL)
+				return ENOMEM;
+			for (j = 0; j < iod->iod_nr; j++) {
+				rgs[j].rg_idx = iod->iod_rgs[j].rg_idx - obj->f.split_off;
+				rgs[j].rg_len = iod->iod_rgs[j].rg_len;
+			}
+			oh = obj->f.tail_oh;
+			/** free in completion cb */
+			rgs_alloc = true;
+		} else {
+			/** head-only read of a PL file: may need tail-aware hole handling */
+			pl_head = true;
+		}
+	}
+
 	if (ev == NULL) {
 		daos_array_iod_t arr_iod;
 
 		/** set array location */
-		arr_iod.arr_nr  = iod->iod_nr;
-		arr_iod.arr_rgs = iod->iod_rgs;
+		arr_iod.arr_nr  = rg_nr;
+		arr_iod.arr_rgs = rgs;
 
-		rc = daos_array_read(obj->oh, dfs->th, &arr_iod, sgl, ev);
+		rc = daos_array_read(oh, dfs->th, &arr_iod, sgl, NULL);
 		if (rc) {
 			D_ERROR("daos_array_read() failed (%d)\n", rc);
+			if (rgs_alloc)
+				D_FREE(rgs);
 			return daos_der2errno(rc);
+		}
+
+		/*
+		 * A short head read past the head's own EOF is an interior hole of the logical file
+		 * when the tail has data; zero the gap and count it as read.
+		 */
+		if (pl_head) {
+			daos_size_t buf_size = 0;
+			uint32_t    j;
+
+			for (j = 0; j < rg_nr; j++)
+				buf_size += rgs[j].rg_len;
+			if (arr_iod.arr_nr_read < buf_size) {
+				rc = dfs_pl_head_short_read(dfs, obj, sgl, rgs, rg_nr, buf_size,
+							    arr_iod.arr_array_size,
+							    &arr_iod.arr_nr_read);
+				if (rc) {
+					D_ERROR("tail size lookup failed, " DF_RC "\n", DP_RC(rc));
+					return daos_der2errno(rc);
+				}
+			}
 		}
 
 		DFS_OP_STAT_INCR(dfs, DOS_READ);
 		*read_size = arr_iod.arr_nr_read;
 		dfs_update_file_metrics(dfs, arr_iod.arr_nr_read, 0);
+		if (rgs_alloc)
+			D_FREE(rgs);
 		return 0;
 	}
 
-	return dfs_read_int(dfs, obj, 0, iod, sgl, 0, read_size, ev);
+	if (pl_head) {
+		daos_size_t buf_size = 0;
+		uint32_t    j;
+
+		for (j = 0; j < rg_nr; j++)
+			buf_size += rgs[j].rg_len;
+		return dfs_pl_head_read_int(dfs, obj, rgs, rg_nr, rgs_alloc, sgl, buf_size,
+					    read_size, ev);
+	}
+
+	return dfs_read_int(dfs, oh, rgs, rg_nr, rgs_alloc, sgl, read_size, ev);
 }
 
 int
@@ -232,6 +1028,7 @@ dfs_write(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off, daos_eve
 {
 	daos_array_iod_t iod;
 	daos_range_t     rg;
+	daos_handle_t    oh;
 	daos_size_t      buf_size;
 	int              i;
 	int              rc;
@@ -266,10 +1063,26 @@ dfs_write(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off, daos_eve
 
 	D_DEBUG(DB_TRACE, "DFS Write: Off %" PRIu64 ", Len %zu\n", off, buf_size);
 
+	oh = obj->oh;
+	if (obj->f.has_tail) {
+		enum dfs_io_loc loc;
+
+		if (!pl_ranges_valid(&rg, 1))
+			return EINVAL;
+		loc = classify_ranges(&rg, 1, obj->f.split_off);
+
+		if (loc == DFS_IO_SPLIT)
+			return dfs_io_split(dfs, obj, &rg, 1, sgl, true, buf_size, NULL, ev);
+		if (loc == DFS_IO_TAIL) {
+			oh        = obj->f.tail_oh;
+			rg.rg_idx = off - obj->f.split_off;
+		}
+	}
+
 	if (ev)
 		daos_event_errno_rc(ev);
 
-	rc = daos_array_write(obj->oh, DAOS_TX_NONE, &iod, sgl, ev);
+	rc = daos_array_write(oh, DAOS_TX_NONE, &iod, sgl, ev);
 	if (rc == 0) {
 		DFS_OP_STAT_INCR(dfs, DOS_WRITE);
 		dfs_update_file_metrics(dfs, 0, buf_size);
@@ -284,6 +1097,9 @@ int
 dfs_writex(dfs_t *dfs, dfs_obj_t *obj, dfs_iod_t *iod, d_sg_list_t *sgl, daos_event_t *ev)
 {
 	daos_array_iod_t arr_iod;
+	daos_handle_t    oh        = DAOS_HDL_INVAL;
+	daos_range_t    *rgs       = NULL;
+	bool             rgs_alloc = false;
 	daos_size_t      buf_size;
 	int              i;
 	int              rc;
@@ -308,25 +1124,60 @@ dfs_writex(dfs_t *dfs, dfs_obj_t *obj, dfs_iod_t *iod, d_sg_list_t *sgl, daos_ev
 		return 0;
 	}
 
-	/** set array location */
-	arr_iod.arr_nr  = iod->iod_nr;
-	arr_iod.arr_rgs = iod->iod_rgs;
-
-	if (ev)
-		daos_event_errno_rc(ev);
-
 	buf_size = 0;
 	if (dfs->metrics != NULL && sgl != NULL)
 		for (i = 0; i < sgl->sg_nr; i++)
 			buf_size += sgl->sg_iovs[i].iov_len;
 
-	rc = daos_array_write(obj->oh, DAOS_TX_NONE, &arr_iod, sgl, ev);
+	oh  = obj->oh;
+	rgs = iod->iod_rgs;
+	if (obj->f.has_tail) {
+		enum dfs_io_loc loc;
+
+		if (!pl_ranges_valid(iod->iod_rgs, iod->iod_nr))
+			return EINVAL;
+		loc = classify_ranges(iod->iod_rgs, iod->iod_nr, obj->f.split_off);
+
+		if (loc == DFS_IO_SPLIT)
+			return dfs_io_split(dfs, obj, iod->iod_rgs, iod->iod_nr, sgl, true,
+					    buf_size, NULL, ev);
+		if (loc == DFS_IO_TAIL) {
+			uint32_t j;
+
+			D_ALLOC_ARRAY(rgs, iod->iod_nr);
+			if (rgs == NULL)
+				return ENOMEM;
+			for (j = 0; j < iod->iod_nr; j++) {
+				rgs[j].rg_idx = iod->iod_rgs[j].rg_idx - obj->f.split_off;
+				rgs[j].rg_len = iod->iod_rgs[j].rg_len;
+			}
+			oh        = obj->f.tail_oh;
+			rgs_alloc = true;
+		}
+	}
+
+	/** set array location */
+	arr_iod.arr_nr  = iod->iod_nr;
+	arr_iod.arr_rgs = rgs;
+
+	if (ev)
+		daos_event_errno_rc(ev);
+
+	/*
+	 * The array layer consumes the range array synchronously while issuing the write, so the
+	 * reindexed tail ranges (when allocated) can be freed as soon as daos_array_write() returns
+	 * even for the asynchronous case.
+	 */
+	rc = daos_array_write(oh, DAOS_TX_NONE, &arr_iod, sgl, ev);
 	if (rc == 0) {
 		DFS_OP_STAT_INCR(dfs, DOS_WRITE);
 		dfs_update_file_metrics(dfs, 0, buf_size);
 	} else {
 		D_ERROR("daos_array_write() failed (%d)\n", rc);
 	}
+
+	if (rgs_alloc)
+		D_FREE(rgs);
 
 	return daos_der2errno(rc);
 }

--- a/src/client/dfs/lookup.c
+++ b/src/client/dfs/lookup.c
@@ -183,7 +183,7 @@ lookup_rel_path_loop:
 				daos_array_stbuf_t array_stbuf = {0};
 
 				rc = file_stat(dfs, obj->oh, obj->f.tail_oh, obj->f.has_tail,
-					       dfs->th, &array_stbuf);
+					       obj->f.split_off, dfs->th, &array_stbuf);
 				if (rc) {
 					if (obj->f.has_tail)
 						daos_array_close(obj->f.tail_oh, NULL);
@@ -509,8 +509,8 @@ lookup_rel_int(dfs_t *dfs, dfs_obj_t *parent, const char *name, int flags, dfs_o
 		if (stbuf) {
 			daos_array_stbuf_t array_stbuf = {0};
 
-			rc = file_stat(dfs, obj->oh, obj->f.tail_oh, obj->f.has_tail, dfs->th,
-				       &array_stbuf);
+			rc = file_stat(dfs, obj->oh, obj->f.tail_oh, obj->f.has_tail,
+				       obj->f.split_off, dfs->th, &array_stbuf);
 			if (rc) {
 				if (obj->f.has_tail)
 					daos_array_close(obj->f.tail_oh, NULL);

--- a/src/client/dfs/obj.c
+++ b/src/client/dfs/obj.c
@@ -1238,7 +1238,15 @@ ostatx_cb(tse_task_t *task, void *data)
 		D_GOTO(out, rc = -DER_ENOENT);
 
 	if (S_ISREG(args->obj->mode) && args->obj->f.has_tail) {
-		op_args->array_stbuf.st_size += op_args->tail_array_stbuf.st_size;
+		daos_size_t tail_size = op_args->tail_array_stbuf.st_size;
+
+		/*
+		 * The head holds logical bytes [0, split_off) and the tail holds [split_off, EOF)
+		 * reindexed from 0. When the tail has data the logical size is split_off + tail
+		 * extent; otherwise it is the head extent already in array_stbuf.st_size.
+		 */
+		if (tail_size > 0)
+			op_args->array_stbuf.st_size = args->obj->f.split_off + tail_size;
 		if (op_args->tail_array_stbuf.st_max_epoch > op_args->array_stbuf.st_max_epoch)
 			op_args->array_stbuf.st_max_epoch = op_args->tail_array_stbuf.st_max_epoch;
 	}
@@ -2038,6 +2046,61 @@ out_obj:
 	return rc;
 }
 
+/*
+ * Truncate a progressive-layout file to \a offset. The head array holds logical bytes [0,
+ * split_off); the tail array holds [split_off, EOF) reindexed from 0. Truncating below split_off
+ * shrinks the head and empties the tail, otherwise only the tail extent changes.
+ */
+static int
+dfs_pl_truncate(dfs_obj_t *obj, daos_off_t offset)
+{
+	daos_size_t split = obj->f.split_off;
+	int         rc;
+
+	if (offset <= split) {
+		rc = daos_array_set_size(obj->oh, DAOS_TX_NONE, offset, NULL);
+		if (rc)
+			return rc;
+		return daos_array_set_size(obj->f.tail_oh, DAOS_TX_NONE, 0, NULL);
+	}
+
+	/* head retains all of [0, split_off); only the tail extent changes */
+	return daos_array_set_size(obj->f.tail_oh, DAOS_TX_NONE, offset - split, NULL);
+}
+
+/* Punch the logical hole [offset, offset + len) of a progressive-layout file across head and tail.
+ */
+static int
+dfs_pl_punch_hole(dfs_obj_t *obj, daos_off_t offset, daos_size_t len)
+{
+	daos_size_t      split = obj->f.split_off;
+	daos_off_t       end   = offset + len;
+	daos_array_iod_t iod;
+	daos_range_t     rg;
+	int              rc;
+
+	iod.arr_nr  = 1;
+	iod.arr_rgs = &rg;
+
+	if (offset < split) {
+		rg.rg_idx = offset;
+		rg.rg_len = (end < split ? end : split) - offset;
+		rc        = daos_array_punch(obj->oh, DAOS_TX_NONE, &iod, NULL);
+		if (rc)
+			return rc;
+	}
+	if (end > split) {
+		daos_off_t tstart = (offset > split ? offset : split);
+
+		rg.rg_idx = tstart - split;
+		rg.rg_len = end - tstart;
+		rc        = daos_array_punch(obj->f.tail_oh, DAOS_TX_NONE, &iod, NULL);
+		if (rc)
+			return rc;
+	}
+	return 0;
+}
+
 int
 dfs_punch(dfs_t *dfs, dfs_obj_t *obj, daos_off_t offset, daos_size_t len)
 {
@@ -2055,6 +2118,54 @@ dfs_punch(dfs_t *dfs, dfs_obj_t *obj, daos_off_t offset, daos_size_t len)
 		return EINVAL;
 	if ((obj->flags & O_ACCMODE) == O_RDONLY)
 		return EPERM;
+
+	if (obj->f.has_tail) {
+		daos_size_t split = obj->f.split_off;
+		daos_size_t hsize = 0;
+		daos_size_t tsize = 0;
+
+		/** simple truncate */
+		if (len == DFS_MAX_FSIZE) {
+			rc = dfs_pl_truncate(obj, offset);
+			return daos_der2errno(rc);
+		}
+
+		/** logical size = split + tail extent when the tail has data, else the head extent
+		 */
+		rc = daos_array_get_size(obj->oh, DAOS_TX_NONE, &hsize, NULL);
+		if (rc)
+			return daos_der2errno(rc);
+		rc = daos_array_get_size(obj->f.tail_oh, DAOS_TX_NONE, &tsize, NULL);
+		if (rc)
+			return daos_der2errno(rc);
+		size = tsize > 0 ? split + tsize : hsize;
+
+		/** nothing to do if offset is larger or equal to the file size */
+		if (size <= offset)
+			return 0;
+
+		if ((offset + len) < offset)
+			hi = DFS_MAX_FSIZE;
+		else
+			hi = offset + len;
+
+		/** if fsize is between the range to punch, just truncate to offset */
+		if (offset < size && size <= hi) {
+			rc = dfs_pl_truncate(obj, offset);
+			return daos_der2errno(rc);
+		}
+
+		D_ASSERT(size > hi);
+
+		rc = dfs_pl_punch_hole(obj, offset, len);
+		if (rc) {
+			D_ERROR("dfs_pl_punch_hole() failed (%d)\n", rc);
+			return daos_der2errno(rc);
+		}
+
+		DFS_OP_STAT_INCR(dfs, DOS_TRUNCATE);
+		return 0;
+	}
 
 	/** simple truncate */
 	if (len == DFS_MAX_FSIZE) {

--- a/src/include/daos_array.h
+++ b/src/include/daos_array.h
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -50,6 +50,13 @@ typedef struct {
 	daos_size_t		arr_nr_short_read;
 	/** (on read only) the number of records that were actually read from the array */
 	daos_size_t		arr_nr_read;
+	/** (on read only, byte arrays) the array size (in records) the read used to resolve short
+	 * reads and holes: the actual array size when a short read was possible (a get_size was
+	 * issued), or UINT64_MAX when no short read was possible (the size was not queried). Lets a
+	 * caller reuse the size the array layer already determined instead of issuing its own
+	 * daos_array_get_size().
+	 */
+	daos_size_t             arr_array_size;
 } daos_array_iod_t;
 
 /** DAOS array stat (size, modification time) information */

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -3827,6 +3827,781 @@ dfs_test_pl_oclass_selection(void **state)
 	assert_success(rc);
 }
 
+/*
+ * Write a buffer at \a off then read it back and verify the contents, using either the synchronous
+ * (\a async == false) or asynchronous path. The pattern is derived from the logical offset so any
+ * mis-routing between the head and tail array objects (e.g. a wrong reindex) corrupts the readback.
+ */
+static void
+pl_io_check(test_arg_t *arg, dfs_t *dfs, dfs_obj_t *obj, daos_off_t off, daos_size_t len,
+	    bool async, unsigned char seed)
+{
+	char         *wbuf;
+	char         *rbuf;
+	d_sg_list_t   wsgl;
+	d_sg_list_t   rsgl;
+	d_iov_t       wiov;
+	d_iov_t       riov;
+	daos_size_t   got = 0;
+	daos_size_t   i;
+	daos_event_t  ev;
+	daos_event_t *evp;
+	int           rc;
+
+	D_ALLOC(wbuf, len);
+	assert_non_null(wbuf);
+	D_ALLOC(rbuf, len);
+	assert_non_null(rbuf);
+	for (i = 0; i < len; i++)
+		wbuf[i] = (char)(seed + ((off + i) & 0xff));
+
+	d_iov_set(&wiov, wbuf, len);
+	wsgl.sg_nr     = 1;
+	wsgl.sg_nr_out = 1;
+	wsgl.sg_iovs   = &wiov;
+	d_iov_set(&riov, rbuf, len);
+	rsgl.sg_nr     = 1;
+	rsgl.sg_nr_out = 1;
+	rsgl.sg_iovs   = &riov;
+
+	if (async) {
+		rc = daos_event_init(&ev, arg->eq, NULL);
+		assert_rc_equal(rc, 0);
+		rc = dfs_write(dfs, obj, &wsgl, off, &ev);
+		assert_int_equal(rc, 0);
+		rc = daos_eq_poll(arg->eq, 0, DAOS_EQ_WAIT, 1, &evp);
+		assert_rc_equal(rc, 1);
+		assert_ptr_equal(evp, &ev);
+		assert_int_equal(evp->ev_error, 0);
+		rc = daos_event_fini(&ev);
+		assert_rc_equal(rc, 0);
+
+		rc = daos_event_init(&ev, arg->eq, NULL);
+		assert_rc_equal(rc, 0);
+		rc = dfs_read(dfs, obj, &rsgl, off, &got, &ev);
+		assert_int_equal(rc, 0);
+		rc = daos_eq_poll(arg->eq, 0, DAOS_EQ_WAIT, 1, &evp);
+		assert_rc_equal(rc, 1);
+		assert_ptr_equal(evp, &ev);
+		assert_int_equal(evp->ev_error, 0);
+		rc = daos_event_fini(&ev);
+		assert_rc_equal(rc, 0);
+	} else {
+		rc = dfs_write(dfs, obj, &wsgl, off, NULL);
+		assert_int_equal(rc, 0);
+		rc = dfs_read(dfs, obj, &rsgl, off, &got, NULL);
+		assert_int_equal(rc, 0);
+	}
+
+	assert_int_equal(got, len);
+	assert_memory_equal(wbuf, rbuf, len);
+	D_FREE(wbuf);
+	D_FREE(rbuf);
+}
+
+/*
+ * Same as pl_io_check() but exercises the scatter dfs_writex()/dfs_readx() paths with two ranges:
+ * one that straddles split_off and one that lands fully in the tail. This covers the multi-range
+ * splitting in dfs_io_build_parts() for both the gather (write) and scatter (read) directions.
+ */
+static void
+pl_iox_check(test_arg_t *arg, dfs_t *dfs, dfs_obj_t *obj, daos_size_t split, bool async,
+	     unsigned char seed)
+{
+	dfs_iod_t     iod;
+	daos_range_t  rgs[2];
+	d_sg_list_t   wsgl;
+	d_sg_list_t   rsgl;
+	d_iov_t       wiov;
+	d_iov_t       riov;
+	char         *wbuf;
+	char         *rbuf;
+	daos_size_t   rlen  = 8192;
+	daos_size_t   total = rlen * 2;
+	daos_size_t   got   = 0;
+	daos_size_t   i;
+	daos_event_t  ev;
+	daos_event_t *evp;
+	int           rc;
+
+	/* rg[0] straddles split_off, rg[1] is fully in the tail. */
+	rgs[0].rg_idx = split - rlen / 2;
+	rgs[0].rg_len = rlen;
+	rgs[1].rg_idx = split + rlen * 4;
+	rgs[1].rg_len = rlen;
+	iod.iod_nr    = 2;
+	iod.iod_rgs   = rgs;
+
+	D_ALLOC(wbuf, total);
+	assert_non_null(wbuf);
+	D_ALLOC(rbuf, total);
+	assert_non_null(rbuf);
+	for (i = 0; i < total; i++)
+		wbuf[i] = (char)(seed + (i & 0xff));
+
+	d_iov_set(&wiov, wbuf, total);
+	wsgl.sg_nr     = 1;
+	wsgl.sg_nr_out = 1;
+	wsgl.sg_iovs   = &wiov;
+	d_iov_set(&riov, rbuf, total);
+	rsgl.sg_nr     = 1;
+	rsgl.sg_nr_out = 1;
+	rsgl.sg_iovs   = &riov;
+
+	if (async) {
+		rc = daos_event_init(&ev, arg->eq, NULL);
+		assert_rc_equal(rc, 0);
+		rc = dfs_writex(dfs, obj, &iod, &wsgl, &ev);
+		assert_int_equal(rc, 0);
+		rc = daos_eq_poll(arg->eq, 0, DAOS_EQ_WAIT, 1, &evp);
+		assert_rc_equal(rc, 1);
+		assert_ptr_equal(evp, &ev);
+		assert_int_equal(evp->ev_error, 0);
+		rc = daos_event_fini(&ev);
+		assert_rc_equal(rc, 0);
+
+		rc = daos_event_init(&ev, arg->eq, NULL);
+		assert_rc_equal(rc, 0);
+		rc = dfs_readx(dfs, obj, &iod, &rsgl, &got, &ev);
+		assert_int_equal(rc, 0);
+		rc = daos_eq_poll(arg->eq, 0, DAOS_EQ_WAIT, 1, &evp);
+		assert_rc_equal(rc, 1);
+		assert_ptr_equal(evp, &ev);
+		assert_int_equal(evp->ev_error, 0);
+		rc = daos_event_fini(&ev);
+		assert_rc_equal(rc, 0);
+	} else {
+		rc = dfs_writex(dfs, obj, &iod, &wsgl, NULL);
+		assert_int_equal(rc, 0);
+		rc = dfs_readx(dfs, obj, &iod, &rsgl, &got, NULL);
+		assert_int_equal(rc, 0);
+	}
+
+	assert_int_equal(got, total);
+	assert_memory_equal(wbuf, rbuf, total);
+	D_FREE(wbuf);
+	D_FREE(rbuf);
+}
+
+/*
+ * Verify a head-only read that may run past the head's written data. The file must already have
+ * head data in [0, hdata). The head array only knows its own EOF, so DFS consults the tail to tell
+ * an interior hole (tail has data -> the gap reads back as zeros and is counted) apart from real
+ * EOF (tail empty -> short read, the gap is not counted). Exercises dfs_read and dfs_readx, sync
+ * and async, for reads that straddle, fully overrun, or stay within the head data.
+ */
+static void
+pl_head_hole_check(test_arg_t *arg, dfs_t *dfs, dfs_obj_t *obj, char *pattern, daos_size_t hdata,
+		   daos_off_t roff, daos_size_t rlen, bool tail_has_data, bool readx, bool async)
+{
+	char         *rbuf;
+	d_sg_list_t   rsgl;
+	d_iov_t       riov;
+	dfs_iod_t     diod;
+	daos_range_t  drg;
+	daos_size_t   got    = 0;
+	daos_size_t   expect = tail_has_data ? rlen : (roff < hdata ? hdata - roff : 0);
+	daos_size_t   i;
+	daos_event_t  ev;
+	daos_event_t *evp;
+	int           rc;
+
+	D_ALLOC(rbuf, rlen);
+	assert_non_null(rbuf);
+	memset(rbuf, 0xff, rlen);
+	d_iov_set(&riov, rbuf, rlen);
+	rsgl.sg_nr     = 1;
+	rsgl.sg_nr_out = 1;
+	rsgl.sg_iovs   = &riov;
+	drg.rg_idx     = roff;
+	drg.rg_len     = rlen;
+	diod.iod_nr    = 1;
+	diod.iod_rgs   = &drg;
+
+	if (async) {
+		rc = daos_event_init(&ev, arg->eq, NULL);
+		assert_rc_equal(rc, 0);
+		if (readx)
+			rc = dfs_readx(dfs, obj, &diod, &rsgl, &got, &ev);
+		else
+			rc = dfs_read(dfs, obj, &rsgl, roff, &got, &ev);
+		assert_int_equal(rc, 0);
+		rc = daos_eq_poll(arg->eq, 0, DAOS_EQ_WAIT, 1, &evp);
+		assert_rc_equal(rc, 1);
+		assert_ptr_equal(evp, &ev);
+		assert_int_equal(evp->ev_error, 0);
+		rc = daos_event_fini(&ev);
+		assert_rc_equal(rc, 0);
+	} else {
+		if (readx)
+			rc = dfs_readx(dfs, obj, &diod, &rsgl, &got, NULL);
+		else
+			rc = dfs_read(dfs, obj, &rsgl, roff, &got, NULL);
+		assert_int_equal(rc, 0);
+	}
+
+	assert_int_equal(got, expect);
+	for (i = 0; i < rlen; i++) {
+		daos_off_t pos = roff + i;
+
+		if (pos < hdata)
+			/* within the head's written data: must match the pattern */
+			assert_int_equal((unsigned char)rbuf[i], (unsigned char)pattern[pos]);
+		else if (tail_has_data)
+			/* interior hole of the logical file: zero-filled and counted */
+			assert_int_equal((unsigned char)rbuf[i], 0);
+		/* else: beyond the logical EOF, the bytes are undefined -> not checked */
+	}
+	D_FREE(rbuf);
+}
+
+/*
+ * Multi-range head-only readx where a short (interior-hole) range PRECEDES a data range in the user
+ * SGL. dfs_readx() does not require ranges to be sorted or contiguous, so the head's short region
+ * is not necessarily at the tail of the SGL. The file must have head data in [0, hdata) and a
+ * non-empty tail. range[0]=[hdata*2, hdata) is a fully-interior hole (its SGL slot must read back
+ * zeros) and range[1]=[0, hdata) is head data (its SGL slot must match the pattern). The buggy
+ * tail-only zero-fill zeros the wrong (last) SGL slot, corrupting the data range and leaving the
+ * hole untouched.
+ */
+static void
+pl_head_holex_check(test_arg_t *arg, dfs_t *dfs, dfs_obj_t *obj, char *pattern, daos_size_t hdata,
+		    bool tail_has_data, bool async)
+{
+	char         *rbuf;
+	d_sg_list_t   rsgl;
+	d_iov_t       riov;
+	dfs_iod_t     iod;
+	daos_range_t  rgs[2];
+	daos_size_t   got = 0;
+	daos_size_t   i;
+	daos_event_t  ev;
+	daos_event_t *evp;
+	int           rc;
+
+	rgs[0].rg_idx = hdata * 2; /* fully past the head data EOF -> interior hole */
+	rgs[0].rg_len = hdata;
+	rgs[1].rg_idx = 0; /* head data */
+	rgs[1].rg_len = hdata;
+	iod.iod_nr    = 2;
+	iod.iod_rgs   = rgs;
+
+	D_ALLOC(rbuf, hdata * 2);
+	assert_non_null(rbuf);
+	memset(rbuf, 0xff, hdata * 2);
+	d_iov_set(&riov, rbuf, hdata * 2);
+	rsgl.sg_nr     = 1;
+	rsgl.sg_nr_out = 1;
+	rsgl.sg_iovs   = &riov;
+
+	if (async) {
+		rc = daos_event_init(&ev, arg->eq, NULL);
+		assert_rc_equal(rc, 0);
+		rc = dfs_readx(dfs, obj, &iod, &rsgl, &got, &ev);
+		assert_int_equal(rc, 0);
+		rc = daos_eq_poll(arg->eq, 0, DAOS_EQ_WAIT, 1, &evp);
+		assert_rc_equal(rc, 1);
+		assert_ptr_equal(evp, &ev);
+		assert_int_equal(evp->ev_error, 0);
+		rc = daos_event_fini(&ev);
+		assert_rc_equal(rc, 0);
+	} else {
+		rc = dfs_readx(dfs, obj, &iod, &rsgl, &got, NULL);
+		assert_int_equal(rc, 0);
+	}
+
+	/*
+	 * range[1] (head data) always contributes hdata bytes. range[0] is past the head data: an
+	 * interior hole counted when the tail has data, or past the logical EOF (not counted) when
+	 * the tail is empty.
+	 */
+	assert_int_equal(got, tail_has_data ? hdata * 2 : hdata);
+	if (tail_has_data)
+		/* SGL[0, hdata) holds range[0] (the interior hole) -> must be zero-filled */
+		for (i = 0; i < hdata; i++)
+			assert_int_equal((unsigned char)rbuf[i], 0);
+	/* SGL[hdata, 2*hdata) holds range[1] (head data) -> must match the pattern */
+	for (i = 0; i < hdata; i++)
+		assert_int_equal((unsigned char)rbuf[hdata + i], (unsigned char)pattern[i]);
+	D_FREE(rbuf);
+}
+
+/*
+ * Regression test for multi-range hole placement on the STRADDLE path (dfs_io_split). A readx whose
+ * ranges cross split_off is split into a concurrent head + tail read. The head array only knows its
+ * own EOF, so a head range that ends in a hole is reported as a trailing short-read even though the
+ * logical file continues into the tail; those untouched bytes must be zeroed PER head range using
+ * the head array size. Zeroing only the tail of the head SGL (the old bug) corrupts data when an
+ * all-hole head range precedes a data head range in the SGL.
+ *
+ * Layout (self-contained): head data at [split-8192, split-4096) so the head array EOF is
+ * split-4096, plus tail data at [split, split+2048). The readx uses two straddling ranges, unsorted
+ * by head content: range[0]=[split-2048, +4096) whose head portion [split-2048, split) is entirely
+ * past the head EOF (a pure hole) and PRECEDES range[1]=[split-6144, +8192) whose head portion
+ * [split-6144, split) starts with data [split-6144, split-4096) then a hole [split-4096, split).
+ * The SGL layout is range0-head (hole) | range0-tail | range1-head (data+hole) | range1-tail.
+ */
+static void
+pl_straddle_holes_check(test_arg_t *arg, dfs_t *dfs, dfs_obj_t *obj, daos_size_t split, bool async)
+{
+	char         *hbuf; /* head data block at [split-8192, split-4096) */
+	char         *tbuf; /* tail data block at [split, split+2048) */
+	char         *rbuf;
+	d_sg_list_t   sgl;
+	d_iov_t       iov;
+	dfs_iod_t     iod;
+	daos_range_t  rgs[3];
+	daos_size_t   got = 0;
+	daos_size_t   i;
+	daos_event_t  ev;
+	daos_event_t *evp;
+	int           rc;
+
+	D_ALLOC(hbuf, 4096);
+	assert_non_null(hbuf);
+	D_ALLOC(tbuf, 2048);
+	assert_non_null(tbuf);
+	for (i = 0; i < 4096; i++)
+		hbuf[i] = (char)(0x80 + (i & 0x3f));
+	for (i = 0; i < 2048; i++)
+		tbuf[i] = (char)(0xc0 + (i & 0x3f));
+
+	/* reset, then lay down the sparse head data and the tail data */
+	rc = dfs_punch(dfs, obj, 0, DFS_MAX_FSIZE);
+	assert_int_equal(rc, 0);
+	sgl.sg_nr     = 1;
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs   = &iov;
+	d_iov_set(&iov, hbuf, 4096);
+	rc = dfs_write(dfs, obj, &sgl, split - 8192, NULL); /* head EOF becomes split-4096 */
+	assert_int_equal(rc, 0);
+	d_iov_set(&iov, tbuf, 2048);
+	rc = dfs_write(dfs, obj, &sgl, split, NULL); /* tail data [split, split+2048) */
+	assert_int_equal(rc, 0);
+
+	/*
+	 * Two head-only ranges (in descending, non-overlapping order) plus a tail-only range. This
+	 * mix drives the straddle path (a head array read + a tail array read). The first head
+	 * range in SGL order is entirely a hole while the second begins with data, so a naive "zero
+	 * the trailing bytes of the head SGL" fixup would corrupt the head data and leave the real
+	 * hole untouched. Correct placement zeros each range's hole using the head array size.
+	 */
+	rgs[0].rg_idx = split - 2048; /* head hole only: [split-2048, split-1024) */
+	rgs[0].rg_len = 1024;
+	rgs[1].rg_idx =
+	    split - 8192; /* head data [split-8192, split-4096) then hole up to split-2048 */
+	rgs[1].rg_len = 6144;
+	rgs[2].rg_idx = split; /* tail data [split, split+2048) */
+	rgs[2].rg_len = 2048;
+	iod.iod_nr    = 3;
+	iod.iod_rgs   = rgs;
+
+	D_ALLOC(rbuf, 9216);
+	assert_non_null(rbuf);
+	memset(rbuf, 0xff, 9216);
+	d_iov_set(&iov, rbuf, 9216);
+	sgl.sg_nr     = 1;
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs   = &iov;
+
+	if (async) {
+		rc = daos_event_init(&ev, arg->eq, NULL);
+		assert_rc_equal(rc, 0);
+		rc = dfs_readx(dfs, obj, &iod, &sgl, &got, &ev);
+		assert_int_equal(rc, 0);
+		rc = daos_eq_poll(arg->eq, 0, DAOS_EQ_WAIT, 1, &evp);
+		assert_rc_equal(rc, 1);
+		assert_ptr_equal(evp, &ev);
+		assert_int_equal(evp->ev_error, 0);
+		rc = daos_event_fini(&ev);
+		assert_rc_equal(rc, 0);
+	} else {
+		rc = dfs_readx(dfs, obj, &iod, &sgl, &got, NULL);
+		assert_int_equal(rc, 0);
+	}
+
+	/* the tail holds data, so every head byte is interior: the full 9216 is read */
+	assert_int_equal(got, 9216);
+	/* range[0]: head hole -> zeros */
+	for (i = 0; i < 1024; i++)
+		assert_int_equal((unsigned char)rbuf[i], 0);
+	/* range[1]: head data hbuf[0..4096) then a 2048-byte head hole */
+	for (i = 0; i < 4096; i++)
+		assert_int_equal((unsigned char)rbuf[1024 + i], (unsigned char)hbuf[i]);
+	for (i = 0; i < 2048; i++)
+		assert_int_equal((unsigned char)rbuf[5120 + i], 0);
+	/* range[2]: tail data */
+	for (i = 0; i < 2048; i++)
+		assert_int_equal((unsigned char)rbuf[7168 + i], (unsigned char)tbuf[i]);
+
+	D_FREE(rbuf);
+	D_FREE(tbuf);
+	D_FREE(hbuf);
+}
+
+/*
+ * Regression: a straddling readx whose tail subrange is itself beyond EOF, while the file still
+ * extends into the tail elsewhere. The head range is therefore an interior hole (must zero + count)
+ * even though the requested tail range returns nothing. The fixup must key off the tail array SIZE
+ * (logical continuation), not the requested tail subrange's returned byte count.
+ */
+static void
+pl_straddle_tail_beyond_eof_check(test_arg_t *arg, dfs_t *dfs, dfs_obj_t *obj, daos_size_t split,
+				  bool async)
+{
+	char         *tbuf; /* tail data block at [split, split+2048) */
+	char         *rbuf;
+	d_sg_list_t   sgl;
+	d_iov_t       iov;
+	dfs_iod_t     iod;
+	daos_range_t  rgs[2];
+	daos_size_t   got = 0;
+	daos_size_t   i;
+	daos_event_t  ev;
+	daos_event_t *evp;
+	int           rc;
+
+	D_ALLOC(tbuf, 2048);
+	assert_non_null(tbuf);
+	for (i = 0; i < 2048; i++)
+		tbuf[i] = (char)(0xc0 + (i & 0x3f));
+
+	/* reset, then write only the tail data; the head region stays a hole below logical EOF */
+	rc = dfs_punch(dfs, obj, 0, DFS_MAX_FSIZE);
+	assert_int_equal(rc, 0);
+	sgl.sg_nr     = 1;
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs   = &iov;
+	d_iov_set(&iov, tbuf, 2048);
+	rc = dfs_write(dfs, obj, &sgl, split, NULL); /* tail size 2048 => logical EOF split+2048 */
+	assert_int_equal(rc, 0);
+
+	/*
+	 * Head range is an interior hole (below split, below logical EOF). The tail range is
+	 * targeted 1 MiB past the split, far beyond the 2048-byte tail data, so it returns nothing.
+	 * With the old arr_nr_read>0 gate the head hole would be left untouched and uncounted.
+	 */
+	rgs[0].rg_idx = split - 2048; /* head interior hole */
+	rgs[0].rg_len = 1024;
+	rgs[1].rg_idx = split + (1 << 20); /* tail range beyond EOF */
+	rgs[1].rg_len = 4096;
+	iod.iod_nr    = 2;
+	iod.iod_rgs   = rgs;
+
+	D_ALLOC(rbuf, 5120);
+	assert_non_null(rbuf);
+	memset(rbuf, 0xff, 5120);
+	d_iov_set(&iov, rbuf, 5120);
+	sgl.sg_nr     = 1;
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs   = &iov;
+
+	if (async) {
+		rc = daos_event_init(&ev, arg->eq, NULL);
+		assert_rc_equal(rc, 0);
+		rc = dfs_readx(dfs, obj, &iod, &sgl, &got, &ev);
+		assert_int_equal(rc, 0);
+		rc = daos_eq_poll(arg->eq, 0, DAOS_EQ_WAIT, 1, &evp);
+		assert_rc_equal(rc, 1);
+		assert_ptr_equal(evp, &ev);
+		assert_int_equal(evp->ev_error, 0);
+		rc = daos_event_fini(&ev);
+		assert_rc_equal(rc, 0);
+	} else {
+		rc = dfs_readx(dfs, obj, &iod, &sgl, &got, NULL);
+		assert_int_equal(rc, 0);
+	}
+
+	/* only the head interior hole is within EOF: 1024 zero bytes read, tail range contributes 0
+	 */
+	assert_int_equal(got, 1024);
+	for (i = 0; i < 1024; i++)
+		assert_int_equal((unsigned char)rbuf[i], 0);
+	/* the beyond-EOF tail range bytes (rbuf[1024..]) are left untouched per POSIX; not asserted
+	 */
+
+	D_FREE(rbuf);
+	D_FREE(tbuf);
+}
+
+static void
+dfs_test_pl_io(void **state)
+{
+	test_arg_t    *arg = *state;
+	dfs_t         *dfs_l;
+	daos_handle_t  coh;
+	dfs_obj_t     *obj;
+	dfs_obj_info_t info     = {0};
+	dfs_attr_t     dattr    = {0};
+	char          *prev_env = NULL;
+	bool           env_was_set;
+	daos_size_t    split;
+	daos_size_t    fsize;
+	struct stat    stbuf;
+	char          *buf;
+	char          *vbuf;
+	d_sg_list_t    sgl;
+	d_iov_t        iov;
+	daos_size_t    got;
+	daos_off_t     hole_off;
+	daos_size_t    hole_len;
+	daos_size_t    i;
+	int            rc;
+
+	if (arg->myrank != 0)
+		return;
+
+	/*
+	 * Force progressive layout regardless of the pool target count so the split IO paths are
+	 * exercised even on a small test pool. Save and restore any pre-existing value so other
+	 * tests in this binary are unaffected.
+	 */
+	rc          = d_agetenv_str(&prev_env, "DFS_PL_BYPASS_TARGET_LIMIT");
+	env_was_set = (rc == 0 && prev_env != NULL);
+	rc          = d_setenv("DFS_PL_BYPASS_TARGET_LIMIT", "1", 1);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_cont_create_with_label(arg->pool.poh, "pl_io", &dattr, NULL, &coh, &dfs_l);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_open(dfs_l, NULL, "pl_io_file", S_IFREG | S_IWUSR | S_IRUSR,
+		      O_RDWR | O_CREAT | O_EXCL, 0, 0, NULL, &obj);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_obj_get_info(dfs_l, obj, &info);
+	assert_int_equal(rc, 0);
+	split = info.doi_split_off;
+	print_message("PL IO: split_off=%zu has_tail=%d chunk=%zu\n", split,
+		      !daos_obj_id_is_nil(info.doi_tail_oid), info.doi_chunk_size);
+
+	if (split == 0) {
+		/* PL did not engage in this environment (e.g. tail class has no group count). */
+		print_message("PL not active; skipping PL IO data-path checks\n");
+		goto out;
+	}
+	assert_false(daos_obj_id_is_nil(info.doi_tail_oid));
+	assert_true(split > 8192);
+
+	/* Head-only IO (entirely below split_off), sync then async. */
+	print_message("PL IO: head-only read/write (sync + async)\n");
+	pl_io_check(arg, dfs_l, obj, 0, 4096, false, 0x11);
+	pl_io_check(arg, dfs_l, obj, 0, 4096, true, 0x12);
+
+	/* Tail-only IO (entirely at/above split_off), sync then async. */
+	print_message("PL IO: tail-only read/write (sync + async)\n");
+	pl_io_check(arg, dfs_l, obj, split + (1 << 20), 4096, false, 0x21);
+	pl_io_check(arg, dfs_l, obj, split + (1 << 20), 4096, true, 0x22);
+
+	/* IO straddling split_off (exercises the concurrent head+tail split), sync then async. */
+	print_message("PL IO: straddling read/write across split_off (sync + async)\n");
+	pl_io_check(arg, dfs_l, obj, split - 2048, 4096, false, 0x31);
+	pl_io_check(arg, dfs_l, obj, split - 2048, 4096, true, 0x32);
+
+	/* Scatter/gather readx/writex with a straddling and a tail range, sync then async. */
+	print_message("PL IO: scatter/gather readx/writex (sync + async)\n");
+	pl_iox_check(arg, dfs_l, obj, split, false, 0x41);
+	pl_iox_check(arg, dfs_l, obj, split, true, 0x42);
+
+	/*
+	 * Straddling readx where an all-hole head range precedes a data head range in the SGL: the
+	 * per-range hole zeroing must not corrupt the data range (regression for dfs_io_split).
+	 */
+	print_message("PL IO: straddling readx multi-range hole placement (sync + async)\n");
+	pl_straddle_holes_check(arg, dfs_l, obj, split, false);
+	pl_straddle_holes_check(arg, dfs_l, obj, split, true);
+
+	/*
+	 * Straddling readx whose tail subrange is beyond EOF while the file still extends into the
+	 * tail: the head interior hole must still be zeroed/counted (regression for dfs_io_split
+	 * keying off the tail array size rather than the requested tail subrange's returned bytes).
+	 */
+	print_message("PL IO: straddling readx tail range beyond EOF (sync + async)\n");
+	pl_straddle_tail_beyond_eof_check(arg, dfs_l, obj, split, false);
+	pl_straddle_tail_beyond_eof_check(arg, dfs_l, obj, split, true);
+
+	/*
+	 * Size aggregation: reset to empty, write into the tail, and verify the logical size is
+	 * reported as split_off + tail_extent through both dfs_get_size() and dfs_ostat().
+	 */
+	print_message("PL IO: size aggregation (dfs_get_size/dfs_ostat == split + tail)\n");
+	rc = dfs_punch(dfs_l, obj, 0, DFS_MAX_FSIZE);
+	assert_int_equal(rc, 0);
+	rc = dfs_get_size(dfs_l, obj, &fsize);
+	assert_int_equal(rc, 0);
+	assert_int_equal(fsize, 0);
+
+	pl_io_check(arg, dfs_l, obj, split + 4096, 4096, false, 0x51);
+	rc = dfs_get_size(dfs_l, obj, &fsize);
+	assert_int_equal(rc, 0);
+	assert_int_equal(fsize, split + 4096 + 4096);
+	rc = dfs_ostat(dfs_l, obj, &stbuf);
+	assert_int_equal(rc, 0);
+	assert_int_equal(stbuf.st_size, split + 4096 + 4096);
+
+	/* Truncate into the tail: size becomes split_off + tail offset. */
+	print_message("PL IO: truncate into tail / into head\n");
+	rc = dfs_punch(dfs_l, obj, split + 1024, DFS_MAX_FSIZE);
+	assert_int_equal(rc, 0);
+	rc = dfs_get_size(dfs_l, obj, &fsize);
+	assert_int_equal(rc, 0);
+	assert_int_equal(fsize, split + 1024);
+
+	/* Truncate into the head: size drops below split_off and the tail is cleared. */
+	rc = dfs_punch(dfs_l, obj, 2048, DFS_MAX_FSIZE);
+	assert_int_equal(rc, 0);
+	rc = dfs_get_size(dfs_l, obj, &fsize);
+	assert_int_equal(rc, 0);
+	assert_int_equal(fsize, 2048);
+
+	/*
+	 * Head-only reads that run past the head's data, covering both tail states and every read
+	 * variant. The head array only knows its own EOF, so DFS must consult the tail to tell an
+	 * interior hole (tail has data -> zero-fill and count) from real EOF (tail empty -> short
+	 * read). Cover dfs_read/dfs_readx x sync/async, for straddling, fully-beyond, and
+	 * within-data reads, against a non-empty and an empty tail.
+	 */
+	{
+		const daos_size_t hdata = 4096; /* head data occupies [0, 4096) */
+		char             *pat;
+		d_sg_list_t       psgl;
+		d_iov_t           piov;
+		int               a;
+		int               x;
+
+		print_message("PL IO: head-only short read fixup, tail-aware "
+			      "(read/readx x sync/async)\n");
+		D_ALLOC(pat, 8192);
+		assert_non_null(pat);
+		for (i = 0; i < 8192; i++)
+			pat[i] = (char)(0x41 + (i & 0x3f));
+		d_iov_set(&piov, pat, hdata);
+		psgl.sg_nr     = 1;
+		psgl.sg_nr_out = 1;
+		psgl.sg_iovs   = &piov;
+
+		/* tail HAS data: gaps past the head data are interior holes (zeroed and counted) */
+		rc = dfs_punch(dfs_l, obj, 0, DFS_MAX_FSIZE);
+		assert_int_equal(rc, 0);
+		rc = dfs_write(dfs_l, obj, &psgl, 0, NULL); /* head data [0, 4096) */
+		assert_int_equal(rc, 0);
+		rc = dfs_write(dfs_l, obj, &psgl, split + 4096, NULL); /* tail data */
+		assert_int_equal(rc, 0);
+
+		for (a = 0; a < 2; a++) {
+			for (x = 0; x < 2; x++) {
+				/* straddle the head data EOF: [0, 8192), hole [4096, 8192) */
+				pl_head_hole_check(arg, dfs_l, obj, pat, hdata, 0, 8192, true, x,
+						   a);
+				/* fully past the head data EOF: [8192, 12288), all hole */
+				pl_head_hole_check(arg, dfs_l, obj, pat, hdata, 8192, 4096, true, x,
+						   a);
+				/* fully within the head data: [0, 4096), no short read */
+				pl_head_hole_check(arg, dfs_l, obj, pat, hdata, 0, hdata, true, x,
+						   a);
+			}
+		}
+
+		/*
+		 * Multi-range readx where the interior-hole range precedes the data range in the
+		 * SGL (ranges need not be sorted/contiguous), sync then async.
+		 */
+		pl_head_holex_check(arg, dfs_l, obj, pat, hdata, true, false);
+		pl_head_holex_check(arg, dfs_l, obj, pat, hdata, true, true);
+
+		/* tail EMPTY: a gap past the head data is the logical EOF (short read, not zeroed)
+		 */
+		rc = dfs_punch(dfs_l, obj, 0, DFS_MAX_FSIZE);
+		assert_int_equal(rc, 0);
+		rc = dfs_write(dfs_l, obj, &psgl, 0, NULL); /* head data only */
+		assert_int_equal(rc, 0);
+
+		for (a = 0; a < 2; a++) {
+			for (x = 0; x < 2; x++) {
+				/* straddle: read past data with empty tail -> got == hdata */
+				pl_head_hole_check(arg, dfs_l, obj, pat, hdata, 0, 8192, false, x,
+						   a);
+				/* fully beyond: read entirely past the logical EOF -> got == 0 */
+				pl_head_hole_check(arg, dfs_l, obj, pat, hdata, 8192, 4096, false,
+						   x, a);
+				/* fully within data: exact read -> got == hdata */
+				pl_head_hole_check(arg, dfs_l, obj, pat, hdata, 0, hdata, false, x,
+						   a);
+			}
+		}
+
+		/* multi-range readx with an empty tail: the hole range is past the logical EOF */
+		pl_head_holex_check(arg, dfs_l, obj, pat, hdata, false, false);
+		pl_head_holex_check(arg, dfs_l, obj, pat, hdata, false, true);
+
+		D_FREE(pat);
+	}
+
+	/*
+	 * Hole punch straddling split_off: write a known buffer across the boundary, punch a hole
+	 * that also straddles it, and verify the hole reads back as zeros while the surrounding
+	 * data is intact.
+	 */
+	print_message("PL IO: hole punch straddling split_off\n");
+	rc = dfs_punch(dfs_l, obj, 0, DFS_MAX_FSIZE);
+	assert_int_equal(rc, 0);
+
+	D_ALLOC(buf, 8192);
+	assert_non_null(buf);
+	D_ALLOC(vbuf, 8192);
+	assert_non_null(vbuf);
+	for (i = 0; i < 8192; i++)
+		buf[i] = (char)(0x61 + (i & 0x3f));
+	d_iov_set(&iov, buf, 8192);
+	sgl.sg_nr     = 1;
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs   = &iov;
+	rc            = dfs_write(dfs_l, obj, &sgl, split - 4096, NULL);
+	assert_int_equal(rc, 0);
+
+	/*
+	 * Punch a hole that straddles split_off: [split-1024, split+1024). The head loses its
+	 * trailing 1024 bytes and the tail loses its leading 1024 bytes, so in the 8192-byte read
+	 * buffer (read from split-4096) the hole maps to [3072, 5120).
+	 */
+	hole_off = split - 1024;
+	hole_len = 2048;
+	rc       = dfs_punch(dfs_l, obj, hole_off, hole_len);
+	assert_int_equal(rc, 0);
+
+	memset(vbuf, 0xff, 8192);
+	d_iov_set(&iov, vbuf, 8192);
+	rc = dfs_read(dfs_l, obj, &sgl, split - 4096, &got, NULL);
+	assert_int_equal(rc, 0);
+	assert_int_equal(got, 8192);
+	for (i = 0; i < 8192; i++) {
+		daos_off_t pos = (split - 4096) + i;
+
+		if (pos >= hole_off && pos < hole_off + hole_len)
+			assert_int_equal((unsigned char)vbuf[i], 0);
+		else
+			assert_int_equal((unsigned char)vbuf[i], (unsigned char)buf[i]);
+	}
+	D_FREE(buf);
+	D_FREE(vbuf);
+
+out:
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+	rc = dfs_umount(dfs_l);
+	assert_int_equal(rc, 0);
+	rc = daos_cont_close(coh, NULL);
+	assert_success(rc);
+	rc = daos_cont_destroy(arg->pool.poh, "pl_io", 0, NULL);
+	assert_success(rc);
+
+	/* Restore the environment to its prior state. */
+	if (env_was_set)
+		d_setenv("DFS_PL_BYPASS_TARGET_LIMIT", prev_env, 1);
+	else
+		d_unsetenv("DFS_PL_BYPASS_TARGET_LIMIT");
+	d_freeenv_str(&prev_env);
+}
+
 static const struct CMUnitTest dfs_unit_tests[] = {
     {"DFS_UNIT_TEST1: DFS mount / umount", dfs_test_mount, async_disable, test_case_teardown},
     {"DFS_UNIT_TEST2: DFS container modes", dfs_test_modes, async_disable, test_case_teardown},
@@ -3869,6 +4644,8 @@ static const struct CMUnitTest dfs_unit_tests[] = {
     {"DFS_UNIT_TEST28: dfs open/lookup flags", dfs_test_oflags, async_disable, test_case_teardown},
     {"DFS_UNIT_TEST29: dfs progressive layout oclass selection", dfs_test_pl_oclass_selection,
      async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST30: dfs progressive layout IO paths", dfs_test_pl_io, async_disable,
+     test_case_teardown},
 };
 
 static int


### PR DESCRIPTION
Route DFS file IO through the progressive-layout (PL) head/tail array
objects. The head array object holds the logical range [0, split_off)
and the tail array object holds [split_off, EOF) reindexed to start at
zero. Reads and writes are dispatched based on where their ranges fall
relative to split_off:

- Head-only and tail-only IO target the respective array object
  directly (tail offsets are rebased by split_off).
- IO straddling split_off is split into concurrent head and tail
  sub-operations driven by a parent tse task, with read_size aggregated
  across both once the dependencies complete.

Reject ranges whose rg_idx + rg_len wraps the 64-bit offset space with
EINVAL before PL classification, so the split routing never operates on
wrapped arithmetic.

Fix byte-array short-read corner cases exposed by the split layout,
honoring POSIX: a read past logical EOF returns a short count and leaves
the caller's buffer untouched, while only interior holes read back as
zeros (the user buffer is never pre-zeroed).

- Head-only reads past the head's own EOF: on a short fetch consult the
  tail size to distinguish an interior hole (zero-fill and count) from
  real EOF (genuine short read). Implemented for both the sync and async
  (dfs_read/dfs_readx) paths; the tail get_size RPC is gated on a short
  read so full-data reads incur no extra round trip.
- Straddle reads: the head object cannot know the tail holds data, so a
  hole at the end of a head range is mis-reported as a short read with
  its buffer left untouched. Gate the fixup on the tail array size
  (logical continuation) rather than the requested tail subrange's
  returned bytes, since a multi-range readx may target a tail range that
  is itself beyond EOF while the file still extends into the tail. Fetch
  the head and tail sizes concurrently with the reads.

Zero the head holes per range using the head array size rather than
blindly zeroing the tail of the head buffer: dfs_readx ranges may be
unsorted, so an interior hole can map anywhere in the SGL. The helper
walks iov_buf_len (capacity) rather than iov_len, since a fetch shrinks
iov_len to the bytes actually returned.

Add DFS_UNIT_TEST30 (dfs_test_pl_io) exercising head-only, tail-only,
straddling, and scatter/gather readx/writex IO (sync + async), logical
size aggregation (dfs_get_size/dfs_ostat), truncate into head/tail, the
tail-aware head-only short-read fixup across read/readx x sync/async,
multi-range head hole placement, a straddle readx whose tail range is
beyond EOF, and a hole punch straddling split_off. PL is forced on small
test pools via DFS_PL_BYPASS_TARGET_LIMIT and the test skips gracefully
when PL does not engage.

Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
