### PR TITLE
DAOS-19350 object: validate array IOD recxs

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2239,6 +2239,8 @@ obj_iod_sgl_valid(daos_obj_id_t oid, unsigned int nr, daos_iod_t *iods,
 	}
 
 	for (i = 0; i < nr; i++) {
+		D_DEBUG(DB_TRACE, "Validating IOD[%d] %p: type=%d nr=%u recxs=%p\n", i, &iods[i],
+			iods[i].iod_type, iods[i].iod_nr, iods[i].iod_recxs);
 		if (iods[i].iod_name.iov_buf == NULL) {
 			D_ERROR("Invalid argument of NULL akey\n");
 			return -DER_INVAL;
@@ -2289,6 +2291,11 @@ obj_iod_sgl_valid(daos_obj_id_t oid, unsigned int nr, daos_iod_t *iods,
 			return -DER_INVAL;
 
 		case DAOS_IOD_ARRAY:
+			if (iods[i].iod_nr > 0 && iods[i].iod_recxs == NULL) {
+				D_ERROR("Invalid array IOD[%d] %p: nr=%u recxs=NULL\n", i, &iods[i],
+					iods[i].iod_nr);
+				return -DER_INVAL;
+			}
 			if (sgls == NULL) {
 				/* size query or punch */
 				if ((iods[i].iod_size == DAOS_REC_ANY) ||

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -206,6 +206,12 @@ crt_proc_daos_iod_and_csum(crt_proc_t proc, crt_proc_op_t proc_op,
 	if (nr == 0)
 		D_GOTO(out, rc = 0);
 #endif
+
+	if (ENCODING(proc_op) && iod->iod_type == DAOS_IOD_ARRAY && iod->iod_recxs == NULL) {
+		D_ERROR("Invalid array IOD before RPC encoding: iod=%p nr=%u recxs=NULL\n", iod,
+			nr);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
 
 	if (ENCODING(proc_op) || FREEING(proc_op)) {
 		if (iod->iod_type == DAOS_IOD_ARRAY && iod->iod_recxs != NULL)

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1452,6 +1452,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc, daos_iod_t *io
 	uint64_t			bio_pre_latency = 0;
 	uint64_t			bio_post_latency = 0;
 	uint32_t			tgt_off = 0;
+	uint32_t                         i;
 	int				rc = 0;
 
 	create_map = orw->orw_flags & ORF_CREATE_MAP;
@@ -1471,6 +1472,20 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc, daos_iod_t *io
 	}
 
 	dkey = (daos_key_t *)&orw->orw_dkey;
+	for (i = 0; i < iods_nr; i++) {
+		if (iods[i].iod_type != DAOS_IOD_ARRAY || iods[i].iod_nr == 0 ||
+		    iods[i].iod_recxs != NULL)
+			continue;
+
+		D_ERROR(DF_CONT " " DF_UOID
+				" invalid array IOD[%u] from RPC: iod=%p nr=%u recxs=NULL, "
+				"flags=%x api_flags=" DF_X64 " co_hdl=" DF_UUID "\n",
+			DP_CONT(orw->orw_pool_uuid, orw->orw_co_uuid), DP_UOID(orw->orw_oid), i,
+			&iods[i], iods[i].iod_nr, orw->orw_flags, orw->orw_api_flags,
+			DP_UUID(orw->orw_co_hdl));
+		return -DER_IO_INVAL;
+	}
+
 	D_DEBUG(DB_IO,
 		"opc %d oid "DF_UOID" dkey "DF_KEY" tag %d epc "DF_X64" flags %x.\n",
 		opc_get(rpc->cr_opc), DP_UOID(orw->orw_oid), DP_KEY(dkey),
@@ -1715,7 +1730,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc, daos_iod_t *io
 	    daos_csummer_initialized(ioc->ioc_coc->sc_csummer)) {
 		if (orw->orw_iod_array.oia_iods != iods) {
 			/* Need to copy iod sizes for checksums */
-			int i, j;
+			int j;
 
 			for (i = 0, j = 0; i < orw->orw_iod_array.oia_iod_nr; i++) {
 				if (skips != NULL && isset(skips, i)) {


### PR DESCRIPTION
Because Object fetch tasks retain caller-owned IOD pointers, and RPC encoding may be deferred or repeated during a retry, if an asynchronous caller clears or reuses an IOD before completion, encoding can observe a positive iod_nr with a NULL iod_recxs, DAOS engine can crash in this case before it doesn't do enough defensive check.

This patch includes these changes:
- Reject array IODs with a positive extent count and no recx array during client validation and RPC encoding.

- Add a server-side guard to prevent malformed requests from reaching VOS.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
