### PR TITLE
DAOS-19450 control: per-pool node cert security library

### DIFF
--- a/src/control/security/node_cert.go
+++ b/src/control/security/node_cert.go
@@ -1,0 +1,348 @@
+//
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package security
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+// NotBeforeSkewTolerance is the maximum allowed clock skew for a
+// node cert's NotBefore time. Also the default server-side PoP
+// timestamp skew (pool_cert_max_clock_skew overrides).
+const NotBeforeSkewTolerance = 5 * time.Minute
+
+// NodeCert is a loaded per-pool node certificate and key.
+type NodeCert struct {
+	PEM  []byte
+	Cert *x509.Certificate
+	Key  crypto.PrivateKey
+}
+
+// NodeCertLoader loads per-pool node certs from disk; refreshes on
+// mtime/size change so revoked-and-reissued certs land without a restart.
+type NodeCertLoader struct {
+	dir   string
+	cache sync.Map
+}
+
+// NewNodeCertLoader returns a loader that reads <pool_uuid>.{crt,key} from dir.
+func NewNodeCertLoader(dir string) *NodeCertLoader {
+	return &NodeCertLoader{dir: dir}
+}
+
+type fileSig struct {
+	mtime time.Time
+	size  int64
+}
+
+type cachedNodeCert struct {
+	cert    *NodeCert
+	certSig fileSig
+	keySig  fileSig
+}
+
+func statSig(path string) (fileSig, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return fileSig{}, err
+	}
+	return fileSig{mtime: fi.ModTime(), size: fi.Size()}, nil
+}
+
+// Load returns the cert+key struct for poolUUID. If a struct was previously
+// loaded and the files have not changed, it is returned from cache.
+func (l *NodeCertLoader) Load(log logging.Logger, poolUUID uuid.UUID) (*NodeCert, error) {
+	uuidStr := poolUUID.String()
+
+	certPath := filepath.Join(l.dir, uuidStr+".crt")
+	keyPath := filepath.Join(l.dir, uuidStr+".key")
+
+	certSig, err := statSig(certPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "stat node certificate")
+	}
+	keySig, err := statSig(keyPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "stat node private key")
+	}
+
+	if v, ok := l.cache.Load(uuidStr); ok {
+		c := v.(*cachedNodeCert)
+		if c.certSig == certSig && c.keySig == keySig {
+			return c.cert, nil
+		}
+		log.Debugf("node cert file for pool %s changed on disk; reloading", uuidStr)
+	}
+
+	certPEM, err := LoadPEMData(certPath, MaxCertPerm)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading node certificate")
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, fmt.Errorf("invalid PEM data in %s", certPath)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing node certificate")
+	}
+	key, err := LoadPrivateKey(keyPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading node private key")
+	}
+	signer, ok := key.(crypto.Signer)
+	if !ok {
+		return nil, fmt.Errorf("unsupported private key type %T in %s", key, keyPath)
+	}
+	pub, ok := signer.Public().(interface{ Equal(crypto.PublicKey) bool })
+	if !ok || !pub.Equal(cert.PublicKey) {
+		return nil, fmt.Errorf("private key %s does not match certificate %s", keyPath, certPath)
+	}
+
+	nc := &NodeCert{PEM: certPEM, Cert: cert, Key: key}
+	l.cache.Store(uuidStr, &cachedNodeCert{cert: nc, certSig: certSig, keySig: keySig})
+
+	log.Debugf("loaded node cert for pool %s: CN=%s, expires=%s",
+		uuidStr, cert.Subject.CommonName, cert.NotAfter.Format(time.RFC3339))
+
+	return nc, nil
+}
+
+// validateNodeCertForUse checks that a loaded cert is currently valid and,
+// for node-scoped certs, that its CN matches machineName.
+func validateNodeCertForUse(cert *x509.Certificate, poolID, machineName string, now time.Time) error {
+	cn := cert.Subject.CommonName
+	prefix, suffix, err := ValidatePoolCertCN(cn)
+	if err != nil {
+		return errors.Wrapf(err, "node cert for pool %s", poolID)
+	}
+	if prefix == CertCNPrefixNode && suffix != machineName {
+		return fmt.Errorf("node cert CN %q does not match machine name %q (pool %s)",
+			cn, machineName, poolID)
+	}
+
+	if now.After(cert.NotAfter) {
+		return fmt.Errorf("node certificate for pool %s expired at %s",
+			poolID, cert.NotAfter.Format(time.RFC3339))
+	}
+	if now.Add(NotBeforeSkewTolerance).Before(cert.NotBefore) {
+		return fmt.Errorf("node certificate for pool %s not yet valid (notBefore=%s, local now=%s)",
+			poolID, cert.NotBefore.Format(time.RFC3339),
+			now.Format(time.RFC3339))
+	}
+	return nil
+}
+
+// CertAndPoP loads the pool's node cert and signs a fresh proof-of-possession
+// binding it to the given handle. machineName must come from the same source
+// as the AUTH_SYS machine name; revoke-by-CN depends on it.
+func (l *NodeCertLoader) CertAndPoP(log logging.Logger, poolUUID, handleUUID uuid.UUID, machineName string) (cert *NodeCert, pop, payload []byte, err error) {
+	cert, err = l.Load(log, poolUUID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if err := validateNodeCertForUse(cert.Cert, poolUUID.String(), machineName, time.Now()); err != nil {
+		return nil, nil, nil, err
+	}
+
+	payload, err = buildPoPPayload(poolUUID, handleUUID)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "building PoP payload")
+	}
+	pop, err = signPoP(cert.Key, payload)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "signing PoP")
+	}
+	return cert, pop, payload, nil
+}
+
+// Sentinel errors classifying NodeCertPresentation failures. Callers map
+// these to wire statuses; the details ride along via error wrapping.
+var (
+	// ErrCertInvalid covers certs that can't be parsed, don't chain to
+	// the root, or violate CN policy.
+	ErrCertInvalid = errors.New("node cert invalid")
+	// ErrCertRevoked covers certs at or below their revocation watermark.
+	ErrCertRevoked = errors.New("node cert revoked")
+	// ErrInvalidInput covers malformed request fields.
+	ErrInvalidInput = errors.New("invalid input")
+	// ErrPoPInvalid covers payload binding and signature failures.
+	ErrPoPInvalid = errors.New("proof-of-possession invalid")
+	// ErrPoPStale covers timestamps outside the allowed clock skew.
+	ErrPoPStale = errors.New("proof-of-possession stale")
+)
+
+// NodeCertPresentation bundles everything a server knows when a node cert is
+// presented at pool connect.
+type NodeCertPresentation struct {
+	Root        *x509.Certificate // trust anchor (the DAOS CA)
+	PoolCA      []byte            // PEM bundle from the pool_ca property
+	Cert        []byte            // PEM, as presented
+	PoPSig      []byte            // signature over PoPPayload
+	PoPPayload  []byte            // raw marshaled PoPPayload bytes
+	PoolUUID    uuid.UUID         // pool being connected to
+	MachineName string            // client's AUTH_SYS machine name
+	Watermarks  []byte            // cert_watermarks property, may be empty
+	MaxSkew     time.Duration     // 0 means NotBeforeSkewTolerance
+	Now         time.Time         // zero means time.Now()
+}
+
+// Validate checks the presented cert and proof-of-possession, returning
+// the parsed payload.
+func (p *NodeCertPresentation) Validate() (*PoPPayload, error) {
+	now := p.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	maxSkew := p.MaxSkew
+	if maxSkew <= 0 {
+		maxSkew = NotBeforeSkewTolerance
+	}
+
+	cert, err := p.verifyCert(now)
+	if err != nil {
+		return nil, err
+	}
+	return p.verifyProof(cert, now, maxSkew)
+}
+
+// parsePoolCABundle parses a PEM bundle into a pool of intermediate CAs.
+func parsePoolCABundle(bundle []byte) (*x509.CertPool, error) {
+	intermediates := x509.NewCertPool()
+	nCAs := 0
+	for rest := bundle; len(rest) > 0; {
+		var caBlock *pem.Block
+		caBlock, rest = pem.Decode(rest)
+		if caBlock == nil {
+			break
+		}
+		if caBlock.Type != "CERTIFICATE" {
+			return nil, errors.Wrapf(ErrCertInvalid,
+				"unexpected PEM block type %q in pool CA bundle", caBlock.Type)
+		}
+		caCert, err := x509.ParseCertificate(caBlock.Bytes)
+		if err != nil {
+			return nil, errors.Wrapf(ErrCertInvalid, "malformed cert in pool CA bundle: %s", err)
+		}
+		intermediates.AddCert(caCert)
+		nCAs++
+	}
+	if nCAs == 0 {
+		return nil, errors.Wrap(ErrCertInvalid, "pool CA bundle contains no certificates")
+	}
+	return intermediates, nil
+}
+
+// verifyCert checks that the presented cert is acceptable
+func (p *NodeCertPresentation) verifyCert(now time.Time) (*x509.Certificate, error) {
+	if p.Root == nil {
+		return nil, errors.Wrap(ErrInvalidInput, "no trust anchor")
+	}
+
+	block, _ := pem.Decode(p.Cert)
+	if block == nil {
+		return nil, errors.Wrap(ErrCertInvalid, "no PEM data in node cert")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, errors.Wrapf(ErrCertInvalid, "parsing node cert: %s", err)
+	}
+
+	intermediates, err := parsePoolCABundle(p.PoolCA)
+	if err != nil {
+		return nil, err
+	}
+
+	roots := x509.NewCertPool()
+	roots.AddCert(p.Root)
+	if _, err := cert.Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		CurrentTime:   now,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		return nil, errors.Wrapf(ErrCertInvalid, "chain validation: %s", err)
+	}
+
+	cn := cert.Subject.CommonName
+	prefix, suffix, err := ValidatePoolCertCN(cn)
+	if err != nil {
+		return nil, errors.Wrapf(ErrCertInvalid, "CN policy: %s", err)
+	}
+	switch prefix {
+	case CertCNPrefixTenant:
+		// Tenant key compromise on any node = full tenant compromise;
+		// containment is via watermark revocation.
+	case CertCNPrefixNode:
+		if p.MachineName == "" {
+			return nil, errors.Wrapf(ErrInvalidInput,
+				"cert CN %q is node-scoped but machine name is empty", cn)
+		}
+		if suffix != p.MachineName {
+			return nil, errors.Wrapf(ErrCertInvalid,
+				"cert CN %q does not match machine name %q", cn, p.MachineName)
+		}
+	}
+
+	if len(p.Watermarks) > 0 {
+		watermarks, err := DecodeCertWatermarks(p.Watermarks)
+		if err != nil {
+			return nil, errors.Wrapf(ErrInvalidInput, "cert watermarks: %s", err)
+		}
+		if wm, ok := watermarks[cn]; ok && !cert.NotBefore.After(wm) {
+			return nil, errors.Wrapf(ErrCertRevoked,
+				"cert for %q revoked (NotBefore=%s, watermark=%s)", cn,
+				cert.NotBefore.Format(time.RFC3339), wm.Format(time.RFC3339))
+		}
+	}
+
+	return cert, nil
+}
+
+// verifyProof checks that the presenter holds the cert key, that the
+// proof is fresh, and that it's bound to the requested pool. The signature
+// is verified over the raw payload bytes before they are parsed.
+func (p *NodeCertPresentation) verifyProof(cert *x509.Certificate, now time.Time, maxSkew time.Duration) (*PoPPayload, error) {
+	if err := verifyPoP(cert.PublicKey, p.PoPPayload, p.PoPSig); err != nil {
+		return nil, errors.Wrapf(ErrPoPInvalid, "signature: %s", err)
+	}
+
+	payload, err := parsePoPPayload(p.PoPPayload)
+	if err != nil {
+		return nil, errors.Wrapf(ErrInvalidInput, "PoP payload: %s", err)
+	}
+
+	// Cross-pool replay defense: a node cert shared across pools must not
+	// let a PoP captured for pool A authenticate a connect to pool B.
+	if payload.PoolID() != p.PoolUUID {
+		return nil, errors.Wrap(ErrPoPInvalid,
+			"payload pool UUID does not match request pool ID")
+	}
+
+	skew := now.Sub(payload.Time())
+	if skew < 0 {
+		skew = -skew
+	}
+	if skew > maxSkew {
+		return nil, errors.Wrapf(ErrPoPStale,
+			"timestamp skew too large: %s (max %s)", skew, maxSkew)
+	}
+
+	return payload, nil
+}

