### PR TITLE
DAOS-19244 packaging: create /var/daos writable by daos_server

### DIFF
--- a/utils/rpms/daos.changelog
+++ b/utils/rpms/daos.changelog
@@ -1,6 +1,6 @@
 %changelog
 * Wed Jul 08 2026 Michael Hennecke <michael.hennecke@hpe.com> 2.9.100-5
-- Add a /var/daos directory writeable for daos_server
+- Add a /var/daos directory writable for daos_server
 
 * Mon May 04 2026 Cedric Koch-Hofer <cedric.koch-hofer@hpe.com> 2.9.100-4
 - Add gperftools-devel as a build dependency of daos-devel

--- a/utils/rpms/daos.changelog
+++ b/utils/rpms/daos.changelog
@@ -1,4 +1,7 @@
 %changelog
+* Wed Jul 08 2026 Michael Hennecke <michael.hennecke@hpe.com> 2.9.100-5
+- Add a /var/daos directory writeable for daos_server
+
 * Mon May 04 2026 Cedric Koch-Hofer <cedric.koch-hofer@hpe.com> 2.9.100-4
 - Add gperftools-devel as a build dependency of daos-devel
 

--- a/utils/rpms/daos.sh
+++ b/utils/rpms/daos.sh
@@ -19,6 +19,7 @@ daoshome="${prefix}/lib/daos"
 server_svc_name="daos_server.service"
 agent_svc_name="daos_agent.service"
 sysctl_script_name="10-daos_server.conf"
+daos_sys_dir="/var/daos"
 daos_log_dir="/var/log/daos"
 
 VERSION=${daos_version}
@@ -157,6 +158,12 @@ getent group daos_metrics >/dev/null || groupadd -r daos_metrics
 getent group daos_server >/dev/null || groupadd -r daos_server
 getent group daos_daemons >/dev/null || groupadd -r daos_daemons
 getent passwd daos_server >/dev/null || useradd -s /sbin/nologin -r -g daos_server -G daos_metrics,daos_daemons daos_server
+# Ensure daos_sys_dir exists
+if [ ! -d ${daos_sys_dir} ]; then
+    mkdir -p ${daos_sys_dir}
+    chown daos_server:daos_daemons ${daos_sys_dir}
+    chmod 775 ${daos_sys_dir}
+fi
 # Ensure daos_log_dir exists
 if [ ! -d ${daos_log_dir} ]; then
     mkdir -p ${daos_log_dir}

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -14,6 +14,7 @@
 %global mercury_version   2.4
 %global argobots_version 1.2
 %global __python %{__python3}
+%global daos_sys_dir "/var/daos"
 %global daos_log_dir "/var/log/daos"
 
 %if (0%{?rhel} >= 8)
@@ -24,7 +25,7 @@
 
 Name:          daos
 Version:       2.9.100
-Release:       4%{?relval}%{?dist}
+Release:       5%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -407,6 +408,12 @@ getent group daos_metrics >/dev/null || groupadd -r daos_metrics
 getent group daos_server >/dev/null || groupadd -r daos_server
 getent group daos_daemons >/dev/null || groupadd -r daos_daemons
 getent passwd daos_server >/dev/null || useradd -s /sbin/nologin -r -g daos_server -G daos_metrics,daos_daemons daos_server
+# Ensure daos_sys_dir exists
+if [ ! -d %{daos_sys_dir} ]; then
+    mkdir -p %{daos_sys_dir}
+    chown daos_server:daos_daemons %{daos_sys_dir}
+    chmod 775 %{daos_sys_dir}
+fi
 # Ensure daos_log_dir exists
 if [ ! -d %{daos_log_dir} ]; then
     mkdir -p %{daos_log_dir}


### PR DESCRIPTION
Add a /var/daos directory that is writable for daos_server, which can then be used as a persistent location for control_meta and the mountpounts for the SCM/tmpfs filesystems (which should not be placed into /tmp).