### PR TITLE
DAOS-18888 tests: set CMOCKA_TEST_ABORT=1 for CMOCKA

### DIFF
--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -83,6 +83,7 @@ class DaosCoreBase(TestWithServers):
         cmocka_utils = CmockaUtils(
             self.hostlist_clients, self.subtest_name, self.outputdir, self.test_dir, self.log)
         daos_test_env = cmocka_utils.get_cmocka_env()
+        daos_test_env["CMOCKA_TEST_ABORT"] = "1"
         daos_test_env["D_LOG_FILE"] = get_log_file(self.client_log)
         daos_test_env["D_LOG_MASK"] = self.get_test_param("test_log_mask", "DEBUG")
         daos_test_env["DD_MASK"] = "mgmt,io,md,epc,rebuild,test"


### PR DESCRIPTION
Explicitly set CMOCKA_TEST_ABORT=1 to change CMOCKA default behavior when some signal is raised during the test. That will abort current sub-test instead of directly longjmp() to next sub-test. So we will have chance to keep related failure context.

Test-provider-cb-medium-md-on-ssd: ucx+dc_x
Test-tag: CsumErrorLog DaosCoreTestDfs DaosCoreTestNvme DaosCoreTestRebuild DaosCoreTest IncReintContRecovTest CatRecovCoreTest
Skip-func-hw-test-medium-ucx-provider: false

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
