### PR TITLE
DAOS-7755 control: support IPv6 management hostlists

### DIFF
--- a/src/control/common/net_utils.go
+++ b/src/control/common/net_utils.go
@@ -102,8 +102,16 @@ func ParseHostList(in []string, defaultPort int) (out []string, err error) {
 		return
 	}
 
+	normalized := make([]string, len(in))
+	for i, host := range in {
+		normalized[i] = host
+		if net.ParseIP(host) != nil && strings.ContainsRune(host, ':') {
+			normalized[i] = net.JoinHostPort(host, strconv.Itoa(defaultPort))
+		}
+	}
+
 	var set *hostlist.HostSet
-	set, err = hostlist.CreateSet(strings.Join(in, ","))
+	set, err = hostlist.CreateSet(strings.Join(normalized, ","))
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/common/net_utils.go
+++ b/src/control/common/net_utils.go
@@ -105,8 +105,12 @@ func ParseHostList(in []string, defaultPort int) (out []string, err error) {
 	normalized := make([]string, len(in))
 	for i, host := range in {
 		normalized[i] = host
-		if net.ParseIP(host) != nil && strings.ContainsRune(host, ':') {
-			normalized[i] = net.JoinHostPort(host, strconv.Itoa(defaultPort))
+		ipLiteral := host
+		if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+			ipLiteral = host[1 : len(host)-1]
+		}
+		if net.ParseIP(ipLiteral) != nil && strings.ContainsRune(ipLiteral, ':') {
+			normalized[i] = net.JoinHostPort(ipLiteral, strconv.Itoa(defaultPort))
 		}
 	}
 

--- a/src/control/common/net_utils.go
+++ b/src/control/common/net_utils.go
@@ -110,14 +110,21 @@ func ParseHostList(in []string, defaultPort int) (out []string, err error) {
 	out = strings.Split(set.DerangedString(), ",")
 
 	for i, host := range out {
-		hostPort := strings.Split(host, ":")
-		switch len(hostPort) {
-		case 1:
-			out[i] = fmt.Sprintf("%s:%d", host, defaultPort)
-		case 2:
-			_, err = strconv.Atoi(hostPort[1])
-		default:
-			err = errors.New("host should conform to hostname[:port]")
+		// Use net.SplitHostPort so IPv6 bracketed literals like
+		// [2a04:...]:10001 parse correctly. Falls back to default port if
+		// no port present.
+		h, p, splitErr := net.SplitHostPort(host)
+		if splitErr != nil {
+			// Likely missing port. Try treating the whole thing as a hostname.
+			if _, _, splitErr2 := net.SplitHostPort(host + ":0"); splitErr2 != nil {
+				err = errors.New("host should conform to hostname[:port]")
+			} else {
+				out[i] = net.JoinHostPort(host, fmt.Sprintf("%d", defaultPort))
+			}
+		} else if _, atoiErr := strconv.Atoi(p); atoiErr != nil {
+			err = atoiErr
+		} else {
+			out[i] = net.JoinHostPort(h, p)
 		}
 
 		if err != nil {

--- a/src/control/common/net_utils_test.go
+++ b/src/control/common/net_utils_test.go
@@ -166,6 +166,21 @@ func TestCommon_ParseHostList(t *testing.T) {
 			in:     mockHostList(":42"),
 			expErr: errors.New("invalid host"),
 		},
+		"IPv6 address without port": {
+			in:     mockHostList("2001:db8::1"),
+			expOut: mockHostList("[2001:db8::1]:12345"),
+		},
+		"IPv6 address with port": {
+			in:     mockHostList("[2001:db8::1]:4242"),
+			expOut: mockHostList("[2001:db8::1]:4242"),
+		},
+		"deduplicate IPv6 addresses": {
+			in: mockHostList(
+				"2001:db8::1",
+				"[2001:db8::1]:12345",
+			),
+			expOut: mockHostList("[2001:db8::1]:12345"),
+		},
 		"should append missing port": {
 			in:     mockHostList("foo"),
 			expOut: mockHostList(fmt.Sprintf("foo:%d", testPort)),

--- a/src/control/common/net_utils_test.go
+++ b/src/control/common/net_utils_test.go
@@ -170,6 +170,10 @@ func TestCommon_ParseHostList(t *testing.T) {
 			in:     mockHostList("2001:db8::1"),
 			expOut: mockHostList("[2001:db8::1]:12345"),
 		},
+		"bracketed IPv6 address without port": {
+			in:     mockHostList("[2001:db8::1]"),
+			expOut: mockHostList("[2001:db8::1]:12345"),
+		},
 		"IPv6 address with port": {
 			in:     mockHostList("[2001:db8::1]:4242"),
 			expOut: mockHostList("[2001:db8::1]:4242"),
@@ -177,6 +181,7 @@ func TestCommon_ParseHostList(t *testing.T) {
 		"deduplicate IPv6 addresses": {
 			in: mockHostList(
 				"2001:db8::1",
+				"[2001:db8::1]",
 				"[2001:db8::1]:12345",
 			),
 			expOut: mockHostList("[2001:db8::1]:12345"),

--- a/src/control/lib/hostlist/hostlist.go
+++ b/src/control/lib/hostlist/hostlist.go
@@ -53,6 +53,15 @@ type (
 )
 
 func (hn *hostName) Parse(input string) error {
+	// IPv6 literal in [bracket]:port form (RFC 3986). Skip the prefix-N
+	// regex; treat the whole thing as an opaque host. Hostnames cannot
+	// otherwise start with '[' so this is unambiguous.
+	if len(input) > 0 && input[0] == '[' {
+		hn.prefix = input
+		hn.hasNumber = false
+		return nil
+	}
+
 	// prefixN (default)
 	re := regexp.MustCompile(`^([a-zA-Z]+)(\d+)?(.*)?`)
 	if strings.Contains(input, "-") {
@@ -214,6 +223,15 @@ func parseBracketedHostList(input, rangeSep, rangeOp string, nameOptional bool) 
 			return nil, fmt.Errorf("invalid range %q", tok)
 		}
 
+		// IPv6 literal in [bracket]:port form (RFC 3986). Bracket
+		// content contains colons, never a range operator; push the
+		// whole token as a single host and skip range expansion.
+		if strings.ContainsRune(tok[leftIndex+1:rightIndex], ':') {
+			if err := hl.PushHost(tok); err != nil {
+				return nil, err
+			}
+			continue
+		}
 		ranges, err := parseRanges(tok[leftIndex+1:rightIndex], rangeOp)
 		if err != nil {
 			return nil, err

--- a/src/control/lib/hostlist/hostlist_test.go
+++ b/src/control/lib/hostlist/hostlist_test.go
@@ -73,6 +73,12 @@ func TestHostList_Create(t *testing.T) {
 			expUniqOut:   "10.5.1.[1-32,42]:10001",
 			expUniqCount: 33,
 		},
+		"IPv6 addresses": {
+			startList:    "[2001:db8::1]:10001,[2001:db8::2]:10001",
+			expRawOut:    "[2001:db8::1]:10001,[2001:db8::2]:10001",
+			expUniqOut:   "[2001:db8::1]:10001,[2001:db8::2]:10001",
+			expUniqCount: 2,
+		},
 		"duplicates removed": {
 			startList:    "node[1-128],node2,node4,node8,node16,node32,node64,node128",
 			expRawOut:    "node[1-128,2,4,8,16,32,64,128]",

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -189,7 +189,7 @@ func getControlAddr(params ctlAddrParams) (*net.TCPAddr, error) {
 func createListener(ctlAddr *net.TCPAddr, listen netListenFn, bindToCtlAddr bool) (net.Listener, error) {
 	// Create and start listener on management network.
 	// Only bind to ctlAddr.IP if explicitly requested (i.e., control_iface is set),
-	// otherwise bind to all interfaces (0.0.0.0) for backwards compatibility.
+	// otherwise bind to all IPv4 and IPv6 interfaces.
 	bindAddr := fmt.Sprintf("[::]:%d", ctlAddr.Port)
 	if bindToCtlAddr {
 		bindAddr = ctlAddr.String()

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -190,11 +190,11 @@ func createListener(ctlAddr *net.TCPAddr, listen netListenFn, bindToCtlAddr bool
 	// Create and start listener on management network.
 	// Only bind to ctlAddr.IP if explicitly requested (i.e., control_iface is set),
 	// otherwise bind to all interfaces (0.0.0.0) for backwards compatibility.
-	bindAddr := fmt.Sprintf("0.0.0.0:%d", ctlAddr.Port)
+	bindAddr := fmt.Sprintf("[::]:%d", ctlAddr.Port)
 	if bindToCtlAddr {
 		bindAddr = ctlAddr.String()
 	}
-	lis, err := listen("tcp4", bindAddr)
+	lis, err := listen("tcp", bindAddr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to listen on %s", bindAddr)
 	}

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -1869,6 +1869,57 @@ func TestServerUtils_resolveFirstAddr(t *testing.T) {
 	}
 }
 
+func TestServerUtils_createListener(t *testing.T) {
+	for name, tc := range map[string]struct {
+		ctlAddr       *net.TCPAddr
+		bindToCtlAddr bool
+		expAddr       string
+	}{
+		"all interfaces": {
+			ctlAddr: &net.TCPAddr{
+				IP:   net.ParseIP("127.0.0.1"),
+				Port: 10001,
+			},
+			expAddr: "[::]:10001",
+		},
+		"configured IPv4 interface": {
+			ctlAddr: &net.TCPAddr{
+				IP:   net.ParseIP("192.0.2.1"),
+				Port: 10001,
+			},
+			bindToCtlAddr: true,
+			expAddr:       "192.0.2.1:10001",
+		},
+		"configured IPv6 interface": {
+			ctlAddr: &net.TCPAddr{
+				IP:   net.ParseIP("2001:db8::1"),
+				Port: 10001,
+			},
+			bindToCtlAddr: true,
+			expAddr:       "[2001:db8::1]:10001",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var gotNetwork, gotAddr string
+			listen := func(network, addr string) (net.Listener, error) {
+				gotNetwork = network
+				gotAddr = addr
+				return nil, nil
+			}
+
+			if _, err := createListener(tc.ctlAddr, listen, tc.bindToCtlAddr); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff("tcp", gotNetwork); diff != "" {
+				t.Fatalf("unexpected network (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.expAddr, gotAddr); diff != "" {
+				t.Fatalf("unexpected address (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestServerUtils_getControlAddr(t *testing.T) {
 	testTCPAddr := &net.TCPAddr{
 		IP:   net.ParseIP("127.0.0.1"),


### PR DESCRIPTION
## Summary

Enable IPv6 management addressing in the DAOS control plane by:

- listening on the dual-stack wildcard address when no control interface is configured;
- accepting bracketed IPv6 literals in hostlists;
- parsing host/port values with `net.SplitHostPort`; and
- normalizing bare IPv6 literals with the default control port before deduplication.

This complements #18484 and #18491; it does not duplicate their address-format propagation changes.

## Testing Done

- `go test ./common ./lib/hostlist`
- Added unit coverage for bare and bracketed IPv6 literals, IPv6 deduplication, and wildcard/IPv4/IPv6 listener addresses.
- The local `server` package test build requires DAOS native development headers not installed in this checkout environment.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).