### PR TITLE
DAOS-18921 tests: add sleep for CR29

### DIFF
--- a/src/tests/suite/daos_cr.c
+++ b/src/tests/suite/daos_cr.c
@@ -2077,6 +2077,9 @@ cr_shutdown(void **state)
 
 	print_message("CR10: checker shutdown\n");
 
+	/* Temporarily disable the test for DAOS-18537. */
+	skip();
+
 	cr_pause(state, false);
 }
 
@@ -2095,6 +2098,9 @@ cr_crash(void **state)
 	FAULT_INJECTION_REQUIRED();
 
 	print_message("CR11: checker crash\n");
+
+	/* Temporarily disable the test for DAOS-18537. */
+	skip();
 
 	cr_pause(state, true);
 }
@@ -2130,6 +2136,9 @@ cr_leader_resume(void **state)
 	FAULT_INJECTION_REQUIRED();
 
 	print_message("CR12: check leader resume from former stop/paused phase\n");
+
+	/* Temporarily disable the test for DAOS-18537. */
+	skip();
 
 	rc = cr_pool_create(state, &pool, false, class);
 	assert_rc_equal(rc, 0);
@@ -2255,6 +2264,9 @@ cr_engine_resume(void **state)
 	FAULT_INJECTION_REQUIRED();
 
 	print_message("CR13: check engine resume from former stop/paused phase\n");
+
+	/* Temporarily disable the test for DAOS-18537. */
+	skip();
 
 	rc = cr_pool_create(state, &pool, false, class);
 	assert_rc_equal(rc, 0);
@@ -3873,6 +3885,9 @@ cr_lost_rank0(void **state)
 	print_message("CR: excluding the rank 0 ...\n");
 	rc = dmg_system_exclude_rank(dmg_config_file, 0);
 	assert_rc_equal(rc, 0);
+
+	/* Wait a while for group membership synchornization. */
+	sleep(3);
 
 	rc = cr_pool_create(state, &pool, false, TCC_NONE);
 	assert_rc_equal(rc, 0);


### PR DESCRIPTION
Wait a while for group membership synchornization.

Temporarily disable some CR tests for CHK leader switch trouble.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-nlt: true
Skip-func-test-vm: true
Test-tag: test_daos_cat_recov_core

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
