### PR TITLE
DAOS-19381 rebuild: merge stopped rebuild targets into running task

### DIFF
--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -197,6 +197,12 @@ layout_find_diff(struct pl_jump_map *jmap, struct pl_obj_layout *old_lo,
 		bool                remap   = false;
 		struct pool_target *new_pot;
 
+		if (new_tgt == (uint32_t)-1) {
+			D_DEBUG(DB_PL, "pool " DF_UUID ", skip shard index %d, po_target -1",
+				DP_UUID(jmap->jmp_map.pl_uuid), index);
+			continue;
+		}
+
 		if (new_tgt != old_tgt)
 			remap = true; /* migrate to a new target, e.g. drain, regular reint */
 		else if (rebuilding && old_lo->ol_shards[index].po_rebuilding)
@@ -204,7 +210,10 @@ layout_find_diff(struct pl_jump_map *jmap, struct pl_obj_layout *old_lo,
 
 		if (remap) {
 			rc = pool_map_find_target(jmap->jmp_map.pl_poolmap, new_tgt, &new_pot);
-			D_ASSERT(rc == 1);
+			D_ASSERTF(rc == 1,
+				  "pool " DF_UUID ", cannot find %u in pool map, index %d,"
+				  " old_tgt %u\n",
+				  DP_UUID(jmap->jmp_map.pl_uuid), new_tgt, index, old_tgt);
 
 			if (pool_target_avail(new_pot,
 					      PO_COMP_ST_UPIN | PO_COMP_ST_UP | PO_COMP_ST_DRAIN)) {

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -380,12 +380,22 @@ determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md, bo
 		 * try next spare.
 		 */
 		if (f_shard->fs_status == PO_COMP_ST_DOWN ||
-		    f_shard->fs_status == PO_COMP_ST_DRAIN)
+		    f_shard->fs_status == PO_COMP_ST_DRAIN) {
+			if (spare_tgt->ta_comp.co_status == PO_COMP_ST_DOWNOUT)
+				D_ERROR(DF_OID
+					": DOWN/DRAIN failed shard remaps through DOWNOUT spare: "
+					"md_ver=%u allow_ver=%u gen_mode=%d failed=(" DF_FAILEDSHARD
+					") spare=" DF_TARGET " spare_fseq=%u spare_out_ver=%u\n",
+					DP_OID(md->omd_id), md->omd_ver, allow_version, gen_mode,
+					DP_FAILEDSHARD(*f_shard), DP_TARGET(spare_tgt),
+					spare_tgt->ta_comp.co_fseq, spare_tgt->ta_comp.co_out_ver);
+
 			D_ASSERTF(spare_tgt->ta_comp.co_status !=
 				  PO_COMP_ST_DOWNOUT,
 				  "down fseq(%u) < downout fseq(%u)\n",
 				  f_shard->fs_fseq,
 				  spare_tgt->ta_comp.co_fseq);
+		}
 
 		f_shard->fs_fseq = spare_tgt->ta_comp.co_fseq;
 		f_shard->fs_status = spare_tgt->ta_comp.co_status;
@@ -520,4 +530,3 @@ out:
 		D_FREE(grp_count);
 	return rc;
 }
-

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1765,6 +1765,34 @@ rebuild_try_merge_tgts(struct ds_pool *pool, uint32_t map_ver,
 			merge_task = merge_post_task;
 	}
 
+	/* No queued task to merge with. If this task is only being (re-)scheduled to wait for a
+	 * merge opportunity (delay_sec == -1, e.g. re-scheduling the original op:Rebuild targets
+	 * after a "dmg pool rebuild stop"), also check for a same-op task that is *currently
+	 * running* for this pool. A running rebuild task scans up to (at least) its own pool map
+	 * version, and since these targets were already down before that scan started, the
+	 * running task will implicitly rebuild their data anyway as part of that broader,
+	 * version-based scan. If we don't fold these targets into that running task's dst_tgts
+	 * here, they would end up in a brand new task with dst_schedule_time left at -1, which
+	 * rebuild_ults() skips forever waiting for a merge that may never come: the target's
+	 * data ends up rebuilt, but ds_pool_tgt_finish_rebuild() is never called for it, so it
+	 * never leaves PO_COMP_ST_DOWN, which can later trip the fseq-ordering assertion in
+	 * determine_valid_spares().
+	 */
+	if (merge_task == NULL && delay_sec == (uint64_t)(-1)) {
+		d_list_for_each_entry(task, &rebuild_gst.rg_running_list, dst_list) {
+			if (uuid_compare(task->dst_pool_uuid, pool->sp_uuid) == 0 &&
+			    task->dst_rebuild_op == rebuild_op && task->dst_map_ver > map_ver) {
+				merge_task = task;
+				break;
+			}
+		}
+		if (merge_task != NULL)
+			D_INFO("pool " DF_UUID " ver=%u, pti_number %d, (id[0] %u) merge to "
+			       "running task %p op=%s\n",
+			       DP_UUID(pool->sp_uuid), map_ver, tgts->pti_number,
+			       tgts->pti_ids[0].pti_id, merge_task, RB_OP_STR(rebuild_op));
+	}
+
 	/* Did not find a suitable target. The task will be added to the @rg_queue_list. */
 	if (merge_task == NULL)
 		return 0;
@@ -1930,6 +1958,65 @@ retry_rebuild_task(struct rebuild_task *task, struct rebuild_global_pool_tracker
 	DL_CDEBUG(error, DLOG_ERR, DLOG_INFO, error, DF_UUID " opc %u/%u, retry.",
 		  DP_UUID(task->dst_pool_uuid), task->dst_rebuild_op, task->dst_map_ver);
 	*opc = RB_OP_REBUILD;
+}
+
+static bool
+rebuild_tgt_in_list(struct pool_target_id_list *tgts, uint32_t tgt_id)
+{
+	int i;
+
+	for (i = 0; tgts != NULL && i < tgts->pti_number; i++) {
+		if (tgts->pti_ids[i].pti_id == tgt_id)
+			return true;
+	}
+
+	return false;
+}
+
+static void
+rebuild_log_finish_scope(struct ds_pool *pool, struct rebuild_task *task,
+			 struct rebuild_global_pool_tracker *rgt)
+{
+	struct pool_target *tgts;
+	unsigned int        tgts_nr;
+	unsigned int        i;
+
+	D_DEBUG(DB_REBUILD, DF_RB " finish scope check: task_ver=%u dst_tgts=%d pool_map_ver=%u",
+		DP_RB_RGT(rgt), task->dst_map_ver, task->dst_tgts.pti_number, pool->sp_map_version);
+
+	ABT_rwlock_rdlock(pool->sp_lock);
+
+	for (i = 0; i < task->dst_tgts.pti_number; i++) {
+		struct pool_target *target = NULL;
+		int                 rc;
+
+		rc = pool_map_find_target(pool->sp_map, task->dst_tgts.pti_ids[i].pti_id, &target);
+		if (rc == 1 && target != NULL)
+			D_DEBUG(DB_REBUILD, DF_RB " finish dst_tgt " DF_TARGET, DP_RB_RGT(rgt),
+				DP_TARGET(target));
+		else
+			D_ERROR(DF_RB " finish dst_tgt id %u not found in pool map", DP_RB_RGT(rgt),
+				task->dst_tgts.pti_ids[i].pti_id);
+	}
+
+	tgts    = pool_map_targets(pool->sp_map);
+	tgts_nr = pool_map_target_nr(pool->sp_map);
+	for (i = 0; i < tgts_nr; i++) {
+		struct pool_target *target = &tgts[i];
+
+		if (target->ta_comp.co_status != PO_COMP_ST_DOWN &&
+		    target->ta_comp.co_status != PO_COMP_ST_DRAIN)
+			continue;
+		if (target->ta_comp.co_fseq == 0 || target->ta_comp.co_fseq > task->dst_map_ver)
+			continue;
+		if (rebuild_tgt_in_list(&task->dst_tgts, target->ta_comp.co_id))
+			continue;
+
+		D_WARN(DF_RB " covered DOWN/DRAIN target not in finish dst_tgts: " DF_TARGET,
+		       DP_RB_RGT(rgt), DP_TARGET(target));
+	}
+
+	ABT_rwlock_unlock(pool->sp_lock);
 }
 
 static void
@@ -2297,6 +2384,7 @@ done:
 			goto iv_stop;
 
 		if (task->dst_rebuild_op == RB_OP_REBUILD) {
+			rebuild_log_finish_scope(pool, task, rgt);
 			rc = ds_pool_tgt_finish_rebuild(pool->sp_uuid, &task->dst_tgts,
 							&obj_reclaim_ver);
 		}


### PR DESCRIPTION
After "dmg pool rebuild stop", the FAIL_RECLAIM cleanup step re-schedules the original op:Rebuild targets with delay_sec == -1, so they can later be merged (via rebuild_try_merge_tgts()) into whatever rebuild task comes next, instead of being run again unilaterally.

rebuild_try_merge_tgts() only searched rebuild_gst.rg_queue_list for a merge candidate, never rebuild_gst.rg_running_list. If the "next" op:Rebuild task for the pool had already been dequeued into rg_running_list by the time the stopped task's targets were re-scheduled with delay_sec == -1, no merge candidate could be found. A brand-new task was created with dst_schedule_time left at -1, which rebuild_ults() skips forever, waiting for a merge that may never come.

Since a rebuild task's scan/pull is driven by pool map version, not by its dst_tgts list, the already-running task actually does migrate the data for the stranded target (it was down before the running task's rebuild version). But because that target is missing from the running task's dst_tgts, ds_pool_tgt_finish_rebuild() is never called for it when the running task completes, so it never leaves PO_COMP_ST_DOWN.

This can leave a lower-fseq target stuck at PO_COMP_ST_DOWN while a higher-fseq target that failed later reaches PO_COMP_ST_DOWNOUT, tripping the fseq-ordering assertion in determine_valid_spares() (src/placement/pl_map_common.c):

  Assertion 'spare_tgt->ta_comp.co_status != PO_COMP_ST_DOWNOUT'
  failed: down fseq(987) < downout fseq(1001)

Fix rebuild_try_merge_tgts() to also look for a same-pool, same-op task in rg_running_list when no queued candidate exists and the task is only waiting to be merged (delay_sec == -1), and fold the new target(s) into that running task's dst_tgts so they are correctly marked PO_COMP_ST_DOWNOUT when the running task completes. This keeps the "wait for merge" behavior intact for admin-stopped rebuilds when there is truly nothing to merge with yet.

another fix is to fix assertion in  layout_find_diff() - src/placement/jump_map.c:207 layout_find_diff() Assertion 'rc == 1' failed Some cases cannot fine a spare target (new_tgt == (uint32_t)-1) in that case need not do remap -> pool_map_find_target().

add some debug log.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
