### PR TITLE
DAOS-19149 test: interactive.py, more rebuild stop attempts

### DIFF
--- a/src/tests/ftest/rebuild/interactive.py
+++ b/src/tests/ftest/rebuild/interactive.py
@@ -103,12 +103,12 @@ class RbldInteractive(TestWithServers):
         pool.wait_for_rebuild_to_start(interval=1)
 
         self.log_step(f'{exclude_method} - Manually stop rebuild')
-        for i in range(3):
+        for i in range(4):
             try:
                 pool.rebuild_stop()
                 break
             except CommandFailure as error:
-                if i == 2 or 'DER_NONEXIST' not in str(error):
+                if i == 3 or 'DER_NONEXIST' not in str(error):
                     raise
                 self.log.info('Assuming rebuild is not started yet. Retrying in 3 seconds...')
                 time.sleep(3)
@@ -161,12 +161,12 @@ class RbldInteractive(TestWithServers):
         pool.wait_for_rebuild_to_start(interval=1)
 
         self.log_step(f'{reint_method} - Manually stop rebuild')
-        for i in range(3):
+        for i in range(4):
             try:
                 pool.rebuild_stop()
                 break
             except CommandFailure as error:
-                if i == 2 or 'DER_NONEXIST' not in str(error):
+                if i == 3 or 'DER_NONEXIST' not in str(error):
                     raise
                 self.log.info('Assuming rebuild is not started yet. Retrying in 3 seconds...')
                 time.sleep(3)


### PR DESCRIPTION
After a rank exclusion, to wait for the rebuild to start (and to interactively stop it), the test uses a limited number of dmg pool rebuild stop command invocations until the command no longer reports DER_NONEXIST. A 3 second delay is inserted between commands. In one CI daily test run, the timing was just short, missing the actual pool rebuild start by a fraction of a second.

Increase the number of tries to reduce the likelihood of a test failure due to close timing.

Test-tag: test_rebuild_interactive
Test-repeat: 10
Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-test-rpms: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
