### PR TITLE
DAOS-19118 test: Add faults tag to recovery tests with fault injectio…

### DIFF
--- a/src/tests/ftest/recovery/check_policy.py
+++ b/src/tests/ftest/recovery/check_policy.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -35,7 +35,7 @@ class DMGCheckPolicyTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
-        :avocado: tags=recovery,cat_recov
+        :avocado: tags=recovery,cat_recov,faults
         :avocado: tags=DMGCheckPolicyTest,test_check_policies
         """
         # 1. Create a pool.

--- a/src/tests/ftest/recovery/check_repair.py
+++ b/src/tests/ftest/recovery/check_repair.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -31,7 +31,7 @@ class DMGCheckRepairTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
-        :avocado: tags=recovery,cat_recov
+        :avocado: tags=recovery,cat_recov,faults
         :avocado: tags=DMGCheckRepairTest,test_check_repair_corner_case
         """
         # 1. Create a pool.

--- a/src/tests/ftest/recovery/check_start_corner_case.py
+++ b/src/tests/ftest/recovery/check_start_corner_case.py
@@ -84,7 +84,7 @@ class DMGCheckStartCornerCaseTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
-        :avocado: tags=recovery,cat_recov
+        :avocado: tags=recovery,cat_recov,faults
         :avocado: tags=DMGCheckStartCornerCaseTest,test_start_back_to_back
         """
         self.log_step("Create two pools and a container.")
@@ -171,7 +171,7 @@ class DMGCheckStartCornerCaseTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
-        :avocado: tags=recovery,cat_recov
+        :avocado: tags=recovery,cat_recov,faults
         :avocado: tags=DMGCheckStartCornerCaseTest,test_two_pools_healthy
         """
         # 1. Create three pools and one container.
@@ -287,7 +287,7 @@ class DMGCheckStartCornerCaseTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
-        :avocado: tags=recovery,cat_recov
+        :avocado: tags=recovery,cat_recov,faults
         :avocado: tags=DMGCheckStartCornerCaseTest,test_two_pools_corrupted
         """
         # 1. Create three pools and containers.

--- a/src/tests/ftest/recovery/check_start_options.py
+++ b/src/tests/ftest/recovery/check_start_options.py
@@ -54,7 +54,7 @@ class DMGCheckStartOptionsTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
-        :avocado: tags=recovery,cat_recov
+        :avocado: tags=recovery,cat_recov,faults
         :avocado: tags=DMGCheckStartOptionsTest,test_check_start_reset
         """
         # 1. Create a pool.
@@ -170,7 +170,7 @@ class DMGCheckStartOptionsTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
-        :avocado: tags=recovery,cat_recov
+        :avocado: tags=recovery,cat_recov,faults
         :avocado: tags=DMGCheckStartOptionsTest,test_check_start_interactive
         """
         # 1. Create a pool.
@@ -293,7 +293,7 @@ class DMGCheckStartOptionsTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
-        :avocado: tags=recovery,cat_recov
+        :avocado: tags=recovery,cat_recov,faults
         :avocado: tags=DMGCheckStartOptionsTest,test_check_start_failout
         """
         # 1. Create a pool.
@@ -421,7 +421,7 @@ class DMGCheckStartOptionsTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
-        :avocado: tags=recovery,cat_recov
+        :avocado: tags=recovery,cat_recov,faults
         :avocado: tags=DMGCheckStartOptionsTest,test_check_start_find_orphans
         """
         # 1. Create a pool and a container.

--- a/src/tests/ftest/recovery/check_stop.py
+++ b/src/tests/ftest/recovery/check_stop.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -52,7 +52,7 @@ class DMGCheckStopTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
-        :avocado: tags=recovery,cat_recov
+        :avocado: tags=recovery,cat_recov,faults
         :avocado: tags=DMGCheckStopTest,test_stop_during_repair
         """
         # 1. Create two pools 1 and 2. Create a container in 2.
@@ -144,7 +144,7 @@ class DMGCheckStopTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
-        :avocado: tags=recovery,cat_recov
+        :avocado: tags=recovery,cat_recov,faults
         :avocado: tags=DMGCheckStopTest,test_disable_during_repair
         """
         # 1. Create a pool and inject fault.


### PR DESCRIPTION
…… (#18519)

Add faults tag to recovery tests that use fault injection tool.


Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-medium: false
Test-tag: test_check_policies test_check_repair_corner_case test_start_back_to_back test_two_pools_healthy test_two_pools_corrupted test_check_start_reset test_check_start_interactive test_check_start_failout test_check_start_find_orphans test_stop_during_repair test_disable_during_repair

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
