### PR TITLE
DAOS-19148 cart: Fix crt_swim_rank_check SUSPECT leaks

### DIFF
--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -1642,8 +1642,10 @@ crt_swim_rank_check(struct crt_grp_priv *grp_priv, d_rank_t rank, uint64_t incar
 	}
 	crt_swim_csm_unlock(csm);
 
-	if (updated)
+	if (updated) {
+		swim_member_reset(csm->csm_ctx, rank);
 		crt_swim_notify_rank_state(rank, &state_prev, &state);
+	}
 
 	return rc;
 }

--- a/src/include/cart/swim.h
+++ b/src/include/cart/swim.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016 UChicago Argonne, LLC
  * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -296,6 +297,19 @@ int swim_net_glitch_update(struct swim_context *ctx, swim_id_t id,
  * @param[in]  id	IDs of member to delete
  */
 void swim_member_del(struct swim_context *ctx, swim_id_t id);
+
+/**
+ * Reset a SWIM member, typically when updating its incarnation number and
+ * setting its state to SWIM_MEMBER_ALIVE.
+ *
+ * @param[in]  ctx	SWIM context pointer from swim_init()
+ * @param[in]  id	IDs of member to reset
+ */
+static inline void
+swim_member_reset(struct swim_context *ctx, swim_id_t id)
+{
+	swim_member_del(ctx, id);
+}
 
 /** @} */
 

--- a/src/tests/ftest/cart/utest/utest_swim.c
+++ b/src/tests/ftest/cart/utest/utest_swim.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2020-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -20,16 +20,32 @@
 #include <cart/api.h>
 #include "../cart/crt_internal.h"
 
-static void
-test_swim(void **state)
+static bool
+rank_is_suspected(struct swim_context *ctx, swim_id_t id)
 {
-	crt_context_t crt_ctx;
+	struct swim_item *item;
+	bool              found = false;
+
+	TAILQ_FOREACH(item, &ctx->sc_suspects, si_link)
+	{
+		if (item->si_id == id) {
+			found = true;
+			break;
+		}
+	}
+
+	return found;
+}
+
+static void
+test_setup(crt_context_t *crt_ctx)
+{
 	int rc;
 
 	rc = crt_init(NULL, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
 	assert_int_equal(rc, 0);
 
-	rc = crt_context_create(&crt_ctx);
+	rc = crt_context_create(crt_ctx);
 	assert_int_equal(rc, 0);
 
 	rc = crt_swim_init(0);
@@ -37,6 +53,27 @@ test_swim(void **state)
 
 	rc = crt_rank_self_set(0, 1 /* group_version_min */);
 	assert_int_equal(rc, 0);
+}
+
+static void
+test_teardown(crt_context_t crt_ctx)
+{
+	int rc;
+
+	crt_swim_fini();
+	rc = crt_context_destroy(crt_ctx, 0);
+	assert_int_equal(rc, 0);
+	rc = crt_finalize();
+	assert_int_equal(rc, 0);
+}
+
+static void
+test_swim(void **state)
+{
+	crt_context_t crt_ctx;
+	int           rc;
+
+	test_setup(&crt_ctx);
 
 	rc = crt_swim_rank_add(crt_grp_pub2priv(NULL), 1, d_hlc_get());
 	assert_int_equal(rc, 0);
@@ -50,11 +87,60 @@ test_swim(void **state)
 	rc = crt_swim_rank_add(crt_grp_pub2priv(NULL), 0, d_hlc_get());
 	assert_int_equal(rc, -DER_ALREADY);
 
-	crt_swim_fini();
-	rc = crt_context_destroy(crt_ctx, 0);
+	test_teardown(crt_ctx);
+}
+
+/*
+ * Calling crt_swim_rank_check() on a suspected member with a newer incarnation
+ * should mark the member ALIVE and remove it from the suspect list.
+ */
+static void
+test_swim_rank_check_clears_suspect(void **state)
+{
+	struct crt_grp_priv      *grp_priv;
+	struct crt_swim_membs    *csm;
+	struct swim_context      *ctx;
+	struct swim_member_update upd;
+	crt_context_t             crt_ctx;
+	uint64_t                  incarnation;
+	int                       rc;
+
+	test_setup(&crt_ctx);
+
+	grp_priv = crt_grp_pub2priv(NULL);
+	csm      = &grp_priv->gp_membs_swim;
+	ctx      = csm->csm_ctx;
+
+	/* Add the member to be suspected (rank 1) and a gossip source (rank 2). */
+	incarnation = d_hlc_get();
+	rc          = crt_swim_rank_add(grp_priv, 1, incarnation);
 	assert_int_equal(rc, 0);
-	rc = crt_finalize();
+
+	rc = crt_swim_rank_add(grp_priv, 2, d_hlc_get());
 	assert_int_equal(rc, 0);
+
+	/*
+	 * Deliver a SUSPECT update about rank 1 from rank 2 (an alive, hence
+	 * trustable, member) so that rank 1 is added to the suspect list.
+	 */
+	upd.smu_id                    = 1;
+	upd.smu_state.sms_incarnation = incarnation;
+	upd.smu_state.sms_status      = SWIM_MEMBER_SUSPECT;
+	upd.smu_state.sms_delay       = 0;
+
+	rc = swim_updates_parse(ctx, 2 /* from */, 1 /* id */, &upd, 1);
+	assert_int_equal(rc, 0);
+	assert_true(rank_is_suspected(ctx, 1));
+
+	/*
+	 * crt_swim_rank_check() with a newer incarnation must clear the
+	 * suspicion of rank 1.
+	 */
+	rc = crt_swim_rank_check(grp_priv, 1, incarnation + 1);
+	assert_int_equal(rc, 0);
+	assert_false(rank_is_suspected(ctx, 1));
+
+	test_teardown(crt_ctx);
 }
 
 static int
@@ -82,7 +168,8 @@ fini_tests(void **state)
 int main(int argc, char **argv)
 {
 	const struct CMUnitTest tests[] = {
-		cmocka_unit_test(test_swim),
+	    cmocka_unit_test(test_swim),
+	    cmocka_unit_test(test_swim_rank_check_clears_suspect),
 	};
 
 	d_register_alt_assert(mock_assert);


### PR DESCRIPTION
We've observed the following events:

    05:10:12.442962 swim_member_suspect() 6: member 0 2747111301814681600 is SUSPECT from 2
    05:10:28.810595 ds_mgmt_group_update() updated group: 120 -> 122: 10 ranks
    05:10:33.344560 swim_member_dead() 6: member 0 2747126810886799360 is DEAD from 6 (self)

PG version 122 includes a rejoined member 0, whose incarnation changed from 2747111301814681600 to 2747126810886799360. Since the suspicion timeout was 20 s, how could there be a DEAD event for the newer incarnation of member 0 within less than 5 s since the PG update? The problem is that crt_swim_rank_check forgets to delete the existing suspicion on member 0, as suggested by the first event, which happened about one suspicion timeout before the DEAD event.

Fundamentally, such suspicions (and perhaps other swim_item objects) should be about specific incarnations, not just member IDs. But that might require a larger change. In this patch, we offer a quick fix, leaving the larger change to a future patch.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
