### PR TITLE
DAOS-19212 object: client retry modification if TX_RESTART repeatedly - b28

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -3035,6 +3035,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	uint32_t                         max_ver = 0;
 	struct dtx_epoch                 epoch   = {0};
 	int                              rc;
+	int                              retry      = 0;
 	bool                             need_abort = false;
 
 	D_ASSERT(orw != NULL);
@@ -3248,6 +3249,17 @@ again:
 		 * old client if reply with -DER_TX_RESTART).
 		 */
 		if (orw->orw_api_flags & DAOS_COND_MASK) {
+			rc = -DER_INPROGRESS;
+			break;
+		}
+
+		/* If we have already retried once, but still failed for -DER_TX_RESTART, then
+		 * it is quite possible that the -DER_TX_RESTART failure is related with server
+		 * overload or some congestion caused RPC delay. Let's ask client to retry with
+		 * some backoff delay. That will avoid increasing server workload/congestion and
+		 * avoid client RPC timeout during server retry repeatedly.
+		 */
+		if (++retry > 1) {
 			rc = -DER_INPROGRESS;
 			break;
 		}
@@ -4023,6 +4035,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	uint32_t                         max_ver   = 0;
 	struct dtx_epoch                 epoch;
 	int                              rc;
+	int                              retry      = 0;
 	bool                             need_abort = false;
 
 	opi = crt_req_get(rpc);
@@ -4159,6 +4172,17 @@ again:
 		 * (to avoid fail old client if reply -DER_TX_RESTART).
 		 */
 		if (opi->opi_api_flags & DAOS_COND_PUNCH) {
+			rc = -DER_INPROGRESS;
+			break;
+		}
+
+		/* If we have already retried once, but still failed for -DER_TX_RESTART, then
+		 * it is quite possible that the -DER_TX_RESTART failure is related with server
+		 * overload or some congestion caused RPC delay. Let's ask client to retry with
+		 * some backoff delay. That will avoid increasing server workload/congestion and
+		 * avoid client RPC timeout during server retry repeatedly.
+		 */
+		if (++retry > 1) {
 			rc = -DER_INPROGRESS;
 			break;
 		}


### PR DESCRIPTION
On server side, when IO handler repeatedly hit -DER_TX_RESTART, then it is quite possible that the -DER_TX_RESTART failure is related with server overload or some congestion caused RPC delay. Under such case, server retry with newer epoch may increase server workload/congestion. Then let's ask client to retry with some backoff delay.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
