### PR TITLE
DAOS-19296 test: Add provider stage support for basic tests (#18640)

### DIFF
--- a/src/tests/ftest/harness/basic.py
+++ b/src/tests/ftest/harness/basic.py
@@ -97,6 +97,16 @@ class HarnessBasicTest(TestWithoutServers):
         """
         self.test_load_mpi()
 
+    def test_load_mpi_hw_provider(self):
+        """Simple test of apricot test code to load the openmpi module.
+
+        :avocado: tags=all
+        :avocado: tags=hw,medium,large,provider
+        :avocado: tags=harness,harness_basic_test,load_mpi
+        :avocado: tags=HarnessBasicTest,test_load_mpi_hw_provider
+        """
+        self.test_load_mpi()
+
     def test_sub_process_command(self):
         """Simple test of the SubProcessCommand object.
 

--- a/src/tests/ftest/harness/core_files.py
+++ b/src/tests/ftest/harness/core_files.py
@@ -98,8 +98,22 @@ class HarnessCoreFilesTest(TestWithServers):
         in launch.py to be tested.
 
         :avocado: tags=all
-        :avocado: tags=hw,medium,large
+        :avocado: tags=hw,cb,medium,large
         :avocado: tags=harness,core_files
         :avocado: tags=HarnessCoreFilesTest,test_core_files_hw
+        """
+        self.test_core_files()
+
+    def test_core_files_hw_provider(self):
+        """Test to verify core file creation.
+
+        This test will send a signal 6 to a random daos_engine process so
+        that it will create a core file, allowing the core file collection code
+        in launch.py to be tested.
+
+        :avocado: tags=all
+        :avocado: tags=hw,medium,large,provider
+        :avocado: tags=harness,core_files
+        :avocado: tags=HarnessCoreFilesTest,test_core_files_hw_provider
         """
         self.test_core_files()


### PR DESCRIPTION
Add load mpi and core file test support for provider testing branches.

Test-tag: HarnessBasicTest,-always_fails HarnessCoreFilesTest

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
