### PR TITLE
DAOS-19261 test: update expected interop compat

### DIFF
--- a/src/tests/ftest/interoperability/README.md
+++ b/src/tests/ftest/interoperability/README.md
@@ -14,8 +14,13 @@ python3 -m pip install -r /path/to/daos-stack/daos/requirements-ftest.txt
 export PYTHONPATH=/path/to/daos/install/lib/daos/TESTING/ftest:$PYTHONPATH;
 ```
 Fake a `pydaos` install by linking to the `pydaos` RPM install.  
+The version of python depends on the distro python and/or the version of DAOS.
 TODO: `pydaos` should be properly installed with the version of python being used.  
-For example:
+To see where pydaos is installed:
+```
+ls -d /usr/lib64/python*/site-packages/pydaos
+```
+Then, for example, to link it:
 ```
 ln -s /usr/lib64/python3.6/site-packages/pydaos ~/venv_interop/lib/python3.6/site-packages/pydaos
 ```

--- a/src/tests/ftest/interoperability/upgrade_downgrade_base.py
+++ b/src/tests/ftest/interoperability/upgrade_downgrade_base.py
@@ -1,6 +1,6 @@
 '''
   (C) Copyright 2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -619,8 +619,18 @@ class UpgradeDowngradeBase(IorTestBase):
             self.verify_write_read(hosts_client, tmp_cont, write=True, read=True)
             tmp_cont.destroy()
 
+            # TODO This is less about the DAOS version and more about the pool layout version.
+            # For now, just put some fuzzy requirements in until we have a better understanding of
+            # the layout versioning and compatibility.
+            expect_old_client_access_new_pool = True
             if self.current_server_version.major > self.current_client_version.major:
-                # Across major versions, old client should not be able to access a new server pool
+                # Major DAOS versions likely bumped the pool layout version
+                expect_old_client_access_new_pool = False
+            elif self.current_server_version >= "2.8.0" > self.current_client_version:
+                # 2.8.0 did bump the layout version
+                expect_old_client_access_new_pool = False
+
+            if not expect_old_client_access_new_pool:
                 self.log_step("Verify old client cannot access new pool")
                 tmp_pool = self.get_pool(connect=False)
                 try:
@@ -639,7 +649,6 @@ class UpgradeDowngradeBase(IorTestBase):
                 finally:
                     tmp_pool.destroy()
             else:
-                # On the same major version, old client should be able to access a new server pool
                 self.log_step("Verify old client can access new pool")
                 self.log.info("Verify IOR write/read - old client, new server, new pool, new data")
                 tmp_pool = self.get_pool(connect=False)

--- a/src/tests/ftest/util/package_utils.py
+++ b/src/tests/ftest/util/package_utils.py
@@ -1,6 +1,6 @@
 """
 (C) Copyright 2023-2024 Intel Corporation.
-(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+(C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -94,9 +94,9 @@ class Version():
 
         try:
             version_match = re.match(r'^v?([0-9]+)\.([0-9]+)\.([0-9]+)', self.__version)
-            self.major = version_match.group(1)
-            self.minor = version_match.group(2)
-            self.patch = version_match.group(3)
+            self.major = int(version_match.group(1))
+            self.minor = int(version_match.group(2))
+            self.patch = int(version_match.group(3))
         except (AttributeError, IndexError) as error:
             raise ValueError(f'Invalid version string {self.__version}') from error
 


### PR DESCRIPTION
Update the expected interop compatibility between 2.8.0 and 2.6.5. Fix class Version to store major,minor,patch as integers so comparisons work for numbers > 9.

Test-tag: always_passes,vm test_setup_vm

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
