### PR TITLE
DAOS-19315 test: Use inclusive tags for VM stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -473,7 +473,7 @@ pipeline {
                             base_branch: params.BaseBranch,
                             label: vm9_label('EL9'),
                             next_version: params.BaseBranch,
-                            stage_tags: '-hw',
+                            stage_tags: 'vm',
                             default_tags: isPr() ? 'always_passes' : 'pr daily_regression',
                             nvme: 'auto',
                             job_status: job_status_internal
@@ -487,7 +487,7 @@ pipeline {
                             base_branch: params.BaseBranch,
                             label: vm9_label('Leap15'),
                             next_version: params.BaseBranch,
-                            stage_tags: '-hw',
+                            stage_tags: 'vm',
                             default_tags: isPr() ? 'always_passes' : 'pr daily_regression',
                             nvme: 'auto',
                             job_status: job_status_internal
@@ -500,7 +500,7 @@ pipeline {
                             base_branch: params.BaseBranch,
                             label: vm9_label('Ubuntu'),
                             next_version: params.BaseBranch,
-                            stage_tags: '-hw',
+                            stage_tags: 'vm',
                             default_tags: isPr() ? 'always_passes' : 'pr daily_regression',
                             nvme: 'auto',
                             job_status: job_status_internal


### PR DESCRIPTION
Update the Functional VM stages to use the 'vm' stage tag instead of '-hw'.

skip-functional-hardware-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
