### PR TITLE
DAOS-19368 object: make fill_[key|rec] do not return error codes

### DIFF
--- a/src/include/daos_srv/object.h
+++ b/src/include/daos_srv/object.h
@@ -49,11 +49,12 @@ struct ds_obj_enum_arg {
 	int			rnum;		/* records num (type == S||R) */
 	daos_size_t		rsize;		/* record size (type == S||R) */
 	daos_unit_oid_t		oid;		/* for unpack */
-	uint32_t		fill_recxs:1,	/* type == S||R */
-				chk_key2big:1,
-				need_punch:1,	/* need to pack punch epoch */
-				obj_punched:1,	/* object punch is packed   */
-				size_query:1;	/* Only query size */
+	uint32_t                fill_recxs : 1, /* type == S||R */
+	    chk_key2big : 1, need_punch : 1,    /* need to pack punch epoch */
+	    obj_punched : 1,                    /* object punch is packed   */
+	    size_query  : 1,                    /* Only query size */
+	    rc_key2big  : 1; /* [out] The requested key is too big. kds[0].kd_key_len contains the
+				minimal required buffer size. */
 };
 
 struct dtx_handle;

--- a/src/include/daos_srv/object.h
+++ b/src/include/daos_srv/object.h
@@ -49,12 +49,11 @@ struct ds_obj_enum_arg {
 	int			rnum;		/* records num (type == S||R) */
 	daos_size_t		rsize;		/* record size (type == S||R) */
 	daos_unit_oid_t		oid;		/* for unpack */
-	uint32_t                fill_recxs : 1, /* type == S||R */
-	    chk_key2big : 1, need_punch : 1,    /* need to pack punch epoch */
-	    obj_punched : 1,                    /* object punch is packed   */
-	    size_query  : 1,                    /* Only query size */
-	    rc_key2big  : 1; /* [out] The requested key is too big. kds[0].kd_key_len contains the
-				minimal required buffer size. */
+	uint32_t		fill_recxs:1,	/* type == S||R */
+				chk_key2big:1,
+				need_punch:1,	/* need to pack punch epoch */
+				obj_punched:1,	/* object punch is packed   */
+				size_query:1;	/* Only query size */
 };
 
 struct dtx_handle;

--- a/src/object/srv_enum.c
+++ b/src/object/srv_enum.c
@@ -17,6 +17,9 @@
 
 #include "obj_internal.h"
 
+#define RC_ENUM_OVERFLOW 1
+#define RC_ENUM_KEY2BIG 2
+
 static int
 fill_recxs(daos_handle_t ih, vos_iter_entry_t *key_ent,
 	   struct ds_obj_enum_arg *arg, vos_iter_type_t type)
@@ -231,7 +234,7 @@ fill_key(daos_handle_t ih, vos_iter_entry_t *key_ent, struct ds_obj_enum_arg *ar
 		arg->kds_len++;
 		arg->kds[0].kd_key_len += total_size;
 		if (arg->kds_len >= kds_cap)
-			return 1;
+			return RC_ENUM_OVERFLOW;
 		return 0;
 	}
 
@@ -244,10 +247,10 @@ fill_key(daos_handle_t ih, vos_iter_entry_t *key_ent, struct ds_obj_enum_arg *ar
 		    (arg->chk_key2big && arg->kds_len <= 2)) {
 			if (arg->kds[0].kd_key_len < total_size)
 				arg->kds[0].kd_key_len = total_size;
-			arg->rc_key2big = 1;
+			return RC_ENUM_KEY2BIG;
+		} else {
+			return RC_ENUM_OVERFLOW;
 		}
-
-		return 1;
 	}
 
 	iov = &arg->sgl->sg_iovs[arg->sgl_idx];
@@ -605,7 +608,7 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct ds_obj_enum_arg *ar
 		arg->kds_len++;
 		arg->kds[0].kd_key_len += size;
 		if (arg->kds_len >= arg->kds_cap)
-			return 1;
+			return RC_ENUM_OVERFLOW;
 		return 0;
 	}
 
