### PR TITLE
DAOS-19369 rdb: Fix invalid lease handling (#18740)

### DIFF
--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -3675,14 +3675,10 @@ rdb_raft_process_reply(struct rdb *db, crt_rpc_t *rpc)
 	if (lease != NULL) {
 		int adjustment = d_hlc2msec(d_hlc_epsilon_get()) + 1 /* ms margin */;
 
-		if (*lease < adjustment) {
-			D_ERROR(DF_DB ": dropping %s response from " RDB_F_RID
-				      ": invalid lease: %ld\n",
-				DP_DB(db), opc == RDB_APPENDENTRIES ? "AE" : "IS",
-				RDB_P_RID(out_op->ro_from), *lease);
-			return;
-		}
-		*lease -= adjustment;
+		if (*lease > adjustment)
+			*lease -= adjustment;
+		else
+			*lease = 0; /* will effectively be ignored by raft_node_set_lease */
 	}
 
 	ABT_mutex_lock(db->d_raft_mutex);

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2017-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */


### PR DESCRIPTION
The lease in an AE or IS response may be zero. Instead of dropping such a response, we could let raft process the rest of the response (e.g., the term), because the zero lease would be ignored effectively by raft_node_set_lease, and a higher term would inform an older leader to immediately begin to step down.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
