### PR TITLE
DAOS-18742 rebuild: Ignore destroyed containers during migration

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -73,6 +73,12 @@ enum {
 };
 #define MIGRATE_DATA_MB_ENV "D_MIGRATE_DATA_MB"
 
+static inline bool
+migrate_cont_gone(int rc)
+{
+	return rc == -DER_CONT_NONEXIST || rc == -DER_CONT_DESTROYING;
+}
+
 struct migr_res_manager;
 
 /* resource consumed by migration */
@@ -3047,6 +3053,8 @@ out:
 		DL_ERROR(rc, DF_RB ": " DF_UOID " migrate punch failed", DP_RB_MPT(tls),
 			 DP_UOID(arg->oid));
 
+	if (migrate_cont_gone(rc))
+		rc = 0;
 	if (tls->mpt_status == 0 && rc != 0)
 		tls->mpt_status = rc;
 
@@ -3563,23 +3571,13 @@ free:
 	if (arg->epoch == DAOS_EPOCH_MAX)
 		tls->mpt_obj_count++;
 
-	if (rc == -DER_CONT_NONEXIST || rc == -DER_CONT_DESTROYING) {
-		struct ds_cont_child *cont_child = NULL;
-
-		/* check again to see if the container is being destroyed. */
-		migrate_get_cont_child(tls, arg->cont_uuid, &cont_child, false);
-		if (cont_child == NULL || cont_child->sc_stopping)
-			rc = 0;
-
-		if (cont_child)
-			ds_cont_child_put(cont_child);
-	}
-
 	if (DAOS_FAIL_CHECK(DAOS_REBUILD_OBJ_FAIL) &&
 	    tls->mpt_obj_count >= daos_fail_value_get())
 		rc = -DER_IO;
 
 out:
+	if (migrate_cont_gone(rc))
+		rc = 0;
 	if (tls->mpt_status == 0 && rc < 0)
 		tls->mpt_status = rc;
 
@@ -3822,7 +3820,7 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 			     MIGRATE_STACK_SIZE);
 	if (rc) {
 		DL_ERROR(rc, DF_RB ": cont_fetch_start_ult failed", DP_RB_MPT(tls));
-		if (rc == -DER_CONT_NONEXIST) {
+		if (migrate_cont_gone(rc)) {
 			DL_ERROR(rc, DF_RB ": " DF_CONT " skip orphan container", DP_RB_MPT(tls),
 				 DP_CONT(tls->mpt_pool_uuid, cont_uuid));
 			D_GOTO(cont_done, rc = 0);


### PR DESCRIPTION
If a container still exists locally but the remote fetch returns DER_CONT_DESTROYING or DER_CONT_NONEXIST, the error is unexpectedly stored in mpt_status and causes rebuild to fail.

A similar issue can happen during punch, so ignore these container-gone errors there as well.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
