### PR TITLE
DAOS-19381 placement: tolerate DOWNOUT spare in remap chain

### DIFF
--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -379,13 +379,13 @@ determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md, bo
 		 * add the spare target to the fail list for remap, and
 		 * try next spare.
 		 */
-		if (f_shard->fs_status == PO_COMP_ST_DOWN ||
-		    f_shard->fs_status == PO_COMP_ST_DRAIN)
-			D_ASSERTF(spare_tgt->ta_comp.co_status !=
-				  PO_COMP_ST_DOWNOUT,
-				  "down fseq(%u) < downout fseq(%u)\n",
-				  f_shard->fs_fseq,
-				  spare_tgt->ta_comp.co_fseq);
+		if ((f_shard->fs_status == PO_COMP_ST_DOWN ||
+		     f_shard->fs_status == PO_COMP_ST_DRAIN) &&
+		    spare_tgt->ta_comp.co_status == PO_COMP_ST_DOWNOUT)
+			D_DEBUG(DB_PL,
+				"failed shard (" DF_FAILEDSHARD
+				") remaps through DOWNOUT spare " DF_TARGET "\n",
+				DP_FAILEDSHARD(*f_shard), DP_TARGET(spare_tgt));
 
 		f_shard->fs_fseq = spare_tgt->ta_comp.co_fseq;
 		f_shard->fs_status = spare_tgt->ta_comp.co_status;

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -1055,6 +1055,47 @@ chained_rebuild_completes_first_shard(void **state)
 }
 
 /*
+ * A rebuild resumed by rebuild start can run with an older rebuild version
+ * against a newer pool map. In that case a failed DOWN shard may remap through
+ * a spare candidate that has already become DOWNOUT. Placement should continue
+ * the remap chain instead of aborting or selecting the DOWNOUT target.
+ */
+static void
+chained_rebuild_remaps_through_downout_spare(void **state)
+{
+	struct jm_test_ctx ctx;
+	uint32_t           failed_tgt;
+	uint32_t           downout_spare;
+	uint32_t           rebuild_tgt;
+
+	jtc_init_with_layout(&ctx, 9, 1, 1, OC_EC_2P1G1, g_verbose);
+
+	failed_tgt = jtc_layout_shard_tgt(&ctx, 0);
+	jtc_set_status_on_target(&ctx, DOWN, failed_tgt);
+	jtc_assert_scan_and_layout(&ctx);
+
+	assert_int_equal(1, ctx.rebuild.out_nr);
+
+	downout_spare = jtc_layout_shard_tgt(&ctx, 0);
+	assert_int_not_equal(failed_tgt, downout_spare);
+
+	jtc_set_status_on_target(&ctx, DOWN, downout_spare);
+	jtc_set_status_on_target(&ctx, DOWNOUT, downout_spare);
+	jtc_assert_scan_and_layout(&ctx);
+
+	assert_int_equal(0, jtc_get_layout_bad_count(&ctx));
+	assert_int_equal(1, ctx.rebuild.out_nr);
+	assert_int_equal(0, ctx.rebuild.ids[0]);
+
+	rebuild_tgt = jtc_get_layout_shard(&ctx, 0)->po_target;
+	assert_int_not_equal(failed_tgt, rebuild_tgt);
+	assert_int_not_equal(downout_spare, rebuild_tgt);
+	assert_int_equal(rebuild_tgt, ctx.rebuild.tgt_ranks[0]);
+
+	jtc_fini(&ctx);
+}
+
+/*
  * This test simulates all the shards' targets have failed and the new
  * targets are rebuilt successfully (failed goes to DOWNOUT state). Keep
  * "failing" until only enough targets are left for a single layout.
@@ -2350,6 +2391,8 @@ static const struct CMUnitTest tests[] = {
 	/* DOWNOUT */
 	T("Rebuild first shard's target repeatedly",
 	  chained_rebuild_completes_first_shard),
+	T("Rebuild remaps through a DOWNOUT spare candidate",
+	  chained_rebuild_remaps_through_downout_spare),
 	T("Rebuild all shards' targets", chained_rebuild_completes_all_at_once),
 	/* UP */
 	T("For each shard at a time, take the shard's target "


### PR DESCRIPTION
A rebuild resumed by rebuild start can run an older rebuild version against a newer pool map.  In that history a failed DOWN/DRAIN shard can select a spare candidate which has already transitioned to DOWNOUT.

That state is valid for placement remap chaining: the selected spare is not a usable final target, but the existing code already updates the failed shard state and re-adds it to the remap list so placement can look for the next candidate.  The assertion that rejects a DOWN/DRAIN failed shard remapping through a DOWNOUT spare is therefore too strict and can abort rebuild scans during interactive rebuild stop/start recovery.

Replace the assertion with placement debug logging and keep the existing chained-remap behavior.  Add a jump-map placement unit test that drives a DOWN shard through a spare candidate that becomes DOWNOUT and verifies placement continues to a different rebuild target.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
