### PR TITLE
DAOS-19151 rebuild: skip orphan container in rebuild puller

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1485,7 +1485,8 @@ crt_hdlr_iv_fetch_aux(void *arg)
 			D_GOTO(reply_direct, rc);
 		}
 	} else {
-		D_ERROR("ERROR happened: "DF_RC"\n", DP_RC(rc));
+		DL_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_CONT_NONEXIST || rc == -DER_NONEXIST,
+			  DB_TRACE, DLOG_ERR, rc, "ERROR happened.");
 		D_GOTO(reply_direct, rc);
 	}
 

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -3519,8 +3519,9 @@ crt_iv_update_internal(crt_iv_namespace_t ivns, uint32_t class_id,
 
 		D_GOTO(exit, rc);
 	} else {
-		DL_CDEBUG(rc == -DER_NONEXIST || rc == -DER_NOTLEADER || rc == -DER_BUSY, DB_TRACE,
-			  DLOG_ERR, rc, "ivo_on_update failed");
+		DL_CDEBUG(rc == -DER_NONEXIST || rc == -DER_CONT_NONEXIST || rc == -DER_NOTLEADER ||
+			      rc == -DER_BUSY,
+			  DB_TRACE, DLOG_ERR, rc, "ivo_on_update failed");
 
 		update_comp_cb(ivns, class_id, iv_key, NULL,
 			       iv_value, rc, cb_arg);

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -477,8 +477,10 @@ again:
 				/* convert to more specific errno */
 				if (rc == -DER_NONEXIST)
 					rc = -DER_CONT_NONEXIST;
-				DL_ERROR(rc, DF_CONT " create IV_CONT_SNAP iv entry failed",
-					 DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
+				DL_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_CONT_NONEXIST, DB_MD,
+					  DLOG_ERR, rc,
+					  DF_CONT " create IV_CONT_SNAP iv entry failed",
+					  DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
 			} else if (class_id == IV_CONT_PROP) {
 				rc = cont_iv_prop_ent_create(entry, key);
 				if (rc == 0)
@@ -486,7 +488,8 @@ again:
 				/* convert to more specific errno */
 				if (rc == -DER_NONEXIST)
 					rc = -DER_CONT_NONEXIST;
-				DL_CDEBUG(rc == -DER_NOTLEADER, DLOG_INFO, DLOG_ERR, rc,
+				DL_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_CONT_NONEXIST, DB_MD,
+					  DLOG_ERR, rc,
 					  DF_CONT " create IV_CONT_PROP iv entry failed",
 					  DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
 			} else if (class_id == IV_CONT_CAPA) {

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -734,8 +734,8 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 
 out:
 	if (rc < 0 && rc != -DER_IVCB_FORWARD)
-		DL_CDEBUG(rc == -DER_NONEXIST || rc == -DER_NOTLEADER, DB_ANY, DLOG_ERR, rc,
-			  "failed to insert");
+		DL_CDEBUG(rc == -DER_NONEXIST || rc == -DER_NOTLEADER || rc == -DER_CONT_NONEXIST,
+			  DB_ANY, DLOG_ERR, rc, "failed to insert");
 
 	return rc;
 }
@@ -869,8 +869,8 @@ cont_iv_update(void *ns, int class_id, uuid_t key_uuid,
 	civ_key->entry_size = cont_iv_len;
 	rc = ds_iv_update(ns, &key, &sgl, shortcut, sync_mode, 0, retry);
 	if (rc)
-		DL_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_NONEXIST, DB_ANY, DLOG_ERR, rc,
-			  DF_UUID " iv update failed", DP_UUID(key_uuid));
+		DL_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_NONEXIST || rc == -DER_CONT_NONEXIST,
+			  DB_ANY, DLOG_ERR, rc, DF_UUID " iv update failed", DP_UUID(key_uuid));
 
 	return rc;
 }
