### PR TITLE
DAOS-19332 server: check non-NULL 'dtc'

### DIFF
--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -106,6 +106,9 @@ dss_get_module_info(void)
 	struct daos_thread_local_storage *dtc;
 
 	dtc = dss_tls_get();
+	if (dtc == NULL)
+		return NULL;
+
 	dmi = (struct dss_module_info *)
 	      dss_module_key_get(dtc, &daos_srv_modkey);
 	return dmi;


### PR DESCRIPTION
Check non-NULL 'dtc' in dss_get_module_info() to avoid assertion in following dss_module_key_get() call.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