--- a/src/control/security/node_cert_test.go
+++ b/src/control/security/node_cert_test.go
@@ -1,0 +1,198 @@
+//
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package security
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/logging"
+	sectest "github.com/daos-stack/daos/src/control/security/test"
+)
+
+const testMachineName = "testhost"
+
+func writeTestNodeCert(t *testing.T, dir, poolUUID string) {
+	t.Helper()
+	sectest.WriteNodeCert(t, dir, poolUUID, CertCNPrefixNode+testMachineName,
+		time.Now().Add(-time.Minute), time.Now().Add(time.Hour))
+}
+
+func TestNodeCertLoader_Load(t *testing.T) {
+	tmpDir, cleanup := test.CreateTestDir(t)
+	defer cleanup()
+
+	log, _ := logging.NewTestLogger(t.Name())
+	loader := NewNodeCertLoader(tmpDir)
+
+	poolUUID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	writeTestNodeCert(t, tmpDir, poolUUID.String())
+
+	c1, err := loader.Load(log, poolUUID)
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	c2, err := loader.Load(log, poolUUID)
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	if c1 != c2 {
+		t.Error("expected cache hit to return same pointer")
+	}
+
+	// Missing cert -> error
+	if _, err := loader.Load(log, uuid.MustParse("bbbbbbbb-cccc-dddd-eeee-ffffffffffff")); err == nil {
+		t.Error("expected error for missing cert")
+	}
+}
+
+func TestNodeCertLoader_ReloadOnFileChange(t *testing.T) {
+	tmpDir, cleanup := test.CreateTestDir(t)
+	defer cleanup()
+
+	log, _ := logging.NewTestLogger(t.Name())
+	loader := NewNodeCertLoader(tmpDir)
+
+	poolUUID := "cccccccc-dddd-eeee-ffff-000000000000"
+	writeTestNodeCert(t, tmpDir, poolUUID)
+
+	c1, err := loader.Load(log, uuid.MustParse(poolUUID))
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+
+	for _, name := range []string{poolUUID + ".crt", poolUUID + ".key"} {
+		if err := os.Remove(filepath.Join(tmpDir, name)); err != nil {
+			t.Fatalf("remove %s: %v", name, err)
+		}
+	}
+	writeTestNodeCert(t, tmpDir, poolUUID)
+	// Bump mtime past 1s resolution so a stat-based change detector
+	// reliably sees it regardless of filesystem granularity.
+	futureTime := time.Now().Add(2 * time.Second)
+	for _, name := range []string{poolUUID + ".crt", poolUUID + ".key"} {
+		p := filepath.Join(tmpDir, name)
+		if err := os.Chtimes(p, futureTime, futureTime); err != nil {
+			t.Fatalf("chtimes %s: %v", p, err)
+		}
+	}
+
+	c2, err := loader.Load(log, uuid.MustParse(poolUUID))
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if c1 == c2 {
+		t.Error("expected cache to invalidate after cert file changed")
+	}
+}
+
+func TestNodeCertLoader_KeyCertMismatch(t *testing.T) {
+	tmpDir, cleanup := test.CreateTestDir(t)
+	defer cleanup()
+
+	log, _ := logging.NewTestLogger(t.Name())
+	loader := NewNodeCertLoader(tmpDir)
+
+	poolUUID := "dddddddd-eeee-ffff-0000-111111111111"
+	writeTestNodeCert(t, tmpDir, poolUUID)
+
+	// Replace the key with one that doesn't match the cert.
+	otherKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(otherKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	keyPath := filepath.Join(tmpDir, poolUUID+".key")
+	if err := os.Remove(keyPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0400); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := loader.Load(log, uuid.MustParse(poolUUID)); err == nil ||
+		!strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected key/cert mismatch error, got %v", err)
+	}
+}
+
+func TestSecurity_ValidateNodeCertForUse(t *testing.T) {
+	now := time.Now()
+	notBefore := now.Add(-time.Minute)
+	notAfter := now.Add(time.Hour)
+
+	cases := map[string]struct {
+		cn        string
+		notBefore time.Time
+		notAfter  time.Time
+		now       time.Time
+		expectErr bool
+	}{
+		"node cert matches machine": {CertCNPrefixNode + testMachineName, notBefore, notAfter, now, false},
+		"node cert wrong machine":   {CertCNPrefixNode + "wronghost", notBefore, notAfter, now, true},
+		"tenant cert skips machine": {CertCNPrefixTenant + "team-a", notBefore, notAfter, now, false},
+		"unrecognized prefix":       {"weird:thing", notBefore, notAfter, now, true},
+		"expired cert":              {CertCNPrefixNode + testMachineName, notBefore, now.Add(-time.Minute), now, true},
+		"not yet valid":             {CertCNPrefixNode + testMachineName, now.Add(time.Hour), notAfter, now, true},
+		"not yet valid within skew": {CertCNPrefixNode + testMachineName, now.Add(time.Minute), notAfter, now, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cert := &x509.Certificate{
+				Subject:   pkix.Name{CommonName: tc.cn},
+				NotBefore: tc.notBefore,
+				NotAfter:  tc.notAfter,
+			}
+			err := validateNodeCertForUse(cert, "12345678-1234-1234-1234-123456789abc",
+				testMachineName, tc.now)
+			if tc.expectErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNodeCertLoader_CertAndPoP(t *testing.T) {
+	tmpDir, cleanup := test.CreateTestDir(t)
+	defer cleanup()
+
+	poolUUID := uuid.MustParse("12345678-1234-1234-1234-123456789abc")
+	handleUUID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	writeTestNodeCert(t, tmpDir, poolUUID.String())
+
+	log, _ := logging.NewTestLogger(t.Name())
+	loader := NewNodeCertLoader(tmpDir)
+	cert, pop, payload, err := loader.CertAndPoP(log, poolUUID, handleUUID, testMachineName)
+	if err != nil {
+		t.Fatalf("CertAndPoP failed: %v", err)
+	}
+	if len(cert.PEM) == 0 || len(pop) == 0 {
+		t.Fatal("expected non-empty cert PEM and pop")
+	}
+	if _, err := parsePoPPayload(payload); err != nil {
+		t.Fatalf("payload does not parse: %v", err)
+	}
+}

--- a/src/control/security/node_cert_validate_test.go
+++ b/src/control/security/node_cert_validate_test.go
@@ -1,0 +1,263 @@
+//
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package security
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+
+	sectest "github.com/daos-stack/daos/src/control/security/test"
+)
+
+type validationFixture struct {
+	root     *x509.Certificate
+	poolCA   []byte
+	caKey    *ecdsa.PrivateKey
+	caCert   *x509.Certificate
+	poolUUID uuid.UUID
+	handle   uuid.UUID
+}
+
+func newValidationFixture(t *testing.T) *validationFixture {
+	t.Helper()
+
+	rootPEM, rootKey := sectest.NewCA(t, "DAOS Test Root", nil, nil)
+	root := sectest.ParseCert(t, rootPEM)
+	poolCAPEM, poolCAKey := sectest.NewCA(t, "Pool CA", root, rootKey)
+
+	return &validationFixture{
+		root:     root,
+		poolCA:   poolCAPEM,
+		caKey:    poolCAKey,
+		caCert:   sectest.ParseCert(t, poolCAPEM),
+		poolUUID: uuid.MustParse("12345678-1234-1234-1234-123456789abc"),
+		handle:   uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+	}
+}
+
+// signedPresentation issues a leaf cert for cn, builds a matching payload, and
+// signs the PoP — a fully valid presentation to mutate per test case.
+func (f *validationFixture) signedPresentation(t *testing.T, cn string) *NodeCertPresentation {
+	t.Helper()
+
+	leafPEM, leafKey := sectest.NewLeafCert(t, cn, f.caCert, f.caKey,
+		time.Now().Add(-time.Minute), time.Now().Add(time.Hour))
+	payload, err := buildPoPPayload(f.poolUUID, f.handle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pop, err := signPoP(leafKey, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &NodeCertPresentation{
+		Root:        f.root,
+		PoolCA:      f.poolCA,
+		Cert:        leafPEM,
+		PoPSig:      pop,
+		PoPPayload:  payload,
+		PoolUUID:    f.poolUUID,
+		MachineName: "machine1",
+	}
+}
+
+func expectValidationErr(t *testing.T, v *NodeCertPresentation, sentinel error) {
+	t.Helper()
+	if _, err := v.Validate(); !errors.Is(err, sentinel) {
+		t.Fatalf("expected %v, got %v", sentinel, err)
+	}
+}
+
+func TestSecurity_NodeCertPresentation(t *testing.T) {
+	f := newValidationFixture(t)
+
+	t.Run("valid node cert", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		payload, err := v.Validate()
+		if err != nil {
+			t.Fatalf("Validate failed: %v", err)
+		}
+		if payload.PoolID() != f.poolUUID || payload.HandleID() != f.handle {
+			t.Fatalf("parsed payload mismatch: %+v", payload)
+		}
+		expKey := f.poolUUID.String() + ":" + f.handle.String()
+		if payload.ReplayKey() != expKey {
+			t.Fatalf("replay key %q, want %q", payload.ReplayKey(), expKey)
+		}
+	})
+
+	t.Run("valid tenant cert ignores machine name", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixTenant+"team-a")
+		v.MachineName = "someone-else"
+		if _, err := v.Validate(); err != nil {
+			t.Fatalf("Validate failed: %v", err)
+		}
+	})
+
+	t.Run("nil root", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		v.Root = nil
+		expectValidationErr(t, v, ErrInvalidInput)
+	})
+
+	t.Run("garbage cert", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		v.Cert = []byte("not a PEM")
+		expectValidationErr(t, v, ErrCertInvalid)
+	})
+
+	t.Run("empty pool CA bundle", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		v.PoolCA = nil
+		expectValidationErr(t, v, ErrCertInvalid)
+	})
+
+	t.Run("cert not chained to root", func(t *testing.T) {
+		otherRootPEM, otherRootKey := sectest.NewCA(t, "Other Root", nil, nil)
+		otherCAPEM, otherCAKey := sectest.NewCA(t, "Other Pool CA",
+			sectest.ParseCert(t, otherRootPEM), otherRootKey)
+		leafPEM, leafKey := sectest.NewLeafCert(t, CertCNPrefixNode+"machine1",
+			sectest.ParseCert(t, otherCAPEM), otherCAKey,
+			time.Now().Add(-time.Minute), time.Now().Add(time.Hour))
+
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		v.Cert = leafPEM
+		v.PoolCA = otherCAPEM
+		payload, err := buildPoPPayload(f.poolUUID, f.handle)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pop, err := signPoP(leafKey, payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		v.PoPPayload = payload
+		v.PoPSig = pop
+		expectValidationErr(t, v, ErrCertInvalid)
+	})
+
+	t.Run("CN policy violation", func(t *testing.T) {
+		v := f.signedPresentation(t, "no-prefix-here")
+		expectValidationErr(t, v, ErrCertInvalid)
+	})
+
+	t.Run("machine name mismatch", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		v.MachineName = "machine2"
+		expectValidationErr(t, v, ErrCertInvalid)
+	})
+
+	t.Run("empty machine name for node cert", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		v.MachineName = ""
+		expectValidationErr(t, v, ErrInvalidInput)
+	})
+
+	t.Run("revoked by watermark", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		wm, err := EncodeCertWatermarks(CertWatermarks{
+			CertCNPrefixNode + "machine1": time.Now().Add(time.Minute),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		v.Watermarks = wm
+		expectValidationErr(t, v, ErrCertRevoked)
+	})
+
+	t.Run("reissued past watermark", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		wm, err := EncodeCertWatermarks(CertWatermarks{
+			CertCNPrefixNode + "machine1": time.Now().Add(-time.Hour),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		v.Watermarks = wm
+		if _, err := v.Validate(); err != nil {
+			t.Fatalf("Validate failed: %v", err)
+		}
+	})
+
+	t.Run("signed garbage payload", func(t *testing.T) {
+		// A correctly signed but unparsable payload is a producer bug,
+		// not an auth failure: signature passes, parse must reject.
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		leafPEM, leafKey := sectest.NewLeafCert(t, CertCNPrefixNode+"machine1",
+			f.caCert, f.caKey, time.Now().Add(-time.Minute), time.Now().Add(time.Hour))
+		garbage := []byte{0xff, 0xff, 0xff, 0xff}
+		pop, err := signPoP(leafKey, garbage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		v.Cert = leafPEM
+		v.PoPPayload = garbage
+		v.PoPSig = pop
+		expectValidationErr(t, v, ErrInvalidInput)
+	})
+
+	t.Run("signed short handle UUID", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		leafPEM, leafKey := sectest.NewLeafCert(t, CertCNPrefixNode+"machine1",
+			f.caCert, f.caKey, time.Now().Add(-time.Minute), time.Now().Add(time.Hour))
+		// Craft a signed payload with a short handle directly; the typed
+		// helper can no longer produce one.
+		payload, err := proto.Marshal(&PoPPayload{
+			PoolUuid:   f.poolUUID[:],
+			HandleUuid: []byte{0x01, 0x02},
+			Timestamp:  time.Now().Unix(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		pop, err := signPoP(leafKey, payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		v.Cert = leafPEM
+		v.PoPPayload = payload
+		v.PoPSig = pop
+		expectValidationErr(t, v, ErrInvalidInput)
+	})
+
+	t.Run("payload bound to other pool", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		v.PoolUUID = uuid.MustParse("99999999-9999-9999-9999-999999999999")
+		expectValidationErr(t, v, ErrPoPInvalid)
+	})
+
+	t.Run("stale timestamp", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		v.Now = time.Now().Add(NotBeforeSkewTolerance + time.Minute)
+		expectValidationErr(t, v, ErrPoPStale)
+	})
+
+	t.Run("tampered payload", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		v.PoPPayload[len(v.PoPPayload)-1] ^= 0xff
+		expectValidationErr(t, v, ErrPoPInvalid)
+	})
+
+	t.Run("signed by wrong key", func(t *testing.T) {
+		v := f.signedPresentation(t, CertCNPrefixNode+"machine1")
+		_, otherKey := sectest.NewLeafCert(t, CertCNPrefixNode+"machine1",
+			f.caCert, f.caKey, time.Now().Add(-time.Minute), time.Now().Add(time.Hour))
+		pop, err := signPoP(otherKey, v.PoPPayload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		v.PoPSig = pop
+		expectValidationErr(t, v, ErrPoPInvalid)
+	})
+}

--- a/src/control/security/pem.go
+++ b/src/control/security/pem.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -8,6 +9,7 @@ package security
 
 import (
 	"crypto"
+	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
@@ -24,7 +26,59 @@ const (
 	MaxGroupKeyPerm    os.FileMode = 0440
 	MaxCertPerm        os.FileMode = 0664
 	MaxDirPerm         os.FileMode = 0750
+
+	// CertCNPrefixNode marks a node-scoped pool cert; suffix must match
+	// the local machine name.
+	CertCNPrefixNode = "node:"
+	// CertCNPrefixTenant marks a tenant-scoped pool cert shared across nodes.
+	CertCNPrefixTenant = "tenant:"
+	// CertCNSuffixMaxLen caps the portion of a pool cert CN after the
+	// prefix, matching the RFC 1035 maximum DNS name length.
+	CertCNSuffixMaxLen = 253
 )
+
+// ValidatePoolCertCN parses a pool cert CN ("node:<suffix>" or
+// "tenant:<suffix>"). Suffix is restricted to DNS-compatible chars to
+// stop hostile values reaching cert-gen or watermark paths.
+func ValidatePoolCertCN(cn string) (prefix, suffix string, err error) {
+	switch {
+	case strings.HasPrefix(cn, CertCNPrefixNode):
+		prefix = CertCNPrefixNode
+	case strings.HasPrefix(cn, CertCNPrefixTenant):
+		prefix = CertCNPrefixTenant
+	default:
+		return "", "", fmt.Errorf("CN %q must start with %q or %q",
+			cn, CertCNPrefixNode, CertCNPrefixTenant)
+	}
+	suffix = cn[len(prefix):]
+	if suffix == "" {
+		return "", "", fmt.Errorf("CN %q has empty suffix", cn)
+	}
+	if len(suffix) > CertCNSuffixMaxLen {
+		return "", "", fmt.Errorf("CN suffix %q exceeds max length %d",
+			suffix, CertCNSuffixMaxLen)
+	}
+	isAlnum := func(c byte) bool {
+		return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+	}
+	if !isAlnum(suffix[0]) || !isAlnum(suffix[len(suffix)-1]) {
+		return "", "", fmt.Errorf("CN suffix %q must start and end with an alphanumeric", suffix)
+	}
+	for i := 0; i < len(suffix); i++ {
+		c := suffix[i]
+		switch {
+		case isAlnum(c):
+		case c == '.' || c == '-' || c == '_':
+			if i > 0 && !isAlnum(suffix[i-1]) {
+				return "", "", fmt.Errorf("CN suffix %q has consecutive separators", suffix)
+			}
+		default:
+			return "", "", fmt.Errorf("CN suffix %q contains disallowed character %q",
+				suffix, c)
+		}
+	}
+	return prefix, suffix, nil
+}
 
 type badPermsError struct {
 	filename string
@@ -193,8 +247,9 @@ func LoadPrivateKey(keyPath string) (crypto.PrivateKey, error) {
 	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 	if err == nil {
 		switch key := key.(type) {
-		// TODO: Support key types other than RSA
 		case *rsa.PrivateKey:
+			return key, nil
+		case *ecdsa.PrivateKey:
 			return key, nil
 		default:
 			return nil, fmt.Errorf("%s contains an unsupported private key type",

--- a/src/control/security/pem_test.go
+++ b/src/control/security/pem_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -204,6 +205,56 @@ func TestSecurity_Pem_ValidateCertDirectory(t *testing.T) {
 			err := ValidateCertDirectory(path)
 
 			test.CmpErr(t, tc.expErr, err)
+		})
+	}
+}
+
+func TestSecurity_ValidatePoolCertCN(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cn         string
+		wantPrefix string
+		wantSuffix string
+		wantErr    string
+	}{
+		"node ok":             {cn: "node:host1", wantPrefix: "node:", wantSuffix: "host1"},
+		"tenant ok":           {cn: "tenant:teamA", wantPrefix: "tenant:", wantSuffix: "teamA"},
+		"fqdn ok":             {cn: "node:host1.example.com", wantPrefix: "node:", wantSuffix: "host1.example.com"},
+		"underscore ok":       {cn: "tenant:team_A", wantPrefix: "tenant:", wantSuffix: "team_A"},
+		"no prefix":           {cn: "host1", wantErr: "must start with"},
+		"empty suffix node":   {cn: "node:", wantErr: "empty suffix"},
+		"empty suffix tenant": {cn: "tenant:", wantErr: "empty suffix"},
+		"embedded null byte":  {cn: "node:host\x00evil", wantErr: "disallowed character"},
+		"embedded newline":    {cn: "node:host\nhostile", wantErr: "disallowed character"},
+		"embedded colon":      {cn: "node:admin:bypass", wantErr: "disallowed character"},
+		"space rejected":      {cn: "node:host one", wantErr: "disallowed character"},
+		"leading dot":         {cn: "node:.host", wantErr: "must start and end with an alphanumeric"},
+		"trailing dot":        {cn: "node:host.", wantErr: "must start and end with an alphanumeric"},
+		"leading hyphen":      {cn: "node:-host", wantErr: "must start and end with an alphanumeric"},
+		"consecutive dots":    {cn: "node:host..example", wantErr: "consecutive separators"},
+		"consecutive hyphens": {cn: "node:host--example", wantErr: "consecutive separators"},
+		"too long": {
+			cn:      "node:" + strings.Repeat("a", CertCNSuffixMaxLen+1),
+			wantErr: "exceeds max length",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			prefix, suffix, err := ValidatePoolCertCN(tc.cn)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if prefix != tc.wantPrefix || suffix != tc.wantSuffix {
+				t.Fatalf("got (%q, %q), want (%q, %q)",
+					prefix, suffix, tc.wantPrefix, tc.wantSuffix)
+			}
 		})
 	}
 }

--- a/src/control/security/pool_cert.go
+++ b/src/control/security/pool_cert.go
@@ -1,0 +1,174 @@
+//
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package security
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// CertWatermarks maps a pool cert CN to a NotBefore boundary. Certs whose
+// NotBefore <= watermark are considered revoked; reissue must produce a
+// cert with NotBefore strictly past the watermark.
+type CertWatermarks map[string]time.Time
+
+// EncodeCertWatermarks serializes wm as JSON. An empty map encodes to nil
+// so the prop layer can distinguish "no revocations" from an empty blob.
+func EncodeCertWatermarks(wm CertWatermarks) ([]byte, error) {
+	if len(wm) == 0 {
+		return nil, nil
+	}
+	raw := make(map[string]string, len(wm))
+	for cn, t := range wm {
+		raw[cn] = t.UTC().Format(time.RFC3339)
+	}
+	return json.Marshal(raw)
+}
+
+// DecodeCertWatermarks parses the JSON watermarks blob.
+func DecodeCertWatermarks(data []byte) (CertWatermarks, error) {
+	raw := make(map[string]string)
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, errors.Wrap(err, "parsing cert watermarks blob")
+	}
+	out := make(CertWatermarks, len(raw))
+	for cn, ts := range raw {
+		t, err := time.Parse(time.RFC3339, ts)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parsing watermark for %s", cn)
+		}
+		out[cn] = t.UTC()
+	}
+	return out, nil
+}
+
+// AdvanceCertWatermark returns a value strictly greater than the existing
+// watermark for cn.
+func AdvanceCertWatermark(existing CertWatermarks, cn string, now time.Time) time.Time {
+	now = now.UTC().Truncate(time.Second)
+	if prev, ok := existing[cn]; ok && !now.After(prev) {
+		return prev.Add(time.Second)
+	}
+	return now
+}
+
+// RemoveCertByFingerprint drops PEM certs matching a SHA-256 hex fingerprint.
+func RemoveCertByFingerprint(bundle []byte, fingerprint string) ([]byte, int, error) {
+	var remaining []byte
+	removed := 0
+	rest := bundle
+
+	for len(rest) > 0 {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			return nil, 0, fmt.Errorf("unexpected PEM block type %q in CA bundle", block.Type)
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, 0, errors.Wrap(err, "malformed cert in CA bundle")
+		}
+		fp := fmt.Sprintf("%x", sha256.Sum256(cert.Raw))
+		if fp == fingerprint {
+			removed++
+			continue
+		}
+		remaining = append(remaining, pem.EncodeToMemory(block)...)
+	}
+
+	if removed == 0 {
+		return nil, 0, fmt.Errorf("no CA with fingerprint %s found in bundle", fingerprint)
+	}
+
+	return remaining, removed, nil
+}
+
+// CountPEMCerts returns the number of CERTIFICATE blocks in a PEM bundle.
+func CountPEMCerts(bundle []byte) int {
+	count := 0
+	rest := bundle
+	for len(rest) > 0 {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			count++
+		}
+	}
+	return count
+}
+
+// ParsePoolCACert parses a single-block CA cert and enforces IsCA + KeyCertSign.
+func ParsePoolCACert(certPEM []byte) (*x509.Certificate, error) {
+	block, rest := pem.Decode(certPEM)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, errors.New("cert_pem is not a PEM-encoded CERTIFICATE block")
+	}
+	if len(rest) > 0 {
+		trailing, _ := pem.Decode(rest)
+		if trailing != nil {
+			return nil, errors.New("cert_pem must contain exactly one CERTIFICATE block")
+		}
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing CA certificate")
+	}
+	if !cert.IsCA {
+		return nil, errors.New("certificate does not have IsCA=true")
+	}
+	if cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+		return nil, errors.New("certificate KeyUsage does not include KeyCertSign")
+	}
+	return cert, nil
+}
+
+// VerifyPoolCAChain confirms cert chains to the DAOS root at rootCAPath.
+func VerifyPoolCAChain(cert *x509.Certificate, rootCAPath string) error {
+	if rootCAPath == "" {
+		return errors.New("DAOS CA root path is empty")
+	}
+	root, err := LoadCertificate(rootCAPath)
+	if err != nil {
+		return errors.Wrap(err, "loading DAOS CA certificate")
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(root)
+
+	// Disable Verify's usage check here, because we only need to check
+	// that the pool CA chains to the DAOS CA. Usage is enforced at connect time.
+	_, err = cert.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	})
+	if err != nil {
+		return errors.Wrap(err, "pool CA does not chain to DAOS CA")
+	}
+	return nil
+}
+
+// AppendCACert validates certPEM as a pool CA and appends it to the bundle.
+func AppendCACert(existing, certPEM []byte) ([]byte, error) {
+	if _, err := ParsePoolCACert(certPEM); err != nil {
+		return nil, err
+	}
+	combined := make([]byte, 0, len(existing)+len(certPEM))
+	combined = append(combined, existing...)
+	combined = append(combined, certPEM...)
+	return combined, nil
+}

