### PR TITLE
DAOS-19367 tests: give more time for DAOS_Single_RDG_TX test

### DIFF
--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -13,6 +13,7 @@ timeouts:
   test_daos_pool: 360
   test_daos_container: 700
   test_daos_epoch: 125
+  test_daos_single_rdg_tx: 700
   test_daos_verify_consistency: 105
   test_daos_io: 350
   test_daos_ec_io: 510

--- a/src/tests/suite/daos_base_tx.c
+++ b/src/tests/suite/daos_base_tx.c
@@ -1235,6 +1235,16 @@ dtx_base_rf1_setup(void **state)
 	return rc;
 }
 
+static inline int
+dtx_base_teardown(void **state)
+{
+	test_arg_t *arg = *state;
+
+	dtx_set_fail_loc(arg, 0);
+	assert_rc_equal(daos_event_priv_reset(), 0);
+	return 0;
+}
+
 /* clang-format off */
 static const struct CMUnitTest dtx_tests[] = {
 	{"DTX1: update/punch single value with DTX successfully",
@@ -1284,9 +1294,9 @@ static const struct CMUnitTest dtx_tests[] = {
 	{"DTX23: Resend with lost reply from non-leader",
 	 dtx_23, NULL, test_case_teardown},
 	{"DTX24: DTX under space pressure with single container",
-	 dtx_24, NULL, test_case_teardown},
+	 dtx_24, NULL, dtx_base_teardown},
 	{"DTX25: DTX under space pressure with multiple containers",
-	 dtx_25, NULL, test_case_teardown},
+	 dtx_25, NULL, dtx_base_teardown},
 };
 /* clang-format on */
 


### PR DESCRIPTION
To avoid new added dtx_2{4,5} timeout (since such two tests will take sometime to generate data), increase the timeout value from 600 seconds to 700 seconds.

Add cleanup logic during test teardown to avoid leaving fail_loc (in case of test failure) that may affect subseqent tests.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
