### PR TITLE
DAOS-13563 vos: prevent zero-IOD flat-dkey fetch crash

### DIFF
--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -3407,7 +3407,82 @@ static const struct CMUnitTest iterator_tests[] = {
      NULL},
 };
 
+static daos_unit_oid_t	vos283_save_oid;
+
+static int
+io_fetch_flat_dkey_zero_iod_teardown(void **state)
+{
+	struct io_test_args	*arg = *state;
+
+	/* restore the oid clobbered by the test so following tests are unaffected */
+	arg->oid = vos283_save_oid;
+	return 0;
+}
+
+/*
+ * DAOS-13563: a CHECK_EXISTENCE / SET_TS_ONLY fetch carries no iods (iod_nr == 0,
+ * permitted by vos_ioc_create()).  For a flat-dkey object (array / flat KV on a
+ * pool with VOS_POOL_FEAT_FLAT_DKEY) dkey_fetch() dereferenced ioc->ic_iods[0]
+ * without an iod_nr guard and crashed the engine (SIGSEGV in the SUBTR_EVT
+ * computation, SIGABRT in the KREC_BF_NO_AKEY branch).  Reproduced here via an
+ * array object; the fetch must complete without crashing after the fix.
+ */
+static void
+io_fetch_flat_dkey_zero_iod(void **state)
+{
+	struct io_test_args	*arg = *state;
+	daos_epoch_t		 epoch = gen_rand_epoch();
+	daos_key_t		 dkey, akey;
+	daos_iod_t		 iod = {0};
+	daos_recx_t		 rex = {0};
+	d_sg_list_t		 sgl = {0};
+	d_iov_t			 val_iov;
+	uint64_t		 dkey_val = 1;
+	char			 akey_buf[UPDATE_AKEY_SIZE];
+	char			 update_buf[UPDATE_BUF_SIZE];
+	daos_handle_t		 ioh;
+	int			 rc;
+
+	vos283_save_oid = arg->oid;
+	/* flat-dkey applies to array/KV objects; an array object uses a uint64 dkey */
+	arg->oid = gen_oid(DAOS_OT_ARRAY_BYTE);
+	dts_buf_render(update_buf, UPDATE_BUF_SIZE);
+	vts_key_gen(&akey_buf[0], arg->akey_size, false, arg);
+	d_iov_set(&dkey, &dkey_val, sizeof(dkey_val));
+	set_iov(&akey, &akey_buf[0], false);
+	d_iov_set(&val_iov, &update_buf[0], UPDATE_BUF_SIZE);
+	rex.rx_idx = 0;
+	rex.rx_nr = UPDATE_BUF_SIZE;
+	iod.iod_name = akey;
+	iod.iod_type = DAOS_IOD_ARRAY;
+	iod.iod_size = 1;
+	iod.iod_recxs = &rex;
+	iod.iod_nr = 1;
+	sgl.sg_nr = 1;
+	sgl.sg_iovs = &val_iov;
+	rc = io_test_obj_update(arg, epoch, 0, &dkey, &iod, &sgl, NULL, false);
+	assert_rc_equal(rc, 0);
+
+	/* Existence-check fetch carrying no iods (iod_nr == 0) - the crash trigger. */
+	rc = vos_fetch_begin(arg->ctx.tc_co_hdl, arg->oid, epoch, &dkey, 0, NULL,
+			     VOS_OF_FETCH_CHECK_EXISTENCE, NULL, &ioh, NULL);
+	/*
+	 * The regression was an engine crash (SIGSEGV/SIGABRT) inside dkey_fetch();
+	 * the fix makes it return cleanly.  With iod_nr == 0 the flat-array dkey
+	 * subtree type is unknown to the probe, so the dkey-level existence check
+	 * legitimately reports DER_NONEXIST - reaching this assertion at all (i.e.
+	 * a clean rc rather than a crash) is what proves the fix.
+	 */
+	assert_true(rc == 0 || rc == -DER_NONEXIST);
+	if (rc == 0) {
+		rc = vos_fetch_end(ioh, NULL, 0);
+		assert_rc_equal(rc, 0);
+	}
+}
+
 static const struct CMUnitTest io_tests[] = {
+    {"VOS283: iod_nr==0 existence fetch on flat-dkey object (DAOS-13563)", io_fetch_flat_dkey_zero_iod,
+     NULL, io_fetch_flat_dkey_zero_iod_teardown},
     {"VOS203: Simple update/fetch/verify test", io_simple_one_key, NULL, NULL},
     {"VOS204: Simple Punch test", io_simple_punch, NULL, NULL},
     {"VOS205: Simple near-epoch retrieval test", io_simple_near_epoch, NULL, NULL},

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1561,7 +1561,12 @@ dkey_fetch(struct vos_io_context *ioc, daos_key_t *dkey)
 
 	if (ioc->ic_skip_akey_support) {
 		flags |= SUBTR_FLAT;
-		if (ioc->ic_iods[0].iod_type == DAOS_IOD_ARRAY)
+		/* ic_iods may be NULL/empty for existence-check or set-TS-only fetches
+		 * (iod_nr == 0 is permitted for those in vos_ioc_create()); guard the
+		 * ic_iods[0] deref so a HEAD/existence fetch on a flat-dkey object does
+		 * not crash the engine.
+		 */
+		if (ioc->ic_iod_nr > 0 && ioc->ic_iods[0].iod_type == DAOS_IOD_ARRAY)
 			flags |= SUBTR_EVT;
 	}
 
@@ -1611,8 +1616,16 @@ dkey_fetch(struct vos_io_context *ioc, daos_key_t *dkey)
 
 fetch_akey:
 	if (krec->kr_bmap & KREC_BF_NO_AKEY) {
-		iod_set_cursor(ioc, 0);
-		rc = fetch_value(ioc, &ioc->ic_iods[0], toh, &ioc->ic_epr, standalone);
+		/* existence-check / set-TS-only fetches carry no iods (iod_nr == 0);
+		 * key existence was already established above, so skip the value fetch
+		 * (the non-flat path is naturally guarded by the ic_iod_nr loop below).
+		 * Without this, iod_set_cursor() asserts (sgl_at < ic_iod_nr) and
+		 * ic_iods[0] is dereferenced NULL, aborting/crashing the engine.
+		 */
+		if (ioc->ic_iod_nr > 0) {
+			iod_set_cursor(ioc, 0);
+			rc = fetch_value(ioc, &ioc->ic_iods[0], toh, &ioc->ic_epr, standalone);
+		}
 	} else {
 		for (i = 0; i < ioc->ic_iod_nr; i++) {
 			iod_set_cursor(ioc, i);


### PR DESCRIPTION
## Summary

Prevent an engine crash when a flat-dkey object is fetched with `iod_nr == 0`
using `VOS_OF_FETCH_CHECK_EXISTENCE` or `VOS_OF_FETCH_SET_TS_ONLY`.

This is an upstream VOS correctness issue, not a project-quota-specific change:

- `vos_ioc_create()` explicitly permits zero-IOD fetches for these two flags.
- DAOS uses zero-IOD dkey existence checks in its own conditional
  transaction/update/punch paths.
- Flat dkeys are a standard pool feature for array and flat-KV objects.

The affected combination is therefore a supported, although uncommon, mainline
path:

```
zero-IOD existence/read-TS fetch
+ VOS_POOL_FEAT_FLAT_DKEY
+ array or flat-KV object
```

## Root cause

`vos_ioc_create()` accepts `iod_nr == 0` for existence and read-TS-only fetches,
leaving `ioc->ic_iods == NULL`. The flat path in `dkey_fetch()` nevertheless
accesses `ic_iods[0]` in two places:

1. The subtree-type calculation dereferences `ic_iods[0].iod_type`, causing
   `SIGSEGV` (`NULL + 0x18`).
2. The `KREC_BF_NO_AKEY` path calls `iod_set_cursor(ioc, 0)`, triggering
   `D_ASSERT(sgl_at < ic_iod_nr)`, and then passes `ic_iods[0]` to
   `fetch_value()`.

The regression was introduced by ae105cb4f ("DAOS-13563 vos: Implement flat
dkey for array and flat KV object types", #13175).

## Fix

Guard both flat-path `ic_iods[0]` accesses with `ic_iod_nr > 0`. For a zero-IOD
operation, dkey visibility is handled by `key_tree_prepare()` and
`key_ilog_check()`; there is no value descriptor to fetch. The non-flat path
already handles zero IODs through its bounded loop.

## Regression test

`VOS283` in `src/vos/tests/vts_io.c`:

- creates and updates a flat-dkey `DAOS_OT_ARRAY_BYTE` object using the required
  uint64 dkey;
- issues a zero-IOD `VOS_OF_FETCH_CHECK_EXISTENCE` fetch; and
- verifies that the operation returns normally rather than terminating the
  process with `SIGSEGV` or `SIGABRT`.

The test restores the shared test OID during teardown so a failure cannot affect
later tests.

Verified on an md-on-SSD hardware build with
`PMEMOBJ_CONF=sds.at_create=0`, using the same `vos_tests` binary and swapping
only `libvos.so`:

- unfixed library: `VOS283 ... Segmentation fault(11)`; process exit 1;
- fixed library: `VOS283 OK`; io group 21/21 PASS.

The failure was also reproduced against the pure upstream merge-base, confirming
that it is an upstream regression.

## Discovery

The bug was first observed when versitygw issued an S3 HEAD/conditional-PUT
existence probe against a flat DFS object. That workload exposed the bug but is
not required to reproduce it.

---
Signed-off-by: hgichon <hgichon@gmail.com>
