### PR TITLE
DAOS-19151 container: refine some logs in IV and EC agg path

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1484,7 +1484,8 @@ crt_hdlr_iv_fetch_aux(void *arg)
 			D_GOTO(reply_direct, rc);
 		}
 	} else {
-		D_ERROR("ERROR happened: "DF_RC"\n", DP_RC(rc));
+		DL_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_CONT_NONEXIST || rc == -DER_NONEXIST,
+			  DB_TRACE, DLOG_ERR, rc, "ERROR happened.");
 		D_GOTO(reply_direct, rc);
 	}
 

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2019-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -476,8 +476,10 @@ again:
 				/* convert to more specific errno */
 				if (rc == -DER_NONEXIST)
 					rc = -DER_CONT_NONEXIST;
-				DL_ERROR(rc, DF_CONT " create IV_CONT_SNAP iv entry failed",
-					 DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
+				DL_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_CONT_NONEXIST, DB_MD,
+					  DLOG_ERR, rc,
+					  DF_CONT " create IV_CONT_SNAP iv entry failed",
+					  DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
 			} else if (class_id == IV_CONT_PROP) {
 				rc = cont_iv_prop_ent_create(entry, key);
 				if (rc == 0)
@@ -485,8 +487,10 @@ again:
 				/* convert to more specific errno */
 				if (rc == -DER_NONEXIST)
 					rc = -DER_CONT_NONEXIST;
-				DL_ERROR(rc, DF_CONT " create IV_CONT_PROP iv entry failed",
-					 DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
+				DL_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_CONT_NONEXIST, DB_MD,
+					  DLOG_ERR, rc,
+					  DF_CONT " create IV_CONT_PROP iv entry failed",
+					  DP_CONT(entry->ns->iv_pool_uuid, civ_key->cont_uuid));
 			} else if (class_id == IV_CONT_CAPA) {
 				struct container_hdl	chdl = { 0 };
 				int			rc1;

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -6150,7 +6150,8 @@ ds_cont_get_prop(uuid_t pool_uuid, uuid_t cont_uuid, daos_prop_t **prop_out)
 	ABT_rwlock_rdlock(svc->cs_lock);
 	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
 	if (rc != 0) {
-		DL_ERROR(rc, DF_CONT " cont_lookup failed", DP_CONT(pool_uuid, cont_uuid));
+		DL_CDEBUG(rc == -DER_NONEXIST, DB_MD, DLOG_ERR, rc, DF_CONT " cont_lookup failed",
+			  DP_CONT(pool_uuid, cont_uuid));
 		D_GOTO(out_lock, rc);
 	}
 

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -694,7 +694,8 @@ ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 	ABT_rwlock_rdlock(svc->cs_lock);
 	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
 	if (rc != 0) {
-		DL_ERROR(rc, DF_CONT " cont_lookup failed", DP_CONT(pool_uuid, cont_uuid));
+		DL_CDEBUG(rc == -DER_NONEXIST, DB_MD, DLOG_ERR, rc, DF_CONT " cont_lookup failed",
+			  DP_CONT(pool_uuid, cont_uuid));
 		D_GOTO(out_lock, rc);
 	}
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1330,13 +1330,14 @@ agg_peer_check_avail(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 	int                    rc;
 
 	if (ds_pool_is_rebuilding(agg_param->ap_cont->sc_pool->spc_pool)) {
+		rc = -DER_OP_CANCELED;
 		/* We currently pause EC aggregation for rebuild, so just cancel the
 		 * aggregation for the current stripe. It means the following peer status
 		 * check may not be checked at all, but let's keep the code because it could
 		 * be useful in the future.
 		 */
-		D_ERROR(DF_UOID " pauses EC aggregation for rebuild\n", DP_UOID(entry->ae_oid));
-		return -DER_OP_CANCELED;
+		DL_ERROR(rc, DF_UOID " pauses EC aggregation for rebuild", DP_UOID(entry->ae_oid));
+		return rc;
 	}
 
 	rc = pool_map_find_failed_tgts(agg_param->ap_pool_info.api_pool->sp_map, &targets,
@@ -1921,9 +1922,9 @@ agg_process_stripe(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 	/* avoid race between EC aggregation and rebuild scanner */
 	agg_param->ap_cont->sc_ec_agg_updates++;
 	if (ds_pool_is_rebuilding(agg_param->ap_cont->sc_pool->spc_pool)) {
-		D_DEBUG(DB_EPC, DF_UOID " abort as rebuild started\n", DP_UOID(entry->ae_oid));
+		rc = -DER_OP_CANCELED;
+		DL_INFO(rc, DF_UOID " abort as rebuild started", DP_UOID(entry->ae_oid));
 		update_vos = false;
-		rc         = -1;
 		goto out;
 	}
 
@@ -2556,11 +2557,12 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	 * (see obj_inflight_io_check()).
 	 */
 	if (ds_pool_is_rebuilding(agg_param->ap_pool_info.api_pool)) {
-		D_INFO(DF_CONT " abort as rebuild started, sp_rebuilding %d\n",
-		       DP_CONT(agg_param->ap_pool_info.api_pool_uuid,
-			       agg_param->ap_pool_info.api_cont_uuid),
-		       atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding));
-		return -1;
+		rc = -DER_OP_CANCELED;
+		DL_INFO(rc, DF_CONT " abort as rebuild started, sp_rebuilding %d.",
+			DP_CONT(agg_param->ap_pool_info.api_pool_uuid,
+				agg_param->ap_pool_info.api_cont_uuid),
+			atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding));
+		return rc;
 	}
 
 	switch (type) {
@@ -2584,9 +2586,9 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	}
 
 	if (rc < 0) {
-		D_ERROR(DF_UUID " EC aggregation (rebuilding %d) failed: " DF_RC "\n",
-			DP_UUID(agg_param->ap_pool_info.api_pool->sp_uuid),
-			atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding), DP_RC(rc));
+		DL_ERROR(rc, DF_UUID " EC aggregation (rebuilding %d) failed",
+			 DP_UUID(agg_param->ap_pool_info.api_pool->sp_uuid),
+			 atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding));
 		return rc;
 	}
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -43,6 +43,7 @@
 		case -DER_BUSY:                                                                    \
 		case -DER_EXIST:                                                                   \
 		case -DER_NONEXIST:                                                                \
+		case -DER_OP_CANCELED:                                                             \
 			__is_err = false;                                                          \
 			break;                                                                     \
 		}                                                                                  \
@@ -62,6 +63,7 @@
 		case -DER_BUSY:                                                                    \
 		case -DER_EXIST:                                                                   \
 		case -DER_NONEXIST:                                                                \
+		case -DER_OP_CANCELED:                                                             \
 			__is_err = false;                                                          \
 			break;                                                                     \
 		}                                                                                  \


### PR DESCRIPTION
1. lower the log level when container IV hit -DER_CONT_NONEXIST
2. refine err code returned when abort EC agg

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
