### PR TITLE
DAOS-19291 test: pin ftest setuptools<82

### DIFF
--- a/requirements-ftest.txt
+++ b/requirements-ftest.txt
@@ -2,6 +2,7 @@ avocado-framework==82
 avocado-framework-plugin-result-html==82
 avocado-framework-plugin-varianter-yaml-to-mux==82
 clustershell
-paramiko
 distro
+paramiko
+setuptools<82
 torch


### PR DESCRIPTION
Pin setuptools<82 since v82 remove pkg_resources, which we are still using.

Test-tag: always_passes,vm
Skip-unit-tests: true
Skip-fault-injection-test: true
skip-functional-test-hardware: true
Priority: 2

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
