### PR TITLE
DAOS-19213 dfs: handle progressive-layout files in the container checker

### DIFF
--- a/src/client/dfs/cont.c
+++ b/src/client/dfs/cont.c
@@ -462,14 +462,16 @@ out_prop:
 #define DFS_ELAPSED_TIME   30
 
 struct dfs_oit_args {
-	daos_handle_t oit;
-	uint64_t      flags;
-	uint64_t      snap_epoch;
-	uint64_t      skipped;
-	uint64_t      failed;
-	time_t        start_time;
-	time_t        print_time;
-	uint64_t      num_scanned;
+	daos_handle_t    oit;
+	uint64_t         flags;
+	uint64_t         snap_epoch;
+	uint64_t         skipped;
+	uint64_t         failed;
+	time_t           start_time;
+	time_t           print_time;
+	uint64_t         num_scanned;
+	/** container layout version, used to locate progressive-layout tail fields in entries */
+	dfs_layout_ver_t layout_v;
 };
 
 static int
@@ -478,8 +480,8 @@ fetch_mark_oids(daos_handle_t coh, daos_obj_id_t oid, daos_key_desc_t *kds, char
 {
 	daos_handle_t oh;
 	d_sg_list_t   sgl, entry_sgl;
-	d_iov_t       iov, sg_iov;
-	daos_recx_t   recx;
+	d_iov_t       iov, sg_iovs[3];
+	daos_recx_t   recxs[3];
 	uint32_t      nr;
 	daos_iod_t    iod;
 	d_iov_t       marker;
@@ -500,17 +502,30 @@ fetch_mark_oids(daos_handle_t coh, daos_obj_id_t oid, daos_key_desc_t *kds, char
 	sgl.sg_iovs = &iov;
 
 	/** set sgl for fetch */
-	entry_sgl.sg_nr     = 1;
 	entry_sgl.sg_nr_out = 0;
-	entry_sgl.sg_iovs   = &sg_iov;
+	entry_sgl.sg_iovs   = sg_iovs;
 
 	d_iov_set(&iod.iod_name, INODE_AKEY_NAME, sizeof(INODE_AKEY_NAME) - 1);
-	recx.rx_idx   = OID_IDX;
-	recx.rx_nr    = sizeof(daos_obj_id_t);
-	iod.iod_nr    = 1;
-	iod.iod_recxs = &recx;
-	iod.iod_type  = DAOS_IOD_ARRAY;
-	iod.iod_size  = 1;
+	recxs[0].rx_idx = OID_IDX;
+	recxs[0].rx_nr  = sizeof(daos_obj_id_t);
+	iod.iod_nr      = 1;
+	iod.iod_recxs   = recxs;
+	iod.iod_type    = DAOS_IOD_ARRAY;
+	iod.iod_size    = 1;
+	/*
+	 * For progressive-layout containers (layout >= DFS_PL_LAYOUT_VERSION) each entry also
+	 * stores a tail object id and tail state. Fetch those alongside the head oid so a regular
+	 * file's tail array can be marked too (see oit_mark_cb for why an unmarked tail is
+	 * dangerous).
+	 */
+	if (args->layout_v >= DFS_PL_LAYOUT_VERSION) {
+		recxs[1].rx_idx = TAIL_OID_IDX;
+		recxs[1].rx_nr  = sizeof(daos_obj_id_t);
+		recxs[2].rx_idx = TAIL_STATE_IDX;
+		recxs[2].rx_nr  = sizeof(uint8_t);
+		iod.iod_nr      = 3;
+	}
+	entry_sgl.sg_nr = iod.iod_nr;
 
 	d_iov_set(&marker, &mark_data, sizeof(mark_data));
 	while (!daos_anchor_is_eof(&anchor)) {
@@ -524,13 +539,17 @@ fetch_mark_oids(daos_handle_t coh, daos_obj_id_t oid, daos_key_desc_t *kds, char
 			D_GOTO(out_obj, rc = daos_der2errno(rc));
 		}
 
-		/** for every entry, fetch its oid and mark it in the oit table */
+		/** for every entry, fetch its oid(s) and mark them in the oit table */
 		for (ptr = enum_buf, i = 0; i < nr; i++) {
 			daos_obj_id_t entry_oid;
+			daos_obj_id_t tail_oid   = DAOS_OBJ_NIL;
+			uint8_t       tail_state = DFS_TAIL_NONE;
 			daos_key_t    dkey;
 
 			d_iov_set(&dkey, ptr, kds[i].kd_key_len);
-			d_iov_set(&sg_iov, &entry_oid, sizeof(daos_obj_id_t));
+			d_iov_set(&sg_iovs[0], &entry_oid, sizeof(daos_obj_id_t));
+			d_iov_set(&sg_iovs[1], &tail_oid, sizeof(daos_obj_id_t));
+			d_iov_set(&sg_iovs[2], &tail_state, sizeof(uint8_t));
 
 			rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_DKEY_FETCH, &dkey, 1, &iod,
 					    &entry_sgl, NULL, NULL);
@@ -539,13 +558,28 @@ fetch_mark_oids(daos_handle_t coh, daos_obj_id_t oid, daos_key_desc_t *kds, char
 				D_GOTO(out_obj, rc = daos_der2errno(rc));
 			}
 
-			/** mark oid in the oit table */
+			/** mark the head oid in the oit table */
 			rc = daos_oit_mark(args->oit, entry_oid, &marker, NULL);
 			if (rc && rc != -DER_NONEXIST) {
 				D_ERROR("daos_oit_mark() failed " DF_RC "\n", DP_RC(rc));
 				D_GOTO(out_obj, rc = daos_der2errno(rc));
 			}
 			rc = 0;
+
+			/*
+			 * Mark the progressive-layout tail oid too, if this entry has an active
+			 * tail. Without this the tail array would be treated as a leaked OID.
+			 */
+			if (args->layout_v >= DFS_PL_LAYOUT_VERSION &&
+			    tail_state == DFS_TAIL_ACTIVE && !daos_obj_id_is_nil(tail_oid)) {
+				rc = daos_oit_mark(args->oit, tail_oid, &marker, NULL);
+				if (rc && rc != -DER_NONEXIST) {
+					D_ERROR("daos_oit_mark() of tail failed " DF_RC "\n",
+						DP_RC(rc));
+					D_GOTO(out_obj, rc = daos_der2errno(rc));
+				}
+				rc = 0;
+			}
 			ptr += kds[i].kd_key_len;
 		}
 	}
@@ -616,6 +650,40 @@ oit_mark_cb(dfs_t *dfs, dfs_obj_t *parent, const char name[], void *args)
 		D_GOTO(out_obj, rc = daos_der2errno(rc));
 	}
 	rc = 0;
+
+	/*
+	 * A progressive-layout regular file is backed by two objects: the head array (obj->oid,
+	 * marked above) and a separate tail array (obj->f.tail_oid). The tail has no directory
+	 * entry of its own but is a real object in the OIT, so it must be marked (and verified)
+	 * together with the head. Otherwise the checker would report it as a leaked OID and, with
+	 * --remove, punch it (destroying the file's [split_off, EOF) data) or, with --relink,
+	 * relink it into lost+found as a bogus standalone file.
+	 */
+	if (S_ISREG(obj->mode) && obj->f.has_tail) {
+		daos_obj_id_t tail_oid = obj->f.tail_oid;
+
+		if (oit_args->flags & DFS_CHECK_VERIFY) {
+			rc = daos_obj_verify(dfs->coh, tail_oid, oit_args->snap_epoch);
+			if (rc == -DER_NOSYS) {
+				oit_args->skipped++;
+			} else if (rc == -DER_MISMATCH) {
+				oit_args->failed++;
+				if (oit_args->flags & DFS_CHECK_PRINT)
+					D_PRINT("" DF_OID " failed data consistency check!\n",
+						DP_OID(tail_oid));
+			} else if (rc) {
+				D_ERROR("daos_obj_verify() failed " DF_RC "\n", DP_RC(rc));
+				D_GOTO(out_obj, rc = daos_der2errno(rc));
+			}
+		}
+
+		rc = daos_oit_mark(oit_args->oit, tail_oid, &marker, NULL);
+		if (rc && rc != -DER_NONEXIST) {
+			D_ERROR("Failed to mark tail OID in OIT: " DF_RC "\n", DP_RC(rc));
+			D_GOTO(out_obj, rc = daos_der2errno(rc));
+		}
+		rc = 0;
+	}
 
 	/** descend into directories */
 	if (S_ISDIR(obj->mode)) {
@@ -783,6 +851,7 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 	oit_args->snap_epoch = snap_epoch;
 	oit_args->start_time = now.tv_sec;
 	oit_args->print_time = now.tv_sec;
+	oit_args->layout_v   = dfs->layout_v;
 
 	/** Open OIT table */
 	rc = daos_oit_open(coh, snap_epoch, &oit_args->oit, NULL);
@@ -1044,6 +1113,19 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 			entry.mtime = entry.ctime = now.tv_sec;
 			entry.mtime_nano = entry.ctime_nano = now.tv_nsec;
 			entry.chunk_size                    = dfs->attr.da_chunk_size;
+
+			/*
+			 * Progressive-layout limitation: a regular file that was itself leaked from
+			 * the namespace cannot be faithfully reconstructed as a head+tail pair. The
+			 * head->tail association (tail_oid/split_off/tail_state) lived only in the
+			 * now-lost parent directory entry, and both the head and tail are plain
+			 * byte arrays with no back-reference, so they are indistinguishable here.
+			 * Each unmarked array is therefore relinked into lost+found as an
+			 * independent, non-PL file (the reconstructed entry leaves has_tail false):
+			 * the head holds logical bytes [0, split_off) and the tail holds
+			 * [split_off, EOF) reindexed from 0. The user can stitch the data back
+			 * together manually if needed.
+			 */
 
 			/*
 			 * If this is a regular file / array object, the user might have used a

--- a/src/client/dfs/dfs-progressive-layout.md
+++ b/src/client/dfs/dfs-progressive-layout.md
@@ -363,7 +363,35 @@ No model changes expected. Existing DFS mount mode and uid/gid/mode checks remai
 
 ## MWC tools update
 
-The DFS check tool needs to be updated to account for tail object scanning and not just the existing oid. Any orphaned objects (head or tail) will be stored in the lost+found. There will be no way to determine if an orphaned object was a head or tail object.
+The DFS check tool (`daos fs check`, `dfs_cont_check()`) must account for the tail object in addition
+to the head oid stored in the directory entry. A progressive-layout file is backed by two objects
+(head and tail), and the object index table (OIT) lists both, so both must be marked as reachable
+during the namespace scan; otherwise the tail is treated as a leaked object.
+
+Implemented behavior:
+
+- Namespace marking (`oit_mark_cb`): after looking up an entry, if it is a regular file with an
+  active tail (`obj->f.has_tail`), the checker marks `obj->f.tail_oid` in the OIT in addition to the
+  head oid. Under `--verify` the tail object is also passed to `daos_obj_verify()`.
+- Relink directory descent (`fetch_mark_oids`): when descending a leaked directory (Pass 1 of
+  `--relink`), each child entry is read for its tail fields (`tail_oid`/`tail_state`, only present at
+  layout >= v4) and any active tail oid is marked too, so it is not double-relinked or removed.
+- Consequence for the other modes:
+  - `--print`: tail objects of intact files are no longer reported as leaked.
+  - `--remove`: tail objects of intact files are no longer punched (previously this destroyed the
+    file's `[split_off, EOF)` data).
+  - `--relink`: tail objects of intact files are no longer relinked as bogus standalone files.
+
+Orphan (leaked) handling and its limitation:
+
+- When a file is itself leaked (its parent directory entry is lost), both the head and tail become
+  unmarked orphans and are relinked into `lost+found` as independent objects. There is no way to
+  determine whether an orphaned array was a head or a tail: the head->tail association
+  (`tail_oid`/`split_off`/`tail_state`) lived only in the lost parent entry, and both objects are
+  plain byte arrays with no back-reference. Each orphan is relinked as a separate, non-PL file — the
+  head holding logical bytes `[0, split_off)` and the tail holding `[split_off, EOF)` reindexed from
+  0 — leaving the user to stitch the data back together manually if needed.
+
 
 ## Test Plan
 

--- a/src/client/dfs/dfs-progressive-layout.md
+++ b/src/client/dfs/dfs-progressive-layout.md
@@ -376,11 +376,6 @@ Implemented behavior:
 - Relink directory descent (`fetch_mark_oids`): when descending a leaked directory (Pass 1 of
   `--relink`), each child entry is read for its tail fields (`tail_oid`/`tail_state`, only present at
   layout >= v4) and any active tail oid is marked too, so it is not double-relinked or removed.
-- Consequence for the other modes:
-  - `--print`: tail objects of intact files are no longer reported as leaked.
-  - `--remove`: tail objects of intact files are no longer punched (previously this destroyed the
-    file's `[split_off, EOF)` data).
-  - `--relink`: tail objects of intact files are no longer relinked as bogus standalone files.
 
 Orphan (leaked) handling and its limitation:
 

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -4611,6 +4611,250 @@ out:
 	d_freeenv_str(&prev_env);
 }
 
+/*
+ * Verify the MWC container checker handles progressive-layout files, which are backed by two
+ * objects (head + tail). Both must be marked as reachable so the tail of an intact file is never
+ * treated as leaked (and, with --remove, punched). This covers three scenarios: an intact PL file
+ * is left untouched by --remove; a leaked PL file has both objects reclaimed; and a leaked
+ * directory containing a PL file is relinked without its child's tail leaking out as a stray
+ * lost+found file.
+ */
+static void
+dfs_test_checker_pl(void **state)
+{
+	test_arg_t    *arg = *state;
+	dfs_t         *dfs;
+	dfs_obj_t     *root, *file, *dir, *lf;
+	dfs_obj_info_t info = {0};
+	daos_obj_id_t  root_oid;
+	daos_handle_t  coh, root_oh;
+	uint64_t       nr_oids = 0;
+	daos_size_t    split;
+	char          *cname    = "cont_chkr_pl";
+	char          *prev_env = NULL;
+	bool           env_was_set;
+	d_sg_list_t    sgl;
+	d_iov_t        iov;
+	d_iov_t        dkey;
+	char           name[] = "plfile";
+	char           buf[4096];
+	daos_anchor_t  anchor;
+	struct dirent  ents[10];
+	struct stat    stbufs[10];
+	uint32_t       num_ents;
+	int            num_files, num_dirs;
+	int            i;
+	int            rc;
+
+	if (arg->myrank != 0)
+		return;
+
+	/*
+	 * Force progressive layout regardless of the pool target count. Save and restore any
+	 * pre-existing value so other tests in this binary are unaffected.
+	 */
+	rc          = d_agetenv_str(&prev_env, "DFS_PL_BYPASS_TARGET_LIMIT");
+	env_was_set = (rc == 0 && prev_env != NULL);
+	rc          = d_setenv("DFS_PL_BYPASS_TARGET_LIMIT", "1", 1);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_init();
+	assert_int_equal(rc, 0);
+	rc = dfs_connect(arg->pool.pool_str, arg->group, cname, O_CREAT | O_RDWR, NULL, &dfs);
+	assert_int_equal(rc, 0);
+
+	/* save the root object ID for later */
+	rc = dfs_lookup(dfs, "/", O_RDWR, &root, NULL, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_obj2id(root, &root_oid);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(root);
+	assert_int_equal(rc, 0);
+
+	/* a default-class file should be created as a progressive-layout head+tail file */
+	rc = dfs_open(dfs, NULL, name, S_IFREG | S_IWUSR | S_IRUSR, O_RDWR | O_CREAT | O_EXCL, 0, 0,
+		      NULL, &file);
+	assert_int_equal(rc, 0);
+	rc = dfs_obj_get_info(dfs, file, &info);
+	assert_int_equal(rc, 0);
+	split = info.doi_pl_nr > 0 ? info.doi_pl_segs[0].pls_split_off : 0;
+	if (split == 0) {
+		/* PL did not engage in this environment; nothing to check. */
+		print_message("PL not active; skipping PL checker test\n");
+		rc = dfs_release(file);
+		assert_int_equal(rc, 0);
+		rc = dfs_disconnect(dfs);
+		assert_int_equal(rc, 0);
+		rc = dfs_fini();
+		assert_int_equal(rc, 0);
+		rc = daos_cont_destroy(arg->pool.poh, cname, 1, NULL);
+		assert_rc_equal(rc, 0);
+		goto restore_env;
+	}
+
+	/* write into both the head (offset 0) and the tail (>= split_off) so both objects exist */
+	memset(buf, 'p', sizeof(buf));
+	d_iov_set(&iov, buf, sizeof(buf));
+	sgl.sg_nr     = 1;
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs   = &iov;
+	rc            = dfs_write(dfs, file, &sgl, 0, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_write(dfs, file, &sgl, split + 4096, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(file);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_disconnect(dfs);
+	assert_int_equal(rc, 0);
+	/* release the cached container handle so the checker can run */
+	rc = dfs_fini();
+	assert_int_equal(rc, 0);
+
+	/*
+	 * Intact PL file: the checker must mark BOTH the head and the tail. Run with REMOVE and
+	 * confirm nothing is reclaimed. Without the tail being marked, the tail would be treated as
+	 * a leaked OID and punched, silently destroying the file's [split_off, EOF) data.
+	 */
+	get_nr_oids(arg->pool.poh, cname, &nr_oids);
+	/* SB + root + file head + file tail */
+	assert_int_equal((int)nr_oids, 4);
+
+	rc = dfs_cont_check(arg->pool.poh, cname,
+			    DFS_CHECK_PRINT | DFS_CHECK_REMOVE | DFS_CHECK_VERIFY, NULL);
+	assert_int_equal(rc, 0);
+
+	get_nr_oids(arg->pool.poh, cname, &nr_oids);
+	/* unchanged: the tail must NOT have been removed */
+	assert_int_equal((int)nr_oids, 4);
+
+	/*
+	 * Now leak the file itself by punching its directory entry. Both the head and the tail
+	 * become orphans, and the checker (REMOVE) should reclaim both.
+	 */
+	rc = daos_cont_open(arg->pool.poh, cname, DAOS_COO_RW, &coh, NULL, NULL);
+	assert_rc_equal(rc, 0);
+	rc = daos_obj_open(coh, root_oid, DAOS_OO_RW, &root_oh, NULL);
+	assert_rc_equal(rc, 0);
+	d_iov_set(&dkey, name, strlen(name));
+	rc = daos_obj_punch_dkeys(root_oh, DAOS_TX_NONE, DAOS_COND_PUNCH, 1, &dkey, NULL);
+	assert_rc_equal(rc, 0);
+	rc = daos_obj_close(root_oh, NULL);
+	assert_rc_equal(rc, 0);
+	rc = daos_cont_close(coh, NULL);
+	assert_int_equal(rc, 0);
+
+	get_nr_oids(arg->pool.poh, cname, &nr_oids);
+	assert_int_equal((int)nr_oids, 4);
+
+	rc = dfs_cont_check(arg->pool.poh, cname, DFS_CHECK_PRINT | DFS_CHECK_REMOVE, NULL);
+	assert_int_equal(rc, 0);
+
+	get_nr_oids(arg->pool.poh, cname, &nr_oids);
+	/* both head and tail reclaimed: SB + root only */
+	assert_int_equal((int)nr_oids, 2);
+
+	/*
+	 * fetch_mark_oids relink-descent coverage: leak a directory that still contains a PL file.
+	 * Under --relink the checker descends the leaked directory (Pass 1) and must mark the child
+	 * file's head AND tail. If the tail is not marked it gets relinked as a stray regular file
+	 * at the top of lost+found instead of remaining inside the relinked directory.
+	 */
+	rc = dfs_init();
+	assert_int_equal(rc, 0);
+	rc = dfs_connect(arg->pool.pool_str, arg->group, cname, O_CREAT | O_RDWR, NULL, &dfs);
+	assert_int_equal(rc, 0);
+
+	/* create /pl_dir (default oclass so children inherit PL) with a default-class PL file in it
+	 */
+	rc = dfs_open(dfs, NULL, "pl_dir", S_IFDIR | S_IWUSR | S_IRUSR, O_RDWR | O_CREAT | O_EXCL,
+		      0, 0, NULL, &dir);
+	assert_int_equal(rc, 0);
+	rc = dfs_open(dfs, dir, "pl_file", S_IFREG | S_IWUSR | S_IRUSR, O_RDWR | O_CREAT | O_EXCL,
+		      0, 0, NULL, &file);
+	assert_int_equal(rc, 0);
+	rc = dfs_obj_get_info(dfs, file, &info);
+	assert_int_equal(rc, 0);
+	/* the child must also be a PL file for this scenario to be meaningful */
+	assert_true(info.doi_pl_nr > 0);
+	d_iov_set(&iov, buf, sizeof(buf));
+	rc = dfs_write(dfs, file, &sgl, 0, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_write(dfs, file, &sgl, split + 4096, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(file);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(dir);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_disconnect(dfs);
+	assert_int_equal(rc, 0);
+	rc = dfs_fini();
+	assert_int_equal(rc, 0);
+
+	/* leak the directory by punching its entry from the root object */
+	rc = daos_cont_open(arg->pool.poh, cname, DAOS_COO_RW, &coh, NULL, NULL);
+	assert_rc_equal(rc, 0);
+	rc = daos_obj_open(coh, root_oid, DAOS_OO_RW, &root_oh, NULL);
+	assert_rc_equal(rc, 0);
+	d_iov_set(&dkey, "pl_dir", strlen("pl_dir"));
+	rc = daos_obj_punch_dkeys(root_oh, DAOS_TX_NONE, DAOS_COND_PUNCH, 1, &dkey, NULL);
+	assert_rc_equal(rc, 0);
+	rc = daos_obj_close(root_oh, NULL);
+	assert_rc_equal(rc, 0);
+	rc = daos_cont_close(coh, NULL);
+	assert_int_equal(rc, 0);
+
+	/* relink: the leaked dir is descended, so its child head+tail are marked (not relinked) */
+	rc = dfs_cont_check(arg->pool.poh, cname, DFS_CHECK_PRINT | DFS_CHECK_RELINK, "tlf");
+	assert_int_equal(rc, 0);
+
+	/*
+	 * readdir /lost+found/tlf: it must contain exactly the relinked directory and no stray tail
+	 * file. Without the tail being marked during the descent, the child's tail array would be
+	 * relinked here as an extra regular file.
+	 */
+	rc = dfs_init();
+	assert_int_equal(rc, 0);
+	rc = dfs_connect(arg->pool.pool_str, arg->group, cname, O_CREAT | O_RDWR, NULL, &dfs);
+	assert_int_equal(rc, 0);
+	rc = dfs_lookup(dfs, "/lost+found/tlf", O_RDWR, &lf, NULL, NULL);
+	assert_rc_equal(rc, 0);
+	num_files = 0;
+	num_dirs  = 0;
+	memset(&anchor, 0, sizeof(anchor));
+	num_ents = 10;
+	while (!daos_anchor_is_eof(&anchor)) {
+		rc = dfs_readdirplus(dfs, lf, &anchor, &num_ents, ents, stbufs);
+		assert_int_equal(rc, 0);
+		for (i = 0; i < num_ents; i++) {
+			if (S_ISREG(stbufs[i].st_mode))
+				num_files++;
+			else if (S_ISDIR(stbufs[i].st_mode))
+				num_dirs++;
+		}
+		num_ents = 10;
+	}
+	/* the child's tail must NOT have leaked out as a stray top-level file */
+	assert_int_equal(num_files, 0);
+	assert_int_equal(num_dirs, 1);
+	rc = dfs_release(lf);
+	assert_int_equal(rc, 0);
+	rc = dfs_disconnect(dfs);
+	assert_int_equal(rc, 0);
+	rc = dfs_destroy(arg->pool.pool_str, arg->group, cname, 0, NULL);
+	assert_rc_equal(rc, 0);
+	rc = dfs_fini();
+	assert_int_equal(rc, 0);
+
+restore_env:
+	if (env_was_set)
+		d_setenv("DFS_PL_BYPASS_TARGET_LIMIT", prev_env, 1);
+	else
+		d_unsetenv("DFS_PL_BYPASS_TARGET_LIMIT");
+	d_freeenv_str(&prev_env);
+}
+
 static const struct CMUnitTest dfs_unit_tests[] = {
     {"DFS_UNIT_TEST1: DFS mount / umount", dfs_test_mount, async_disable, test_case_teardown},
     {"DFS_UNIT_TEST2: DFS container modes", dfs_test_modes, async_disable, test_case_teardown},
@@ -4655,6 +4899,8 @@ static const struct CMUnitTest dfs_unit_tests[] = {
      async_disable, test_case_teardown},
     {"DFS_UNIT_TEST30: dfs progressive layout IO paths", dfs_test_pl_io, async_disable,
      test_case_teardown},
+    {"DFS_UNIT_TEST31: dfs MWC container checker with progressive layout", dfs_test_checker_pl,
+     async_disable, test_case_teardown},
 };
 
 static int


### PR DESCRIPTION
A progressive-layout (PL) file is backed by two objects: a compact head array and a separate wide tail array. The MWC container checker only marked the head OID, so the tail of an intact file was treated as a leaked object. Depending on the mode this caused false leaked-OID reports (--print), silent data loss by punching the live tail (--remove), or relinking the tail into lost+found as a bogus standalone file (--relink).

Mark (and, under --verify, verify) the tail object alongside the head in both marking paths:

- oit_mark_cb(): when an entry is a regular file with an active tail, also mark/verify obj->f.tail_oid.
- fetch_mark_oids(): when descending a leaked directory during --relink, read each child entry's tail_oid/tail_state (layout >= v4) and mark the tail too. The container layout version is plumbed through struct dfs_oit_args.

Document the inherent limitation that a leaked PL file whose own parent entry is lost cannot be reconstructed as a head+tail pair (the association lived only in the lost entry and both objects are plain byte arrays), so head and tail are relinked as separate files in lost+found.

Add DFS_UNIT_TEST31 (dfs_test_checker_pl) covering three scenarios: an intact PL file is untouched by --remove; a leaked PL file has both objects reclaimed; and a leaked directory containing a PL file is relinked without its child's tail leaking out as a stray lost+found file. Update the progressive-layout design doc accordingly.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
