### PR TITLE
DAOS-19209 dfs: refresh cached PL pool info on pool map changes

### DIFF
--- a/src/client/dfs/dfs-progressive-layout.md
+++ b/src/client/dfs/dfs-progressive-layout.md
@@ -185,6 +185,29 @@ Worked examples:
 - Do not recompute split_off per file or per I/O.
 - Existing files keep the policy effective at their creation time (unless a future explicit migration feature is added).
 
+### 6) Tuning constants and rationale
+
+The policy above depends on three tunables. All are initial heuristics chosen to keep the head
+compact while still scaling with pool size; they should be validated with rebuild and performance
+benchmarks and are the intended knobs to adjust.
+
+- **1000 targets (PL enable gate).** Below this a pool is too small to benefit from a compact
+  non-GX head: with few targets there is little placement diversity to exploit, and the metadata
+  and rebuild savings of a narrow head do not outweigh the added complexity of a second object. It
+  is a round order-of-magnitude threshold, not a hard boundary.
+
+- **0.2% (head_capacity_fraction, 0.002).** The fraction of per-target pool capacity budgeted to
+  head data before switching to the tail. It is deliberately conservative: it keeps the head small
+  enough to preserve the rebuild/metadata benefit while still giving a meaningful head region.
+  Lower values switch to the tail earlier (more compact); higher values keep more data in the head.
+
+- **Divide by 8 (head group compactness bias).** `g_raw = floor(max_groups_pool / 8)` starts the
+  head at roughly one-eighth of the pool's maximum scalable group count, keeping the head
+  materially narrower than the wide tail. Being a power of two, it composes cleanly with the
+  allowed group set `{1,2,4,6,8,12,16,32}`, and after clamping the head only reaches the maximum
+  of 32 groups on very large pools (`max_groups_pool >= 256`). A smaller divisor widens the head; a
+  larger one narrows it.
+
 ## On-Disk Metadata Design
 
 ### Existing Inode Entry (base fields)

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -221,6 +221,8 @@ struct dfs {
 	uint64_t             pl_total_nvme;
 	/** Pool map version the cached PL pool values above were queried at */
 	uint32_t             pl_map_ver;
+	/** serialize PL pool info refreshers so only one issues the pool query */
+	pthread_mutex_t      pl_refresh_lock;
 	/** Optional prefix to account for when resolving an absolute path */
 	char                *prefix;
 	daos_size_t          prefix_len;

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -219,6 +219,8 @@ struct dfs {
 	uint64_t             pl_total_scm;
 	/** Cached total NVMe capacity for progressive-layout selection */
 	uint64_t             pl_total_nvme;
+	/** Pool map version the cached PL pool values above were queried at */
+	uint32_t             pl_map_ver;
 	/** Optional prefix to account for when resolving an absolute path */
 	char                *prefix;
 	daos_size_t          prefix_len;
@@ -500,6 +502,8 @@ file_truncate_zero(dfs_obj_t *obj, daos_handle_t th);
 int
 dfs_default_file_pl(dfs_t *dfs, daos_size_t chunk_size, daos_oclass_id_t *head_cid,
 		    daos_oclass_id_t *tail_cid, daos_size_t *split_off, bool *has_tail);
+void
+dfs_refresh_pl_pool_info(dfs_t *dfs);
 int
 get_num_entries(daos_handle_t oh, daos_handle_t th, uint32_t *nr, bool check_empty);
 int

--- a/src/client/dfs/mnt.c
+++ b/src/client/dfs/mnt.c
@@ -85,19 +85,30 @@ dfs_refresh_pl_pool_info(dfs_t *dfs)
 	if (cur_ver <= dfs->pl_map_ver)
 		return;
 
+	/*
+	 * Serialize refreshers on a dedicated lock so a single thread issues the (potentially
+	 * expensive) pool query while the rest wait and then short-circuit on the re-check below. A
+	 * separate lock is used so the query does not block the create path's oid_gen() on
+	 * dfs->lock.
+	 */
+	D_MUTEX_LOCK(&dfs->pl_refresh_lock);
+	if (cur_ver <= dfs->pl_map_ver) {
+		D_MUTEX_UNLOCK(&dfs->pl_refresh_lock);
+		return;
+	}
+
 	rc = daos_pool_query(dfs->poh, NULL, &pool_info, NULL, NULL);
 	if (rc != 0) {
 		D_WARN("daos_pool_query() failed while refreshing PL pool info, " DF_RC "\n",
 		       DP_RC(rc));
+		D_MUTEX_UNLOCK(&dfs->pl_refresh_lock);
 		return;
 	}
 
-	/* Only move the cached values forward if a racing refresh has not already applied a newer
-	 * map. */
-	D_MUTEX_LOCK(&dfs->lock);
+	/* Only move the cached values forward to keep the map version monotonic. */
 	if (pool_info.pi_map_ver > dfs->pl_map_ver)
 		dfs_set_pl_pool_info(dfs, &pool_info);
-	D_MUTEX_UNLOCK(&dfs->lock);
+	D_MUTEX_UNLOCK(&dfs->pl_refresh_lock);
 }
 
 static inline struct dfs_mnt_hdls *
@@ -700,6 +711,12 @@ dfs_mount_int(daos_handle_t poh, daos_handle_t coh, int flags, daos_epoch_t epoc
 	if (rc != 0)
 		D_GOTO(err_dfs, rc = daos_der2errno(rc));
 
+	rc = D_MUTEX_INIT(&dfs->pl_refresh_lock, NULL);
+	if (rc != 0) {
+		D_MUTEX_DESTROY(&dfs->lock);
+		D_GOTO(err_dfs, rc = daos_der2errno(rc));
+	}
+
 	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_ROOTS);
 	D_ASSERT(entry != NULL);
 	roots = (struct daos_prop_co_roots *)entry->dpe_val_ptr;
@@ -930,6 +947,7 @@ dfs_umount(dfs_t *dfs)
 	dfs_metrics_fini(dfs);
 
 	D_FREE(dfs->prefix);
+	D_MUTEX_DESTROY(&dfs->pl_refresh_lock);
 	D_MUTEX_DESTROY(&dfs->lock);
 	D_FREE(dfs);
 
@@ -1277,6 +1295,13 @@ dfs_global2local(daos_handle_t poh, daos_handle_t coh, int flags, d_iov_t glob, 
 		return daos_der2errno(rc);
 	}
 
+	rc = D_MUTEX_INIT(&dfs->pl_refresh_lock, NULL);
+	if (rc != 0) {
+		D_MUTEX_DESTROY(&dfs->lock);
+		D_FREE(dfs);
+		return daos_der2errno(rc);
+	}
+
 	/** Open SB object */
 	rc = daos_obj_open(coh, dfs->super_oid, DAOS_OO_RO, &dfs->super_oh, NULL);
 	if (rc) {
@@ -1315,6 +1340,7 @@ dfs_global2local(daos_handle_t poh, daos_handle_t coh, int flags, d_iov_t glob, 
 
 	return rc;
 err_dfs:
+	D_MUTEX_DESTROY(&dfs->pl_refresh_lock);
 	D_MUTEX_DESTROY(&dfs->lock);
 	D_FREE(dfs);
 	return rc;

--- a/src/client/dfs/mnt.c
+++ b/src/client/dfs/mnt.c
@@ -722,7 +722,7 @@ dfs_mount_int(daos_handle_t poh, daos_handle_t coh, int flags, daos_epoch_t epoc
 	roots = (struct daos_prop_co_roots *)entry->dpe_val_ptr;
 	if (daos_obj_id_is_nil(roots->cr_oids[0]) || daos_obj_id_is_nil(roots->cr_oids[1])) {
 		D_ERROR("Invalid superblock or root object ID\n");
-		D_GOTO(err_dfs, rc = EIO);
+		D_GOTO(err_mutex, rc = EIO);
 	}
 
 	dfs->super_oid       = roots->cr_oids[0];
@@ -733,7 +733,7 @@ dfs_mount_int(daos_handle_t poh, daos_handle_t coh, int flags, daos_epoch_t epoc
 	rc = open_sb(coh, false, false, omode, dfs->super_oid, &dfs->attr, &dfs->super_oh,
 		     &dfs->layout_v);
 	if (rc)
-		D_GOTO(err_dfs, rc);
+		D_GOTO(err_mutex, rc);
 
 	/** set oid hints for files and dirs */
 	if (dfs->attr.da_hints[0] != 0) {
@@ -838,6 +838,9 @@ err_root:
 	daos_obj_close(dfs->root.oh, NULL);
 err_super:
 	daos_obj_close(dfs->super_oh, NULL);
+err_mutex:
+	D_MUTEX_DESTROY(&dfs->pl_refresh_lock);
+	D_MUTEX_DESTROY(&dfs->lock);
 err_dfs:
 	D_FREE(dfs);
 err_prop:

--- a/src/client/dfs/mnt.c
+++ b/src/client/dfs/mnt.c
@@ -13,6 +13,7 @@
 #include <daos/common.h>
 #include <daos/container.h>
 #include <daos/object.h>
+#include <daos/pool.h>
 
 #include "dfs_internal.h"
 
@@ -37,6 +38,7 @@ dfs_set_pl_pool_info(dfs_t *dfs, const daos_pool_info_t *pool_info)
 	dfs->pl_target_nr  = pool_info->pi_ntargets;
 	dfs->pl_total_nvme = pool_info->pi_space.ps_space.s_total[DAOS_MEDIA_NVME];
 	dfs->pl_total_scm  = pool_info->pi_space.ps_space.s_total[DAOS_MEDIA_SCM];
+	dfs->pl_map_ver    = pool_info->pi_map_ver;
 }
 
 static void
@@ -56,6 +58,46 @@ dfs_cache_pl_pool_info(dfs_t *dfs)
 	}
 
 	dfs_set_pl_pool_info(dfs, &pool_info);
+}
+
+/*
+ * Re-query the PL pool values only when the client's cached pool map advanced (e.g. a pool extend).
+ * The version read is a local, no-RPC check, so the pool service is queried at most once per map
+ * change rather than on every file create.
+ */
+void
+dfs_refresh_pl_pool_info(dfs_t *dfs)
+{
+	struct dc_pool  *pool;
+	daos_pool_info_t pool_info = {.pi_bits = DPI_SPACE};
+	uint32_t         cur_ver;
+	int              rc;
+
+	if (dfs == NULL)
+		return;
+
+	pool = dc_hdl2pool(dfs->poh);
+	if (pool == NULL)
+		return;
+	cur_ver = dc_pool_get_version(pool);
+	dc_pool_put(pool);
+
+	if (cur_ver <= dfs->pl_map_ver)
+		return;
+
+	rc = daos_pool_query(dfs->poh, NULL, &pool_info, NULL, NULL);
+	if (rc != 0) {
+		D_WARN("daos_pool_query() failed while refreshing PL pool info, " DF_RC "\n",
+		       DP_RC(rc));
+		return;
+	}
+
+	/* Only move the cached values forward if a racing refresh has not already applied a newer
+	 * map. */
+	D_MUTEX_LOCK(&dfs->lock);
+	if (pool_info.pi_map_ver > dfs->pl_map_ver)
+		dfs_set_pl_pool_info(dfs, &pool_info);
+	D_MUTEX_UNLOCK(&dfs->lock);
 }
 
 static inline struct dfs_mnt_hdls *

--- a/src/client/dfs/obj.c
+++ b/src/client/dfs/obj.c
@@ -182,6 +182,10 @@ file_oclasses(dfs_t *dfs, daos_oclass_id_t parent_oclass, daos_oclass_id_t cid,
 	if (cid != 0 || !dfs_file_layout_has_tail(dfs->layout_v, S_IFREG))
 		return 0;
 
+	/* Pick up target/space growth (e.g. a pool extend) without querying the pool every create.
+	 */
+	dfs_refresh_pl_pool_info(dfs);
+
 	if (dfs->pl_target_nr == 0)
 		return 0;
 


### PR DESCRIPTION
dfs caches the pool target count and space used for progressive-layout oclass decisions at mount time, so a later pool extend goes unnoticed. Track the queried pool map version and re-query in file_oclasses() only when a cheap local dc_pool_get_version() check shows it advanced.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
