### PR TITLE
DAOS-19317 test: fix auto test tag for ftest/cart

### DIFF
--- a/ci/commit_pragma_mapping.yaml
+++ b/ci/commit_pragma_mapping.yaml
@@ -19,7 +19,7 @@ ftest-only: &ftest-only
   need-unit-test: False
 
 # Run only cart ftest for cart ftest C utilities
-src/tests/ftest/cart/*.[ch]:
+src/tests/ftest/cart/.*\.[ch]$:
   test-tag: cart
   <<: *ftest-only
 


### PR DESCRIPTION
By example, the old pattern was incorrect:
path = 'src/tests/ftest/cart/iv_client.c'
old_pattern = r'src/tests/ftest/cart/*.[ch]'
print(re.search(old_pattern, path))
None
new_pattern = 'src/tests/ftest/cart/.*\.[ch]$'
print(re.search(new_pattern, path))
<re.Match object; span=(0, 32), match='src/tests/ftest/cart/iv_client.c'>

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