@@ -1153,8 +1153,8 @@ cont_iv_track_eph_update_internal(void *ns, uuid_t cont_uuid, daos_epoch_t ec_ag
 	rc = cont_iv_update(ns, op, cont_uuid, &iv_entry, sizeof(iv_entry), shortcut, sync_mode,
 			    false);
 	if (rc && !cont_iv_retryable_error(rc))
-		D_ERROR(DF_UUID" op %d, cont_iv_update failed "DF_RC"\n",
-			DP_UUID(cont_uuid), op, DP_RC(rc));
+		DL_CDEBUG(rc == -DER_NONEXIST || rc == -DER_CONT_NONEXIST, DB_MD, DLOG_ERR, rc,
+			  DF_UUID " op %d, cont_iv_update failed", DP_UUID(cont_uuid), op);
 	return rc;
 }
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -2148,6 +2148,7 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 	uint64_t                         cur_ts;
 	int				 i;
 	int                              warn_slug_ranks = 8; /* 8 ranks at most */
+	int                              cont_num        = 0;
 	int				 rc = 0;
 
 	rc = map_ranks_failed(pool->sp_map, &fail_ranks);
@@ -2158,6 +2159,7 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 
 	ABT_mutex_lock(svc->cs_cont_ephs_mutex);
 	d_list_for_each_entry_safe(eph_ldr, tmp, &svc->cs_cont_ephs_leader_list, cte_list) {
+		cont_num++;
 		if (eph_ldr->cte_deleted) {
 			d_list_del(&eph_ldr->cte_list);
 			D_FREE(eph_ldr->cte_server_ephs);
@@ -2216,8 +2218,11 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 
 		if (min_ec_agg_eph == eph_ldr->cte_current_ec_agg_eph &&
 		    min_stable_eph == eph_ldr->cte_current_stable_eph &&
-		    eph_ldr->cte_current_ec_agg_eph != 0)
+		    eph_ldr->cte_current_ec_agg_eph != 0) {
+			if (cont_num % 10 == 0)
+				dss_sleep(0);
 			continue;
+		}
 
 		/**
 		 * NB: during extending or reintegration, the new
@@ -6364,7 +6369,8 @@ ds_cont_get_prop(uuid_t pool_uuid, uuid_t cont_uuid, daos_prop_t **prop_out)
 	ABT_rwlock_rdlock(svc->cs_lock);
 	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
 	if (rc != 0) {
-		DL_ERROR(rc, DF_CONT " cont_lookup failed", DP_CONT(pool_uuid, cont_uuid));
+		DL_CDEBUG(rc == -DER_NONEXIST, DB_MD, DLOG_ERR, rc, DF_CONT " cont_lookup failed",
+			  DP_CONT(pool_uuid, cont_uuid));
 		D_GOTO(out_lock, rc);
 	}
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1999,7 +1999,7 @@ ds_cont_tgt_refresh_track_eph(uuid_t pool_uuid, uuid_t cont_uuid,
 	rc = ds_pool_thread_collective(
 	    pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
 	    cont_refresh_track_eph_one, &arg, DSS_ULT_DEEP_STACK | DSS_ULT_FL_PERIODIC);
-	DL_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG, rc,
+	DL_CDEBUG(rc == 0 || rc == -DER_CONT_NONEXIST, DLOG_DBG, DLOG_ERR, rc,
 		  DF_CONT ": refresh ec_agg_eph " DF_X64 ", "
 			  "stable_eph " DF_X64,
 		  DP_CONT(pool_uuid, cont_uuid), ec_agg_eph, stable_eph);
@@ -2273,8 +2273,8 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 					       min_ec_agg_eph, min_stable_eph,
 					       svc->cs_cont_ephs_leader_req);
 		if (rc) {
-			DL_CDEBUG(rc == -DER_NONEXIST, DLOG_INFO, DLOG_ERR, rc,
-				  DF_CONT ": refresh failed",
+			DL_CDEBUG(rc == -DER_NONEXIST || rc == -DER_CONT_NONEXIST, DB_MD, DLOG_ERR,
+				  rc, DF_CONT ": refresh failed",
 				  DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid));
 
 			/* If ULT is exiting, break out */

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -692,7 +692,8 @@ ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 	ABT_rwlock_rdlock(svc->cs_lock);
 	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
 	if (rc != 0) {
-		DL_ERROR(rc, DF_CONT " cont_lookup failed", DP_CONT(pool_uuid, cont_uuid));
+		DL_CDEBUG(rc == -DER_NONEXIST, DB_MD, DLOG_ERR, rc, DF_CONT " cont_lookup failed",
+			  DP_CONT(pool_uuid, cont_uuid));
 		D_GOTO(out_lock, rc);
 	}
 

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -2785,6 +2785,7 @@ ds_cont_eph_report(struct ds_pool *pool)
 	struct cont_track_eph	*ec_eph;
 	struct cont_track_eph	*tmp;
 	int                      rc, ret, *failed_tgts = NULL;
+	int                      cont_num = 0;
 	unsigned int             failed_tgts_nr;
 
 	D_ASSERT(pool != NULL && pool->sp_map != NULL);
@@ -2799,6 +2800,7 @@ ds_cont_eph_report(struct ds_pool *pool)
 		daos_epoch_t min_stable_eph;
 		int          i;
 
+		cont_num++;
 		if (dss_ult_exiting(pool->sp_ec_ephs_req))
 			break;
 
@@ -2830,8 +2832,11 @@ ds_cont_eph_report(struct ds_pool *pool)
 
 		if (min_ec_agg_eph <= ec_eph->cte_last_ec_agg_epoch &&
 		    min_stable_eph <= ec_eph->cte_last_stable_epoch &&
-		    pool->sp_reclaim == DAOS_RECLAIM_DISABLED)
+		    pool->sp_reclaim == DAOS_RECLAIM_DISABLED) {
+			if (cont_num % 10 == 0)
+				dss_sleep(0);
 			continue;
+		}
 
 		/* if aggregation enabled, make sure to report ec_agg_eph at the start phase
 		 * when min_ec_agg_eph and cte_last_ec_agg_epoch are both zero.
@@ -2855,6 +2860,8 @@ ds_cont_eph_report(struct ds_pool *pool)
 					min_ec_agg_eph, ec_eph->cte_last_ec_agg_epoch,
 					min_stable_eph, ec_eph->cte_last_stable_epoch,
 					DP_UUID(ec_eph->cte_cont_uuid));
+			if (cont_num % 10 == 0)
+				dss_sleep(0);
 			continue;
 		}
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1341,13 +1341,14 @@ agg_peer_check_avail(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 	int                    rc;
 
 	if (ds_pool_is_rebuilding(agg_param->ap_cont->sc_pool->spc_pool)) {
+		rc = -DER_OP_CANCELED;
 		/* We currently pause EC aggregation for rebuild, so just cancel the
 		 * aggregation for the current stripe. It means the following peer status
 		 * check may not be checked at all, but let's keep the code because it could
 		 * be useful in the future.
 		 */
