### PR TITLE
DAOS-19212 container: check container before creating cont_track_eph_…

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -3519,8 +3519,9 @@ crt_iv_update_internal(crt_iv_namespace_t ivns, uint32_t class_id,
 
 		D_GOTO(exit, rc);
 	} else {
-		DL_CDEBUG(rc == -DER_NONEXIST || rc == -DER_NOTLEADER || rc == -DER_BUSY, DB_TRACE,
-			  DLOG_ERR, rc, "ivo_on_update failed");
+		DL_CDEBUG(rc == -DER_NONEXIST || rc == -DER_CONT_NONEXIST || rc == -DER_NOTLEADER ||
+			      rc == -DER_BUSY,
+			  DB_TRACE, DLOG_ERR, rc, "ivo_on_update failed");
 
 		update_comp_cb(ivns, class_id, iv_key, NULL,
 			       iv_value, rc, cb_arg);

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -732,8 +732,8 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 
 out:
 	if (rc < 0 && rc != -DER_IVCB_FORWARD)
-		DL_CDEBUG(rc == -DER_NONEXIST || rc == -DER_NOTLEADER, DB_ANY, DLOG_ERR, rc,
-			  "failed to insert");
+		DL_CDEBUG(rc == -DER_NONEXIST || rc == -DER_CONT_NONEXIST || rc == -DER_NOTLEADER,
+			  DB_ANY, DLOG_ERR, rc, "failed to insert");
 
 	return rc;
 }
@@ -867,8 +867,8 @@ cont_iv_update(void *ns, int class_id, uuid_t key_uuid,
 	civ_key->entry_size = cont_iv_len;
 	rc = ds_iv_update(ns, &key, &sgl, shortcut, sync_mode, 0, retry);
 	if (rc)
-		DL_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_NONEXIST, DB_ANY, DLOG_ERR, rc,
-			  DF_UUID " iv update failed", DP_UUID(key_uuid));
+		DL_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_NONEXIST || rc == -DER_CONT_NONEXIST,
+			  DB_ANY, DLOG_ERR, rc, DF_UUID " iv update failed", DP_UUID(key_uuid));
 
 	return rc;
 }
