### PR TITLE
DAOS-19359 test: remove src/tests/ftest/__init__.py

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       - /
     ignore:
       - dependency-name: "avocado-framework*"
+      - dependency-name: "setuptools"
     schedule:
       interval: weekly
     groups:

--- a/requirements-ftest.txt
+++ b/requirements-ftest.txt
@@ -4,5 +4,5 @@ avocado-framework-plugin-varianter-yaml-to-mux==82
 clustershell
 distro
 paramiko
-setuptools<82
+setuptools
 torch

--- a/requirements-ftest.txt
+++ b/requirements-ftest.txt
@@ -4,5 +4,6 @@ avocado-framework-plugin-varianter-yaml-to-mux==82
 clustershell
 distro
 paramiko
-setuptools
+# Newer setuptools does not have pkg_resources, which avocado 82 uses
+setuptools<82
 torch

--- a/src/tests/ftest/__init__.py
+++ b/src/tests/ftest/__init__.py
@@ -1,4 +1,0 @@
-"""ftest __init__.py."""
-import pkg_resources
-
-pkg_resources.declare_namespace(__name__)


### PR DESCRIPTION
Remove src/tests/ftest/__init__.py as its behavior is implicit since python 3.3.

Test-tag: always_passes,vm
Skip-Functional-on-Leap-15: false

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
