### PR TITLE
DAOS-18825 pool: reserve fields for pool creation

### DIFF
--- a/src/pool/rpc.c
+++ b/src/pool/rpc.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -81,6 +81,7 @@ crt_proc_struct_pool_op_out(crt_proc_t proc, crt_proc_op_t proc_op,
 	return crt_proc_pool_op_out(proc, data);
 }
 
+CRT_RPC_DEFINE(pool_create_v6, DAOS_ISEQ_POOL_CREATE_V6, DAOS_OSEQ_POOL_CREATE)
 CRT_RPC_DEFINE(pool_create, DAOS_ISEQ_POOL_CREATE, DAOS_OSEQ_POOL_CREATE)
 CRT_RPC_DEFINE(pool_connect, DAOS_ISEQ_POOL_CONNECT, DAOS_OSEQ_POOL_CONNECT)
 CRT_RPC_DEFINE(pool_disconnect, DAOS_ISEQ_POOL_DISCONNECT, DAOS_OSEQ_POOL_DISCONNECT)
@@ -436,4 +437,3 @@ map_bulk_destroy(crt_bulk_t bulk, struct pool_buf *buf)
 	crt_bulk_free(bulk);
 	pool_buf_free(buf);
 }
-

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -34,10 +34,13 @@
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */
 
-#define POOL_PROTO_VER_WITH_SVC_OP_KEY 6
+#define POOL_PROTO_VER_WITH_SVC_OP_KEY    6
+#define POOL_PROTO_VER_WITH_DOWNOUT_RANKS 7
 
 #define POOL_PROTO_CLI_RPC_LIST(ver)                                                               \
-	X(POOL_CREATE, 0, &CQF_pool_create, ds_pool_create_handler, NULL)                          \
+	X(POOL_CREATE, 0,                                                                          \
+	  ver >= POOL_PROTO_VER_WITH_DOWNOUT_RANKS ? &CQF_pool_create : &CQF_pool_create_v6,       \
+	  ds_pool_create_handler, NULL)                                                            \
 	X(POOL_CONNECT, 0, &CQF_pool_connect, ds_pool_connect_handler, NULL)                       \
 	X(POOL_DISCONNECT, 0, &CQF_pool_disconnect, ds_pool_disconnect_handler, NULL)              \
 	X(POOL_QUERY, 0, ver >= 7 ? &CQF_pool_query : &CQF_pool_query_v6,                          \
@@ -121,7 +124,7 @@ extern int dc_pool_proto_version;
 CRT_RPC_DECLARE(pool_op, DAOS_ISEQ_POOL_OP, DAOS_OSEQ_POOL_OP)
 
 /* If pri_op.pi_hdl is not null, call rdb_campaign. */
-#define DAOS_ISEQ_POOL_CREATE	/* input fields */			\
+#define DAOS_ISEQ_POOL_CREATE_V6 /* input fields */			\
 	((struct pool_op_in)	(pri_op)		CRT_VAR)	\
 	((d_rank_list_t)	(pri_tgt_ranks)		CRT_PTR)	\
 	((daos_prop_t)		(pri_prop)		CRT_PTR)	\
@@ -129,9 +132,14 @@ CRT_RPC_DECLARE(pool_op, DAOS_ISEQ_POOL_OP, DAOS_OSEQ_POOL_OP)
 	((uint32_t)		(pri_ntgts)		CRT_VAR)	\
 	((uint32_t)		(pri_domains)		CRT_ARRAY)
 
+#define DAOS_ISEQ_POOL_CREATE	/* input fields */			\
+	DAOS_ISEQ_POOL_CREATE_V6					\
+	((d_rank_list_t)	(pri_downout_ranks)	CRT_PTR)
+
 #define DAOS_OSEQ_POOL_CREATE	/* output fields */		 \
 	((struct pool_op_out)	(pro_op)		CRT_VAR)
 
+CRT_RPC_DECLARE(pool_create_v6, DAOS_ISEQ_POOL_CREATE_V6, DAOS_OSEQ_POOL_CREATE)
 CRT_RPC_DECLARE(pool_create, DAOS_ISEQ_POOL_CREATE, DAOS_OSEQ_POOL_CREATE)
 
 /* clang-format on */
@@ -199,10 +207,11 @@ pool_opc_2map_opc(uint32_t pool_opc)
 
 static inline void
 pool_create_in_get_data(crt_rpc_t *rpc, d_rank_list_t **pri_tgt_ranksp, daos_prop_t **pri_propp,
-			uint32_t *pri_ndomainsp, uint32_t *pri_ntgtsp, uint32_t **pri_domainsp)
+			uint32_t *pri_ndomainsp, uint32_t *pri_ntgtsp, uint32_t **pri_domainsp,
+			d_rank_list_t **pri_downout_ranksp)
 {
-	struct pool_create_in *in      = crt_req_get(rpc);
-	uint8_t                rpc_ver = opc_get_rpc_ver(rpc->cr_opc);
+	struct pool_create_v6_in *in      = crt_req_get(rpc);
+	uint8_t                   rpc_ver = opc_get_rpc_ver(rpc->cr_opc);
 
 	D_ASSERT(rpc_ver >= POOL_PROTO_VER_WITH_SVC_OP_KEY);
 	*pri_tgt_ranksp = in->pri_tgt_ranks;
@@ -210,15 +219,22 @@ pool_create_in_get_data(crt_rpc_t *rpc, d_rank_list_t **pri_tgt_ranksp, daos_pro
 	*pri_ndomainsp  = in->pri_ndomains;
 	*pri_ntgtsp     = in->pri_ntgts;
 	*pri_domainsp   = in->pri_domains.ca_arrays;
+	if (pri_downout_ranksp != NULL) {
+		if (rpc_ver >= POOL_PROTO_VER_WITH_DOWNOUT_RANKS)
+			*pri_downout_ranksp = ((struct pool_create_in *)in)->pri_downout_ranks;
+		else
+			*pri_downout_ranksp = NULL;
+	}
 	D_ASSERT(*pri_ndomainsp == in->pri_domains.ca_count);
 }
 
 static inline void
 pool_create_in_set_data(crt_rpc_t *rpc, d_rank_list_t *pri_tgt_ranks, daos_prop_t *pri_prop,
-			uint32_t pri_ndomains, uint32_t pri_ntgts, uint32_t *pri_domains)
+			uint32_t pri_ndomains, uint32_t pri_ntgts, uint32_t *pri_domains,
+			d_rank_list_t *pri_downout_ranks)
 {
-	struct pool_create_in *in      = crt_req_get(rpc);
-	uint8_t                rpc_ver = opc_get_rpc_ver(rpc->cr_opc);
+	struct pool_create_v6_in *in      = crt_req_get(rpc);
+	uint8_t                   rpc_ver = opc_get_rpc_ver(rpc->cr_opc);
 
 	D_ASSERT(rpc_ver >= POOL_PROTO_VER_WITH_SVC_OP_KEY);
 	in->pri_tgt_ranks         = pri_tgt_ranks;
@@ -227,6 +243,8 @@ pool_create_in_set_data(crt_rpc_t *rpc, d_rank_list_t *pri_tgt_ranks, daos_prop_
 	in->pri_ntgts             = pri_ntgts;
 	in->pri_domains.ca_arrays = pri_domains;
 	in->pri_domains.ca_count  = pri_ndomains;
+	if (rpc_ver >= POOL_PROTO_VER_WITH_DOWNOUT_RANKS)
+		((struct pool_create_in *)in)->pri_downout_ranks = pri_downout_ranks;
 }
 
 /* clang-format off */

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1165,7 +1165,8 @@ rechoose:
 		goto out_backoff_seq;
 	}
 	/* We could send map_buf to simplify things. */