-		D_ERROR(DF_UOID " pauses EC aggregation for rebuild\n", DP_UOID(entry->ae_oid));
-		return -DER_OP_CANCELED;
+		DL_ERROR(rc, DF_UOID " pauses EC aggregation for rebuild", DP_UOID(entry->ae_oid));
+		return rc;
 	}
 
 	rc = pool_map_find_failed_tgts(agg_param->ap_pool_info.api_pool->sp_map, &targets,
@@ -1939,9 +1940,9 @@ agg_process_stripe(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 	/* avoid race between EC aggregation and rebuild scanner */
 	agg_param->ap_cont->sc_ec_agg_updates++;
 	if (ds_pool_is_rebuilding(agg_param->ap_cont->sc_pool->spc_pool)) {
-		D_DEBUG(DB_EPC, DF_UOID " abort as rebuild started\n", DP_UOID(entry->ae_oid));
+		rc = -DER_OP_CANCELED;
+		DL_INFO(rc, DF_UOID " abort as rebuild started", DP_UOID(entry->ae_oid));
 		update_vos = false;
-		rc         = -1;
 		goto out;
 	}
 
@@ -2581,11 +2582,12 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	 * (see obj_inflight_io_check()).
 	 */
 	if (ds_pool_is_rebuilding(agg_param->ap_pool_info.api_pool)) {
-		D_INFO(DF_CONT " abort as rebuild started, sp_rebuilding %d\n",
-		       DP_CONT(agg_param->ap_pool_info.api_pool_uuid,
-			       agg_param->ap_pool_info.api_cont_uuid),
-		       atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding));
-		return -1;
+		rc = -DER_OP_CANCELED;
+		DL_INFO(rc, DF_CONT " abort as rebuild started, sp_rebuilding %d.",
+			DP_CONT(agg_param->ap_pool_info.api_pool_uuid,
+				agg_param->ap_pool_info.api_cont_uuid),
+			atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding));
+		return rc;
 	}
 
 	switch (type) {
@@ -2609,9 +2611,9 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	}
 
 	if (rc < 0) {
-		D_ERROR(DF_UUID " EC aggregation (rebuilding %d) failed: " DF_RC "\n",
-			DP_UUID(agg_param->ap_pool_info.api_pool->sp_uuid),
-			atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding), DP_RC(rc));
+		DL_ERROR(rc, DF_UUID " EC aggregation (rebuilding %d) failed",
+			 DP_UUID(agg_param->ap_pool_info.api_pool->sp_uuid),
+			 atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding));
 		return rc;
 	}
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -3793,7 +3793,8 @@ cont_fetch_start_ult(void *arg)
 	rc = ds_cont_fetch_snaps(fetch_arg->pool->sp_iv_ns, fetch_arg->cont_uuid,
 				 &fetch_arg->snapshots, &fetch_arg->snap_cnt);
 	if (rc) {
-		D_ERROR("ds_cont_fetch_snaps failed: " DF_RC "\n", DP_RC(rc));
+		DL_ERROR(rc, DF_CONT ": ds_cont_fetch_snaps failed",
+			 DP_CONT(fetch_arg->pool_uuid, fetch_arg->cont_uuid));
 		return rc;
 	}
 
