### PR TITLE
DAOS-19377 build: make pipeline a runtime feature toggle (#18732)

### DIFF
--- a/site_scons/site_tools/compiler_setup.py
+++ b/site_scons/site_tools/compiler_setup.py
@@ -105,7 +105,6 @@ def _base_setup(env):
 
     if build_type != 'release':
         env.AppendUnique(CPPDEFINES={'FAULT_INJECTION': '1'})
-        env.AppendUnique(CPPDEFINES={'BUILD_PIPELINE': '1'})
 
     if env['CMOCKA_FILTER_SUPPORTED']:
         env.AppendUnique(CPPDEFINES={'CMOCKA_FILTER_SUPPORTED': '1'})

--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -1,7 +1,7 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
  * (C) Copyright 2025 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -26,9 +26,7 @@
 #include <daos/placement.h>
 #include <daos/job.h>
 #include <daos/metrics.h>
-#if BUILD_PIPELINE
 #include <daos/pipeline.h>
-#endif
 #include "task_internal.h"
 #include <pthread.h>
 
@@ -37,6 +35,9 @@ static pthread_mutex_t	module_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /** refcount on how many times daos_init has been called */
 static int                 module_initialized;
+
+/** whether the pipeline feature was enabled at daos_init() time */
+static bool                pipeline_enabled;
 
 /* clang-format off */
 
@@ -137,10 +138,8 @@ const struct daos_task_api dc_funcs[] = {
 	{dc_cont_snap_oit_create, sizeof(daos_cont_snap_oit_create_t)},
 	{dc_cont_snap_oit_destroy, sizeof(daos_cont_snap_oit_destroy_t)},
 
-#if BUILD_PIPELINE
 	/** Pipeline */
 	{dc_pipeline_run, sizeof(daos_pipeline_run_t)},
-#endif
 };
 
 /* clang-format on */
@@ -266,20 +265,21 @@ daos_init(void)
 	if (rc != 0)
 		D_GOTO(out_co, rc);
 
-#if BUILD_PIPELINE
-	/** set up pipeline */
-	rc = dc_pipeline_init();
-	if (rc != 0)
-		D_GOTO(out_obj, rc);
-#endif
+	/** set up pipeline if the feature is enabled (disabled by default) */
+	pipeline_enabled = false;
+	d_getenv_bool("DAOS_PIPELINE", &pipeline_enabled);
+	if (pipeline_enabled) {
+		rc = dc_pipeline_init();
+		if (rc != 0)
+			D_GOTO(out_obj, rc);
+	}
+
 	daos_array_env_init();
 	module_initialized++;
 	D_GOTO(unlock, rc = 0);
 
-#if BUILD_PIPELINE
 out_obj:
 	dc_obj_fini();
-#endif
 out_co:
 	dc_cont_fini();
 out_pool:
@@ -343,9 +343,8 @@ daos_fini(void)
 
 	/** clean up all registered per-module metrics */
 	daos_metrics_fini();
-#if BUILD_PIPELINE
-	dc_pipeline_fini();
-#endif
+	if (pipeline_enabled)
+		dc_pipeline_fini();
 	dc_obj_fini();
 	dc_cont_fini();
 	dc_pool_fini();

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -31,12 +31,8 @@
 #include <gurt/telemetry_common.h>
 #include <gurt/telemetry_producer.h>
 
-#define MAX_MODULE_OPTIONS	64
-#if BUILD_PIPELINE
-#define MODULE_LIST	"vos,rdb,rsvc,security,mgmt,dtx,pool,cont,obj,rebuild,pipeline"
-#else
-#define MODULE_LIST	"vos,rdb,rsvc,security,mgmt,dtx,pool,cont,obj,rebuild"
-#endif
+#define MAX_MODULE_OPTIONS 64
+#define MODULE_LIST        "vos,rdb,rsvc,security,mgmt,dtx,pool,cont,obj,rebuild"
 #define MODS_LIST_CHK	"vos,rdb,rsvc,security,mgmt,dtx,pool,cont,obj,rebuild,chk"
 
 /** List of modules to load */
@@ -1115,6 +1111,21 @@ parse(int argc, char **argv)
 		}
 		if (rc)
 			exit(EXIT_FAILURE);
+	}
+
+	/*
+	 * Load the pipeline module only if the feature is explicitly enabled (disabled by
+	 * default). Skip when a specific module list was requested or under check mode.
+	 */
+	if (!spec_mod && !dss_check_mode) {
+		bool pipeline_enabled = false;
+
+		d_getenv_bool("DAOS_PIPELINE", &pipeline_enabled);
+		if (pipeline_enabled) {
+			size_t len = strlen(modules);
+
+			snprintf(modules + len, sizeof(modules) - len, "%s", ",pipeline");
+		}
 	}
 }
 

--- a/src/tests/ftest/daos_test/dfs.yaml
+++ b/src/tests/ftest/daos_test/dfs.yaml
@@ -22,6 +22,7 @@ server_config:
       log_file: daos_server0.log
       env_vars:
         - D_LOG_FILE_APPEND_PID=1
+        - DAOS_PIPELINE=1
       storage:
         0:
           class: dcpm
@@ -33,6 +34,7 @@ server_config:
       log_file: daos_server1.log
       env_vars:
         - D_LOG_FILE_APPEND_PID=1
+        - DAOS_PIPELINE=1
       storage:
         0:
           class: dcpm

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -52,6 +52,7 @@ server_config:
         - D_LOG_FLUSH=DEBUG
         - FI_LOG_LEVEL=warn
         - D_LOG_STDERR_IN_LOG=1
