### PR TITLE
DAOS-19212 container: check container before creating cont_track_eph_…

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1857,7 +1857,9 @@ ds_cont_leader_update_track_eph(uuid_t pool_uuid, uuid_t cont_uuid, d_rank_t ran
 				daos_epoch_t ec_agg_eph, daos_epoch_t stable_eph)
 {
 	struct cont_svc			*svc;
+	struct rdb_tx                    tx;
 	struct cont_track_eph_leader	*eph_ldr;
+	struct cont                     *cont = NULL;
 	int				 rc;
 	bool				 retried = false;
 	int				 i;
@@ -1869,6 +1871,22 @@ ds_cont_leader_update_track_eph(uuid_t pool_uuid, uuid_t cont_uuid, d_rank_t ran
 retry:
 	eph_ldr = cont_track_eph_leader_lookup(svc, cont_uuid);
 	if (eph_ldr == NULL) {
+		/* check container's existence before creating cont_track_eph_leader */
+		rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+		if (rc != 0)
+			D_GOTO(out_put, rc);
+
+		ABT_rwlock_rdlock(svc->cs_lock);
+		rc = cont_lookup(&tx, svc, cont_uuid, &cont);
+		ABT_rwlock_unlock(svc->cs_lock);
+		rdb_tx_end(&tx);
+		if (rc != 0) {
+			DL_CDEBUG(rc == -DER_NONEXIST, DB_MD, DLOG_ERR, rc,
+				  DF_CONT " cont_lookup failed", DP_CONT(pool_uuid, cont_uuid));
+			D_GOTO(out_put, rc);
+		}
+		cont_put(cont);
+
 		rc = cont_track_eph_leader_alloc(svc, cont_uuid, &eph_ldr);
 		if (rc)
 			D_GOTO(out_put, rc);

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1887,9 +1887,12 @@ retry:
 		}
 		cont_put(cont);
 
-		rc = cont_track_eph_leader_alloc(svc, cont_uuid, &eph_ldr);
-		if (rc)
-			D_GOTO(out_put, rc);
+		eph_ldr = cont_track_eph_leader_lookup(svc, cont_uuid);
+		if (eph_ldr == NULL) {
+			rc = cont_track_eph_leader_alloc(svc, cont_uuid, &eph_ldr);
+			if (rc)
+				D_GOTO(out_put, rc);
+		}
 	}
 
 	for (i = 0; i < eph_ldr->cte_servers_num; i++) {

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1929,7 +1929,7 @@ retry:
 
 out_put:
 	cont_svc_put_leader(svc);
-	return 0;
+	return rc;
 }
 
 #define EPH_ARG_TGT_INLINE	(64)

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -681,7 +681,8 @@ ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 	rc = cont_svc_lookup_leader(pool_uuid, 0, &svc, NULL);
 	if (rc != 0) {
-		DL_ERROR(rc, "pool " DF_UUID " cont_svc_lookup_leader failed", DP_UUID(pool_uuid));
+		DL_CDEBUG(rc == -DER_NOTLEADER, DB_MD, DLOG_ERR, rc,
+			  "pool " DF_UUID " cont_svc_lookup_leader failed", DP_UUID(pool_uuid));
 		return rc;
 	}
 

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -2875,9 +2875,10 @@ ds_cont_eph_report(struct ds_pool *pool)
 			ec_eph->cte_last_ec_agg_epoch = min_ec_agg_eph;
 			ec_eph->cte_last_stable_epoch = min_stable_eph;
 		} else {
-			DL_ERROR(ret, DF_CONT ": Failed to update EC agg report IV.",
-				 DP_CONT(pool->sp_uuid, ec_eph->cte_cont_uuid));
 			rc = ret;
+			DL_CDEBUG(rc == -DER_CONT_NONEXIST || rc == -DER_NONEXIST, DB_MD, DLOG_ERR,
+				  rc, DF_CONT ": Failed to update EC agg report IV.",
+				  DP_CONT(pool->sp_uuid, ec_eph->cte_cont_uuid));
 		}
 	}
 	D_FREE(failed_tgts);

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1221,8 +1221,10 @@ eph_report_ult(void *data)
 		/* Report EC agg epoch boundary */
 		rc = ds_cont_eph_report(pool);
 		if (rc) {
-			DL_ERROR(rc, "Failed to report EC agg epoch.");
-			sleep_intvl = EPH_REPORT_RETRY_INTVL;
+			DL_CDEBUG(rc == -DER_CONT_NONEXIST || rc == -DER_NONEXIST, DB_MD, DLOG_ERR,
+				  rc, "Failed to report EC agg epoch.");
+			if (rc != -DER_CONT_NONEXIST && rc != -DER_NONEXIST)
+				sleep_intvl = EPH_REPORT_RETRY_INTVL;
 		}
 
 		if (eph_report_exiting(pool))


### PR DESCRIPTION
…leader

In ds_cont_leader_update_track_eph(), check container's existence before creating cont_track_eph_leader. Because for orphan container case the other engine possibly reports its track_eph to leader, leader should check container's valid in that case.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
