### PR TITLE
DAOS-18982 test: increase dfuse/fio_small timeout

### DIFF
--- a/src/tests/ftest/dfuse/fio_small.yaml
+++ b/src/tests/ftest/dfuse/fio_small.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 2
   test_clients: 1
 
-timeout: 360
+timeout: 540
 
 server_config:
   name: daos_server
@@ -20,8 +20,8 @@ server_config:
       storage: auto
 
 pool:
-  scm_size: 2G
-  nvme_size: 20G
+  scm_size: 4G
+  nvme_size: 40G
 
 container:
   type: POSIX


### PR DESCRIPTION
Increase dfuse/fio_small timeout from 360 -> 420.

Test-tag: FioSmall
Test-repeat: 3
Skip-Functional-on-EL-9: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