@@ -1151,8 +1151,8 @@ cont_iv_track_eph_update_internal(void *ns, uuid_t cont_uuid, daos_epoch_t ec_ag
 	rc = cont_iv_update(ns, op, cont_uuid, &iv_entry, sizeof(iv_entry), shortcut, sync_mode,
 			    false);
 	if (rc && !cont_iv_retryable_error(rc))
-		D_ERROR(DF_UUID" op %d, cont_iv_update failed "DF_RC"\n",
-			DP_UUID(cont_uuid), op, DP_RC(rc));
+		DL_CDEBUG(rc == -DER_CONT_NONEXIST || rc == -DER_NONEXIST, DB_ANY, DLOG_ERR, rc,
+			  DF_UUID " op %d, cont_iv_update failed", DP_UUID(cont_uuid), op);
 	return rc;
 }
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1857,7 +1857,9 @@ ds_cont_leader_update_track_eph(uuid_t pool_uuid, uuid_t cont_uuid, d_rank_t ran
 				daos_epoch_t ec_agg_eph, daos_epoch_t stable_eph)
 {
 	struct cont_svc			*svc;
+	struct rdb_tx                    tx;
 	struct cont_track_eph_leader	*eph_ldr;
+	struct cont                     *cont = NULL;
 	int				 rc;
 	bool				 retried = false;
 	int				 i;
@@ -1869,6 +1871,22 @@ ds_cont_leader_update_track_eph(uuid_t pool_uuid, uuid_t cont_uuid, d_rank_t ran
 retry:
 	eph_ldr = cont_track_eph_leader_lookup(svc, cont_uuid);
 	if (eph_ldr == NULL) {
+		/* check container's existence before creating cont_track_eph_leader */
+		rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+		if (rc != 0)
+			D_GOTO(out_put, rc);
+
+		ABT_rwlock_rdlock(svc->cs_lock);
+		rc = cont_lookup(&tx, svc, cont_uuid, &cont);
+		ABT_rwlock_unlock(svc->cs_lock);
+		rdb_tx_end(&tx);
+		if (rc != 0) {
+			DL_CDEBUG(rc == -DER_NONEXIST, DB_MD, DLOG_ERR, rc,
+				  DF_CONT " cont_lookup failed", DP_CONT(pool_uuid, cont_uuid));
+			D_GOTO(out_put, rc);
+		}
+		cont_put(cont);
+
 		rc = cont_track_eph_leader_alloc(svc, cont_uuid, &eph_ldr);
 		if (rc)
 			D_GOTO(out_put, rc);

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -2020,7 +2020,7 @@ ds_cont_tgt_refresh_track_eph(uuid_t pool_uuid, uuid_t cont_uuid,
 	rc = ds_pool_thread_collective(
 	    pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
 	    cont_refresh_track_eph_one, &arg, DSS_ULT_DEEP_STACK | DSS_ULT_FL_PERIODIC);
-	DL_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG, rc,
+	DL_CDEBUG(rc != 0 && rc != -DER_CONT_NONEXIST && rc != -DER_NONEXIST, DLOG_ERR, DB_MD, rc,
 		  DF_CONT ": refresh ec_agg_eph " DF_X64 ", "
 			  "stable_eph " DF_X64,
 		  DP_CONT(pool_uuid, cont_uuid), ec_agg_eph, stable_eph);
@@ -2294,8 +2294,8 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 					       min_ec_agg_eph, min_stable_eph,
 					       svc->cs_cont_ephs_leader_req);
 		if (rc) {
-			DL_CDEBUG(rc == -DER_NONEXIST, DLOG_INFO, DLOG_ERR, rc,
-				  DF_CONT ": refresh failed",
+			DL_CDEBUG(rc == -DER_CONT_NONEXIST || rc == -DER_NONEXIST, DB_MD, DLOG_ERR,
+				  rc, DF_CONT ": refresh failed",
 				  DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid));
 
 			/* If ULT is exiting, break out */

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1887,9 +1887,12 @@ retry:
 		}
 		cont_put(cont);
 
-		rc = cont_track_eph_leader_alloc(svc, cont_uuid, &eph_ldr);
-		if (rc)
-			D_GOTO(out_put, rc);
+		eph_ldr = cont_track_eph_leader_lookup(svc, cont_uuid);
+		if (eph_ldr == NULL) {
+			rc = cont_track_eph_leader_alloc(svc, cont_uuid, &eph_ldr);
+			if (rc)
+				D_GOTO(out_put, rc);
+		}
 	}
 
 	for (i = 0; i < eph_ldr->cte_servers_num; i++) {

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1929,7 +1929,7 @@ retry:
 
 out_put:
 	cont_svc_put_leader(svc);
-	return 0;
+	return rc;
 }
 
 #define EPH_ARG_TGT_INLINE	(64)

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -681,7 +681,8 @@ ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 	rc = cont_svc_lookup_leader(pool_uuid, 0, &svc, NULL);
 	if (rc != 0) {
-		DL_ERROR(rc, "pool " DF_UUID " cont_svc_lookup_leader failed", DP_UUID(pool_uuid));
+		DL_CDEBUG(rc == -DER_NOTLEADER, DB_MD, DLOG_ERR, rc,
+			  "pool " DF_UUID " cont_svc_lookup_leader failed", DP_UUID(pool_uuid));
 		return rc;
 	}
 

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -2875,9 +2875,10 @@ ds_cont_eph_report(struct ds_pool *pool)
 			ec_eph->cte_last_ec_agg_epoch = min_ec_agg_eph;
 			ec_eph->cte_last_stable_epoch = min_stable_eph;
 		} else {
-			DL_ERROR(ret, DF_CONT ": Failed to update EC agg report IV.",
-				 DP_CONT(pool->sp_uuid, ec_eph->cte_cont_uuid));
 			rc = ret;
+			DL_CDEBUG(rc == -DER_CONT_NONEXIST || rc == -DER_NONEXIST, DB_MD, DLOG_ERR,
+				  rc, DF_CONT ": Failed to update EC agg report IV.",
+				  DP_CONT(pool->sp_uuid, ec_eph->cte_cont_uuid));
 		}
 	}
 	D_FREE(failed_tgts);

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1221,8 +1221,10 @@ eph_report_ult(void *data)
 		/* Report EC agg epoch boundary */
 		rc = ds_cont_eph_report(pool);
 		if (rc) {
-			DL_ERROR(rc, "Failed to report EC agg epoch.");
-			sleep_intvl = EPH_REPORT_RETRY_INTVL;
+			DL_CDEBUG(rc == -DER_CONT_NONEXIST || rc == -DER_NONEXIST, DB_MD, DLOG_ERR,
+				  rc, "Failed to report EC agg epoch.");
+			if (rc != -DER_CONT_NONEXIST && rc != -DER_NONEXIST)
+				sleep_intvl = EPH_REPORT_RETRY_INTVL;
 		}
 
 		if (eph_report_exiting(pool))


### PR DESCRIPTION
…leader

In ds_cont_leader_update_track_eph(), check container's existence before creating cont_track_eph_leader. Because for orphan container case the other engine possibly reports its track_eph to leader, leader should check container's valid in that case.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
