### PR TITLE
DAOS-19289 build: run ldconfig on client post install

### DIFF
--- a/utils/rpms/daos.sh
+++ b/utils/rpms/daos.sh
@@ -310,23 +310,33 @@ if [ ! -d ${daos_log_dir} ]; then
     chmod 775 ${daos_log_dir}
 fi
 EOF
+chmod +x "${tmp}/pre_install_client"
 EXTRA_OPTS+=("--before-install" "${tmp}/pre_install_client")
 
 cat << EOF  > "${tmp}/post_install_client"
+#!/bin/bash
+set -x
+ldconfig
 systemctl --no-reload preset daos_agent.service  &>/dev/null || :
 EOF
+chmod +x "${tmp}/post_install_client"
 EXTRA_OPTS+=("--after-install" "${tmp}/post_install_client")
 
 cat << EOF  > "${tmp}/pre_uninstall_client"
 systemctl --no-reload disable --now daos_agent.service >& /dev/null || :
 EOF
+chmod +x "${tmp}/pre_uninstall_client"
 EXTRA_OPTS+=("--before-remove" "${tmp}/pre_uninstall_client")
 
 if [[ "${DISTRO:-el8}" =~ suse ]]; then
   cat << EOF  > "${tmp}/post_uninstall_client"
+#!/bin/bash
+set -x
+ldconfig
 rm -f "/var/lib/systemd/migrated/daos_agent.service" || :
 /usr/bin/systemctl daemon-reload || :
 EOF
+  chmod +x "${tmp}/post_uninstall_client"
   EXTRA_OPTS+=("--after-remove" "${tmp}/post_uninstall_client")
 fi
 


### PR DESCRIPTION
Run ldconfig on daos-client post install and uninstall. This fixes issues where other packages run ldconfig between daos-client installs and break the linkage. See DAOS-19289 for more details.

Skip-Functional-on-Leap-15: false
Allow-unstable-test: true
Priority: 2

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
