### PR TITLE
DAOS-18998 vos: ignore non-committed DTX for rebuild iteration

### DIFF
--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -131,11 +131,11 @@ test_d_errstr(void **state)
 	assert_string_equal(value, "DER_UNKNOWN");
 
 	/* Check the end of the DAOS error numbers. */
-	value = d_errstr(-DER_CONT_DESTROYING);
-	assert_string_equal(value, "DER_CONT_DESTROYING");
-	value = d_errstr(-2051);
-	assert_string_equal(value, "DER_CONT_DESTROYING");
-	value = d_errstr(-(DER_CONT_DESTROYING + 1));
+	value = d_errstr(-DER_IGNORE);
+	assert_string_equal(value, "DER_IGNORE");
+	value = d_errstr(-2052);
+	assert_string_equal(value, "DER_IGNORE");
+	value = d_errstr(-(DER_IGNORE + 1));
 	assert_string_equal(value, "DER_UNKNOWN");
 }
 

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -214,7 +214,8 @@ extern "C" {
 	ACTION(DER_OVERLOAD_RETRY, retry later because of overloaded service)			   \
 	ACTION(DER_NOT_RESUME, Cannot resume former DAOS check instance)			   \
 	ACTION(DER_CONT_NONEXIST, The specified container does not exist) \
-	ACTION(DER_CONT_DESTROYING, The specified container is being destroyed)
+	ACTION(DER_CONT_DESTROYING, The specified container is being destroyed) \
+	ACTION(DER_IGNORE, current item for iteration or something else should be ignored)
 
 /* clang-format on */
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1435,10 +1435,10 @@ vos_iter_intent(struct vos_iterator *iter)
 		return DAOS_INTENT_PURGE;
 	if (iter->it_for_discard)
 		return DAOS_INTENT_DISCARD;
-	if (iter->it_ignore_uncommitted)
-		return DAOS_INTENT_IGNORE_NONCOMMITTED;
 	if (iter->it_for_migration)
 		return DAOS_INTENT_MIGRATION;
+	if (iter->it_ignore_uncommitted)
+		return DAOS_INTENT_IGNORE_NONCOMMITTED;
 	if (iter->it_for_check)
 		return DAOS_INTENT_CHECK;
 	return DAOS_INTENT_DEFAULT;

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -513,6 +513,9 @@ oi_iter_ilog_check(struct vos_obj_df *obj, struct vos_oi_iter *oiter,
 	rc = vos_ilog_check(&oiter->oit_ilog_info, &oiter->oit_epr, epr,
 			    (oiter->oit_flags & VOS_IT_PUNCHED) == 0);
 out:
+	if (rc == -DER_INPROGRESS && oiter->oit_iter.it_ignore_uncommitted)
+		rc = -DER_IGNORE;
+
 	D_ASSERTF(check_existence || rc != -DER_NONEXIST,
 		  "Probe is required before fetch\n");
 	return rc;
@@ -697,7 +700,7 @@ oi_iter_match_probe(struct vos_iterator *iter, daos_anchor_t *anchor, uint32_t f
 		rc = oi_iter_ilog_check(obj, oiter, NULL, true);
 		if (rc == 0)
 			break;
-		if (rc != -DER_NONEXIST) {
+		if (rc != -DER_NONEXIST && rc != -DER_IGNORE) {
 			str = "ilog check";
 			goto failed;
 		}


### PR DESCRIPTION
The DTX flag DTX_IGNORE_UNCOMMITTED was introduced for the purpose of skipping non-committed DTX during object iteration for rebuild. But the old ilog logic did to handle that as to non-committed DTX for new created object may break rebuild scan process.

The patch fixes such issue via returning new error# -DER_IGNORE if hit non-committed DTX during object iteration for rebuild.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