@@ -622,9 +625,9 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct ds_obj_enum_arg *ar
 			    (arg->kds_len < 3 || (arg->kds_len == 3 && !bump_kds_len))) {
 				if (arg->kds[0].kd_key_len < size)
 					arg->kds[0].kd_key_len = size;
-				arg->rc_key2big = 1;
+				D_GOTO(out, rc = RC_ENUM_KEY2BIG);
 			}
-			D_GOTO(out, rc = 1);
+			D_GOTO(out, rc = RC_ENUM_OVERFLOW);
 		} else {
 			insert_new_rec(arg, key_ent, type, iod_size, &rec);
 		}
@@ -754,14 +757,12 @@ ds_obj_enum_pack(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 	D_ASSERT(!arg->fill_recxs ||
 		 type == VOS_ITER_SINGLE || type == VOS_ITER_RECX);
 
-	arg->rc_key2big = 0;
-
 	rc = iter_cb(param, type, recursive, anchors, enum_pack_cb, NULL,
 		     arg, dth);
 
-	D_DEBUG(DB_IO, "enum type %d rc %d rc_key2big %d\n", type, rc, arg->rc_key2big == 1);
+	D_DEBUG(DB_IO, "enum type %d rc %d\n", type, rc);
 
-	if (arg->rc_key2big == 1) {
+	if (rc == RC_ENUM_KEY2BIG) {
 		rc = -DER_KEY2BIG;
 	}
 

--- a/src/object/srv_enum.c
+++ b/src/object/srv_enum.c
@@ -244,10 +244,10 @@ fill_key(daos_handle_t ih, vos_iter_entry_t *key_ent, struct ds_obj_enum_arg *ar
 		    (arg->chk_key2big && arg->kds_len <= 2)) {
 			if (arg->kds[0].kd_key_len < total_size)
 				arg->kds[0].kd_key_len = total_size;
-			return -DER_KEY2BIG;
-		} else {
-			return 1;
+			arg->rc_key2big = 1;
 		}
+
+		return 1;
 	}
 
 	iov = &arg->sgl->sg_iovs[arg->sgl_idx];
@@ -622,7 +622,7 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct ds_obj_enum_arg *ar
 			    (arg->kds_len < 3 || (arg->kds_len == 3 && !bump_kds_len))) {
 				if (arg->kds[0].kd_key_len < size)
 					arg->kds[0].kd_key_len = size;
-				D_GOTO(out, rc = -DER_KEY2BIG);
+				arg->rc_key2big = 1;
 			}
 			D_GOTO(out, rc = 1);
 		} else {
@@ -757,6 +757,11 @@ ds_obj_enum_pack(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 	rc = iter_cb(param, type, recursive, anchors, enum_pack_cb, NULL,
 		     arg, dth);
 
-	D_DEBUG(DB_IO, "enum type %d rc %d\n", type, rc);
+	D_DEBUG(DB_IO, "enum type %d rc %d rc_key2big %d\n", type, rc, arg->rc_key2big == 1);
+
+	if (arg->rc_key2big) {
+		rc = -DER_KEY2BIG;
+	}
+
 	return rc;
 }

--- a/src/object/srv_enum.c
+++ b/src/object/srv_enum.c
@@ -18,7 +18,7 @@
 #include "obj_internal.h"
 
 #define RC_ENUM_OVERFLOW 1
-#define RC_ENUM_KEY2BIG 2
+#define RC_ENUM_KEY2BIG  2
 
 static int
 fill_recxs(daos_handle_t ih, vos_iter_entry_t *key_ent,

--- a/src/object/srv_enum.c
+++ b/src/object/srv_enum.c
@@ -754,12 +754,14 @@ ds_obj_enum_pack(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 	D_ASSERT(!arg->fill_recxs ||
 		 type == VOS_ITER_SINGLE || type == VOS_ITER_RECX);
 
+	arg->rc_key2big = 0;
+
 	rc = iter_cb(param, type, recursive, anchors, enum_pack_cb, NULL,
 		     arg, dth);
 
 	D_DEBUG(DB_IO, "enum type %d rc %d rc_key2big %d\n", type, rc, arg->rc_key2big == 1);
 
-	if (arg->rc_key2big) {
+	if (arg->rc_key2big == 1) {
 		rc = -DER_KEY2BIG;
 	}
 


### PR DESCRIPTION
### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
