### PR TITLE
DAOS-18690 vos: fix engine abort in DTX commit blob fallback on ENOSPC

### DIFF
--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -806,6 +806,8 @@ pmem_tx_alloc(struct umem_instance *umm, size_t size, uint64_t flags, unsigned i
 		pflags |= POBJ_FLAG_ZERO;
 	if (flags & UMEM_FLAG_NO_FLUSH)
 		pflags |= POBJ_FLAG_NO_FLUSH;
+	if (flags & UMEM_FLAG_NO_ABORT)
+		pflags |= POBJ_XALLOC_NO_ABORT;
 	return umem_id2off(umm, pmemobj_tx_xalloc(size, type_num, pflags));
 }
 
@@ -1244,6 +1246,8 @@ bmem_tx_alloc(struct umem_instance *umm, size_t size, uint64_t flags, unsigned i
 		pflags |= DAV_FLAG_ZERO;
 	if (flags & UMEM_FLAG_NO_FLUSH)
 		pflags |= DAV_FLAG_NO_FLUSH;
+	if (flags & UMEM_FLAG_NO_ABORT)
+		pflags |= DAV_XALLOC_NO_ABORT;
 	return dav_tx_xalloc(size, type_num, pflags);
 }
 
@@ -1483,6 +1487,8 @@ bmem_tx_alloc_v2(struct umem_instance *umm, size_t size, uint64_t flags, unsigne
 		pflags |= DAV_FLAG_ZERO;
 	if (flags & UMEM_FLAG_NO_FLUSH)
 		pflags |= DAV_FLAG_NO_FLUSH;
+	if (flags & UMEM_FLAG_NO_ABORT)
+		pflags |= DAV_XALLOC_NO_ABORT;
 	if (mbkt_id != 0)
 		pflags |= DAV_EZONE_ID(mbkt_id);
 	return dav_tx_alloc_v2(size, type_num, pflags);

--- a/src/common/tests/umem_test.c
+++ b/src/common/tests/umem_test.c
@@ -360,6 +360,58 @@ done:
 	assert_int_equal(rc, 0);
 }
 
