### PR TITLE
DAOS-19381 rebuild: skip -1 target in layout_find_diff

### DIFF
--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -173,7 +173,7 @@ jm_obj_shard_pd(struct jm_obj_placement *jmop, uint32_t shard)
  * 				means comparing full layout.
  */
 static inline int
-layout_find_diff(struct pl_jump_map *jmap, struct pl_obj_layout *old_lo,
+layout_find_diff(struct pl_jump_map *jmap, struct daos_obj_md *md, struct pl_obj_layout *old_lo,
 		 struct pl_obj_layout *new_lo, d_list_t *diff, bool rebuilding, int grp_spec)
 {
 	int index;
@@ -197,6 +197,14 @@ layout_find_diff(struct pl_jump_map *jmap, struct pl_obj_layout *old_lo,
 		bool                remap   = false;
 		struct pool_target *new_pot;
 
+		if (new_tgt == (uint32_t)-1) {
+			D_INFO("pool " DF_UUID ", oid " DF_OID "skip remap shard %d, "
+			       "new_tgt -1, old_tgt %u (%u, %u)",
+			       DP_UUID(jmap->jmp_map.pl_uuid), DP_OID(md->omd_id), index, old_tgt,
+			       old_lo->ol_shards[index].po_rank, old_lo->ol_shards[index].po_index);
+			continue;
+		}
+
 		if (new_tgt != old_tgt)
 			remap = true; /* migrate to a new target, e.g. drain, regular reint */
 		else if (rebuilding && old_lo->ol_shards[index].po_rebuilding)
@@ -204,7 +212,14 @@ layout_find_diff(struct pl_jump_map *jmap, struct pl_obj_layout *old_lo,
 
 		if (remap) {
 			rc = pool_map_find_target(jmap->jmp_map.pl_poolmap, new_tgt, &new_pot);
-			D_ASSERT(rc == 1);
+			D_ASSERTF(rc == 1,
+				  "pool " DF_UUID ", oid " DF_OID "cannot find new_tgt %u (%u, %u),"
+				  " shard %d,  old_tgt %u (%u, %u)\n",
+				  DP_UUID(jmap->jmp_map.pl_uuid), DP_OID(md->omd_id), new_tgt,
+				  new_lo->ol_shards[index].po_rank,
+				  new_lo->ol_shards[index].po_index, index, old_tgt,
+				  old_lo->ol_shards[index].po_rank,
+				  old_lo->ol_shards[index].po_index);
 
 			if (pool_target_avail(new_pot,
 					      PO_COMP_ST_UPIN | PO_COMP_ST_UP | PO_COMP_ST_DRAIN)) {
@@ -960,7 +975,7 @@ jump_map_obj_extend_layout(struct pl_jump_map *jmap, struct jm_obj_placement *jm
 
 	obj_layout_dump(md->omd_id, new_layout);
 
-	rc = layout_find_diff(jmap, layout, new_layout, &extend_list, false, PL_GRP_MAX);
+	rc = layout_find_diff(jmap, md, layout, new_layout, &extend_list, false, PL_GRP_MAX);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -1131,7 +1146,7 @@ jump_map_obj_find_diff(struct pl_map *map, uint32_t layout_ver, struct daos_obj_
 		D_GOTO(out, rc);
 
 	obj_layout_dump(md->omd_id, reint_layout);
-	rc = layout_find_diff(jmap, layout, reint_layout, &reint_list, true,
+	rc = layout_find_diff(jmap, md, layout, reint_layout, &reint_list, true,
 			      (md->omd_flags & PL_FL_GRP_SPEC) ? md->omd_grp_spec : PL_GRP_MAX);
 	if (rc)
 		D_GOTO(out, rc);

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -380,12 +380,22 @@ determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md, bo
 		 * try next spare.
 		 */
 		if (f_shard->fs_status == PO_COMP_ST_DOWN ||
-		    f_shard->fs_status == PO_COMP_ST_DRAIN)
+		    f_shard->fs_status == PO_COMP_ST_DRAIN) {
+			if (spare_tgt->ta_comp.co_status == PO_COMP_ST_DOWNOUT)
+				D_ERROR(DF_OID
+					": DOWN/DRAIN failed shard remaps through DOWNOUT spare: "
+					"md_ver=%u allow_ver=%u gen_mode=%d failed=(" DF_FAILEDSHARD
+					") spare=" DF_TARGET " spare_fseq=%u spare_out_ver=%u\n",
+					DP_OID(md->omd_id), md->omd_ver, allow_version, gen_mode,
+					DP_FAILEDSHARD(*f_shard), DP_TARGET(spare_tgt),
+					spare_tgt->ta_comp.co_fseq, spare_tgt->ta_comp.co_out_ver);
+
 			D_ASSERTF(spare_tgt->ta_comp.co_status !=
 				  PO_COMP_ST_DOWNOUT,
 				  "down fseq(%u) < downout fseq(%u)\n",
 				  f_shard->fs_fseq,
 				  spare_tgt->ta_comp.co_fseq);
+		}
 
 		f_shard->fs_fseq = spare_tgt->ta_comp.co_fseq;
 		f_shard->fs_status = spare_tgt->ta_comp.co_status;
@@ -520,4 +530,3 @@ out:
 		D_FREE(grp_count);
 	return rc;
 }
-

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1873,6 +1873,65 @@ rebuild_retryable_err(int error)
 		error == -DER_STALE || error == -DER_VOS_PARTIAL_UPDATE);
 }
 
+static bool
+rebuild_tgt_in_list(struct pool_target_id_list *tgts, uint32_t tgt_id)
+{
+	int i;
+
+	for (i = 0; tgts != NULL && i < tgts->pti_number; i++) {
+		if (tgts->pti_ids[i].pti_id == tgt_id)
+			return true;
+	}
+
+	return false;
+}
+
+static void
+rebuild_log_finish_scope(struct ds_pool *pool, struct rebuild_task *task,
+			 struct rebuild_global_pool_tracker *rgt)
+{
+	struct pool_target *tgts;
+	unsigned int        tgts_nr;
+	unsigned int        i;
+
+	D_DEBUG(DB_REBUILD, DF_RB " finish scope check: task_ver=%u dst_tgts=%d pool_map_ver=%u",
+		DP_RB_RGT(rgt), task->dst_map_ver, task->dst_tgts.pti_number, pool->sp_map_version);
+
+	ABT_rwlock_rdlock(pool->sp_lock);
+
+	for (i = 0; i < task->dst_tgts.pti_number; i++) {
+		struct pool_target *target = NULL;
+		int                 rc;
+
+		rc = pool_map_find_target(pool->sp_map, task->dst_tgts.pti_ids[i].pti_id, &target);
+		if (rc == 1 && target != NULL)
+			D_DEBUG(DB_REBUILD, DF_RB " finish dst_tgt " DF_TARGET, DP_RB_RGT(rgt),
+				DP_TARGET(target));
+		else
+			D_ERROR(DF_RB " finish dst_tgt id %u not found in pool map", DP_RB_RGT(rgt),
+				task->dst_tgts.pti_ids[i].pti_id);
+	}
+
+	tgts    = pool_map_targets(pool->sp_map);
+	tgts_nr = pool_map_target_nr(pool->sp_map);
+	for (i = 0; i < tgts_nr; i++) {
+		struct pool_target *target = &tgts[i];
+
+		if (target->ta_comp.co_status != PO_COMP_ST_DOWN &&
+		    target->ta_comp.co_status != PO_COMP_ST_DRAIN)
+			continue;
+		if (target->ta_comp.co_fseq == 0 || target->ta_comp.co_fseq > task->dst_map_ver)
+			continue;
+		if (rebuild_tgt_in_list(&task->dst_tgts, target->ta_comp.co_id))
+			continue;
+
+		D_WARN(DF_RB " covered DOWN/DRAIN target not in finish dst_tgts: " DF_TARGET,
+		       DP_RB_RGT(rgt), DP_TARGET(target));
+	}
+
+	ABT_rwlock_unlock(pool->sp_lock);
+}
+
 static void
 retry_rebuild_task(struct rebuild_task *task, struct rebuild_global_pool_tracker *rgt,
 		   daos_rebuild_opc_t *opc)
@@ -2275,6 +2334,7 @@ done:
 			goto iv_stop;
 
 		if (task->dst_rebuild_op == RB_OP_REBUILD) {
+			rebuild_log_finish_scope(pool, task, rgt);
 			rc = ds_pool_tgt_finish_rebuild(pool->sp_uuid, &task->dst_tgts,
 							&obj_reclaim_ver);
 		}


### PR DESCRIPTION
When no spare target available, the new_tgt possibly be -1 in POST_REBUILD layout, skip that shard's remap to avoid such assertion - placement/jump_map.c:207 layout_find_diff() Assertion 'rc == 1' failed (pool_map_find_target(jmap->jmp_map.pl_poolmap, new_tgt, &new_pot) failed).

Add some debug log about rebuild target list.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