+        - DAOS_PIPELINE=1
       storage: auto
     1:
       pinned_numa_node: 1
@@ -65,6 +66,7 @@ server_config:
         - D_LOG_FLUSH=DEBUG
         - FI_LOG_LEVEL=warn
         - D_LOG_STDERR_IN_LOG=1
+        - DAOS_PIPELINE=1
       storage: auto
   transport_config:
     allow_insecure: true

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -89,6 +89,7 @@ class DaosCoreBase(TestWithServers):
         daos_test_env["COVFILE"] = "/tmp/test.cov"
         daos_test_env["POOL_SCM_SIZE"] = str(scm_size)
         daos_test_env["POOL_NVME_SIZE"] = str(nvme_size)
+        daos_test_env["DAOS_PIPELINE"] = "1"
         parameters = " ".join(filter(None, [f"-n {dmg_config_file}", f"-{subtest}", str(args)]))
         daos_test_cmd = get_cmocka_command(command, parameters)
         job = get_job_manager(self, "Orterun", daos_test_cmd, mpi_type="openmpi")

--- a/src/tests/suite/daos_pipeline.c
+++ b/src/tests/suite/daos_pipeline.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -9,12 +10,9 @@
  * src/tests/suite/daos_pipeline.c
  */
 #include <daos.h>
-#if BUILD_PIPELINE
 #include <daos_pipeline.h>
-#endif
 #include "daos_test.h"
 
-#if BUILD_PIPELINE
 #define NUM_AKEYS 4
 #define VALUE_MAX_SIZE 10
 
@@ -252,10 +250,24 @@ cleanup_pipe(daos_pipeline_t *p)
 }
 
 static void
+skip_if_pipeline_disabled(void)
+{
+	bool pipeline_enabled = false;
+
+	d_getenv_bool("DAOS_PIPELINE", &pipeline_enabled);
+	if (!pipeline_enabled) {
+		print_message("DAOS PIPELINE is not enabled (set DAOS_PIPELINE=1 to enable)\n");
+		skip();
+	}
+}
+
+static void
 check_pipelines(void **state)
 {
 	daos_pipeline_t	*p0 = NULL;
 	int		rc = 0;
+
+	skip_if_pipeline_disabled();
 
 	print_message(" A. Check that NULL pipelines get detected.\n");
 	rc = daos_pipeline_check(p0);
@@ -1091,6 +1103,8 @@ simple_pipeline(void **state)
 	static char	*fields[NR_IODS] = {"Owner", "Species", "Sex", "Age"};
 	int		nr_aggr;
 
+	skip_if_pipeline_disabled();
+
 	rc = daos_cont_create_with_label(arg->pool.poh, "simple_pipeline_cont", NULL, NULL, NULL);
 	assert_rc_equal(rc, 0);
 
@@ -1559,6 +1573,8 @@ simple_pipeline_arrays(void **state)
 	static char	field[] = "Array";
 	int		rc;
 
+	skip_if_pipeline_disabled();
+
 	rc = daos_cont_create_with_label(arg->pool.poh, "simple_pipeline_arrays", NULL, NULL, NULL);
 	assert_rc_equal(rc, 0);
 
@@ -1957,6 +1973,8 @@ simple_pipeline_dfs(void **state)
 	static char	field[] = "DFS_ENTRY";
 	int		rc;
 
+	skip_if_pipeline_disabled();
+
 	rc = daos_cont_create_with_label(arg->pool.poh, "simple_pipeline_dfs", NULL, NULL, NULL);
 	assert_rc_equal(rc, 0);
 
@@ -2007,19 +2025,14 @@ pipeline_setup(void **state)
 {
 	return test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE, 0, NULL);
 }
-#endif
 
 int
 run_daos_pipeline_test(int rank, int size)
 {
 	int rc = 0;
 
-#if BUILD_PIPELINE
 	rc = cmocka_run_group_tests_name("DAOS_Pipeline", pipeline_tests, pipeline_setup,
 					 test_teardown);
-#else
-	print_message("DAOS PIPELINE is not enabled in release builds\n");
-#endif
 	par_barrier(PAR_COMM_WORLD);
 	return rc;
 }

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -3430,9 +3430,7 @@ dfs_test_oflags(void **state)
 static void
 test_pipeline_find(void **state, daos_oclass_id_t dir_oclass)
 {
-#ifndef BUILD_PIPELINE
-	skip();
-#endif
+	bool             pipeline_enabled = false;
 	dfs_obj_t	*dir1, *f1;
 	int		i;
 	time_t		ts = 0;
@@ -3440,6 +3438,10 @@ test_pipeline_find(void **state, daos_oclass_id_t dir_oclass)
 	int		create_flags = O_RDWR | O_CREAT | O_EXCL;
 	char		*dirname = "pipeline_dir";
 	int		rc;
+
+	d_getenv_bool("DAOS_PIPELINE", &pipeline_enabled);
+	if (!pipeline_enabled)
+		skip();
 
 	rc = dfs_open(dfs_mt, NULL, dirname, create_mode | S_IFDIR, create_flags, dir_oclass, 0,
 		      NULL, &dir1);


### PR DESCRIPTION
Remove the BUILD_PIPELINE compile-time define and replace it with the DAOS_PIPELINE environment variable (disabled by default). The client and server init/fini now enable pipeline support at runtime based on this variable, and the pipeline code is always compiled into libdaos.

Update the pipeline test suites to compile unconditionally and gate execution on DAOS_PIPELINE, and set DAOS_PIPELINE=1 for the client and server when running the daos_test suite.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
