### PR TITLE
DAOS-19056 pipeline: fix double-free and potential memory leaks (#18411)

### DIFF
--- a/src/client/dfs/pipeline.c
+++ b/src/client/dfs/pipeline.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2018-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -225,16 +225,26 @@ dfs_pipeline_create(dfs_t *dfs, dfs_predicate_t pred, uint64_t flags, dfs_pipeli
 	*_dpipe = dpipe;
 	return 0;
 err:
-	printf("failed to create pipeline. rc = %d\n", rc);
-	D_FREE(dpipe);
+	dfs_pipeline_destroy(dpipe);
 	return rc;
 }
 
 int
 dfs_pipeline_destroy(dfs_pipeline_t *dpipe)
 {
-	if (dpipe->pipeline.num_filters)
-		D_FREE(dpipe->pipeline.filters);
+	if (dpipe == NULL)
+		return 0;
+
+	/*
+	 * Ownership invariant: daos_pipeline_add() stores a pointer to dpipe->pipef
+	 * inside pipeline.filters[].  Once that succeeds (num_filters > 0),
+	 * daos_pipeline_free() is responsible for freeing pipef.parts via free_filters().
+	 * Before that point pipef.parts must be freed directly.
+	 */
+	if (dpipe->pipeline.num_filters || dpipe->pipeline.num_aggr_filters)
+		daos_pipeline_free(&dpipe->pipeline);
+	else if (dpipe->pipef.num_parts)
+		D_FREE(dpipe->pipef.parts);
 	D_FREE(dpipe);
 	return 0;
 }
@@ -293,7 +303,7 @@ dfs_readdir_with_filter(dfs_t *dfs, dfs_obj_t *obj, dfs_pipeline_t *dpipe, daos_
 
 	D_ALLOC_ARRAY(kds, nr_kds);
 	if (kds == NULL)
-		return ENOMEM;
+		D_GOTO(out, rc = ENOMEM);
 
 	/** alloc buffer to store dkeys enumerated */
 	sgl_keys.sg_nr     = 1;

--- a/src/pipeline/srv_pipeline.c
+++ b/src/pipeline/srv_pipeline.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -53,8 +54,10 @@ enum_pack_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
 		D_ASSERTF(false, "unknown/unsupported type %d\n", type);
 		return -DER_INVAL;
 	}
-	if (d_key->iov_len != 0) /** one dkey at a time */
-		return 1;
+	if (d_key->iov_len != 0) { /** one dkey at a time */
+		*acts |= VOS_ITER_CB_EXIT;
+		return 0;
+	}
 	if (entry->ie_key.iov_len > 0)
 		*d_key = entry->ie_key;
 
@@ -91,7 +94,10 @@ pipeline_fetch_record(daos_handle_t vos_coh, daos_unit_oid_t oid, struct vos_ite
 
 	/** iterating over dkeys only */
 	rc = vos_iterate(&param, type, false, anchors, enum_pack_cb, NULL, d_key, NULL);
-	D_DEBUG(DB_IO, "enum type %d rc " DF_RC "\n", type, DP_RC(rc));
+	if (rc < 0)
+		D_DEBUG(DB_IO, "enum type %d rc " DF_RC "\n", type, DP_RC(rc));
+	else if (rc > 0)
+		D_DEBUG(DB_IO, "enum type %d rc %d\n", type, rc);
 	if (rc < 0)
 		return rc;
 	if (d_key->iov_len == 0) /** d_key not found */
@@ -870,6 +876,11 @@ exit:
 
 		/** handle any data that has to be transferred in bulk (RDMA) */
 		rc = pipeline_bulk_transfer(rpc);
+		/** pipeline_bulk_transfer already freed kds/recx_size via the reply arrays */
+		if (pri->pri_kds_bulk != NULL && nr_kds_out > 0)
+			kds = NULL;
+		if (pri->pri_iods_bulk != NULL && nr_iods_out > 0)
+			recx_size = NULL;
 	}
 
 	/** -- send RPC */


### PR DESCRIPTION
Fix several resource management issues in the pipeline code paths:

 - Free client filter parts correctly on dfs_pipeline_create/destroy error paths
 - Keep SGL iov cleanup consistent when kds allocation fails in dfs_readdir_with_filter
 - Fix the server-side pipeline handler to release bulk reply buffers and SGL iov buffers according to ownership, avoiding double-free when data is transferred via RDMA bulk

Also stop returning a positive value from enum_pack_cb to terminate dkey iteration (use VOS_ITER_CB_EXIT instead), and suppress misleading DER_UNKNOWN debug logs for non-error return codes.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
