### PR TITLE
DAOS-19028 test: REBUILD29 use more precise timing (#18546)

### DIFF
--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1333,10 +1333,15 @@ rebuild_kill_rank_during_rebuild(void **state)
 static void
 rebuild_kill_PS_leader_during_rebuild(void **state)
 {
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	d_rank_t	leader;
-	int		i;
+	test_arg_t   *arg = *state;
+	daos_obj_id_t oids[OBJ_NR];
+	d_rank_t      leader;
+	d_rank_t      non_leader;
+	int           i;
+
+	par_barrier(PAR_COMM_WORLD);
+	if (arg->myrank != 0)
+		return;
 
 	if (!test_runable(arg, 7) || arg->pool.alive_svc->rl_nr < 5) {
 		print_message("need at least 5 svcs, -s5\n");
@@ -1350,25 +1355,30 @@ rebuild_kill_PS_leader_during_rebuild(void **state)
 		oids[i] = dts_oid_set_rank(oids[i], 6);
 	}
 	rebuild_io(arg, oids, OBJ_NR);
+	non_leader = leader != 6 ? 6 : 5;
+	print_message("leader=%u non_leader=%u pre_rs_version=%u pre_pool_ver=%u\n", leader,
+		      non_leader, arg->pool.pool_info.pi_rebuild_st.rs_version,
+		      arg->pool.pool_info.pi_map_ver);
 
 	/* kill non-leader rank */
-	if (leader != 6)
-		daos_kill_server(arg, arg->pool.pool_uuid, arg->group,
-				 arg->pool.alive_svc, 6);
-	else
-		daos_kill_server(arg, arg->pool.pool_uuid, arg->group,
-				 arg->pool.alive_svc, 5);
-	/* hang the rebuild */
-	if (arg->myrank == 0) {
-		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
-				      DAOS_REBUILD_TGT_SCAN_HANG, 0, NULL);
-		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_VALUE, 5,
-				      0, NULL);
-	}
-	sleep(2);
+	print_message("killing non-leader rank=%u to trigger first rebuild\n", non_leader);
+	daos_kill_server(arg, arg->pool.pool_uuid, arg->group, arg->pool.alive_svc, non_leader);
+
+	/* Wait for the first rebuild to start scanning */
+	test_rebuild_wait_to_scanning_next(&arg, 1);
+	print_message("first rebuild started: rs_version=%u state=%d errno=%d tobe_obj=" DF_U64
+		      " rebuilt_obj=" DF_U64 "\n",
+		      arg->pool.pool_info.pi_rebuild_st.rs_version,
+		      arg->pool.pool_info.pi_rebuild_st.rs_state,
+		      arg->pool.pool_info.pi_rebuild_st.rs_errno,
+		      arg->pool.pool_info.pi_rebuild_st.rs_toberb_obj_nr,
+		      arg->pool.pool_info.pi_rebuild_st.rs_obj_nr);
+
+	print_message("killing PS leader rank=%u during active first rebuild\n", leader);
 	rebuild_single_pool_rank(arg, leader, true);
 
 	sleep(5);
+	print_message("restart/reintegrate previous PS leader rank=%u\n", leader);
 	reintegrate_single_pool_rank(arg, leader, true);
 }
 

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -423,6 +423,8 @@ test_rebuild_wait_to_start(test_arg_t **args, int args_cnt);
 void
 test_rebuild_wait_to_start_next(test_arg_t **args, int args_cnt);
 void
+test_rebuild_wait_to_scanning_next(test_arg_t **args, int args_cnt);
+void
 test_rebuild_wait_to_start_lower(test_arg_t **args, int args_cnt);
 void
     test_rebuild_wait_to_error(test_arg_t **args, int args_cnt);

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -882,6 +882,42 @@ rebuild_pool_started_after_ver(test_arg_t *arg, uint32_t rs_version)
 	}
 }
 
