### PR TITLE
DAOS-19330 vos: Find highest minor_epc for rebuild overwrite

### DIFF
--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2791,6 +2791,17 @@ replace_ent:
 			default:
 				D_ASSERTF(0, "%d\n", find_opc);
 			case EVT_FIND_OVERWRITE:
+				/*
+				 * For rebuild overwrites (EVT_REBUILD_MINOR_MIN) we must scan ALL
+				 * overlapping entries at this epoch and keep the one with the
+				 * highest minor_epc.
+				 *
+				 * For non-rebuild exact overwrites the first match is the only
+				 * relevant entry, so we terminate as before.
+				 */
+				if (rect->rc_minor_epc == EVT_REBUILD_MINOR_MIN)
+					break; /* keep scanning for a higher minor_epc */
+					       /* fall through */
 			case EVT_FIND_FIRST:
 			case EVT_FIND_SAME:
 				/* store the trace and return for clip or


### PR DESCRIPTION
For rebuild overwrites, the code must identify the overlapping extent with the highest minor epoch to ensure the minor epoch is bumped correctly. However, a bug in evt_ent_array_fill() causes the scan to terminate prematurely. This can result in two overlapping extents incorrectly sharing the exact same epoch and minor epoch (EVT_REBUILD_MINOR_MIN + 1).

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