+/* A failed allocation with UMEM_FLAG_NO_ABORT must leave the transaction
+ * alive so in-tx fallbacks (e.g. vos_dtx_reuse_cmt_blob) keep working;
+ * without the flag the failure aborts the TX and any further tx_add is a
+ * fatal usage error in the allocator.
+ */
+static void
+test_alloc_no_abort(void **state)
+{
+	struct test_arg		*arg = *state;
+	struct umem_instance	*umm = utest_utx2umm(arg->ta_utx);
+	int			*value;
+	umem_off_t		 umoff = 0;
+	umem_off_t		 huge;
+	int			 rc;
+
+	rc = utest_tx_begin(arg->ta_utx);
+	if (rc != 0)
+		goto done;
+
+	/* Larger than the pool: must fail, but must NOT abort the TX */
+	huge = umem_alloc_verb(umm, UMEM_FLAG_ZERO | UMEM_FLAG_NO_ABORT,
+			       POOL_SIZE, UMEM_DEFAULT_MBKT_ID);
+	if (!UMOFF_IS_NULL(huge)) {
+		print_message("huge allocation unexpectedly succeeded\n");
+		rc = 1;
+		goto end;
+	}
+
+	/* TX still alive: alloc + snapshot + write must all work */
+	umoff = umem_zalloc(umm, 4);
+	if (UMOFF_IS_NULL(umoff)) {
+		print_message("small alloc failed after NO_ABORT failure\n");
+		rc = 1;
+		goto end;
+	}
+
+	value = umem_off2ptr(umm, umoff);
+	rc = umem_tx_add_ptr(umm, value, 4);
+	if (rc != 0) {
+		print_message("tx_add_ptr failed after NO_ABORT failure\n");
+		rc = 1;
+		goto end;
+	}
+	*value = 42;
+
+	rc = umem_free(umm, umoff);
+end:
+	rc = utest_tx_end(arg->ta_utx, rc);
+done:
+	assert_int_equal(rc, 0);
+}
+
 static int
 flush_prep(struct umem_store *store, struct umem_store_iod *iod, daos_handle_t *fh)
 {
@@ -757,6 +809,7 @@ main(int argc, char **argv)
 	    {"UMEM002: Test null flags vmem", test_invalid_flags, setup_vmem, teardown_vmem},
 	    {"UMEM003: Test alloc pmem", test_alloc, setup_pmem, teardown_pmem},
 	    {"UMEM004: Test alloc vmem", test_alloc, setup_vmem, teardown_vmem},
+	    {"UMEM010: Test alloc NO_ABORT pmem", test_alloc_no_abort, setup_pmem, teardown_pmem},
 	    {"UMEM005: Test page cache", test_page_cache, NULL, NULL},
 	    {"UMEM006: Test page cache many pages", test_many_pages, NULL, NULL},
 	    {"UMEM007: Test page cache many writes", test_many_writes, NULL, NULL},

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -681,6 +681,10 @@ struct umem_instance;
 #define UMEM_FLAG_ZERO		(((uint64_t)1) << 0)
 #define UMEM_FLAG_NO_FLUSH	(((uint64_t)1) << 1)
 #define UMEM_XADD_NO_SNAPSHOT	(((uint64_t)1) << 2)
+/* On allocation failure, return UMOFF_NULL without aborting the current
+ * transaction, so the caller can fall back to another strategy in-tx.
+ */
+#define UMEM_FLAG_NO_ABORT	(((uint64_t)1) << 3)
 
 /* Macros associated with Memory buckets */
 #define	UMEM_DEFAULT_MBKT_ID	0

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1293,8 +1293,14 @@ vos_dtx_extend_cmt_table(struct vos_container *cont)
 	umem_off_t              dbd_off = UMOFF_NULL;
 	int                     rc;
 
+	/* NO_ABORT: on ENOSPC the fallback below (vos_dtx_reuse_cmt_blob)
+	 * keeps working inside the same transaction; a plain alloc failure
+	 * would have aborted the tx and any further tx_add would be a fatal
+	 * usage error in the allocator (engine abort).
+	 */
 	if (!DAOS_FAIL_CHECK(DAOS_DTX_NOSPACE_NOREFRESH))
-		dbd_off = umem_zalloc(umm, DTX_CMT_BLOB_SIZE);
+		dbd_off = umem_alloc_verb(umm, UMEM_FLAG_ZERO | UMEM_FLAG_NO_ABORT,
+					  DTX_CMT_BLOB_SIZE, UMEM_DEFAULT_MBKT_ID);
 
 	if (UMOFF_IS_NULL(dbd_off))
 		return vos_dtx_reuse_cmt_blob(cont);


### PR DESCRIPTION
## Summary

**Regression introduced by PR #18141 (DAOS-18690 "vos: handle DTX commit under space pressure", commit b36dd7b06, 2026-05-14) — master only.** Release branches (2.6.x/2.8) are not affected: their `vos_dtx_commit_internal()` returns `-DER_NOSPACE` directly on blob allocation failure without touching the aborted TX.


When the pool is physically full (ENOSPC), extending the DTX **committed** table during a punch/update commit crashes the whole engine with SIGABRT.

`vos_dtx_extend_cmt_table()` allocates a new commit blob with `umem_zalloc()`. On allocation failure it falls back to `vos_dtx_reuse_cmt_blob()` **inside the same transaction**. However, all three allocator backends (pmemobj, dav, dav_v2) **abort the transaction automatically** when a tx alloc fails (no `*_NO_ABORT` flag is passed by the umem wrappers). The fallback then calls `umem_tx_add_ptr()` / `dbtree_delete()` on the aborted TX, which is a fatal usage error in the allocator:

```
ERR  pmdk pmdk/src/common/set.c:2260 util_pool_extend() extending the pool by appending parts with headers is not supported!
ERR  pmdk pmdk/tx.c:618 tx_alloc_common() out of memory
CRIT pmdk pmdk/tx.c:1403 pmemobj_tx_add_range_direct() pmemobj_tx_add_range_direct called in invalid stage 3
ERR  *** Process 1551736 (daos_engine) received signal 6 (Aborted) ***
```

Backtrace (master, commit ~f6b827e3e):

```
pmemobj_tx_add_range_direct
libdaos_common_pmem.so(+0x2979f)            # umem_tx_add_ptr
libvos_srv.so(+0x9ca53)                     # vos_dtx_* (reuse/commit path)
vos_dtx_commit_internal+0xf91
vos_dtx_prepared+0xb7d
vos_tx_end+0x5fe
vos_obj_punch+0x263
ds_obj_punch_handler+0x840
```

## Why CI doesn't catch it

The reuse-blob fallback is exercised in tests via the `DAOS_DTX_NOSPACE_NOREFRESH` fail-check, which **skips the allocation entirely** — the TX stays alive, so the fallback works. A real ENOSPC allocation failure aborts the TX first, which the fail-check path never reproduces.

## Reproduction

1. Small pool (tested: 400 MB tmpfs SCM, 2 targets, master build).
2. Fill the pool to ENOSPC via POSIX container (dd through dfuse).
3. Run a create/unlink storm (a few hundred small files) so punch DTX commits force `vos_dtx_extend_cmt_table()` while the pool is full.
4. Engine aborts within seconds (`invalid stage 3` + SIGABRT). A pool-full production system can be taken down by any client issuing unlinks.

## Suggested fix (verified)

Add a `UMEM_FLAG_NO_ABORT` alloc flag, map it to `POBJ_XALLOC_NO_ABORT` / `DAV_XALLOC_NO_ABORT` in the pmem/dav/dav_v2 backends, and use it for the commit-blob allocation in `vos_dtx_extend_cmt_table()` so the TX survives the failure and the reuse fallback can run as designed:

- `src/include/daos/mem.h`: `#define UMEM_FLAG_NO_ABORT (((uint64_t)1) << 2)`
- `src/common/mem.c`: `pmem_tx_alloc()` → `POBJ_XALLOC_NO_ABORT`, `bmem_tx_alloc()`/`bmem_tx_alloc_v2()` → `DAV_XALLOC_NO_ABORT`
- `src/vos/vos_dtx.c` `vos_dtx_extend_cmt_table()`:
  `umem_zalloc(umm, DTX_CMT_BLOB_SIZE)` → `umem_alloc_verb(umm, UMEM_FLAG_ZERO | UMEM_FLAG_NO_ABORT, DTX_CMT_BLOB_SIZE, UMEM_DEFAULT_MBKT_ID)`

With this patch the same reproduction survives: unlink storms on a full pool return `-DER_NOSPACE` cleanly and the engine stays up (verified on tmpfs SCM/pmemobj backend; dav paths compile-verified only).



---
Note: filed as a PR because GitHub issues are disabled on this repo; happy to file a Jira ticket as well if preferred.

---
**Update (2026-07-04):**
- `UMEM_FLAG_NO_ABORT` moved to `1 << 3` to avoid sharing a bit with `UMEM_XADD_NO_SNAPSHOT` (`1 << 2`) in the same flags namespace.
- Added a umem regression test (**UMEM010**): a failed `UMEM_FLAG_NO_ABORT` allocation must leave the TX alive so a subsequent alloc/`umem_tx_add_ptr()`/commit succeeds — this covers the TX-abort path that the `DAOS_DTX_NOSPACE_NOREFRESH` fail-check cannot reproduce. Passes 10/10 locally (pmem backend on tmpfs needs `PMEMOBJ_CONF=sds.at_create=0`).
- Clarified in the commit message that the failing allocation is a plain (non-NO_ABORT) alloc inside the regular `vos_tx_begin()` object transaction, whose failure behavior is left at the default (abort) rather than `TX_FAILURE_RETURN`.
