### PR TITLE
DAOS-16759 test: DO NOT LAND

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -433,7 +433,7 @@ grp_uri_cache_set(struct crt_grp_priv *grp_priv, d_rank_t rank, int tag, const c
 				       &ui->ui_link,
 				       true /* exclusive */);
 		if (rc != 0) {
-			D_ERROR("Entry already present\n");
+			D_ERROR("Entry for rank=%d already present\n", rank);
 
 			if (crt_provider_is_contig_ep(provider)) {
 				for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++)
@@ -759,6 +759,7 @@ crt_grp_hg_addr_cache_insert(struct crt_grp_priv *passed_grp_priv, struct crt_co
 	struct crt_grp_priv	*grp_priv;
 	int			 ctx_idx;
 	int			 rc = 0;
+	bool                     need_decref = false;
 	uint32_t                 key;
 
 	D_ASSERT(crt_ctx != NULL);
@@ -795,12 +796,30 @@ crt_grp_hg_addr_cache_insert(struct crt_grp_priv *passed_grp_priv, struct crt_co
 		li->li_rank        = rank;
 		li->li_tag         = tag;
 		li->li_initialized = 1;
-	}
 
-	li = crt_li_link2ptr(rlink);
-	D_ASSERT(li->li_rank == rank);
-	D_ASSERT(li->li_tag == tag);
-	D_ASSERT(li->li_initialized != 0);
+		rc = d_hash_rec_insert(&grp_priv->gp_lookup_cache[ctx_idx], &key, sizeof(key),
+				       &li->li_link, true /* exclusive */);
+		if (rc != 0) {
+			D_DEBUG(DB_TRACE,
+				"entry already exists in lookup "
+				"table, grp_priv %p ctx_idx %d, rank: %d.\n",
+				grp_priv, ctx_idx, rank);
+			crt_li_destroy(li);
+			rc = 0;
+		} else {
+			D_DEBUG(DB_TRACE,
+				"Filling in URI in lookup table. "
+				" grp_priv %p ctx_idx %d, rank: %d, rlink %p\n",
+				grp_priv, ctx_idx, rank, &li->li_link);
+		}
+	} else {
+		li = crt_li_link2ptr(rlink);
+		D_ASSERT(li->li_rank == rank);
+		D_ASSERT(li->li_tag == tag);
+		D_ASSERT(li->li_initialized != 0);
+
+		need_decref = true;
+	}
 
 	D_MUTEX_LOCK(&li->li_mutex);
 	if (li->li_tag_addr == NULL) {
@@ -821,8 +840,10 @@ crt_grp_hg_addr_cache_insert(struct crt_grp_priv *passed_grp_priv, struct crt_co
 out:
 	D_MUTEX_UNLOCK(&li->li_mutex);
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
-	d_hash_rec_decref(&grp_priv->gp_lookup_cache[ctx_idx], rlink);
 
+	/* decref needed if we looked up item, not if we inserted it */
+	if (need_decref)
+		d_hash_rec_decref(&grp_priv->gp_lookup_cache[ctx_idx], rlink);
 	return rc;
 
 err_free_li:

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -374,21 +374,16 @@ exit:
 }
 
 static inline int
-grp_li_uri_set(struct crt_lookup_item *li, int tag, const char *uri)
+grp_uri_cache_set(struct crt_grp_priv *grp_priv, d_rank_t rank, int tag, const char *uri)
 {
 	char			base_addr[CRT_ADDR_STR_MAX_LEN];
 	struct crt_uri_item	*ui;
-	d_list_t		*rlink;
-	struct crt_grp_priv	*grp_priv;
+	d_list_t                *rlink;
 	char                    *nul_str = NULL;
 	char                    *uri_dup;
-	d_rank_t		rank;
 	int			rc = 0;
 	int			i;
 	crt_provider_t		provider;
-
-	rank = li->li_rank;
-	grp_priv = li->li_grp_priv;
 
 	rlink = d_hash_rec_find(&grp_priv->gp_uri_lookup_cache,
 				(void *)&rank, sizeof(rank));
@@ -400,7 +395,7 @@ grp_li_uri_set(struct crt_lookup_item *li, int tag, const char *uri)
 		D_INIT_LIST_HEAD(&ui->ui_link);
 		ui->ui_ref = 0;
 		ui->ui_initialized = 1;
-		ui->ui_rank = li->li_rank;
+		ui->ui_rank        = rank;
 
 		rc = crt_hg_parse_uri(uri, &provider, base_addr);
 		if (rc)
@@ -618,98 +613,6 @@ crt_grp_lc_uri_remove(struct crt_grp_priv *passed_grp_priv, int ctx_idx,
 	}
 }
 
-static int
-grp_lc_uri_insert_internal_locked(struct crt_grp_priv *grp_priv,
-				  int ctx_idx, d_rank_t rank,
-				  uint32_t tag,	const char *uri)
-{
-	struct crt_lookup_item	*li;
-	int			 rc = 0;
-	d_list_t		*rlink;
-	uint32_t                 key;
-
-	key = crt_lc_lookup_key(rank, tag);
-
-	rlink = d_hash_rec_find(&grp_priv->gp_lookup_cache[ctx_idx], (void *)&key, sizeof(key));
-	if (rlink == NULL) {
-		/* target rank not in cache */
-		D_ALLOC_PTR(li);
-		if (li == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-
-		rc = D_MUTEX_INIT(&li->li_mutex, NULL);
-		if (rc != 0)
-			D_GOTO(err_free_li, rc);
-
-		D_INIT_LIST_HEAD(&li->li_link);
-		li->li_grp_priv = grp_priv;
-		li->li_key      = key;
-		li->li_rank = rank;
-		li->li_tag      = tag;
-
-		if (uri) {
-			rc = grp_li_uri_set(li, tag, uri);
-			if (rc != DER_SUCCESS)
-				D_GOTO(err_destroy_mutex, rc);
-		}
-
-		li->li_initialized = 1;
-
-		rc = d_hash_rec_insert(&grp_priv->gp_lookup_cache[ctx_idx], &key, sizeof(key),
-				       &li->li_link, true /* exclusive */);
-		if (rc != 0) {
-			D_DEBUG(DB_TRACE, "entry already exists in lookup "
-				"table, grp_priv %p ctx_idx %d, rank: %d.\n",
-				grp_priv, ctx_idx, rank);
-			crt_li_destroy(li);
-			rc = 0;
-		} else {
-			D_DEBUG(DB_TRACE, "Filling in URI in lookup table. "
-				" grp_priv %p ctx_idx %d, rank: %d, rlink %p\n",
-				grp_priv, ctx_idx, rank, &li->li_link);
-		}
-		D_GOTO(out, rc);
-	}
-
-	if (!uri)
-		D_GOTO(decref, rc);
-
-	li = crt_li_link2ptr(rlink);
-	D_ASSERT(li->li_grp_priv == grp_priv);
-	D_ASSERT(li->li_rank == rank);
-	D_ASSERT(li->li_tag == tag);
-	D_ASSERT(li->li_initialized != 0);
-	D_MUTEX_LOCK(&li->li_mutex);
-
-	if (grp_li_uri_get(li, tag) == NULL) {
-		rc = grp_li_uri_set(li, tag, uri);
-
-		if (rc != DER_SUCCESS) {
-			D_ERROR("Failed to set uri for %d:%d, uri=%s\n",
-				li->li_rank, tag, uri);
-			rc = -DER_NOMEM;
-		}
-
-		D_DEBUG(DB_TRACE, "Filling in URI in lookup table. "
-			"grp_priv %p ctx_idx %d, rank: %d, tag: %u rlink %p\n",
-			grp_priv, ctx_idx, rank, tag, &li->li_link);
-	}
-	D_MUTEX_UNLOCK(&li->li_mutex);
-
-decref:
-	d_hash_rec_decref(&grp_priv->gp_lookup_cache[ctx_idx], rlink);
-	return rc;
-
-err_destroy_mutex:
-	D_MUTEX_DESTROY(&li->li_mutex);
-
-err_free_li:
-	D_FREE(li);
-
-out:
-	return rc;
-}
-
 /*
  * Fill in the base URI of rank in the lookup cache of the crt_ctx.
  */
@@ -718,8 +621,7 @@ crt_grp_lc_uri_insert(struct crt_grp_priv *passed_grp_priv,
 		      d_rank_t rank, uint32_t tag, const char *uri)
 {
 	struct crt_grp_priv	*grp_priv;
-	int			 rc = 0;
-	int			 i;
+	int                      rc = 0;
 
 	if (tag >= CRT_SRV_CONTEXT_NUM) {
 		D_ERROR("tag %d out of range [0, %d].\n",
@@ -735,16 +637,7 @@ crt_grp_lc_uri_insert(struct crt_grp_priv *passed_grp_priv,
 	}
 
 	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
-	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++) {
-		rc = grp_lc_uri_insert_internal_locked(grp_priv, i, rank,
-						       tag, uri);
-		if (rc != 0) {
-			D_ERROR("Insertion failed, " DF_RC "\n", DP_RC(rc));
-			D_GOTO(unlock, rc);
-		}
-	}
-
-unlock:
+	grp_uri_cache_set(grp_priv, rank, tag, uri);
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 
 	return rc;
@@ -858,9 +751,8 @@ out:
  * routine.
  */
 int
-crt_grp_lc_addr_insert(struct crt_grp_priv *passed_grp_priv,
-		       struct crt_context *crt_ctx,
-		       d_rank_t rank, uint32_t tag, hg_addr_t *hg_addr)
+crt_grp_hg_addr_cache_insert(struct crt_grp_priv *passed_grp_priv, struct crt_context *crt_ctx,
+			     d_rank_t rank, uint32_t tag, hg_addr_t *hg_addr)
 {
 	d_list_t		*rlink;
 	struct crt_lookup_item	*li;
@@ -880,15 +772,32 @@ crt_grp_lc_addr_insert(struct crt_grp_priv *passed_grp_priv,
 		grp_priv = passed_grp_priv->gp_priv_prim;
 		rank = crt_grp_priv_get_primary_rank(passed_grp_priv, rank);
 	}
-	key = crt_lc_lookup_key(rank, tag);
 
+	key     = crt_lc_lookup_key(rank, tag);
 	ctx_idx = crt_ctx->cc_idx;
+
 	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
 
 	rlink = d_hash_rec_find(&grp_priv->gp_lookup_cache[ctx_idx], (void *)&key, sizeof(key));
-	D_ASSERT(rlink != NULL);
+	if (rlink == NULL) {
+		/* target rank not in cache */
+		D_ALLOC_PTR(li);
+		if (li == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		rc = D_MUTEX_INIT(&li->li_mutex, NULL);
+		if (rc != 0)
+			D_GOTO(err_free_li, rc);
+
+		D_INIT_LIST_HEAD(&li->li_link);
+		li->li_grp_priv    = grp_priv;
+		li->li_key         = key;
+		li->li_rank        = rank;
+		li->li_tag         = tag;
+		li->li_initialized = 1;
+	}
+
 	li = crt_li_link2ptr(rlink);
-	D_ASSERT(li->li_grp_priv == grp_priv);
 	D_ASSERT(li->li_rank == rank);
 	D_ASSERT(li->li_tag == tag);
 	D_ASSERT(li->li_initialized != 0);
@@ -897,7 +806,7 @@ crt_grp_lc_addr_insert(struct crt_grp_priv *passed_grp_priv,
 	if (li->li_tag_addr == NULL) {
 		li->li_tag_addr = *hg_addr;
 	} else {
-		D_INFO("NA address already exits. "
+		D_INFO("HG address already exits. "
 		       " grp_priv %p ctx_idx %d, rank: %d, tag %d, rlink %p\n",
 		       grp_priv, ctx_idx, rank, tag, &li->li_link);
 		rc = crt_hg_addr_free(&crt_ctx->cc_hg_ctx, *hg_addr);
@@ -908,11 +817,16 @@ crt_grp_lc_addr_insert(struct crt_grp_priv *passed_grp_priv,
 		}
 		*hg_addr = li->li_tag_addr;
 	}
+
 out:
 	D_MUTEX_UNLOCK(&li->li_mutex);
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 	d_hash_rec_decref(&grp_priv->gp_lookup_cache[ctx_idx], rlink);
 
+	return rc;
+
+err_free_li:
+	D_FREE(li);
 	return rc;
 }
 
@@ -3379,12 +3293,7 @@ crt_group_primary_modify(crt_group_t *grp, crt_context_t *ctxs, int num_ctxs, d_
 		}
 
 		/* TODO: Change for multi-provider support */
-		for (k = 0; k < CRT_SRV_CONTEXT_NUM; k++) {
-			rc = grp_lc_uri_insert_internal_locked(grp_priv, k, rank, 0, uris[idx]);
-
-			if (rc != 0)
-				D_GOTO(cleanup, rc);
-		}
+		rc = grp_uri_cache_set(grp_priv, rank, 0, uris[idx]);
 
 		/* Notify about members being added */
 		for (cb_idx = 0; cb_idx < cbs_size; cb_idx++) {

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -938,14 +938,13 @@ crt_grp_lc_lookup(struct crt_grp_priv *grp_priv, int ctx_idx, d_rank_t rank, uin
 	D_ASSERT(uri != NULL || hg_addr != NULL);
 	D_ASSERT(ctx_idx >= 0 && ctx_idx < CRT_SRV_CONTEXT_NUM);
 
-	if (rank == CRT_NO_RANK) {
-		if (uri)
-			*uri = NULL;
+	if (uri)
+		*uri = NULL;
+	if (hg_addr)
+		*hg_addr = NULL;
 
-		if (hg_addr)
-			*hg_addr = NULL;
+	if (rank == CRT_NO_RANK)
 		return;
-	}
 
 	provider = crt_gdata.cg_primary_prov;
 
@@ -961,10 +960,8 @@ crt_grp_lc_lookup(struct crt_grp_priv *grp_priv, int ctx_idx, d_rank_t rank, uin
 		rank = crt_grp_priv_get_primary_rank(grp_priv, rank);
 	}
 
-	if (uri)
-		*uri = NULL;
-	if (hg_addr)
-		*hg_addr = NULL;
+	if (uri == NULL)
+		D_GOTO(skip_uri_lookup, 0);
 
 	/* Get URI from uri lookup cache */
 	if (uri != NULL) {
@@ -983,6 +980,11 @@ crt_grp_lc_lookup(struct crt_grp_priv *grp_priv, int ctx_idx, d_rank_t rank, uin
 
 		D_RWLOCK_UNLOCK(&default_grp_priv->gp_rwlock);
 	}
+
+skip_uri_lookup:
+
+	if (hg_addr == NULL)
+		D_GOTO(skip_hg_addr_lookup, 0);
 
 	/* Get HG handle from HG lookup cache */
 	key = crt_lc_lookup_key(rank, tag);
@@ -1004,6 +1006,8 @@ crt_grp_lc_lookup(struct crt_grp_priv *grp_priv, int ctx_idx, d_rank_t rank, uin
 		D_DEBUG(DB_ALL, "HG entry for rank=%d:%d not found\n", rank, tag);
 	}
 	D_RWLOCK_UNLOCK(&default_grp_priv->gp_rwlock);
+
+skip_hg_addr_lookup:
 
 	return;
 }

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -247,35 +247,6 @@ crt_ui_destroy(struct crt_uri_item *ui)
 	D_FREE(ui);
 }
 
-static inline char *
-grp_li_uri_get(struct crt_lookup_item *li, int tag)
-{
-	struct crt_uri_item	*ui;
-	d_list_t		*rlink;
-	struct crt_grp_priv	*grp_priv;
-	d_rank_t		rank;
-
-	rank = li->li_rank;
-	grp_priv = li->li_grp_priv;
-
-	rlink = d_hash_rec_find(&grp_priv->gp_uri_lookup_cache,
-				(void *)&rank, sizeof(rank));
-	/* It's possible to have crt_lookup_item for which uri
-	 * info has not been populated yet
-	 */
-	if (rlink == NULL) {
-		D_DEBUG(DB_TRACE,
-			"Failed to find uri_info for %d:%d\n",
-			rank, tag);
-		return NULL;
-	}
-
-	ui = crt_ui_link2ptr(rlink);
-	d_hash_rec_decref(&grp_priv->gp_uri_lookup_cache, rlink);
-
-	return atomic_load_relaxed(&ui->ui_uri[tag]);
-}
-
 static int
 generate_cxi_uris(int prov_type, char *addr, int tag, struct crt_uri_item *ui)
 {

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -917,13 +917,10 @@ out:
 }
 
 /*
- * Lookup the URI and NA address of a (rank, tag) combination in the addr cache.
- * This function only looks into the address cache. If the requested (rank, tag)
- * pair doesn't exist in the address cache, *hg_addr will be NULL on return, and
- * an empty record for the requested rank with NULL values will be inserted to
- * the cache. For input parameters, base_addr and hg_addr can not be both NULL.
- * (hg_addr == NULL) means the caller only want to lookup the base_addr.
- * (base_addr == NULL) means the caller only want to lookup the hg_addr.
+ * Lookup URI and HG Address based on passed rank:tag combination
+ *
+ * URIs are looked up from URI cache based on rank key
+ * HG Addresses are looked up from HG Address cache basedon rank:tag key
  */
 void
 crt_grp_lc_lookup(struct crt_grp_priv *grp_priv, int ctx_idx, d_rank_t rank, uint32_t tag,
@@ -964,6 +961,30 @@ crt_grp_lc_lookup(struct crt_grp_priv *grp_priv, int ctx_idx, d_rank_t rank, uin
 		rank = crt_grp_priv_get_primary_rank(grp_priv, rank);
 	}
 
+	if (uri)
+		*uri = NULL;
+	if (hg_addr)
+		*hg_addr = NULL;
+
+	/* Get URI from uri lookup cache */
+	if (uri != NULL) {
+		struct crt_uri_item *ui;
+
+		D_RWLOCK_RDLOCK(&default_grp_priv->gp_rwlock);
+		rlink = d_hash_rec_find(&default_grp_priv->gp_uri_lookup_cache, (void *)&rank,
+					sizeof(rank));
+		if (rlink != NULL) {
+			ui   = crt_ui_link2ptr(rlink);
+			*uri = atomic_load_relaxed(&ui->ui_uri[tag]);
+			d_hash_rec_decref(&default_grp_priv->gp_uri_lookup_cache, rlink);
+		} else {
+			D_DEBUG(DB_ALL, "URI entry for rank=%d not found\n", rank);
+		}
+
+		D_RWLOCK_UNLOCK(&default_grp_priv->gp_rwlock);
+	}
+
+	/* Get HG handle from HG lookup cache */
 	key = crt_lc_lookup_key(rank, tag);
 
 	D_RWLOCK_RDLOCK(&default_grp_priv->gp_rwlock);
@@ -976,30 +997,14 @@ crt_grp_lc_lookup(struct crt_grp_priv *grp_priv, int ctx_idx, d_rank_t rank, uin
 		D_ASSERT(li->li_tag == tag);
 		D_ASSERT(li->li_initialized != 0);
 
-		if (uri != NULL)
-			*uri = grp_li_uri_get(li, tag);
+		*hg_addr = li->li_tag_addr;
 
-		if (hg_addr == NULL)
-			D_ASSERT(uri != NULL);
-		else if (li->li_tag_addr != NULL)
-			*hg_addr = li->li_tag_addr;
-		d_hash_rec_decref(&default_grp_priv->gp_lookup_cache[ctx_idx],
-				  rlink);
-		D_GOTO(out, 0);
+		d_hash_rec_decref(&default_grp_priv->gp_lookup_cache[ctx_idx], rlink);
 	} else {
-		D_DEBUG(DB_ALL, "Entry for rank=%d not found\n", rank);
+		D_DEBUG(DB_ALL, "HG entry for rank=%d:%d not found\n", rank, tag);
 	}
 	D_RWLOCK_UNLOCK(&default_grp_priv->gp_rwlock);
 
-	if (uri)
-		*uri = NULL;
-	if (hg_addr)
-		*hg_addr = NULL;
-
-	return;
-
-out:
-	D_RWLOCK_UNLOCK(&default_grp_priv->gp_rwlock);
 	return;
 }
 

--- a/src/cart/crt_group.h
+++ b/src/cart/crt_group.h
@@ -242,9 +242,9 @@ void
 		      char **base_addr, hg_addr_t *hg_addr);
 int crt_grp_lc_uri_insert(struct crt_grp_priv *grp_priv,
 			  d_rank_t rank, uint32_t tag, const char *uri);
-int crt_grp_lc_addr_insert(struct crt_grp_priv *grp_priv,
-			   struct crt_context *ctx_idx,
-			   d_rank_t rank, uint32_t tag, hg_addr_t *hg_addr);
+int
+    crt_grp_hg_addr_cache_insert(struct crt_grp_priv *grp_priv, struct crt_context *ctx_idx,
+				 d_rank_t rank, uint32_t tag, hg_addr_t *hg_addr);
 int crt_grp_ctx_invalid(struct crt_context *ctx, bool locked);
 struct crt_grp_priv *crt_grp_lookup_int_grpid(uint64_t int_grpid);
 struct crt_grp_priv *crt_grp_lookup_grpid(crt_group_id_t grp_id);

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1291,10 +1291,9 @@ crt_req_hg_addr_lookup(struct crt_rpc_priv *rpc_priv)
 		D_GOTO(out, rc = crt_hgret_2_der(hg_ret));
 	}
 
-	rc = crt_grp_lc_addr_insert(rpc_priv->crp_grp_priv, crt_ctx,
-				    rpc_priv->crp_pub.cr_ep.ep_rank,
-				    rpc_priv->crp_pub.cr_ep.ep_tag,
-				    &hg_addr);
+	rc = crt_grp_hg_addr_cache_insert(rpc_priv->crp_grp_priv, crt_ctx,
+					  rpc_priv->crp_pub.cr_ep.ep_rank,
+					  rpc_priv->crp_pub.cr_ep.ep_tag, &hg_addr);
 	if (rc != 0) {
 		D_ERROR("Failed to insert: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);

--- a/src/tests/ftest/daos_test/suite.py
+++ b/src/tests/ftest/daos_test/suite.py
@@ -334,6 +334,22 @@ class DaosCoreTest(DaosCoreBase):
         """
         self.run_subtest()
 
+    def test_daos_extend_simple_13(self):
+        """Jira ID: DAOS-1568
+
+        Test Description:
+            Run daos_test -B --subtests="13"
+
+        Use cases:
+            Core tests for daos_test
+
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=hw,medium,provider
+        :avocado: tags=daos_test,daos_core_test,rebuild
+        :avocado: tags=DaosCoreTest,test_daos_extend_simple_13
+        """
+        self.run_subtest()
+
     def test_daos_rebuild_interactive(self):
         """Jira ID: DAOS-17358
 

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -26,6 +26,7 @@ timeouts:
   test_daos_rebuild_simple: 2400
   test_daos_drain_simple: 3720
   test_daos_extend_simple: 3600
+  test_daos_extend_simple_13: 600
   test_daos_rebuild_interactive: 1185
   test_daos_oid_allocator: 640
   test_daos_checksum: 500
@@ -105,6 +106,7 @@ daos_tests:
     test_daos_rebuild_simple: 1
     test_daos_drain_simple: 1
     test_daos_extend_simple: 1
+    test_daos_extend_simple_13: 1
     test_daos_rebuild_interactive: 1
     test_daos_oid_allocator: 1
     test_daos_checksum: 1
@@ -141,6 +143,7 @@ daos_tests:
     test_daos_degraded_ec: DAOS_Degraded_EC
     test_daos_dedup: DAOS_Dedup
     test_daos_extend_simple: DAOS_Extend_Simple
+    test_daos_extend_simple_13: DAOS_Extend_Simple_13
     test_daos_rebuild_interactive: DAOS_Rebuild_Interactive
     test_daos_upgrade: DAOS_Upgrade
     test_daos_pipeline: DAOS_Pipeline
@@ -165,6 +168,7 @@ daos_tests:
     test_daos_rebuild_simple: v
     test_daos_drain_simple: b
     test_daos_extend_simple: B
+    test_daos_extend_simple_13: B
     test_daos_rebuild_interactive: j
     test_daos_oid_allocator: O
     test_daos_checksum: z
@@ -182,6 +186,7 @@ daos_tests:
     test_daos_rebuild_simple: -s3
     test_daos_drain_simple: -s3
     test_daos_extend_simple: -s3
+    test_daos_extend_simple_13: -s3 -u subtests="13"
     test_daos_rebuild_interactive: -s3
     test_daos_oid_allocator: -s5
   stopped_ranks:

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -33,7 +33,7 @@ from util.storage_utils import StorageException
 from util.yaml_utils import YamlException
 
 DEFAULT_LOGS_THRESHOLD = "2150M"    # 2.1G
-MAX_CI_REPETITIONS = 10
+MAX_CI_REPETITIONS = 50
 
 
 class LaunchError(Exception):

--- a/src/tests/suite/daos_extend_common.c
+++ b/src/tests/suite/daos_extend_common.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -180,8 +180,13 @@ dfs_extend_internal(void **state, int opc, test_rebuild_cb_t extend_cb, bool kil
 	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 			      DAOS_REBUILD_TGT_SCAN_HANG | DAOS_FAIL_ALWAYS, 0, NULL);
 
-	arg->no_rebuild =
-	    1; /* This has no effect for RB_OP_TYPE_ADD - so can this be removed here? */
+	/*
+	 * For RB_OP_TYPE_ADD, rebuild_targets() still performs the extend and invokes
+	 * rebuild_cb, but no_rebuild=1 disables its internal waits
+	 * (test_rebuild_wait_to_start_next/test_rebuild_wait). Therefore,
+	 * extend_single_pool_rank() returns without waiting for rebuild completion.
+	 */
+	arg->no_rebuild = 1;
 	extend_single_pool_rank(arg, extend_rank);
 	arg->no_rebuild = 0;
 

--- a/src/tests/suite/daos_extend_simple.c
+++ b/src/tests/suite/daos_extend_simple.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -247,8 +247,17 @@ extend_cb_internal(void *arg)
 	int                   rc;
 	int                   i;
 
-	print_message("Extending, sleep 10, %s another rank %u, and start op %d (%s)\n", pre_op,
-		      cb_arg->rank, opc, extend_opstrs[opc]);
+	/* Wait for first extend to start (immediate return expected since it's running).
+	 * We want a post-effect: test_arg->pool.pool_info.pi_rebuild_st has the first rs_version.
+	 * Then later we can wait for the second rebuild to start with another similar call.
+	 */
+	print_message("before waiting for rebuild to start, pmap_ver=%u, rs_version=%u\n",
+		      test_arg->pool.pool_info.pi_map_ver,
+		      test_arg->pool.pool_info.pi_rebuild_st.rs_version);
+	test_rebuild_wait_to_start_next(&test_arg, 1);
+	print_message("Extending (rs_version=%u), sleep 10, %s rank %u, and start op %d (%s)\n",
+		      test_arg->pool.pool_info.pi_rebuild_st.rs_version, pre_op, cb_arg->rank, opc,
+		      extend_opstrs[opc]);
 
 	sleep(10);
 
@@ -314,7 +323,15 @@ extend_cb_internal(void *arg)
 		break;
 	}
 
-	daos_debug_set_params(test_arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
+	if (cb_arg->kill) {
+		print_message(
+		    "extend_cb_internal: waiting for next rebuild start before clearing FI\n");
+		test_rebuild_wait_to_start_next(&test_arg, 1);
+	}
+
+	print_message("extend_cb_internal: clear FI via daos_debug_set_params()\n");
+	rc = daos_debug_set_params(test_arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
+	assert_success(rc);
 
 	return 0;
 }


### PR DESCRIPTION
Try EXTEND14 dfs_extend_write_kill() (extend_simple subtest 13) with test change to wait for rebuild start before clearing fault injection.

Test-repeat: 25
Test-tag: test_daos_extend_simple_13
Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-test-rpms: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
