### PR TITLE
DAOS-19205 control: Improve dmg system rebuild-stop output (#18538)

### DIFF
--- a/src/control/cmd/dmg/pretty/system.go
+++ b/src/control/cmd/dmg/pretty/system.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -15,6 +15,7 @@ import (
 	"github.com/dustin/go-humanize/english"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
@@ -255,4 +256,125 @@ func PrintSystemProperties(out io.Writer, props []*daos.SystemProperty) {
 	tf := txtfmt.NewTableFormatter(nameTitle, valueTitle)
 	tf.InitWriter(out)
 	tf.Format(table)
+}
+
+func printRebuildManageLines(out io.Writer, inTxt string, items []string, verbose bool) {
+	extra := ""
+	if verbose {
+		extra = fmt.Sprintf(" (%s)", strings.Join(items, ", "))
+	}
+	fmt.Fprintf(out, "- %-34s %d %s%s\n", inTxt, len(items),
+		common.Pluralise("pool", len(items)), extra)
+}
+
+func printSystemRebuildStopResp(out io.Writer, resp *control.SystemRebuildManageResp, verbose bool) error {
+	// Categorize results: successful (or finishing - DER_BUSY), not-rebuilding (DER_NONEXIST)
+	// and errors
+	var succeeded, notRebuilding, actualErrors, errMsgs []string
+	for _, res := range resp.Results {
+		if !res.Errored || strings.Contains(res.Msg, "DER_BUSY") {
+			succeeded = append(succeeded, res.ID)
+		} else if strings.Contains(res.Msg, "DER_NONEXIST") ||
+			strings.Contains(res.Msg, "entity does not exist") {
+			notRebuilding = append(notRebuilding, res.ID)
+		} else {
+			actualErrors = append(actualErrors, res.ID)
+			errMsgs = append(errMsgs,
+				fmt.Sprintf("pool-rebuild stop failed on pool %s: %s", res.ID,
+					res.Msg))
+		}
+	}
+
+	// Print structured output in a consistent format
+	totalPools := len(resp.Results)
+	fmt.Fprintf(out, "System-rebuild stop requested for %d %s\n", totalPools,
+		common.Pluralise("pool", totalPools))
+
+	if len(succeeded) > 0 {
+		printRebuildManageLines(out, "With active or finishing rebuild:", succeeded,
+			verbose)
+	}
+
+	if len(notRebuilding) > 0 {
+		printRebuildManageLines(out, "Without active rebuild:", notRebuilding, verbose)
+	}
+
+	// Only return error if there are actual failures (not DER_NONEXIST)
+	if len(actualErrors) > 0 {
+		printRebuildManageLines(out, "Errors:", actualErrors, verbose)
+
+		return errors.New(strings.Join(errMsgs, ", "))
+	}
+
+	fmt.Fprintln(out, "Command completed successfully.")
+
+	return nil
+}
+
+func printSystemRebuildStartResp(out io.Writer, resp *control.SystemRebuildManageResp, verbose bool) error {
+	// Categorize results: successful and errors
+	var succeeded, actualErrors, errMsgs []string
+	for _, res := range resp.Results {
+		if !res.Errored {
+			succeeded = append(succeeded, res.ID)
+		} else {
+			actualErrors = append(actualErrors, res.ID)
+			errMsgs = append(errMsgs,
+				fmt.Sprintf("pool-rebuild start failed on pool %s: %s", res.ID,
+					res.Msg))
+		}
+	}
+
+	// Print structured output in a consistent format
+	totalPools := len(resp.Results)
+	fmt.Fprintf(out, "System-rebuild start requested for %d %s\n", totalPools,
+		common.Pluralise("pool", totalPools))
+
+	if len(succeeded) > 0 {
+		printRebuildManageLines(out, "Successfully requested:", succeeded, verbose)
+	}
+
+	// Only return error if there are actual failures (not DER_NONEXIST)
+	if len(actualErrors) > 0 {
+		printRebuildManageLines(out, "Errors:", actualErrors, verbose)
+
+		return errors.New(strings.Join(errMsgs, ", "))
+	}
+
+	fmt.Fprintln(out, "Command completed successfully.")
+
+	return nil
+}
+
+// PrintSystemRebuildManageResp renders a human readable output representing the results of a dmg
+// system rebuild manage command response. If <operation>==stop, pools that have no active rebuild
+// to stop will be reported in the output but not result in an error being reported.
+func PrintSystemRebuildManageResp(out io.Writer, resp *control.SystemRebuildManageResp, verbose bool) error {
+	// Handle special case: no pools in system
+	if len(resp.Results) == 0 {
+		fmt.Fprintln(out, "No pools in system.")
+		fmt.Fprintln(out, "Command completed successfully.")
+
+		return nil
+	}
+
+	// Determine operation type
+	var opCode control.PoolRebuildOpCode
+	for idx, res := range resp.Results {
+		if idx == 0 {
+			opCode = res.OpCode
+		} else if opCode != res.OpCode {
+			return errors.Errorf("different system rebuild manage opcodes found in "+
+				"results: %s and %s", opCode, res.OpCode)
+		}
+	}
+
+	switch opCode {
+	case control.PoolRebuildOpCodeStop:
+		return printSystemRebuildStopResp(out, resp, verbose)
+	case control.PoolRebuildOpCodeStart:
+		return printSystemRebuildStartResp(out, resp, verbose)
+	default:
+		return errors.Errorf("unrecognized system rebuild opcode: %d", opCode)
+	}
 }

--- a/src/control/cmd/dmg/pretty/system_test.go
+++ b/src/control/cmd/dmg/pretty/system_test.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -687,6 +687,334 @@ Unknown 3 hosts: foo[7-9]
 			// parameters to mimic combined output seen on terminal
 			if err := PrintSystemStopResponse(&bld, &bld, tc.resp); err != nil {
 				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(strings.TrimLeft(tc.expPrintStr, "\n"), bld.String()); diff != "" {
+				t.Fatalf("unexpected string output (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestPretty_PrintSystemRebuildManageResp(t *testing.T) {
+	for name, tc := range map[string]struct {
+		resp        *control.SystemRebuildManageResp
+		verbose     bool
+		expPrintStr string
+		expErr      error
+	}{
+		"no pools in system": {
+			resp: &control.SystemRebuildManageResp{
+				Results: []*control.PoolRebuildManageResult{},
+			},
+			expPrintStr: `
+No pools in system.
+Command completed successfully.
+`,
+		},
+		"rebuild stop - all successful": {
+			resp: &control.SystemRebuildManageResp{
+				Results: []*control.PoolRebuildManageResult{
+					{
+						ID:     "pool1",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+					{
+						ID:     "pool2",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+					{
+						ID:     "pool3",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+				},
+			},
+			expPrintStr: `
+System-rebuild stop requested for 3 pools
+- With active or finishing rebuild:  3 pools
+Command completed successfully.
+`,
+		},
+		"rebuild stop - all successful verbose": {
+			resp: &control.SystemRebuildManageResp{
+				Results: []*control.PoolRebuildManageResult{
+					{
+						ID:     "pool1",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+					{
+						ID:     "pool2",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+					{
+						ID:     "pool3",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+				},
+			},
+			verbose: true,
+			expPrintStr: `
+System-rebuild stop requested for 3 pools
+- With active or finishing rebuild:  3 pools (pool1, pool2, pool3)
+Command completed successfully.
+`,
+		},
+		"rebuild stop - mixed success and DER_NONEXIST": {
+			resp: &control.SystemRebuildManageResp{
+				Results: []*control.PoolRebuildManageResult{
+					{
+						ID:     "pool1",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+					{
+						ID:      "pool2",
+						OpCode:  control.PoolRebuildOpCodeStop,
+						Errored: true,
+						Msg:     "DER_NONEXIST(-1005): The specified entity does not exist",
+					},
+				},
+			},
+			expPrintStr: `
+System-rebuild stop requested for 2 pools
+- With active or finishing rebuild:  1 pool
+- Without active rebuild:            1 pool
+Command completed successfully.
+`,
+		},
+		"rebuild stop - only DER_NONEXIST": {
+			resp: &control.SystemRebuildManageResp{
+				Results: []*control.PoolRebuildManageResult{
+					{
+						ID:      "pool1",
+						OpCode:  control.PoolRebuildOpCodeStop,
+						Errored: true,
+						Msg:     "DER_NONEXIST(-1005): The specified entity does not exist",
+					},
+					{
+						ID:      "pool2",
+						OpCode:  control.PoolRebuildOpCodeStop,
+						Errored: true,
+						Msg:     "DER_NONEXIST(-1005): entity does not exist",
+					},
+				},
+			},
+			expPrintStr: `
+System-rebuild stop requested for 2 pools
+- Without active rebuild:            2 pools
+Command completed successfully.
+`,
+		},
+		"rebuild stop - with real errors": {
+			resp: &control.SystemRebuildManageResp{
+				Results: []*control.PoolRebuildManageResult{
+					{
+						ID:     "pool1",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+					{
+						ID:      "pool2",
+						OpCode:  control.PoolRebuildOpCodeStop,
+						Errored: true,
+						Msg:     "failed to stop rebuild",
+					},
+				},
+			},
+			expPrintStr: `
+System-rebuild stop requested for 2 pools
+- With active rebuild:    1 pool
+- Errors:                 1 pool
+`,
+			expErr: errors.New("pool-rebuild stop failed on pool pool2: failed to stop rebuild"),
+		},
+		"rebuild stop - mixed categories verbose": {
+			resp: &control.SystemRebuildManageResp{
+				Results: []*control.PoolRebuildManageResult{
+					{
+						ID:     "pool1",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+					{
+						ID:     "pool2",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+					{
+						ID:      "pool3",
+						OpCode:  control.PoolRebuildOpCodeStop,
+						Errored: true,
+						Msg:     "DER_NONEXIST(-1005): The specified entity does not exist",
+					},
+					{
+						ID:      "pool4",
+						OpCode:  control.PoolRebuildOpCodeStop,
+						Errored: true,
+						Msg:     "error 1",
+					},
+					{
+						ID:      "pool5",
+						OpCode:  control.PoolRebuildOpCodeStop,
+						Errored: true,
+						Msg:     "error 2",
+					},
+				},
+			},
+			verbose: true,
+			expPrintStr: `
+System-rebuild stop requested for 5 pools
+- With active or finishing rebuild:    2 pools (pool1, pool2)
+- Without active rebuild:              1 pool (pool3)
+- Errors:                              2 pools (pool4, pool5)
+`,
+			expErr: errors.New("pool-rebuild stop failed on pool pool4: error 1, pool-rebuild stop failed on pool pool5: error 2"),
+		},
+		"rebuild start - all successful": {
+			resp: &control.SystemRebuildManageResp{
+				Results: []*control.PoolRebuildManageResult{
+					{
+						ID:     "pool1",
+						OpCode: control.PoolRebuildOpCodeStart,
+					},
+					{
+						ID:     "pool2",
+						OpCode: control.PoolRebuildOpCodeStart,
+					},
+				},
+			},
+			expPrintStr: `
+System-rebuild start requested for 2 pools
+- Successfully requested:            2 pools
+Command completed successfully.
+`,
+		},
+		"rebuild start - with errors": {
+			resp: &control.SystemRebuildManageResp{
+				Results: []*control.PoolRebuildManageResult{
+					{
+						ID:     "pool1",
+						OpCode: control.PoolRebuildOpCodeStart,
+					},
+					{
+						ID:      "pool2",
+						OpCode:  control.PoolRebuildOpCodeStart,
+						Errored: true,
+						Msg:     "failed to start rebuild",
+					},
+				},
+			},
+			expPrintStr: `
+System-rebuild start requested for 2 pools
+- Successfully requested: 1 pool
+- Errors:                 1 pool
+`,
+			expErr: errors.New("pool-rebuild start failed on pool pool2: failed to start rebuild"),
+		},
+		"rebuild stop with DER_BUSY - treated as success": {
+			resp: &control.SystemRebuildManageResp{
+				Results: []*control.PoolRebuildManageResult{
+					{
+						ID:     "pool1",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+					{
+						ID:      "pool2",
+						OpCode:  control.PoolRebuildOpCodeStop,
+						Errored: true,
+						Msg:     "DER_BUSY(-1012): Device or resource busy",
+					},
+				},
+			},
+			expPrintStr: `
+System-rebuild stop requested for 2 pools
+- With active or finishing rebuild:  2 pools
+Command completed successfully.
+`,
+		},
+		"rebuild stop with DER_BUSY verbose": {
+			resp: &control.SystemRebuildManageResp{
+				Results: []*control.PoolRebuildManageResult{
+					{
+						ID:     "pool1",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+					{
+						ID:      "pool2",
+						OpCode:  control.PoolRebuildOpCodeStop,
+						Errored: true,
+						Msg:     "DER_BUSY(-1012): Device or resource busy",
+					},
+					{
+						ID:      "pool3",
+						OpCode:  control.PoolRebuildOpCodeStop,
+						Errored: true,
+						Msg:     "DER_BUSY(-1012): Device or resource busy",
+					},
+				},
+			},
+			verbose: true,
+			expPrintStr: `
+System-rebuild stop requested for 3 pools
+- With active or finishing rebuild:  3 pools (pool1, pool2, pool3)
+Command completed successfully.
+`,
+		},
+		"rebuild stop mixed DER_BUSY DER_NONEXIST success and errors": {
+			resp: &control.SystemRebuildManageResp{
+				Results: []*control.PoolRebuildManageResult{
+					{
+						ID:     "pool_ok",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+					{
+						ID:      "pool_busy",
+						OpCode:  control.PoolRebuildOpCodeStop,
+						Errored: true,
+						Msg:     "DER_BUSY(-1012): Device or resource busy",
+					},
+					{
+						ID:      "pool_nonexist",
+						OpCode:  control.PoolRebuildOpCodeStop,
+						Errored: true,
+						Msg:     "DER_NONEXIST(-1005): The specified entity does not exist",
+					},
+					{
+						ID:      "pool_error",
+						OpCode:  control.PoolRebuildOpCodeStop,
+						Errored: true,
+						Msg:     "some error",
+					},
+				},
+			},
+			verbose: true,
+			expPrintStr: `
+System-rebuild stop requested for 4 pools
+- With active or finishing rebuild:    2 pools (pool_ok, pool_busy)
+- Without active rebuild:              1 pool (pool_nonexist)
+- Errors:                              1 pool (pool_error)
+`,
+			expErr: errors.New("pool-rebuild stop failed on pool pool_error: some error"),
+		},
+		"mismatched opcodes": {
+			resp: &control.SystemRebuildManageResp{
+				Results: []*control.PoolRebuildManageResult{
+					{
+						ID:     "pool1",
+						OpCode: control.PoolRebuildOpCodeStart,
+					},
+					{
+						ID:     "pool2",
+						OpCode: control.PoolRebuildOpCodeStop,
+					},
+				},
+			},
+			expErr: errors.New("different system rebuild manage opcodes found in results: start and stop"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var bld strings.Builder
+
+			gotErr := PrintSystemRebuildManageResp(&bld, tc.resp, tc.verbose)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
 			}
 
 			if diff := cmp.Diff(strings.TrimLeft(tc.expPrintStr, "\n"), bld.String()); diff != "" {

--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -16,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/cmd/dmg/pretty"
-	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/common/cmdutil"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/daos"
@@ -709,26 +708,11 @@ func (cmd *systemRebuildOpCmd) execute(opCode control.PoolRebuildOpCode, force b
 		return cmd.OutputJSON(resp, resp.Errors())
 	}
 
-	// Print successful results before returning any error.
-	respPoolsSuccess := []string{}
-	for _, res := range resp.Results {
-		if !res.Errored {
-			respPoolsSuccess = append(respPoolsSuccess, res.ID)
-		}
-	}
-	msg := fmt.Sprintf("System-rebuild %s request succeeded", opCode)
-	pStr := common.Pluralise("pool", len(respPoolsSuccess))
-	if cmd.Verbose {
-		cmd.Infof("%s on %d %s %v", msg, len(respPoolsSuccess), pStr, respPoolsSuccess)
-	} else {
-		cmd.Infof("%s on %d %s", msg, len(respPoolsSuccess), pStr)
-	}
+	var out strings.Builder
+	err = pretty.PrintSystemRebuildManageResp(&out, resp, cmd.Verbose)
+	cmd.Info(out.String())
 
-	if resp.Errors() != nil {
-		return resp.Errors()
-	}
-
-	return nil
+	return err
 }
 
 type systemRebuildStartCmd struct {

--- a/src/control/cmd/dmg/system_test.go
+++ b/src/control/cmd/dmg/system_test.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -24,6 +24,62 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
+
+// extractInfoMessages extracts INFO level messages from a log buffer, returning just
+// the message content without timestamps or prefixes. Returns a single string with
+// messages joined by newlines, terminated with a newline if any messages were found.
+// Continuation lines (lines that don't contain log level markers) are appended to
+// the previous INFO message.
+func extractInfoMessages(logOutput string) string {
+	var infoLines []string
+	lines := strings.Split(logOutput, "\n")
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		if strings.Contains(line, " INFO ") {
+			// Extract just the message part after the timestamp
+			// Format: "prefix INFO YYYY/MM/DD HH:MM:SS message"
+			parts := strings.SplitN(line, " INFO ", 2)
+			if len(parts) == 2 {
+				// Skip the date and time to get just the message
+				// After " INFO ", we have "YYYY/MM/DD HH:MM:SS message"
+				remainder := parts[1]
+
+				// Find the message by skipping two space-separated fields (date and time)
+				fields := strings.SplitN(remainder, " ", 3)
+				if len(fields) == 3 {
+					// fields[0] = date, fields[1] = time, fields[2] = message
+					msg := fields[2]
+
+					// Collect continuation lines (lines that don't have log level markers)
+					for i+1 < len(lines) {
+						nextLine := lines[i+1]
+						// Check if it's a continuation line (no log level marker)
+						if len(nextLine) > 0 &&
+							!strings.Contains(nextLine, " INFO ") &&
+							!strings.Contains(nextLine, " DEBUG ") &&
+							!strings.Contains(nextLine, " WARN ") &&
+							!strings.Contains(nextLine, " ERROR ") &&
+							nextLine != "captured log output:" &&
+							!strings.HasPrefix(nextLine, "---") &&
+							!strings.HasPrefix(nextLine, "===") {
+							msg += "\n" + nextLine
+							i++
+						} else {
+							break
+						}
+					}
+
+					infoLines = append(infoLines, msg)
+				}
+			}
+		}
+	}
+	if len(infoLines) == 0 {
+		return ""
+	}
+	return strings.Join(infoLines, "\n") + "\n"
+}
 
 func TestDmg_SystemCommands(t *testing.T) {
 	withRanks := func(req control.UnaryRequest, ranks ...ranklist.Rank) control.UnaryRequest {
@@ -623,17 +679,42 @@ func TestDmg_systemRebuildOpCmd_execute(t *testing.T) {
 			expErr: errors.New("failed"),
 		},
 		"no pools": {
-			ctlCfg:  &control.Config{},
-			opCode:  control.PoolRebuildOpCodeStop,
-			resp:    &mgmtpb.SystemRebuildManageResp{},
-			expInfo: "System-rebuild stop request succeeded on 0 pools",
+			ctlCfg: &control.Config{},
+			opCode: control.PoolRebuildOpCodeStop,
+			resp:   &mgmtpb.SystemRebuildManageResp{},
+			expInfo: `No pools in system.
+Command completed successfully.
+`,
 		},
-		"no pools; verbose": {
-			ctlCfg:  &control.Config{},
-			opCode:  control.PoolRebuildOpCodeStart,
-			verbose: true,
-			resp:    &mgmtpb.SystemRebuildManageResp{},
-			expInfo: "System-rebuild start request succeeded on 0 pools []",
+		"rebuild stop with DER_NONEXIST and real errors": {
+			ctlCfg: &control.Config{},
+			opCode: control.PoolRebuildOpCodeStop,
+			resp: &mgmtpb.SystemRebuildManageResp{
+				Results: []*mgmtpb.PoolRebuildManageResult{
+					{
+						Id:     "pool_success",
+						OpCode: uint32(control.PoolRebuildOpCodeStop),
+					},
+					{
+						Errored: true,
+						Msg:     "DER_NONEXIST(-1005): The specified entity does not exist",
+						Id:      "pool_notrebuilding",
+						OpCode:  uint32(control.PoolRebuildOpCodeStop),
+					},
+					{
+						Errored: true,
+						Msg:     "real error happened",
+						Id:      "pool_failed",
+						OpCode:  uint32(control.PoolRebuildOpCodeStop),
+					},
+				},
+			},
+			expErr: errors.New("pool-rebuild stop failed on pool pool_failed: real error happened"),
+			expInfo: `System-rebuild stop requested for 3 pools
+- With active or finishing rebuild:  1 pool
+- Without active rebuild:            1 pool
+- Errors:                            1 pool
+`,
 		},
 		"rebuild stop failed": {
 			ctlCfg: &control.Config{},
@@ -658,8 +739,11 @@ func TestDmg_systemRebuildOpCmd_execute(t *testing.T) {
 					},
 				},
 			},
-			expErr:  errors.New("failed on pool foo: failed, pool-rebuild stop failed on pool bar"),
-			expInfo: "System-rebuild stop request succeeded on 1 pool",
+			expErr: errors.New("pool-rebuild stop failed on pool foo: failed, pool-rebuild stop failed on pool bar: failed"),
+			expInfo: `System-rebuild stop requested for 3 pools
+- With active or finishing rebuild:  1 pool
+- Errors:                            2 pools
+`,
 		},
 		"rebuild start succeeded; verbose": {
 			ctlCfg:  &control.Config{},
@@ -669,19 +753,135 @@ func TestDmg_systemRebuildOpCmd_execute(t *testing.T) {
 				Results: []*mgmtpb.PoolRebuildManageResult{
 					{
 						Id:     "foo",
-						OpCode: uint32(control.PoolRebuildOpCodeStop),
+						OpCode: uint32(control.PoolRebuildOpCodeStart),
 					},
 					{
 						Id:     "bar",
-						OpCode: uint32(control.PoolRebuildOpCodeStop),
+						OpCode: uint32(control.PoolRebuildOpCodeStart),
 					},
 					{
 						Id:     "baz",
-						OpCode: uint32(control.PoolRebuildOpCodeStop),
+						OpCode: uint32(control.PoolRebuildOpCodeStart),
 					},
 				},
 			},
-			expInfo: "System-rebuild start request succeeded on 3 pools [foo bar baz]",
+			expInfo: `System-rebuild start requested for 3 pools
+- Successfully requested:            3 pools (foo, bar, baz)
+Command completed successfully.
+`,
+		},
+		"rebuild stop with only DER_NONEXIST; verbose": {
+			ctlCfg:  &control.Config{},
+			opCode:  control.PoolRebuildOpCodeStop,
+			verbose: true,
+			resp: &mgmtpb.SystemRebuildManageResp{
+				Results: []*mgmtpb.PoolRebuildManageResult{
+					{
+						Errored: true,
+						Msg:     "DER_NONEXIST(-1005): The specified entity does not exist",
+						Id:      "uuid1",
+						OpCode:  uint32(control.PoolRebuildOpCodeStop),
+					},
+					{
+						Errored: true,
+						Msg:     "DER_NONEXIST(-1005): The specified entity does not exist",
+						Id:      "uuid2",
+						OpCode:  uint32(control.PoolRebuildOpCodeStop),
+					},
+					{
+						Errored: true,
+						Msg:     "DER_NONEXIST(-1005): The specified entity does not exist",
+						Id:      "uuid3",
+						OpCode:  uint32(control.PoolRebuildOpCodeStop),
+					},
+				},
+			},
+			expInfo: `System-rebuild stop requested for 3 pools
+- Without active rebuild:            3 pools (uuid1, uuid2, uuid3)
+Command completed successfully.
+`,
+		},
+		"rebuild stop with DER_BUSY - treated as success": {
+			ctlCfg: &control.Config{},
+			opCode: control.PoolRebuildOpCodeStop,
+			resp: &mgmtpb.SystemRebuildManageResp{
+				Results: []*mgmtpb.PoolRebuildManageResult{
+					{
+						Id:     "pool1",
+						OpCode: uint32(control.PoolRebuildOpCodeStop),
+					},
+					{
+						Errored: true,
+						Msg:     "DER_BUSY(-1012): Device or resource busy",
+						Id:      "pool2",
+						OpCode:  uint32(control.PoolRebuildOpCodeStop),
+					},
+					{
+						Errored: true,
+						Msg:     "DER_BUSY(-1012): Device or resource busy",
+						Id:      "pool3",
+						OpCode:  uint32(control.PoolRebuildOpCodeStop),
+					},
+				},
+			},
+			expInfo: `System-rebuild stop requested for 3 pools
+- With active or finishing rebuild:  3 pools
+Command completed successfully.
+`,
+		},
+		"rebuild stop mixed DER_BUSY DER_NONEXIST and success": {
+			ctlCfg: &control.Config{},
+			opCode: control.PoolRebuildOpCodeStop,
+			resp: &mgmtpb.SystemRebuildManageResp{
+				Results: []*mgmtpb.PoolRebuildManageResult{
+					{
+						Id:     "pool_success",
+						OpCode: uint32(control.PoolRebuildOpCodeStop),
+					},
+					{
+						Errored: true,
+						Msg:     "DER_BUSY(-1012): Device or resource busy",
+						Id:      "pool_busy",
+						OpCode:  uint32(control.PoolRebuildOpCodeStop),
+					},
+					{
+						Errored: true,
+						Msg:     "DER_NONEXIST(-1005): The specified entity does not exist",
+						Id:      "pool_norebuild",
+						OpCode:  uint32(control.PoolRebuildOpCodeStop),
+					},
+				},
+			},
+			expInfo: `System-rebuild stop requested for 3 pools
+- With active or finishing rebuild:  2 pools
+- Without active rebuild:            1 pool
+Command completed successfully.
+`,
+		},
+		"rebuild stop with DER_BUSY and real errors": {
+			ctlCfg: &control.Config{},
+			opCode: control.PoolRebuildOpCodeStop,
+			resp: &mgmtpb.SystemRebuildManageResp{
+				Results: []*mgmtpb.PoolRebuildManageResult{
+					{
+						Errored: true,
+						Msg:     "DER_BUSY(-1012): Device or resource busy",
+						Id:      "pool_busy",
+						OpCode:  uint32(control.PoolRebuildOpCodeStop),
+					},
+					{
+						Errored: true,
+						Msg:     "real error",
+						Id:      "pool_error",
+						OpCode:  uint32(control.PoolRebuildOpCodeStop),
+					},
+				},
+			},
+			expErr: errors.New("pool-rebuild stop failed on pool pool_error: real error"),
+			expInfo: `System-rebuild stop requested for 2 pools
+- With active or finishing rebuild:  1 pool
+- Errors:                            1 pool
+`,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -702,16 +902,17 @@ func TestDmg_systemRebuildOpCmd_execute(t *testing.T) {
 			gotErr := rbldCmd.execute(tc.opCode, tc.force)
 			test.CmpErr(t, tc.expErr, gotErr)
 
-			// Note this doesn't verify that the text is on an INFO or DEBUG line
-			// specifically, just that it appears in log output.
-
-			if !strings.Contains(buf.String(), tc.expInfo) {
-				t.Fatalf("expected info log output to contain %s, got %s\n",
-					tc.expInfo, buf.String())
+			if tc.expInfo == "" {
+				if strings.Contains(buf.String(), "INFO") {
+					t.Fatalf("unexpected INFO log output printed, got:\n%s", buf.String())
+				}
+				return
 			}
-			if tc.expInfo == "" && strings.Contains(buf.String(), "INFO") {
-				t.Fatalf("unexpected info log output printed, got %s\n",
-					buf.String())
+
+			gotInfo := extractInfoMessages(buf.String())
+			if gotInfo != tc.expInfo {
+				t.Fatalf("INFO output mismatch:\nexpected:\n%s\ngot:\n%s\nfull buffer:\n%s",
+					tc.expInfo, gotInfo, buf.String())
 			}
 		})
 	}


### PR DESCRIPTION
Enhance rebuild-stop command to distinguish between successful stops,
pools without active rebuilds (DER_NONEXIST), and actual errors.
Provide structured output showing counts for each category and only
fail on real errors, not when pools aren't rebuilding.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
