### PR TITLE
DAOS-19131 control: allow dmg storage format --replace on MS replicas

### DIFF
--- a/src/control/lib/control/storage.go
+++ b/src/control/lib/control/storage.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -389,7 +389,16 @@ func (sfr *StorageFormatResp) addHostResponse(hr *HostResponse) (err error) {
 // system should be erased before allowing a format request for the hosts
 // in the request. The goal is to prevent reformatting a running system while
 // allowing (re-)format of hosts that are not participating as MS replicas.
+// When Replace is true, control_metadata format will be skipped on the engine
+// side, so the MS replica check can be bypassed to allow replacing MS replica
+// ranks after metadata loss.
 func checkFormatReq(ctx context.Context, rpcClient UnaryInvoker, req *StorageFormatReq) error {
+	// Skip MS replica checks when replacing a rank, as control_metadata
+	// format is skipped in this case.
+	if req.Replace {
+		return nil
+	}
+
 	reqHosts, err := common.ParseHostList(req.HostList, build.DefaultControlPort)
 	if err != nil {
 		return err

--- a/src/control/lib/control/storage_test.go
+++ b/src/control/lib/control/storage_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -770,6 +771,7 @@ func TestControl_checkFormatReq(t *testing.T) {
 
 	for name, tc := range map[string]struct {
 		reqHosts   []string
+		replace    bool
 		invokerErr error
 		responses  []*UnaryResponse
 		expErr     error
@@ -818,6 +820,21 @@ func TestControl_checkFormatReq(t *testing.T) {
 			},
 			expErr: errors.New("oops"),
 		},
+		"replace on replica running": {
+			reqHosts: reqHosts("replica"),
+			replace:  true,
+			responses: []*UnaryResponse{
+				MockMSResponse("replica", nil, &mgmtpb.SystemQueryResp{}),
+			},
+			// Should succeed because Replace bypasses MS replica check
+		},
+		"replace on localserver running": {
+			replace: true,
+			responses: []*UnaryResponse{
+				MockMSResponse(localServer, nil, &mgmtpb.SystemQueryResp{}),
+			},
+			// Should succeed because Replace bypasses MS replica check
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
@@ -828,7 +845,7 @@ func TestControl_checkFormatReq(t *testing.T) {
 				UnaryResponseSet: tc.responses,
 			})
 
-			req := &StorageFormatReq{}
+			req := &StorageFormatReq{Replace: tc.replace}
 			req.SetHostList(tc.reqHosts)
 			err := checkFormatReq(test.Context(t), mi, req)
 			test.CmpErr(t, tc.expErr, err)


### PR DESCRIPTION
Remove restriction that prevents 'dmg storage format --replace' from being run on MS replica ranks. When the --replace flag is specified, control_metadata format is skipped on the engine side, so it is safe to bypass the MS replica check that normally prevents format operations on running system replicas.

This allows administrators to replace MS replica ranks after metadata loss due to storage media failure.

Add test cases to verify that format with --replace flag succeeds even when MS replicas are running.

Features: control
Priority: 2

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
