### PR TITLE
DAOS-19258 vos: fix akey conditional ignored when combined with other…

### DIFF
--- a/src/tests/suite/daos_obj_array.c
+++ b/src/tests/suite/daos_obj_array.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2022 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1391,6 +1391,23 @@ cond_ops(void **state)
 	iod[1].iod_flags = DAOS_COND_AKEY_UPDATE;
 	rc = daos_obj_update(oh, DAOS_TX_NONE, flags, &dkey, 2, iod, sgl, NULL);
 	assert_rc_equal(rc, -DER_EXIST);
+
+	/**
+	 * Combined global (non per-akey) dkey + akey conditionals. The dkey
+	 * exists and akey_0 exists at this point.
+	 */
+
+	/** akey_0 exists, so COND_DKEY_UPDATE | COND_AKEY_INSERT should fail */
+	d_iov_set(&iod[0].iod_name, akey_str[0], strlen(akey_str[0]));
+	flags = DAOS_COND_DKEY_UPDATE | DAOS_COND_AKEY_INSERT;
+	rc    = daos_obj_update(oh, DAOS_TX_NONE, flags, &dkey, 1, iod, sgl, NULL);
+	assert_rc_equal(rc, -DER_EXIST);
+
+	/** akey doesn't exist, so COND_DKEY_UPDATE | COND_AKEY_UPDATE should fail */
+	d_iov_set(&iod[0].iod_name, "akey_ne", strlen("akey_ne"));
+	flags = DAOS_COND_DKEY_UPDATE | DAOS_COND_AKEY_UPDATE;
+	rc    = daos_obj_update(oh, DAOS_TX_NONE, flags, &dkey, 1, iod, sgl, NULL);
+	assert_rc_equal(rc, -DER_NONEXIST);
 
 	/** close object */
 	rc = daos_obj_close(oh, NULL);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2044,7 +2044,7 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 		else
 			akey_flags = ioc->ic_ts_set->ts_flags;
 
-		switch (akey_flags) {
+		switch (akey_flags & VOS_COND_AKEY_UPDATE_MASK) {
 		case VOS_OF_COND_AKEY_UPDATE:
 			update_cond = VOS_ILOG_COND_UPDATE;
 			break;


### PR DESCRIPTION
… flags

akey_update() switched on the raw flags value rather than masking to the akey conditional bits. When DAOS_COND_AKEY_INSERT/UPDATE was combined with any other flag (e.g. DAOS_COND_DKEY_UPDATE, or internal flags like VOS_OF_EC), the switch fell through to default and the akey condition was silently ignored, so the update wrongly succeeded instead of returning -DER_EXIST / -DER_NONEXIST.

Restore the "& VOS_COND_AKEY_UPDATE_MASK" mask so only the akey conditional bits are evaluated. This keeps the per-akey path (iod_flags) working while fixing the global combined dkey+akey conditional path.

Add coverage to the cond_ops test (daos_obj_array) for combined global COND_DKEY_UPDATE|COND_AKEY_INSERT and COND_DKEY_UPDATE|COND_AKEY_UPDATE.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