--- a/src/control/security/pool_cert_test.go
+++ b/src/control/security/pool_cert_test.go
@@ -1,0 +1,336 @@
+//
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package security
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDecodeCertWatermarks(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input   string
+		wantLen int
+		wantErr bool
+	}{
+		"empty object":     {`{}`, 0, false},
+		"one entry":        {`{"node:host1":"2026-01-02T03:04:05Z"}`, 1, false},
+		"two entries":      {`{"node:host1":"2026-01-02T03:04:05Z","tenant:t1":"2026-02-01T00:00:00Z"}`, 2, false},
+		"malformed JSON":   {`not json`, 0, true},
+		"bad timestamp":    {`{"node:host1":"not-a-time"}`, 0, true},
+		"missing timezone": {`{"node:host1":"2026-01-02T03:04:05"}`, 0, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := DecodeCertWatermarks([]byte(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != tc.wantLen {
+				t.Errorf("got %d entries, want %d", len(got), tc.wantLen)
+			}
+			for cn, ts := range got {
+				if ts.Location() != time.UTC {
+					t.Errorf("watermark for %q is not UTC: %v", cn, ts)
+				}
+			}
+		})
+	}
+}
+
+func TestCertWatermarks_RoundTrip(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input CertWatermarks
+	}{
+		"empty": {input: nil},
+		"single node": {input: CertWatermarks{
+			"node:node1": time.Date(2026, 4, 15, 14, 0, 29, 0, time.UTC),
+		}},
+		"multiple": {input: CertWatermarks{
+			"node:node1":   time.Date(2026, 4, 15, 14, 0, 29, 0, time.UTC),
+			"node:node2":   time.Date(2026, 4, 15, 14, 0, 30, 0, time.UTC),
+			"tenant:teamA": time.Date(2026, 4, 20, 9, 15, 0, 0, time.UTC),
+		}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			encoded, err := EncodeCertWatermarks(tc.input)
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+			if len(tc.input) == 0 {
+				if encoded != nil {
+					t.Fatalf("empty map must encode to nil, got %q", encoded)
+				}
+				return
+			}
+			got, err := DecodeCertWatermarks(encoded)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if diff := cmp.Diff(tc.input, got); diff != "" {
+				t.Fatalf("round-trip mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAdvanceCertWatermark(t *testing.T) {
+	t0 := time.Date(2026, 4, 15, 14, 0, 0, 0, time.UTC)
+	for name, tc := range map[string]struct {
+		existing CertWatermarks
+		cn       string
+		now      time.Time
+		want     time.Time
+	}{
+		"no prior":             {nil, "node:n1", t0.Add(500 * time.Millisecond), t0},
+		"no prior for cn":      {CertWatermarks{"node:other": t0.Add(time.Hour)}, "node:n1", t0, t0},
+		"now > prior":          {CertWatermarks{"node:n1": t0}, "node:n1", t0.Add(time.Minute), t0.Add(time.Minute)},
+		"now == prior":         {CertWatermarks{"node:n1": t0}, "node:n1", t0, t0.Add(time.Second)},
+		"now < prior":          {CertWatermarks{"node:n1": t0.Add(time.Hour)}, "node:n1", t0, t0.Add(time.Hour).Add(time.Second)},
+		"sub-second truncated": {nil, "node:n1", t0.Add(999 * time.Millisecond), t0},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := AdvanceCertWatermark(tc.existing, tc.cn, tc.now)
+			if !got.Equal(tc.want) {
+				t.Errorf("got %s, want %s", got.Format(time.RFC3339), tc.want.Format(time.RFC3339))
+			}
+		})
+	}
+}
+
+// generateTestCA produces a self-signed CA cert + key.
+func generateTestCA(t *testing.T, cn string) (*x509.Certificate, *ecdsa.PrivateKey, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, _ := x509.ParseCertificate(der)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return cert, key, pemBytes
+}
+
+// signCertWith creates a leaf cert (or intermediate CA) signed by parent.
+func signCertWith(t *testing.T, parent *x509.Certificate, parentKey *ecdsa.PrivateKey, cn string, isCA bool) ([]byte, *x509.Certificate) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	usage := x509.KeyUsageDigitalSignature
+	if isCA {
+		usage |= x509.KeyUsageCertSign
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  isCA,
+		KeyUsage:              usage,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, &key.PublicKey, parentKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, _ := x509.ParseCertificate(der)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), cert
+}
+
+func TestRemoveCertByFingerprint(t *testing.T) {
+	_, _, pemA := generateTestCA(t, "CA-A")
+	certA, _ := x509.ParseCertificate(decodePEM(t, pemA))
+	_, _, pemB := generateTestCA(t, "CA-B")
+	certB, _ := x509.ParseCertificate(decodePEM(t, pemB))
+	_, _, pemC := generateTestCA(t, "CA-C")
+
+	bundle := append(append(pemA, pemB...), pemC...)
+	fpA := fmt.Sprintf("%x", sha256.Sum256(certA.Raw))
+	fpB := fmt.Sprintf("%x", sha256.Sum256(certB.Raw))
+
+	for name, tc := range map[string]struct {
+		fp     string
+		want   int
+		errSub string
+	}{
+		"remove first":  {fpA, 1, ""},
+		"remove middle": {fpB, 1, ""},
+		"not found":     {"deadbeef", 0, "no CA with fingerprint"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, removed, err := RemoveCertByFingerprint(bundle, tc.fp)
+			if tc.errSub != "" {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if removed != tc.want {
+				t.Errorf("removed=%d, want %d", removed, tc.want)
+			}
+		})
+	}
+}
+
+func TestRemoveCertByFingerprint_MalformedBundle(t *testing.T) {
+	_, _, validCA := generateTestCA(t, "valid")
+
+	// Non-CERTIFICATE PEM block in bundle is rejected.
+	notACert := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("x")})
+	if _, _, err := RemoveCertByFingerprint(append(validCA, notACert...), "anything"); err == nil {
+		t.Fatal("expected error for non-CERTIFICATE PEM block")
+	}
+
+	// CERTIFICATE block with garbage bytes is rejected.
+	garbage := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not der")})
+	if _, _, err := RemoveCertByFingerprint(append(validCA, garbage...), "anything"); err == nil {
+		t.Fatal("expected error for malformed CERTIFICATE block")
+	}
+}
+
+func TestCountPEMCerts(t *testing.T) {
+	_, _, pemA := generateTestCA(t, "A")
+	_, _, pemB := generateTestCA(t, "B")
+	if got := CountPEMCerts(pemA); got != 1 {
+		t.Errorf("one cert: got %d, want 1", got)
+	}
+	if got := CountPEMCerts(append(pemA, pemB...)); got != 2 {
+		t.Errorf("two certs: got %d, want 2", got)
+	}
+	if got := CountPEMCerts(nil); got != 0 {
+		t.Errorf("nil bundle: got %d, want 0", got)
+	}
+	// A non-CERTIFICATE block does not count.
+	notACert := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("x")})
+	if got := CountPEMCerts(append(pemA, notACert...)); got != 1 {
+		t.Errorf("cert+other: got %d, want 1", got)
+	}
+}
+
+func TestParsePoolCACert(t *testing.T) {
+	_, _, caPEM := generateTestCA(t, "valid CA")
+
+	// Build a non-CA cert (leaf) for the IsCA-false case.
+	rootCert, rootKey, _ := generateTestCA(t, "root")
+	leafPEM, _ := signCertWith(t, rootCert, rootKey, "leaf", false)
+
+	for name, tc := range map[string]struct {
+		input   []byte
+		wantErr string
+	}{
+		"valid CA":    {caPEM, ""},
+		"not a CA":    {leafPEM, "IsCA"},
+		"empty input": {nil, "PEM-encoded CERTIFICATE"},
+		"two blocks":  {append(caPEM, caPEM...), "exactly one CERTIFICATE"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParsePoolCACert(tc.input)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestVerifyPoolCAChain(t *testing.T) {
+	rootCert, rootKey, rootPEM := generateTestCA(t, "root")
+	_, interPEM := signCertWith(t, rootCert, rootKey, "pool CA", true)
+
+	// Write root to a temp file (LoadCertificate requires MaxCertPerm).
+	dir := t.TempDir()
+	rootPath := filepath.Join(dir, "root.crt")
+	if err := os.WriteFile(rootPath, rootPEM, MaxCertPerm); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := VerifyPoolCAChain(interPEM, rootPath); err != nil {
+		t.Fatalf("valid chain rejected: %v", err)
+	}
+
+	// Empty rootCAPath is an error; skipping is the caller's decision.
+	if err := VerifyPoolCAChain(interPEM, ""); err == nil {
+		t.Fatal("empty rootCAPath should be rejected")
+	}
+
+	// Cert signed by a different root must not validate against rootPath.
+	freshRoot, freshKey, _ := generateTestCA(t, "fresh root")
+	_, badPEM := signCertWith(t, freshRoot, freshKey, "bad chain", true)
+	if err := VerifyPoolCAChain(badPEM, rootPath); err == nil {
+		t.Fatal("cert not chaining to root should be rejected")
+	}
+}
+
+func TestAppendCACert(t *testing.T) {
+	_, _, caA := generateTestCA(t, "A")
+	_, _, caB := generateTestCA(t, "B")
+	bundle, err := AppendCACert(caA, caB)
+	if err != nil {
+		t.Fatalf("valid append failed: %v", err)
+	}
+	if CountPEMCerts(bundle) != 2 {
+		t.Errorf("bundle should have 2 certs, got %d", CountPEMCerts(bundle))
+	}
+	// Non-CA cert rejected.
+	root, key, _ := generateTestCA(t, "root")
+	leaf, _ := signCertWith(t, root, key, "leaf", false)
+	if _, err := AppendCACert(caA, leaf); err == nil {
+		t.Fatal("AppendCACert should reject non-CA cert")
+	}
+}
+
+// decodePEM returns the DER bytes of the first PEM block, or fails.
+func decodePEM(t *testing.T, data []byte) []byte {
+	t.Helper()
+	block, _ := pem.Decode(data)
+	if block == nil {
+		t.Fatal("no PEM block")
+	}
+	return block.Bytes
+}

--- a/src/control/security/pop.go
+++ b/src/control/security/pop.go
@@ -1,0 +1,148 @@
+//
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package security
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+)
+
+// A proof-of-possession (PoP) ties the presenter of a cert to its private
+// key: the client signs a payload binding pool, handle, and timestamp; the
+// server checks the signature against the cert's public key.
+
+// popSigDomain separates PoP signatures from any other signing operation
+// that might reuse a node cert key.
+const popSigDomain = "DAOS-NODE-POP-V1\x00"
+
+// PoolID returns the pool UUID bound into the payload.
+// Valid only after parsePoPPayload has validated field lengths.
+func (p *PoPPayload) PoolID() uuid.UUID {
+	var id uuid.UUID
+	copy(id[:], p.PoolUuid)
+	return id
+}
+
+// HandleID returns the pool handle UUID bound into the payload.
+// Valid only after parsePoPPayload has validated field lengths.
+func (p *PoPPayload) HandleID() uuid.UUID {
+	var id uuid.UUID
+	copy(id[:], p.HandleUuid)
+	return id
+}
+
+// Time returns the payload creation timestamp.
+func (p *PoPPayload) Time() time.Time {
+	return time.Unix(p.Timestamp, 0)
+}
+
+// ReplayKey returns a stable identifier for this proof's (pool, handle)
+// binding, for use in replay caches.
+func (p *PoPPayload) ReplayKey() string {
+	return p.PoolID().String() + ":" + p.HandleID().String()
+}
+
+// parsePoPPayload unmarshals raw payload bytes and validates field shape.
+// Only call on bytes whose signature has already been verified.
+func parsePoPPayload(raw []byte) (*PoPPayload, error) {
+	p := &PoPPayload{}
+	if err := proto.Unmarshal(raw, p); err != nil {
+		return nil, errors.Wrap(err, "unmarshaling PoP payload")
+	}
+	uuidLen := len(uuid.UUID{})
+	if len(p.PoolUuid) != uuidLen {
+		return nil, fmt.Errorf("PoP payload pool UUID is %d bytes, want %d",
+			len(p.PoolUuid), uuidLen)
+	}
+	if len(p.HandleUuid) != uuidLen {
+		return nil, fmt.Errorf("PoP payload handle UUID is %d bytes, want %d",
+			len(p.HandleUuid), uuidLen)
+	}
+	if p.Timestamp <= 0 {
+		return nil, fmt.Errorf("PoP payload timestamp %d is not positive", p.Timestamp)
+	}
+	return p, nil
+}
+
+// buildPoPPayload assembles and marshals a fresh proof-of-possession payload.
+func buildPoPPayload(poolUUID, handleUUID uuid.UUID) ([]byte, error) {
+	return proto.Marshal(&PoPPayload{
+		PoolUuid:   poolUUID[:],
+		HandleUuid: handleUUID[:],
+		Timestamp:  time.Now().Unix(),
+	})
+}
+
+// signPoP signs payload with key, using a hash chosen for the key type.
+func signPoP(key crypto.PrivateKey, payload []byte) ([]byte, error) {
+	signInput := append([]byte(popSigDomain), payload...)
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		h := sha512.Sum512(signInput)
+		return rsa.SignPSS(rand.Reader, k, crypto.SHA512, h[:], &rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthEqualsHash,
+			Hash:       crypto.SHA512,
+		})
+	case *ecdsa.PrivateKey:
+		var hash []byte
+		switch k.Curve {
+		case elliptic.P256():
+			h := sha256.Sum256(signInput)
+			hash = h[:]
+		case elliptic.P384():
+			h := sha512.Sum384(signInput)
+			hash = h[:]
+		default:
+			return nil, fmt.Errorf("unsupported ECDSA curve: %v", k.Curve.Params().Name)
+		}
+		return ecdsa.SignASN1(rand.Reader, k, hash)
+	default:
+		return nil, fmt.Errorf("unsupported key type: %T", key)
+	}
+}
+
+// verifyPoP verifies a signPoP signature using the matching domain prefix.
+func verifyPoP(pub crypto.PublicKey, payload, sig []byte) error {
+	signInput := append([]byte(popSigDomain), payload...)
+	switch k := pub.(type) {
+	case *rsa.PublicKey:
+		h := sha512.Sum512(signInput)
+		return rsa.VerifyPSS(k, crypto.SHA512, h[:], sig, &rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthEqualsHash,
+			Hash:       crypto.SHA512,
+		})
+	case *ecdsa.PublicKey:
+		var hash []byte
+		switch k.Curve {
+		case elliptic.P256():
+			h := sha256.Sum256(signInput)
+			hash = h[:]
+		case elliptic.P384():
+			h := sha512.Sum384(signInput)
+			hash = h[:]
+		default:
+			return fmt.Errorf("unsupported ECDSA curve: %v", k.Curve.Params().Name)
+		}
+		if !ecdsa.VerifyASN1(k, hash, sig) {
+			return fmt.Errorf("ECDSA signature verification failed")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported public key type: %T", pub)
+	}
+}