-	pool_create_in_set_data(rpc, target_addrs, prop, ndomains, ntargets, domains);
+	pool_create_in_set_data(rpc, target_addrs, prop, ndomains, ntargets, domains,
+				NULL /* downout_ranks */);
 
 	/* Send the POOL_CREATE request. */
 	rc = dss_rpc_send(rpc);
@@ -4012,8 +4013,8 @@ out:
 void
 ds_pool_create_handler(crt_rpc_t *rpc)
 {
-	struct pool_create_in  *in = crt_req_get(rpc);
-	struct pool_create_out *out = crt_reply_get(rpc);
+	struct pool_create_v6_in *in  = crt_req_get(rpc);
+	struct pool_create_out   *out = crt_reply_get(rpc);
 	struct pool_svc	       *svc;
 	struct rdb_tx		tx;
 	d_iov_t			value;
@@ -4028,7 +4029,8 @@ ds_pool_create_handler(crt_rpc_t *rpc)
 	D_DEBUG(DB_MD, DF_UUID": processing rpc %p\n",
 		DP_UUID(in->pri_op.pi_uuid), rpc);
 
-	pool_create_in_get_data(rpc, &tgt_ranks, &prop, &ndomains, &ntgts, &domains);
+	pool_create_in_get_data(rpc, &tgt_ranks, &prop, &ndomains, &ntgts, &domains,
+				NULL /* downout_ranks */);
 
 	if (ntgts != tgt_ranks->rl_nr)
 		D_GOTO(out, rc = -DER_PROTO);


### PR DESCRIPTION
Reserve fields in the pool creation RPC for future use. This will allow pool creation to pass DOWNOUT ranks so they can be included in the pool map without creating pool targets on those ranks.

Add a v6 POOL_CREATE request format and use it for older pool protocol versions so that v7 can append downout ranks without changing the v6 wire format.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
