### PR TITLE
DAOS-19255 control: Translate net.ErrClosed to Fault (#18572)

### DIFF
--- a/src/control/lib/control/interceptors.go
+++ b/src/control/lib/control/interceptors.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -8,6 +9,7 @@ package control
 
 import (
 	"context"
+	"net"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -28,7 +30,8 @@ func connErrToFault(st *status.Status, target string) error {
 		return FaultConnectionRefused(target)
 	case strings.Contains(st.Message(), "connection closed"),
 		strings.Contains(st.Message(), "transport is closing"),
-		strings.Contains(st.Message(), "closed the connection"):
+		strings.Contains(st.Message(), "closed the connection"),
+		strings.Contains(st.Message(), net.ErrClosed.Error()):
 		return FaultConnectionClosed(target)
 	case strings.Contains(st.Message(), "no route to host"):
 		return FaultConnectionNoRoute(target)

--- a/src/control/lib/control/interceptors_test.go
+++ b/src/control/lib/control/interceptors_test.go
@@ -1,0 +1,74 @@
+//
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package control
+
+import (
+	"net"
+	"testing"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/security"
+)
+
+func TestControl_connErrToFault(t *testing.T) {
+	testTarget := "10.0.0.7"
+	for name, tc := range map[string]struct {
+		st     *status.Status
+		expErr error
+	}{
+		"connection refused": {
+			st:     status.New(codes.Unavailable, "connection refused"),
+			expErr: FaultConnectionRefused(testTarget),
+		},
+		"no route to host": {
+			st:     status.New(codes.Unavailable, "no route to host"),
+			expErr: FaultConnectionNoRoute(testTarget),
+		},
+		"nonexistent host": {
+			st:     status.New(codes.Unavailable, "no such host"),
+			expErr: FaultConnectionBadHost(testTarget),
+		},
+		"i/o timeout": {
+			st:     status.New(codes.Unavailable, "i/o timeout"),
+			expErr: FaultConnectionTimedOut(testTarget),
+		},
+		"certificate has expired": {
+			st:     status.New(codes.Unavailable, "certificate has expired"),
+			expErr: security.FaultInvalidCert(errors.New("certificate has expired")),
+		},
+		"connection closed": {
+			st:     status.New(codes.Unavailable, "connection closed"),
+			expErr: FaultConnectionClosed(testTarget),
+		},
+		"transport is closing": {
+			st:     status.New(codes.Unavailable, "transport is closing"),
+			expErr: FaultConnectionClosed(testTarget),
+		},
+		"closed the connection": {
+			st:     status.New(codes.Unavailable, "closed the connection"),
+			expErr: FaultConnectionClosed(testTarget),
+		},
+		"net.ErrClosed": {
+			st:     status.New(codes.Unavailable, net.ErrClosed.Error()),
+			expErr: FaultConnectionClosed(testTarget),
+		},
+		"misc error": {
+			st:     status.New(codes.Unavailable, "foobar"),
+			expErr: errors.New("foobar"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := connErrToFault(tc.st, testTarget)
+
+			test.CmpErr(t, tc.expErr, err)
+		})
+	}
+}


### PR DESCRIPTION
net.ErrClosed got past our interceptors and was being unhelpfully returned to the user.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