--- a/src/control/security/pop_test.go
+++ b/src/control/security/pop_test.go
@@ -1,0 +1,203 @@
+//
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package security
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestBuildPoPPayload(t *testing.T) {
+	poolUUID := uuid.MustParse("12345678-1234-1234-1234-123456789abc")
+	handleUUID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+	before := time.Now().Unix()
+	payload, err := buildPoPPayload(poolUUID, handleUUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after := time.Now().Unix()
+
+	parsed, err := parsePoPPayload(payload)
+	if err != nil {
+		t.Fatalf("parsePoPPayload: %v", err)
+	}
+	if parsed.PoolID() != poolUUID {
+		t.Errorf("pool UUID mismatch: got %s, want %s", parsed.PoolID(), poolUUID)
+	}
+	if parsed.HandleID() != handleUUID {
+		t.Errorf("handle UUID mismatch: got %s, want %s", parsed.HandleID(), handleUUID)
+	}
+	if ts := parsed.Timestamp; ts < before || ts > after {
+		t.Errorf("timestamp %d not in range [%d, %d]", ts, before, after)
+	}
+}
+
+func TestParsePoPPayload_Invalid(t *testing.T) {
+	poolUUID := uuid.MustParse("12345678-1234-1234-1234-123456789abc")
+	handleUUID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+	for name, raw := range map[string]func(t *testing.T) []byte{
+		"not a proto message": func(t *testing.T) []byte {
+			return []byte{0xff, 0xff, 0xff, 0xff}
+		},
+		"short pool UUID": func(t *testing.T) []byte {
+			b, err := proto.Marshal(&PoPPayload{
+				PoolUuid: []byte{0x01}, HandleUuid: handleUUID[:],
+				Timestamp: time.Now().Unix(),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			return b
+		},
+		"short handle UUID": func(t *testing.T) []byte {
+			b, err := proto.Marshal(&PoPPayload{
+				PoolUuid: poolUUID[:], HandleUuid: []byte{0x01},
+				Timestamp: time.Now().Unix(),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			return b
+		},
+		"missing timestamp": func(t *testing.T) []byte {
+			b, err := proto.Marshal(&PoPPayload{
+				PoolUuid: poolUUID[:], HandleUuid: handleUUID[:],
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			return b
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parsePoPPayload(raw(t)); err == nil {
+				t.Fatal("expected parse error, got nil")
+			}
+		})
+	}
+}
+
+func TestSignPoP_ECDSA_P384(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := make([]byte, 64)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	sig, err := signPoP(key, payload)
+	if err != nil {
+		t.Fatalf("signPoP failed: %v", err)
+	}
+	h := sha512.Sum384(append([]byte(popSigDomain), payload...))
+	if !ecdsa.VerifyASN1(&key.PublicKey, h[:], sig) {
+		t.Fatal("ECDSA P-384 signature verification failed")
+	}
+}
+
+func TestSignPoP_ECDSA_P256(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := make([]byte, 64)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	sig, err := signPoP(key, payload)
+	if err != nil {
+		t.Fatalf("signPoP failed: %v", err)
+	}
+	h := sha256.Sum256(append([]byte(popSigDomain), payload...))
+	if !ecdsa.VerifyASN1(&key.PublicKey, h[:], sig) {
+		t.Fatal("ECDSA P-256 signature verification failed")
+	}
+}
+
+func TestSignPoP_RSA(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := make([]byte, 64)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	sig, err := signPoP(key, payload)
+	if err != nil {
+		t.Fatalf("signPoP failed: %v", err)
+	}
+	h := sha512.Sum512(append([]byte(popSigDomain), payload...))
+	if err := rsa.VerifyPSS(&key.PublicKey, crypto.SHA512, h[:], sig, &rsa.PSSOptions{
+		SaltLength: rsa.PSSSaltLengthEqualsHash,
+		Hash:       crypto.SHA512,
+	}); err != nil {
+		t.Fatalf("RSA-PSS signature verification failed: %v", err)
+	}
+}
+
+func TestVerifyPoP_RoundTrip(t *testing.T) {
+	payload := make([]byte, 64)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	ec384, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ec256, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, k := range map[string]struct {
+		priv crypto.PrivateKey
+		pub  crypto.PublicKey
+	}{
+		"ECDSA P-384": {ec384, &ec384.PublicKey},
+		"ECDSA P-256": {ec256, &ec256.PublicKey},
+		"RSA-PSS":     {rsaKey, &rsaKey.PublicKey},
+	} {
+		t.Run(name, func(t *testing.T) {
+			sig, err := signPoP(k.priv, payload)
+			if err != nil {
+				t.Fatalf("signPoP: %v", err)
+			}
+			if err := verifyPoP(k.pub, payload, sig); err != nil {
+				t.Fatalf("verifyPoP: %v", err)
+			}
+			// Tampering the payload must fail verification.
+			tampered := make([]byte, len(payload))
+			copy(tampered, payload)
+			tampered[0] ^= 0xff
+			if err := verifyPoP(k.pub, tampered, sig); err == nil {
+				t.Fatal("verifyPoP accepted a tampered payload")
+			}
+		})
+	}
+}

--- a/src/control/security/test/nodecert.go
+++ b/src/control/security/test/nodecert.go
@@ -1,0 +1,96 @@
+//
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// WriteNodeCert writes a self-signed per-pool node cert and key
+// (<poolUUID>.{crt,key}) to dir with the permissions the loader expects.
+func WriteNodeCert(t *testing.T, dir, poolUUID, cn string, notBefore, notAfter time.Time) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	if err := os.WriteFile(filepath.Join(dir, poolUUID+".crt"), certPEM, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(filepath.Join(dir, poolUUID+".key"), keyPEM, 0400); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ParseCert parses the first CERTIFICATE block in a PEM bundle.
+func ParseCert(t *testing.T, certPEM []byte) *x509.Certificate {
+	t.Helper()
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatal("pem.Decode returned nil block")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert
+}
+
+// NewLeafCert returns a leaf cert (PEM) with the given CN and validity,
+// signed by parent/parentKey, along with its private key.
+func NewLeafCert(t *testing.T, cn string, parent *x509.Certificate, parentKey *ecdsa.PrivateKey, notBefore, notAfter time.Time) ([]byte, *ecdsa.PrivateKey) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, &key.PublicKey, parentKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), key
+}

--- a/src/control/security/test/testca.go
+++ b/src/control/security/test/testca.go
@@ -1,0 +1,92 @@
+//
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+// Package test provides crypto fixtures for DAOS test code.
+package test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// NewCA returns a fresh CA cert (PEM) and its private key. If parent is
+// non-nil the new cert is signed by parent/parentKey; otherwise it is
+// self-signed.
+func NewCA(t *testing.T, cn string, parent *x509.Certificate, parentKey *ecdsa.PrivateKey) ([]byte, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	issuer := tmpl
+	signerKey := key
+	if parent != nil {
+		issuer = parent
+		signerKey = parentKey
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, issuer, &key.PublicKey, signerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), key
+}
+
+// CertFingerprint returns the SHA-256 fingerprint (hex) of a PEM cert.
+func CertFingerprint(t *testing.T, certPEM []byte) string {
+	t.Helper()
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatal("pem.Decode returned nil block")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(cert.Raw))
+}
+
+// WriteCAFiles writes a fresh self-signed CA cert + key into dir as
+// "test_ca.crt" / "test_ca.key" and returns their paths.
+func WriteCAFiles(t *testing.T, dir string) (keyPath, certPath string) {
+	t.Helper()
+	certPEM, key := NewCA(t, "Test CA", nil, nil)
+	certPath = filepath.Join(dir, "test_ca.crt")
+	if err := os.WriteFile(certPath, certPEM, 0644); err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath = filepath.Join(dir, "test_ca.key")
+	if err := os.WriteFile(keyPath,
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}),
+		0400); err != nil {
+		t.Fatal(err)
+	}
+	return keyPath, certPath
+}


### PR DESCRIPTION
Extend the security package with new types and utility methods
for managing per-pool node certificates. When per-pool auth
is enabled, clients must present a signed proof-of-possession
which is validated by the server before allowing a connection.

Subsequent commits will build on this infrastructure to
implement the full feature.

Patch: 3/8
Signed-off-by: Michael MacDonald <github@macdonald.cx>