### PR TITLE
DAOS-19368 vos: make DER_KEY2BIG a warn

### DIFF
--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -32,7 +32,8 @@
 
 #define VOS_TX_LOG_FAIL(rc, ...)                                                                   \
 	do {                                                                                       \
-		bool __is_err = true;                                                              \
+		bool __is_err  = true;                                                             \
+		bool __is_warn = false;                                                            \
                                                                                                    \
 		if (rc >= 0)                                                                       \
 			break;                                                                     \
@@ -46,8 +47,13 @@
 		case -DER_OP_CANCELED:                                                             \
 			__is_err = false;                                                          \
 			break;                                                                     \
+		case -DER_KEY2BIG:                                                                 \
+			__is_err  = false;                                                         \
+			__is_warn = true;                                                          \
+			break;                                                                     \
 		}                                                                                  \
 		D_CDEBUG(__is_err, DLOG_ERR, DB_IO, __VA_ARGS__);                                  \
+		D_CDEBUG(__is_warn, DLOG_WARN, DB_IO, __VA_ARGS__);                                \
 	} while (0)
 
 #define VOS_TX_TRACE_FAIL(rc, ...)                                                                 \


### PR DESCRIPTION
Since DER_KEY2BIG is often used by rebuild to signal an accepted behaviour logging this as an error is confusing.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
