### PR TITLE
DAOS-19331 control: fix swapped dir and oclass in JSONOutputEnabled

### DIFF
--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 // (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -258,6 +259,49 @@ type fsGetAttrCmd struct {
 	fsAttrCmd
 }
 
+// fsGetAttrDirJSON is the JSON representation of a directory's default
+// creation attributes returned by the fs get-attr command.
+type fsGetAttrDirJSON struct {
+	ObjAttr struct {
+		OID      string `json:"oid"`
+		ObjClass string `json:"oclass"`
+	} `json:"object"`
+	DirAttr struct {
+		DirObjClass  string `json:"dir_oclass"`
+		FileObjClass string `json:"file_oclass"`
+		ChunkSize    uint64 `json:"chunk_size"`
+	} `json:"directory"`
+}
+
+// fsGetAttrFileJSON is the JSON representation of a file's attributes
+// returned by the fs get-attr command.
+type fsGetAttrFileJSON struct {
+	OID       string `json:"oid"`
+	ObjClass  string `json:"oclass"`
+	ChunkSize uint64 `json:"chunk_size"`
+}
+
+// newFSGetAttrJSON builds the JSON output value for the fs get-attr command.
+// It is kept free of cgo so that the attribute-to-field mapping can be unit
+// tested.
+func newFSGetAttrJSON(isDir bool, oidStr, oclass, dirOclass, fileOclass string, chunkSize uint64) any {
+	if isDir {
+		out := fsGetAttrDirJSON{}
+		out.ObjAttr.OID = oidStr
+		out.ObjAttr.ObjClass = oclass
+		out.DirAttr.DirObjClass = dirOclass
+		out.DirAttr.FileObjClass = fileOclass
+		out.DirAttr.ChunkSize = chunkSize
+		return out
+	}
+
+	return fsGetAttrFileJSON{
+		OID:       oidStr,
+		ObjClass:  oclass,
+		ChunkSize: chunkSize,
+	}
+}
+
 func (cmd *fsGetAttrCmd) Execute(_ []string) error {
 	ap, deallocCmdArgs, err := setupFSAttrCmd(&cmd.fsAttrCmd)
 	if err != nil {
@@ -286,59 +330,22 @@ func (cmd *fsGetAttrCmd) Execute(_ []string) error {
 	var fileoclassName [16]C.char
 	var oid C.daos_obj_id_t = attrs.doi_oid
 	var oidStr string = fmt.Sprintf("%d.%d", oid.hi, oid.lo)
-	if C.mode_is_dir(cmode) {
+	isDir := bool(C.mode_is_dir(cmode))
+	if isDir {
 		C.daos_oclass_id2name(attrs.doi_dir_oclass_id, &diroclassName[0])
 		C.daos_oclass_id2name(attrs.doi_file_oclass_id, &fileoclassName[0])
 	}
 
 	if cmd.JSONOutputEnabled() {
-		if C.mode_is_dir(cmode) {
-			jsonAttrs := struct {
-				ObjAttr struct {
-					OID      string `json:"oid"`
-					ObjClass string `json:"oclass"`
-				} `json:"object"`
-				DirAttr struct {
-					DirObjClass  string `json:"dir_oclass"`
-					FileObjClass string `json:"file_oclass"`
-					ChunkSize    uint64 `json:"chunk_size"`
-				} `json:"directory"`
-			}{
-				ObjAttr: struct {
-					OID      string `json:"oid"`
-					ObjClass string `json:"oclass"`
-				}{
-					OID:      oidStr,
-					ObjClass: C.GoString(&oclassName[0]),
-				},
-				DirAttr: struct {
-					DirObjClass  string `json:"dir_oclass"`
-					FileObjClass string `json:"file_oclass"`
-					ChunkSize    uint64 `json:"chunk_size"`
-				}{
-					FileObjClass: C.GoString(&diroclassName[0]),
-					DirObjClass:  C.GoString(&fileoclassName[0]),
-					ChunkSize:    uint64(attrs.doi_chunk_size),
-				},
-			}
-			return cmd.OutputJSON(jsonAttrs, nil)
-		} else {
-			jsonAttrs := &struct {
-				OID       string `json:"oid"`
-				ObjClass  string `json:"oclass"`
-				ChunkSize uint64 `json:"chunk_size"`
-			}{
-				OID:       oidStr,
-				ObjClass:  C.GoString(&oclassName[0]),
-				ChunkSize: uint64(attrs.doi_chunk_size),
-			}
-			return cmd.OutputJSON(jsonAttrs, nil)
-		}
+		jsonAttrs := newFSGetAttrJSON(isDir, oidStr, C.GoString(&oclassName[0]),
+			C.GoString(&diroclassName[0]), C.GoString(&fileoclassName[0]),
+			uint64(attrs.doi_chunk_size))
+		return cmd.OutputJSON(jsonAttrs, nil)
 	}
 
 	cmd.Infof("OID = %s", oidStr)
 	cmd.Infof("Object Class = %s", C.GoString(&oclassName[0]))
-	if C.mode_is_dir(cmode) {
+	if isDir {
 		cmd.Infof("Directory Creation Object Class = %s", C.GoString(&diroclassName[0]))
 		cmd.Infof("File Creation Object Class = %s", C.GoString(&fileoclassName[0]))
 		cmd.Infof("File Creation Chunk Size = %d", attrs.doi_chunk_size)

--- a/src/control/cmd/daos/filesystem_test.go
+++ b/src/control/cmd/daos/filesystem_test.go
@@ -1,0 +1,76 @@
+//
+// (C) Copyright 2025 Google LLC
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDaos_newFSGetAttrJSON(t *testing.T) {
+	for name, tc := range map[string]struct {
+		isDir      bool
+		oidStr     string
+		oclass     string
+		dirOclass  string
+		fileOclass string
+		chunkSize  uint64
+		expJSON    string
+	}{
+		"file": {
+			isDir:     false,
+			oidStr:    "1.2",
+			oclass:    "S1",
+			chunkSize: 1048576,
+			expJSON:   `{"oid":"1.2","oclass":"S1","chunk_size":1048576}`,
+		},
+		"file ignores dir/file oclass": {
+			isDir:      false,
+			oidStr:     "3.4",
+			oclass:     "SX",
+			dirOclass:  "RP_2G1",
+			fileOclass: "EC_2P1G1",
+			chunkSize:  4096,
+			expJSON:    `{"oid":"3.4","oclass":"SX","chunk_size":4096}`,
+		},
+		"directory": {
+			isDir:      true,
+			oidStr:     "5.6",
+			oclass:     "S1",
+			dirOclass:  "RP_2G1",
+			fileOclass: "EC_2P1G1",
+			chunkSize:  1048576,
+			expJSON: `{"object":{"oid":"5.6","oclass":"S1"},` +
+				`"directory":{"dir_oclass":"RP_2G1","file_oclass":"EC_2P1G1","chunk_size":1048576}}`,
+		},
+		"directory distinct dir/file oclass not swapped": {
+			isDir:      true,
+			oidStr:     "7.8",
+			oclass:     "SX",
+			dirOclass:  "S1",
+			fileOclass: "S2",
+			chunkSize:  0,
+			expJSON: `{"object":{"oid":"7.8","oclass":"SX"},` +
+				`"directory":{"dir_oclass":"S1","file_oclass":"S2","chunk_size":0}}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := newFSGetAttrJSON(tc.isDir, tc.oidStr, tc.oclass, tc.dirOclass, tc.fileOclass, tc.chunkSize)
+
+			gotBytes, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("failed to marshal JSON: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expJSON, string(gotBytes)); diff != "" {
+				t.Fatalf("unexpected JSON output (-want, +got)\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -2281,7 +2281,7 @@ class PosixTests():
             ofd.write('hello')
 
         data = run_fs_get_attr(self.conf, '--path', dir1)
-        assert check_dir_attr(data, 'S2', 'S2', 'S4', 1048576)
+        assert check_dir_attr(data, 'S2', 'S4', 'S2', 1048576)
 
         data = run_fs_get_attr(self.conf, '--path', file1)
         assert check_file_attr(data, 'S4', 1048576)
@@ -3995,17 +3995,17 @@ class PosixTests():
 
         # Run a command to get attr of new dir and file
         data = run_fs_get_attr(self.conf, '--path', dir1)
-        assert check_dir_attr(data, 'S1', 'S1', None, 1048576)
+        assert check_dir_attr(data, 'S1', None, 'S1', 1048576)
 
         # run same command using pool, container, dfs-path, and dfs-prefix
         data = run_fs_get_attr(self.conf, pool, uns_container.id(),
                                '--dfs-path', dir1, '--dfs-prefix', uns_path)
-        assert check_dir_attr(data, 'S1', 'S1', None, 1048576)
+        assert check_dir_attr(data, 'S1', None, 'S1', 1048576)
 
         # run same command using pool, container, dfs-path
         data = run_fs_get_attr(self.conf, pool, uns_container.id(),
                                '--dfs-path', '/d1')
-        assert check_dir_attr(data, 'S1', 'S1', None, 1048576)
+        assert check_dir_attr(data, 'S1', None, 'S1', 1048576)
 
         data = run_fs_get_attr(self.conf, '--path', file1)
         assert check_file_attr(data, None, 1048576)


### PR DESCRIPTION
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
