### PR TITLE
DAOS-19386 test: Add dfuse wedge watchdog to NLT

### DIFF
--- a/ci/unit/test_nlt_node.sh
+++ b/ci/unit/test_nlt_node.sh
@@ -51,7 +51,9 @@ mkdir -p nlt_logs
 sudo mount -t tmpfs tmpfs nlt_logs
 sudo chown jenkins:jenkins nlt_logs
 
+# Unbuffered so the console shows exactly where a hang occurs.
 TMPDIR="$(pwd)/nlt_logs" \
+    PYTHONUNBUFFERED=1 \
     HTTPS_PROXY="${DAOS_HTTPS_PROXY:-}" \
     NO_PROXY="${DAOS_NO_PROXY:-}" \
     exec ./utils/node_local_test.py "$@"

--- a/src/tests/nlt/README.md
+++ b/src/tests/nlt/README.md
@@ -78,6 +78,7 @@ The former ~7k-line script is split into a dependency-ordered package (low level
 | Module                | Responsibility                                                        |
 | --------------------- | -------------------------------------------------------------------- |
 | `base.py`             | exceptions, ids, per-thread active-test context, timers, ratchet     |
+| `watchdog.py`         | FUSE-wedge watchdog (`WedgeWatch`) and stall diagnostics             |
 | `config.py`           | build config (`NLTConf`) and environment helpers                     |
 | `reporting.py`        | `WarningsFactory`: JUnit/JSON output and the `nlt-summary.md` report  |
 | `logging_utils.py`    | output capture and DAOS log-file analysis (`log_test`)               |

--- a/src/tests/nlt/cli.py
+++ b/src/tests/nlt/cli.py
@@ -9,7 +9,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
 import argparse
+import faulthandler
 import resource
+import signal
 import sys
 import traceback
 
@@ -17,6 +19,7 @@ from .fault_injection import server_fi
 from .posix_tests import PosixTests
 from .reporting import WarningsFactory
 from .runner import printable_test_list, run
+from .watchdog import exit_now
 
 
 def _positive_int(value):
@@ -36,6 +39,10 @@ def main():
     Test names can either be 'pure' or include suffices that encode a particular caching
     regimen (e.g., read_caching_off).
     """
+    # SIGUSR1 dumps every thread's Python stack.  sys.__stderr__ because NLT's stderr
+    # wrapper lacks the fileno() that faulthandler requires.
+    faulthandler.register(signal.SIGUSR1, file=sys.__stderr__, all_threads=True)
+
     parser = argparse.ArgumentParser(description='Run DAOS client on local node')
     parser.add_argument('--server-debug', default=None)
     parser.add_argument('--dfuse-debug', default=None)
@@ -51,7 +58,7 @@ def main():
     parser.add_argument('--repeat', type=_positive_int, default=1,
                         help='Repeat the test execution N times (soak/stability testing)')
     parser.add_argument('--failfast', action='store_true',
-                        help='With --repeat, stop after the first failing iteration')
+                        help='Stop after the first failing --repeat iteration or stalled re-run')
     parser.add_argument('--system-ram-reserved', type=int, default=None, help='GiB reserved RAM')
     parser.add_argument('--dfuse-dir', default='/tmp', help='parent directory for all dfuse mounts')
     parser.add_argument('--summary', default=None,
@@ -142,4 +149,5 @@ Tests are:
 
     if fatal_errors.errors:
         print("Significant errors encountered")
-        sys.exit(1)
+        exit_now(1)
+    exit_now(0)

--- a/src/tests/nlt/client.py
+++ b/src/tests/nlt/client.py
@@ -12,6 +12,7 @@ import json
 import os
 import pprint
 import re
+import signal
 import subprocess  # nosec
 import tempfile
 from os.path import join
@@ -20,6 +21,7 @@ from types import NoneType
 from .base import get_inc_id
 from .config import get_base_env
 from .logging_utils import log_test
+from .watchdog import KILL_GRACE
 
 
 class DaosPool():
@@ -251,7 +253,8 @@ def run_daos_cmd(conf,
                  log_check=True,
                  ignore_busy=False,
                  use_json=False,
-                 cwd=None):
+                 cwd=None,
+                 timeout=None):
     """Run a DAOS command
 
     Run a command, returning what subprocess.run() would.
@@ -298,8 +301,24 @@ def run_daos_cmd(conf,
 
     cmd_env['DAOS_AGENT_DRPC_DIR'] = conf.agent_dir
 
-    rc = subprocess.run(exec_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                        env=cmd_env, check=False, cwd=cwd)
+    # Avoid getting stuck on child processes that are blocked in the kernel.
+    # pylint: disable-next=consider-using-with
+    proc = subprocess.Popen(exec_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            env=cmd_env, cwd=cwd)
+    timed_out = False
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        print(f'Timeout after {timeout}s running {" ".join(cmd)}', flush=True)
+        proc.kill()
+        try:
+            stdout, stderr = proc.communicate(timeout=KILL_GRACE)
+        except subprocess.TimeoutExpired:
+            print(f'Command did not exit after kill: {" ".join(cmd)}', flush=True)
+            stdout, stderr = b'', b''
+    returncode = -signal.SIGKILL if proc.returncode is None else proc.returncode
+    rc = subprocess.CompletedProcess(exec_cmd, returncode, stdout, stderr)
 
     if rc.stderr != b'':
         print('Stderr from command')
@@ -328,7 +347,14 @@ def run_daos_cmd(conf,
         conf.valgrind_errors = True
         rc.returncode = 0
     if use_json:
-        rc.json = json.loads(rc.stdout.decode('utf-8'))
+        try:
+            rc.json = json.loads(rc.stdout.decode('utf-8'))
+        except json.JSONDecodeError:
+            if timed_out:
+                print(f'No JSON output from timed-out command: {" ".join(cmd)}')
+                rc.json = None
+            else:
+                raise
     dcr.rc = rc
     return dcr
 

--- a/src/tests/nlt/config.py
+++ b/src/tests/nlt/config.py
@@ -15,6 +15,7 @@ import tempfile
 from os.path import join
 
 from .base import CulmTimer, NLTestFail
+from .watchdog import abort_fuse_connections, dfuse_connection_ids
 
 
 class NLTConf():
@@ -43,10 +44,30 @@ class NLTConf():
             os.makedirs(self.tmp_dir)
 
         self._compress_procs = []
+        self._cleaned = False
 
     def __del__(self):
+        self.cleanup()
+
+    def cleanup(self):
+        """Report any leaked dfuse mount, flush compression and remove the working directory"""
+        if self._cleaned:
+            return
+        self._cleaned = True
+
+        leaked = {conn: mnt for conn, mnt in dfuse_connection_ids().items()
+                  if mnt.startswith(self.dfuse_parent_dir)}
+        if leaked:
+            print(f'Leaked dfuse mounts at exit: {sorted(leaked.values())}', flush=True)
+            for line in abort_fuse_connections()[1]:
+                print(line, flush=True)
+
         self.flush_bz2()
-        os.rmdir(self.dfuse_parent_dir)
+
+        try:
+            os.rmdir(self.dfuse_parent_dir)
+        except OSError as err:
+            print(f'Could not remove {self.dfuse_parent_dir}: {err}', flush=True)
 
     def set_wf(self, wf):
         """Set the WarningsFactory object"""

--- a/src/tests/nlt/dfuse.py
+++ b/src/tests/nlt/dfuse.py
@@ -212,7 +212,8 @@ class DFuse():
         print('Stopping fuse')
 
         if self.container:
-            self.run_query(use_json=True)
+            # This queries the mount that may itself be wedged.
+            self.run_query(use_json=True, timeout=120)
         ret = umount(self.dir)
         if ret:
             umount(self.dir, background=True)
@@ -299,10 +300,10 @@ class DFuse():
         assert ret.returncode == 0, ret
         return ret
 
-    def run_query(self, use_json=False, quiet=False):
+    def run_query(self, use_json=False, quiet=False, timeout=None):
         """Run filesystem query"""
         rc = run_daos_cmd(self.conf, ['filesystem', 'query', self.dir],
-                          use_json=use_json, log_check=quiet, valgrind=quiet)
+                          use_json=use_json, log_check=quiet, valgrind=quiet, timeout=timeout)
         print(rc)
         return rc
 

--- a/src/tests/nlt/fault_injection.py
+++ b/src/tests/nlt/fault_injection.py
@@ -11,6 +11,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 # pylint: disable=too-many-lines
 
 import os
+import signal
 import subprocess  # nosec
 import tempfile
 import time
@@ -18,13 +19,14 @@ from os.path import join
 
 import yaml
 
-from .base import NLTestNoFi
+from .base import NLTestFail, NLTestNoFi
 from .client import ValgrindHelper, create_cont, run_daos_cmd
 from .config import get_base_env, load_conf
 from .dfuse import DFuse
 from .logging_utils import log_test, setup_log_test
 from .reporting import WarningsFactory
 from .server import DaosServer
+from .watchdog import KILL_GRACE, MEMCHECK_STALL_SECS, STALL_SECS, handle_stalled
 
 # Fault injection testing.
 #
@@ -61,6 +63,8 @@ class AllocFailTestRun():
         self.dir_handle = None
         self.stdout = None
         self.returncode = None
+        self.was_killed = False
+        self._start_time = None
 
         # Set this to disable memory leak checking if the command outputs a DER_BUSY message.  This
         # is to allow tests to leak memory if there are errors during shutdown.
@@ -146,6 +150,26 @@ class AllocFailTestRun():
                                     stdin=subprocess.PIPE,
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE)
+        self._start_time = time.monotonic()
+
+    def pid(self):
+        """Return the pid of the command"""
+        return self._sp.pid
+
+    def elapsed(self):
+        """Return seconds since the command started"""
+        return time.monotonic() - self._start_time
+
+    def hang_kill(self):
+        """Kill a wedged command; result checks are skipped on reap"""
+        if self._sp.poll() is not None:
+            return
+        self.was_killed = True
+        self._sp.kill()
+
+    def is_dead(self):
+        """Return whether the command has exited, without blocking"""
+        return self._sp.poll() is not None
 
     def has_finished(self):
         """Check if the command has completed"""
@@ -155,15 +179,45 @@ class AllocFailTestRun():
         rc = self._sp.poll()
         if rc is None:
             return False
-        self._post(rc)
+        self._reap(rc)
         return True
 
-    def wait(self):
+    def wait(self, timeout=None):
         """Wait for the command to complete"""
         if self.returncode is not None:
             return
 
-        self._post(self._sp.wait())
+        if timeout is not None:
+            try:
+                self._reap(self._sp.wait(timeout=timeout))
+            except subprocess.TimeoutExpired:
+                handle_stalled([self], log_dir=self._aft.log_dir)
+                try:
+                    self._reap(self._sp.wait(timeout=KILL_GRACE))
+                except subprocess.TimeoutExpired:
+                    # Blocked in the kernel; record the kill rather than joining the hang.
+                    self._post_killed(-signal.SIGKILL)
+            return
+
+        self._reap(self._sp.wait())
+
+    def _reap(self, rc):
+        """Process a completed command, bypassing result checks for watchdog kills"""
+        if self.was_killed:
+            self._post_killed(rc)
+        else:
+            self._post(rc)
+
+    def _post_killed(self, rc):
+        """Reap after a watchdog kill; the positive returncode stops a valgrind re-run"""
+        print()
+        self.returncode = 128 - rc if rc < 0 else rc
+        try:
+            self.stdout, self._stderr = self._sp.communicate(timeout=KILL_GRACE)
+        except subprocess.TimeoutExpired:
+            self.stdout = b'<stdout unavailable: pipe held open after kill>'
+            self._stderr = b''
+        self.fault_injected = True
 
     def _significant_issues(self, wf):
         """Count findings that warrant keeping this iteration's log.
@@ -419,7 +473,9 @@ class AllocFailTest():
 
         def _prep(self):
             rc = self._run_cmd(None)
-            rc.wait()
+            rc.wait(timeout=STALL_SECS)
+            if rc.was_killed:
+                raise NLTestFail('prep run (no faults enabled) stalled and was killed')
             self.expected_stdout = rc.stdout
             assert not rc.fault_injected
 
@@ -454,6 +510,9 @@ class AllocFailTest():
         fatal_errors = False
 
         max_load_avg = 100
+
+        last_progress = time.monotonic()
+        stalled_out = False
 
         # Now run all iterations in parallel up to max_child.  Iterations will be launched
         # in order but may not finish in order, rather they are processed in the order they
@@ -495,6 +554,7 @@ class AllocFailTest():
                 if not ret.has_finished():
                     continue
                 active.remove(ret)
+                last_progress = time.monotonic()
                 print()
                 print(ret)
                 if ret.returncode < 0:
@@ -506,15 +566,35 @@ class AllocFailTest():
                     finished = True
                 break
 
+            if active and time.monotonic() - last_progress > STALL_SECS:
+                fatal_errors = True
+                stalled_out = True
+                finished = True
+                handle_stalled(active, log_dir=self.log_dir)
+                print('Sweep stalled; abandoning remaining iterations')
+                # Reap the children that died; waiting for one that is stuck in
+                # the kernel would hang the run.
+                for child in active:
+                    if not child.has_finished():
+                        print(f'Abandoning stuck pid {child.pid()} (loc {child.loc})',
+                              flush=True)
+                active.clear()
+
         print(f'Completed, fid {fid}')
         print(f'Max in flight {max_count}/{max_child}')
         if to_rerun:
             print(f'Number of indexes to re-run {len(to_rerun)}')
+            if stalled_out:
+                print('Skipping valgrind re-runs; the mount did not survive the sweep')
+                to_rerun = []
 
         for fid in to_rerun:
             rerun = self._run_cmd(fid, valgrind=True)
             print(rerun)
-            rerun.wait()
+            rerun.wait(timeout=MEMCHECK_STALL_SECS)
+            if rerun.was_killed and self.conf.args.failfast:
+                print(f'--failfast set; skipping remaining re-runs after stall at {fid}')
+                break
 
         return fatal_errors
 

--- a/src/tests/nlt/runner.py
+++ b/src/tests/nlt/runner.py
@@ -29,6 +29,7 @@ from .reporting import WarningsFactory
 from .server import DaosServer
 from .special_tests import (check_readdir_perf, run_dfuse, run_duns_overlay_test, run_in_fg,
                             test_pydaos_kv, test_pydaos_kv_obj_class)
+from .watchdog import WedgeWatch
 
 
 def generate_special_test_list():
@@ -204,6 +205,12 @@ def run(wf, args):
     # Arm the summary now so it is still emitted if a test, startup or teardown raises.
     wf.arm_summary(args.summary, args, conf, run_start)
 
+    def _report_wedge(failure, output):
+        wf.add_test_case('wedge_watchdog', failure, output=output)
+
+    WedgeWatch(args.failfast, log_dir=conf.tmp_dir, report=_report_wedge,
+               finalize=wf.write_summary).start()
+
     fi_test = False
     fi_test_dfuse = False
 
@@ -269,6 +276,9 @@ def run(wf, args):
         print(fs)
         if fs.returncode == 0:
             run_fi = True
+        elif fi_test or fi_test_dfuse:
+            raise NLTestFail('Unable to detect fault injection feature '
+                             '- cannot run requested FI tests')
         else:
             print("Unable to detect fault injection feature - skipping FI testing")
 
@@ -345,6 +355,7 @@ def run(wf, args):
 
     wf_server.close()
     close_log_test(conf)
+    conf.cleanup()
     if args.summary:
         wf.write_summary()
     print(f'Total time in log analysis: {conf.log_timer.total:.2f} seconds')

--- a/src/tests/nlt/watchdog.py
+++ b/src/tests/nlt/watchdog.py
@@ -1,0 +1,380 @@
+"""NLT: stall detection and diagnostics for wedged child processes.
+
+(C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+
+import os
+import signal
+import subprocess  # nosec
+import sys
+import threading
+import time
+import traceback
+from os.path import join
+
+# How long a process may show no sign of progress before it is declared stalled.
+STALL_SECS = int(os.environ.get('NLT_STALL_SECS', '300'))
+# Whole-command bound for a complete run under memcheck; unlike the per-request
+# wedge checks this covers an entire (heavily slowed) process lifetime.
+MEMCHECK_STALL_SECS = STALL_SECS * 6
+
+# Bounds on the stall diagnostics themselves.
+DIAG_TIMEOUT = 60
+STACK_READ_TIMEOUT = 15
+DUMP_DEADLINE_SECS = 120
+
+# How long a killed process gets to shut down; longer than this is assumed to be hung.
+KILL_GRACE = 30
+
+# How often the wedge watchdog samples kernel state.
+WATCH_INTERVAL = 20
+
+
+def _run_diag(cmd, timeout=DIAG_TIMEOUT):
+    """Run a diagnostic command returning (exit code, output), never raising or blocking
+
+    A command that outlives timeout is killed and reports a nonzero code.
+    """
+    try:
+        # pylint: disable-next=consider-using-with
+        proc = subprocess.Popen(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT, start_new_session=True)
+    except OSError as err:
+        return 127, f'<{cmd[0]} failed: {err}>'
+
+    def output(wait_secs):
+        return proc.communicate(timeout=wait_secs)[0].decode('utf-8', errors='replace').rstrip()
+
+    try:
+        text = output(timeout)
+    except subprocess.TimeoutExpired:
+        # Overdue: kill the process group and salvage whatever it wrote.
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except OSError:
+            pass
+        try:
+            return -1, f'{output(KILL_GRACE)}\n<{cmd[0]} exceeded {timeout}s>'
+        except subprocess.TimeoutExpired:
+            proc.stdout.close()
+            return -1, f'<{cmd[0]} exceeded {timeout}s and could not be reaped>'
+    return proc.returncode, text
+
+
+def _read_file(path):
+    """Return the stripped content of a small /proc or /sys file, or None"""
+    try:
+        with open(path, encoding='utf-8', errors='replace') as pfile:
+            return pfile.read().strip()
+    except OSError:
+        return None
+
+
+def _proc_state(pid):
+    """Return blocked system-call state for a pid from /proc"""
+    out = []
+    for name in ('wchan', 'syscall'):
+        out.append(f'{name}={_read_file(f"/proc/{pid}/{name}") or "<unreadable>"}')
+    status = _read_file(f'/proc/{pid}/status') or ''
+    for line in status.splitlines():
+        if line.startswith(('State:', 'Threads:')):
+            out.append(line.strip())
+    return ' '.join(out)
+
+
+def _proc_threads(pid, deadline=None):
+    """Report every thread of a process from /proc; debuggers cannot attach in D state"""
+    lines = []
+    stack_err = None
+    try:
+        tids = sorted(os.listdir(f'/proc/{pid}/task'), key=int)
+    except OSError as err:
+        return f'<cannot list threads of {pid}: {err}>'
+    for tid in tids:
+        if deadline is not None and time.monotonic() > deadline:
+            lines.append(f'  <dump deadline reached; skipping remaining of {len(tids)} threads>')
+            break
+        base = f'/proc/{pid}/task/{tid}'
+        fields = []
+        for name in ('comm', 'wchan'):
+            fields.append(f'{name}={_read_file(f"{base}/{name}") or "?"}')
+        # The state field follows the parenthesized command name, which can itself
+        # contain ') ', so anchor on the last occurrence per proc(5).
+        state = (_read_file(f'{base}/stat') or '').rpartition(') ')[2].split()
+        if state:
+            fields.append(f'state={state[0]}')
+        lines.append(f'  TID {tid}: ' + ' '.join(fields))
+        rc, kstack = _run_diag(['sudo', 'cat', f'{base}/stack'], timeout=STACK_READ_TIMEOUT)
+        if rc == 0 and kstack:
+            for kline in kstack.splitlines()[:12]:
+                lines.append(f'      {kline.strip()}')
+        elif rc != 0 and stack_err is None:
+            stack_err = (kstack or '<no output>').splitlines()[0].strip()
+            lines.append(f'  <kernel stack reads failing: rc={rc} {stack_err}>')
+    return '\n'.join(lines)
+
+
+def exit_now(code):
+    """Terminate without interpreter shutdown, whose cleanup can block on a wedged mount"""
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(code)  # pylint: disable=protected-access
+
+
+def dump_stalled(tasks, log_dir=None):
+    """Dump diagnostics for wedged processes given as (pid, description) pairs"""
+    dump_file = None
+    if log_dir:
+        try:
+            # The dnt*.log name is what CI's log collection keeps; append across stalls.
+            # pylint: disable-next=consider-using-with
+            dump_file = open(join(log_dir, 'dnt_stall_dump.log'), 'a', encoding='utf-8')
+        except OSError:
+            dump_file = None
+
+    def emit(text):
+        # File first; a stalled stdout consumer must not cost us the dump.
+        if dump_file:
+            try:
+                dump_file.write(f'{text}\n')
+                dump_file.flush()
+            except OSError:
+                pass
+        print(text, flush=True)
+
+    try:
+        deadline = time.monotonic() + DUMP_DEADLINE_SECS
+        emit(f'\n===== NLT STALL DETECTED {time.strftime("%Y-%m-%d %H:%M:%S")} =====')
+        # /proc cannot block, so gather it before anything that can.
+        for pid, desc in tasks:
+            emit(f'--- stalled: pid={pid} {desc}')
+            emit(_proc_threads(pid, deadline=deadline))
+        daemons = _run_diag(['pgrep', '-a', 'daos_engine|daos_agent|dfuse'])[1]
+        emit(f'--- daemons:\n{daemons}')
+        daemon_pids = [int(line.split()[0]) for line in daemons.splitlines()
+                       if line and line.split()[0].isdigit()]
+        for pid in daemon_pids:
+            if time.monotonic() > deadline:
+                emit('<dump deadline reached; skipping remaining daemons>')
+                break
+            emit(f'--- daemon pid={pid}:')
+            emit(_proc_threads(pid, deadline=deadline))
+        emit('--- process tree:')
+        emit(_run_diag(['ps', 'auxwwf'])[1])
+        emit('===== NLT STALL DUMP COMPLETE =====')
+    except Exception as err:  # pylint: disable=broad-except
+        emit(f'===== NLT STALL DUMP ABORTED: {err!r} =====')
+        traceback.print_exc(file=sys.stdout)
+        sys.stdout.flush()
+    finally:
+        if dump_file:
+            dump_file.close()
+
+
+def dfuse_connection_ids():
+    """Return the FUSE connection ids of dfuse mounts, mapped to their mount points"""
+    ids = {}
+    # Safer than stat, which could block on a wedged mount
+    for line in (_read_file('/proc/self/mountinfo') or '').splitlines():
+        fields = line.split()
+        if '-' in fields and 'fuse.daos' in fields[fields.index('-'):]:
+            ids[fields[2].split(':')[1]] = fields[4]
+    return ids
+
+
+def abort_fuse_connections(only=None):
+    """Abort every backed-up dfuse connection, failing its requests so blocked processes can die
+
+    only: if given, restrict aborts to these connection ids.
+    """
+    done = []
+    aborted = 0
+    dfuse_conns = dfuse_connection_ids()
+    try:
+        conns = sorted(os.listdir('/sys/fs/fuse/connections'))
+    except OSError as err:
+        return 0, [f'<cannot list fuse connections: {err}>']
+    for conn in conns:
+        if conn not in dfuse_conns:
+            continue
+        if only is not None and conn not in only:
+            continue
+        waiting = _read_file(f'/sys/fs/fuse/connections/{conn}/waiting')
+        if waiting is None:
+            done.append(f'<cannot read waiting count of dfuse connection {conn}>')
+            continue
+        if waiting in ('', '0'):
+            continue
+        path = f'/sys/fs/fuse/connections/{conn}/abort'
+        rc, res = _run_diag(['sudo', 'sh', '-c', f'echo 1 > {path}'])
+        if rc == 0:
+            aborted += 1
+            done.append(f'aborted dfuse connection {conn} (waiting={waiting}): {res or "ok"}')
+        else:
+            done.append(f'<abort of dfuse connection {conn} failed rc={rc}: {res}>')
+    return aborted, (done or ['<no backed-up dfuse connections found>'])
+
+
+def handle_stalled(active, log_dir=None):
+    """Dump diagnostics then clear the wedged children"""
+    dump_stalled([(child.pid(), f'loc={child.loc} elapsed={child.elapsed():.0f}s')
+                  for child in active], log_dir=log_dir)
+    for child in active:
+        child.hang_kill()
+
+    def _find_zombies(wait_sec):
+        deadline = time.monotonic() + wait_sec
+        alive = list(active)
+        while alive and time.monotonic() < deadline:
+            alive = [c for c in alive if not c.is_dead()]
+            if alive:
+                time.sleep(1)
+        return alive
+
+    zombies = _find_zombies(KILL_GRACE)
+    if zombies:
+        # A child that outlives the kill grace is likely blocked in the kernel.
+        # We can try to free it up by failing its FUSE requests so that it
+        # can exit.
+        print(f'{len(zombies)} child(ren) survived the kill; '
+              f'aborting backed-up FUSE connections to release them', flush=True)
+        aborted, lines = abort_fuse_connections()
+        for line in lines:
+            print(line, flush=True)
+        if aborted:
+            zombies = _find_zombies(KILL_GRACE)
+
+    for child in zombies:
+        print(f'WARNING: pid {child.pid()} (loc {child.loc}) survived SIGKILL: '
+              f'{_proc_state(child.pid())}', flush=True)
+
+
+def _fuse_blocked(wchan):
+    """Return whether a wait channel is a FUSE request wait"""
+    return wchan is not None and (wchan == 'request_wait_answer' or wchan.startswith('fuse_'))
+
+
+def _descendant_pids(root):
+    """Return root and every live descendant process id"""
+    children = {}
+    for entry in os.listdir('/proc'):
+        if not entry.isdigit():
+            continue
+        stat = _read_file(f'/proc/{entry}/stat')
+        if not stat:
+            continue
+        fields = stat.rpartition(') ')[2].split()
+        if len(fields) < 2:
+            continue
+        children.setdefault(int(fields[1]), []).append(int(entry))
+    pids = []
+    queue = [root]
+    while queue:
+        pid = queue.pop()
+        pids.append(pid)
+        queue.extend(children.get(pid, []))
+    return pids
+
+
+def _voluntary_switches(pid, tid):
+    """Return a task's voluntary context-switch count, or None"""
+    status = _read_file(f'/proc/{pid}/task/{tid}/status') or ''
+    for line in status.splitlines():
+        if line.startswith('voluntary_ctxt_switches:'):
+            return line.split()[-1]
+    return None
+
+
+class WedgeWatch(threading.Thread):
+    """Detect tasks wedged on FUSE requests anywhere in the NLT process tree.
+
+    A task is wedged when it sits in the same FUSE wait channel with an unchanged
+    voluntary context-switch count for the whole threshold window; a busy-but-healthy
+    task advances its counters with every request.  Detection reads kernel state, so
+    tests need no timeout or heartbeat plumbing.  On a wedge: dump diagnostics, then
+    either end the run (--failfast, nothing to abort, or a repeat wedge) or abort just
+    the backed-up mounts so their blocked calls fail and surviving tests still report.
+    """
+
+    def __init__(self, failfast, log_dir=None, report=None, finalize=None,
+                 threshold=STALL_SECS):
+        super().__init__(name='nlt-wedge-watch', daemon=True)
+        self._failfast = failfast
+        self._log_dir = log_dir
+        self._report = report
+        self._finalize = finalize
+        self._threshold = threshold
+        self._tasks = {}
+        self._conns = {}
+        self._fired = False
+
+    def run(self):
+        while True:
+            time.sleep(WATCH_INTERVAL)
+            try:
+                self._check()
+            except Exception as err:  # pylint: disable=broad-except
+                # The watchdog must never take down a healthy run.
+                print(f'wedge watchdog error (ignored): {err!r}', flush=True)
+
+    def _sample(self):
+        """Update task and connection tracking; return what has been parked too long"""
+        now = time.monotonic()
+        seen = set()
+        wedged = []
+        for pid in _descendant_pids(os.getpid()):
+            try:
+                tids = os.listdir(f'/proc/{pid}/task')
+            except OSError:
+                continue
+            for tid in tids:
+                wchan = _read_file(f'/proc/{pid}/task/{tid}/wchan')
+                if not _fuse_blocked(wchan):
+                    self._tasks.pop((pid, tid), None)
+                    continue
+                seen.add((pid, tid))
+                switches = _voluntary_switches(pid, tid)
+                prev = self._tasks.get((pid, tid))
+                if prev and prev[0] == wchan and prev[1] == switches:
+                    if now - prev[2] > self._threshold:
+                        wedged.append((pid, tid, wchan, now - prev[2]))
+                else:
+                    self._tasks[(pid, tid)] = (wchan, switches, now)
+        for key in [key for key in self._tasks if key not in seen]:
+            del self._tasks[key]
+
+        current = {}
+        for conn in dfuse_connection_ids():
+            waiting = _read_file(f'/sys/fs/fuse/connections/{conn}/waiting')
+            if waiting not in (None, '', '0'):
+                current[conn] = self._conns.get(conn, now)
+        self._conns = current
+        pinned = [conn for conn, since in current.items() if now - since > self._threshold]
+        return wedged, pinned
+
+    def _check(self):
+        wedged, pinned = self._sample()
+        if not wedged:
+            return
+        notes = {}
+        for pid, tid, wchan, age in wedged:
+            notes.setdefault(pid, []).append(f'TID {tid} parked {age:.0f}s in {wchan}')
+        dump_stalled([(pid, '; '.join(lines)) for pid, lines in notes.items()],
+                     log_dir=self._log_dir)
+        detail = '\n'.join(f'pid {pid}: {"; ".join(lines)}' for pid, lines in notes.items())
+        if self._report:
+            self._report('FUSE wedge detected', detail)
+        if self._failfast or self._fired or not pinned:
+            print('Wedge watchdog: ending the run', flush=True)
+            if self._finalize:
+                self._finalize()
+            exit_now(1)
+        self._fired = True
+        _, lines = abort_fuse_connections(only=pinned)
+        for line in lines:
+            print(line, flush=True)
+        # Re-measure from scratch; a cleared wedge must not re-fire on stale state.
+        self._tasks.clear()
+        self._conns.clear()

--- a/utils/cq/words.dict
+++ b/utils/cq/words.dict
@@ -183,7 +183,9 @@ epcrange
 epilog
 errored
 ethernet
+failfast
 fallocate
+faulthandler
 fchmod
 fcntl
 filename


### PR DESCRIPTION
Don't allow a wedged child process to hang the entire NLT
run to timeout. When a wedge is detected, attempt to capture
stack traces and fail early.

The /proc dump shows a real wedge directly. From the hang that
motivated this patch: the wedged child holds the parent-dir lock
while waiting on its LOOKUP reply, and every dfuse worker is blocked
on that same lock trying to write a dentry invalidation:

  TID 34163: comm=daos  wchan=request_wait_answer  state=S
      [<0>] request_wait_answer+0xfa/0x210 [fuse]
      [<0>] fuse_simple_request+0x1b8/0x330 [fuse]
      [<0>] fuse_lookup_name+0xa4/0x1c0 [fuse]
      [<0>] fuse_lookup+0x66/0x190 [fuse]
      [<0>] __lookup_hash+0x70/0xa0
      [<0>] __filename_create+0x87/0x150
      [<0>] do_mkdirat+0x4c/0x160
      [<0>] __x64_sys_mkdir+0x47/0x70

  TID 29212: comm=dfuse worker  wchan=fuse_reverse_inval_entry  state=D
      [<0>] fuse_reverse_inval_entry+0x40/0x210 [fuse]
      [<0>] fuse_notify+0x287/0x500 [fuse]
      [<0>] fuse_dev_do_write+0x305/0x4e0 [fuse]
      [<0>] fuse_dev_write+0x50/0x80 [fuse]
  TID 29213, 29214: identical (the whole worker pool)

Signed-off-by: Michael MacDonald <github@macdonald.cx>
