### PR TITLE
DAOS-19251 test: Disable Unit Test memcheck stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -620,7 +620,7 @@ pipeline {
                      defaultValue: true,
                      description: 'Run the NLT stage.')
         booleanParam(name: bashName('Unit Test with memcheck'),
-                     defaultValue: false,
+                     defaultValue: true,
                      description: 'Run the Unit Test with memcheck stage.')
         booleanParam(name: bashName('Unit Test bdev with memcheck'),
                      defaultValue: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ void updateRunStage() {
                     || stage.contains('NLT')
                     || stage.contains('Fault injection')
                     || stage.contains('Test RPMs')
-                    || (stage.contains('Functional on') && !stage.contains('Ubuntu'))) {
+                    || stage == 'Functional on EL 9') {
                 runStage[stage] = true
             } else {
                 runStage[stage] = false
@@ -620,10 +620,10 @@ pipeline {
                      defaultValue: true,
                      description: 'Run the NLT stage.')
         booleanParam(name: bashName('Unit Test with memcheck'),
-                     defaultValue: true,
+                     defaultValue: false,
                      description: 'Run the Unit Test with memcheck stage.')
         booleanParam(name: bashName('Unit Test bdev with memcheck'),
-                     defaultValue: true,
+                     defaultValue: false,
                      description: 'Run the Unit Test bdev with memcheck stage.')
         booleanParam(name: bashName('Test'),
                      defaultValue: true,


### PR DESCRIPTION
Disable running the Unit Test memcheck stages by default in PRs, but enable running them in landing builds.

Also fix the Functional VM test stages run in landing builds to only include the EL 9 stage.

skip-test: true
skip-test-hardware: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
