### PR TITLE
DAOS-19345 build: propagate no_proxy/NO_PROXY through SCons MINIMAL_ENV

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -371,7 +371,8 @@ def load_local(env_script, env):
 
 
 # Environment variables that are kept when SCONS_ENV=minimal (the default).
-MINIMAL_ENV = ('HOME', 'TERM', 'SSH_AUTH_SOCK', 'http_proxy', 'https_proxy', 'PKG_CONFIG_PATH',
+MINIMAL_ENV = ('HOME', 'TERM', 'SSH_AUTH_SOCK', 'http_proxy', 'https_proxy',
+               'no_proxy', 'NO_PROXY', 'PKG_CONFIG_PATH',
                'MODULEPATH', 'MODULESHOME', 'MODULESLOADED', 'I_MPI_ROOT', 'COVFILE')
 
 # Environment variables that are also kept when LD_PRELOAD is set.


### PR DESCRIPTION
When a build host has an HTTP proxy configured (`http_proxy`/`https_proxy`) together with a `no_proxy`/`NO_PROXY` bypass list for hosts that should be reached directly, `scons --build-deps=yes` can fail to reach those bypassed hosts.

`SConstruct`'s `MINIMAL_ENV` allow-list — used by `_copy_env()` to build the `ENV` dict passed to build subprocesses (see `site_scons/prereq_tools/base.py`) — forwards `http_proxy`/`https_proxy` but not `no_proxy`/`NO_PROXY`. Subprocesses such as `pip`/`uv` therefore inherit the proxy with no bypass exemption at all, and route requests for hosts that should be reached directly through a proxy that may not be able to reach them.

Add `no_proxy` and `NO_PROXY` to `MINIMAL_ENV` to `SConstruct`, mirroring the existing `http_proxy`/`https_proxy` entries:

```diff
-MINIMAL_ENV = ('HOME', 'TERM', 'SSH_AUTH_SOCK', 'http_proxy', 'https_proxy', 'PKG_CONFIG_PATH',
-               'MODULEPATH', 'MODULESHOME', 'MODULESLOADED', 'I_MPI_ROOT', 'COVFILE')
+MINIMAL_ENV = ('HOME', 'TERM', 'SSH_AUTH_SOCK', 'http_proxy', 'https_proxy',
+               'no_proxy', 'NO_PROXY', 'PKG_CONFIG_PATH',
+               'MODULEPATH', 'MODULESHOME', 'MODULESLOADED', 'I_MPI_ROOT', 'COVFILE')
```

`_copy_env()`'s existing `if value:` guard (unchanged) already skips variables that aren't set in the caller's environment, so this is a no-op for any build that doesn't configure a proxy.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