@@ -3848,9 +3849,17 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 	rc = dss_ult_execute(cont_fetch_start_ult, &fetch_arg, NULL, NULL, DSS_XS_SYS, 0,
 			     MIGRATE_STACK_SIZE);
 	if (rc) {
-		DL_ERROR(rc, DF_RB ": ds_pool_lookup failed", DP_RB_MPT(tls));
-		if (rc == -DER_SHUTDOWN)
-			rc = 0;
+		if (rc == -DER_CONT_NONEXIST) {
+			DL_INFO(rc, DF_RB ": " DF_CONT " skip orphan container", DP_RB_MPT(tls),
+				DP_CONT(tls->mpt_pool_uuid, cont_uuid));
+			D_GOTO(cont_done, rc = 0);
+		}
+		if (rc == -DER_SHUTDOWN) {
+			tls->mpt_fini = 1;
+			DL_ERROR(rc, DF_RB ": cont_fetch_start_ult failed, set mpt_fini",
+				 DP_RB_MPT(tls));
+		}
+		DL_ERROR(rc, DF_RB ": cont_fetch_start_ult failed", DP_RB_MPT(tls));
 		D_GOTO(free, rc);
 	}
 
@@ -3881,6 +3890,7 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 		}
 	}
 
+cont_done:
 	D_DEBUG(DB_REBUILD, DF_RB ": iter cont " DF_UUID "/%" PRIx64 " finish.\n", DP_RB_MPT(tls),
 		DP_UUID(cont_uuid), ih.cookie);
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -43,6 +43,7 @@
 		case -DER_BUSY:                                                                    \
 		case -DER_EXIST:                                                                   \
 		case -DER_NONEXIST:                                                                \
+		case -DER_OP_CANCELED:                                                             \
 			__is_err = false;                                                          \
 			break;                                                                     \
 		}                                                                                  \
@@ -62,6 +63,7 @@
 		case -DER_BUSY:                                                                    \
 		case -DER_EXIST:                                                                   \
 		case -DER_NONEXIST:                                                                \
+		case -DER_OP_CANCELED:                                                             \
 			__is_err = false;                                                          \
 			break;                                                                     \
 		}                                                                                  \


### PR DESCRIPTION
master commit 098208660d8 -
At rebuild puller side, the migrate_cont_iter_cb() -> cont_fetch_start_ult() -> ds_cont_fetch_snaps() possibly get -2050/-DER_CONT_NONEXIST for orphan container case. In that case skip the container and continue rebuild task.

master commit 26ee6377d88 -
1. fixed a case of -DER_SHUTDOWN err handling.
2. lower the log level when container IV hit -DER_CONT_NONEXIST
3. refine err code returned when abort EC agg
4. add yield() in cont_agg_eph_sync()/ds_cont_eph_report()

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