+/* Determine if pool rebuild has started scanning and rebuild version > rs_version */
+static bool
+rebuild_pool_scanning_after_ver(test_arg_t *arg, uint32_t rs_version)
+{
+	daos_pool_info_t            pinfo = {0};
+	struct daos_rebuild_status *rst;
+	int                         rc;
+
+	pinfo.pi_bits = DPI_REBUILD_STATUS;
+	rc            = test_pool_get_info(arg, &pinfo, NULL /* engine_ranks */);
+	rst           = &pinfo.pi_rebuild_st;
+
+	if (rc != 0) {
+		print_message("pool query for rebuild status failed, rc=%d, pool " DF_UUIDF "\n",
+			      rc, DP_UUID(arg->pool.pool_uuid));
+		return false;
+	} else {
+		bool in_progress   = (rst->rs_state == DRS_IN_PROGRESS);
+		bool ver_advanced  = (rst->rs_version > rs_version);
+		bool scanning_seen = (rst->rs_toberb_obj_nr > 0);
+
+		print_message("rebuild for pool " DF_UUIDF
+			      " state=%d rs_version=%u (waiting for > %u), tobe_obj=" DF_U64
+			      " (waiting for > 0)\n",
+			      DP_UUID(arg->pool.pool_uuid), rst->rs_state, rst->rs_version,
+			      rs_version, rst->rs_toberb_obj_nr);
+
+		if (in_progress && ver_advanced && scanning_seen) {
+			/* save final pool query info to be able to inspect rebuild status */
+			memcpy(&arg->pool.pool_info, &pinfo, sizeof(pinfo));
+			return true;
+		}
+		return false;
+	}
+}
+
 /* Determine if pool rebuild is busy, and the rebuild version is < rs_version */
 static bool
 rebuild_pool_started_before_ver(test_arg_t *arg, uint32_t rs_version)
@@ -1052,6 +1088,24 @@ test_rebuild_started_after(test_arg_t **args, int args_cnt, uint32_t *cur_versio
 	return all_started;
 }
 
+static bool
+test_rebuild_scanning_after(test_arg_t **args, int args_cnt, uint32_t *cur_versions)
+{
+	bool all_scanning = true;
+	int  i;
+
+	for (i = 0; i < args_cnt; i++) {
+		bool scanning = true;
+
+		if (!args[i]->pool.destroyed)
+			scanning = rebuild_pool_scanning_after_ver(args[i], cur_versions[i]);
+
+		if (!scanning)
+			all_scanning = false;
+	}
+	return all_scanning;
+}
+
 /* wait until pools start rebuilds with rs_version < current (e.g.,. expecting op:Fail_reclaim) */
 void
 test_rebuild_wait_to_start_lower(test_arg_t **args, int args_cnt)
@@ -1086,6 +1140,27 @@ test_rebuild_wait_to_start_next(test_arg_t **args, int args_cnt)
 		cur_versions[i] = args[i]->pool.pool_info.pi_rebuild_st.rs_version;
 
 	while (!test_rebuild_started_after(args, args_cnt, cur_versions))
+		sleep(2);
+
+	/* NB: when control reaches here, each pool's current rs_version has been updated
+	 * (for subsequent calls that will rely on it as a baseline)
+	 */
+	D_FREE(cur_versions);
+}
+
+/* wait until pools start rebuilds with rs_version > current and scanning activity is observed */
+void
+test_rebuild_wait_to_scanning_next(test_arg_t **args, int args_cnt)
+{
+	uint32_t *cur_versions;
+	int       i;
+
+	D_ALLOC_ARRAY(cur_versions, args_cnt);
+	assert_true(cur_versions != NULL);
+	for (i = 0; i < args_cnt; i++)
+		cur_versions[i] = args[i]->pool.pool_info.pi_rebuild_st.rs_version;
+
+	while (!test_rebuild_scanning_after(args, args_cnt, cur_versions))
 		sleep(2);
 
 	/* NB: when control reaches here, each pool's current rs_version has been updated


### PR DESCRIPTION
Before this change, rebuild_kill_PS_leader_during_rebuild() killed a non-leader engine and immediately (tried to) inject fault DAOS_REBUILD_TGT_SCAN_HANG on "all engines". This fault injection itself suffered RPC timeouts due to the killed engine. This further affected the test's overall timing, contradicting the goal of killing the PS leader engine during the first rebuild.

With this change, the test no longer uses fault injection. Instead it waits for the first rebuild to start *and* demonstrate evidence of scanning activity (rs_toberb_obj_nr > 0). This is accomplished using a new common function test_rebuild_wait_to_scanning_next() that waits for both the rs_version (pool map version) to increment and the to-be-rebuilt number of objects to become nonzero.

Test-repeat: 10
Test-tag: test_rebuild_29
Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-test-rpms: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
