### PR TITLE
DAOS-19279 ci: disable GHA unit-testing.yml

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -11,7 +11,8 @@ concurrency:
 
 jobs:
   Run_in_docker:
-    if: github.repository == 'daos-stack/daos'
+    if: false  # Disabled because we do not have self-hosted runners
+    # if: github.repository == 'daos-stack/daos'
     runs-on: [self-hosted, docker]
     steps:
       - name: Checkout code

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -1,7 +1,7 @@
 name: Unit testing
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 permissions: {}
 
@@ -11,8 +11,7 @@ concurrency:
 
 jobs:
   Run_in_docker:
-    if: false  # Disabled because we do not have self-hosted runners
-    # if: github.repository == 'daos-stack/daos'
+    if: github.repository == 'daos-stack/daos'
     runs-on: [self-hosted, docker]
     steps:
       - name: Checkout code


### PR DESCRIPTION
Disable unit-testing.yml since we do not have self-hosted runners.

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
