### PR TITLE
DAOS-19333 build: Don't fail release builds on memcheck

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1171,7 +1171,9 @@ pipeline {
                         ),
                         'Fault injection testing': scriptedUnitTestStage(
                             name: 'Fault injection testing',
-                            runStage: shouldStageRun('Fault injection testing'),
+                            // Release builds compile out fault injection
+                            runStage: shouldStageRun('Fault injection testing') &&
+                                      !sconsArgs().contains('BUILD_TYPE=release'),
                             label: params.CI_FI_1_LABEL,
                             jobStatus: job_status_internal,
                             distro: 'el9',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -844,12 +844,9 @@ pipeline {
                                                       ' PREFIX=/opt/daos TARGET_TYPE=release'))
                             sh label: 'Generate RPMs',
                                 script: './ci/rpm/gen_rpms.sh el9 "' + env.DAOS_RELVAL + '"'
-                            // For non-release builds, create a separate build with the valgrind
-                            // tag for NLT memcheck testing.  This is necessary to avoid problems
-                            // caused by valgrind being confused by the Go runtime. We don't want
-                            // to use the valgrind build for normal testing because it is much slower.
-                            // BUILD_TYPE=dev is set for PR/dev builds in sconsArgs(), and
-                            // TARGET_TYPE=release is used to select pre-built cached prerequisites.
+                            // Go binaries need to be instrumented in order to work reliably
+                            // with valgrind. We do this in a separate build because we don't
+                            // want to ship the instrumented binaries.
                             job_step_update(
                                 sconsBuild(parallel_build: true,
                                            build_deps: 'no',

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -516,8 +516,7 @@ class PreReqComponent():
                               ['warning', 'warn', 'error'], ignorecase=2))
         opts.Add(('SANITIZERS', 'Instrument C code with Google Sanitizers', None))
         opts.Add(BoolVariable('BUILD_GO_VALGRIND',
-                              'Build Go artifacts with the Go "valgrind" tag for Memcheck '
-                              '(also drops -race; ignored for release)',
+                              'Build Go artifacts with the Go "valgrind" tag for Memcheck',
                               False))
         opts.Add(BoolVariable('CMOCKA_FILTER_SUPPORTED', 'Allows to filter cmocka tests', False))
         opts.Add(BoolVariable('CRT_PP', 'Preprocess CaRT sources', False))

--- a/site_scons/site_tools/go_builder.py
+++ b/site_scons/site_tools/go_builder.py
@@ -14,12 +14,9 @@ include_re = re.compile(r'\#include [<"](\S+[>"])', re.M)
 def _is_valgrind_build(env):
     """Return True if Go artifacts should be built with the Go 1.25+ "valgrind" tag.
 
-    BUILD_GO_VALGRIND=1 makes the Go runtime cooperate with Memcheck. Ignored for
-    release builds.
+    BUILD_GO_VALGRIND=1 makes the Go runtime cooperate with Memcheck.
     """
     if not env.get('BUILD_GO_VALGRIND'):
-        return False
-    if env.get('BUILD_TYPE') == 'release':
         return False
     if env.get('SANITIZERS'):
         Exit('BUILD_GO_VALGRIND=1 is incompatible with SANITIZERS')

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -12,7 +12,8 @@ from os.path import join
 def get_build_tags(benv):
     "Get custom go build tags."
     tags = ["spdk"]
-    if not is_release_build(benv):
+    # The memcheck build always uses the non-release tags
+    if not is_release_build(benv) or benv.d_is_valgrind_build():
         tags.append("fault_injection")
         tags.append("pprof")
     else:
@@ -43,13 +44,12 @@ def is_release_build(benv):
 
 def get_build_flags(benv):
     """Return string of build flags"""
-    if is_release_build(benv):
+    # The memcheck build always uses non-release flags
+    if is_release_build(benv) and not benv.d_is_valgrind_build():
         return '-buildmode=pie'
     # Disable optimizations and inlining for debugger support
     flags = '-gcflags "all=-N -l"'
-    # Valgrind variant: instrument the Go runtime for Memcheck and leave the
-    # race detector off because it does not stack with memcheck.
-    #
+    # Leave the race detector off because it does not stack with memcheck.
     if benv.d_is_valgrind_build():
         return flags
     # enable AddressSanitizer to detect memory safety issues at runtime


### PR DESCRIPTION
The memcheck stage uses a separate instrumented build for Go
binaries regardless of the BUILD_TYPE value.

faults-enabled: false
Signed-off-by: Michael MacDonald <github@macdonald.cx>
