### PR TITLE
DAOS-19246 test: use REBUILD_POOL_SIZE for dfs_extend_write_kill/_extend

### DIFF
--- a/src/tests/suite/daos_extend_common.c
+++ b/src/tests/suite/daos_extend_common.c
@@ -126,7 +126,7 @@ dfs_extend_internal(void **state, int opc, test_rebuild_cb_t extend_cb, bool kil
 	d_rank_t             extend_rank = 3;
 	char                 str[37];
 	daos_obj_id_t        oids[EXTEND_OBJ_NR];
-	struct extend_cb_arg cb_arg;
+	struct extend_cb_arg cb_arg = {0};
 	dfs_attr_t           attr = {};
 	int                  rc;
 

--- a/src/tests/suite/daos_extend_simple.c
+++ b/src/tests/suite/daos_extend_simple.c
@@ -522,9 +522,9 @@ static const struct CMUnitTest extend_tests[] = {
     {"EXTEND13: read object during extend and extend", dfs_extend_fetch_extend,
      rebuild_sub_3nodes_rf0_setup, test_teardown},
     {"EXTEND14: write object during extend and kill", dfs_extend_write_kill,
-     rebuild_sub_3nodes_rf0_setup, test_teardown},
+     rebuild_sub_3nodes_rf0_setup_rebuild_pool_size, test_teardown},
     {"EXTEND15: write object during extend and extend", dfs_extend_write_extend,
-     rebuild_sub_3nodes_rf0_setup, test_teardown},
+     rebuild_sub_3nodes_rf0_setup_rebuild_pool_size, test_teardown},
     {"EXTEND16: extend fail then retry", dfs_extend_fail_retry, rebuild_sub_3nodes_rf0_setup,
      test_teardown},
 };

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -1501,6 +1501,12 @@ rebuild_sub_rf0_setup(void **state)
 }
 
 int
+rebuild_sub_3nodes_rf0_setup_rebuild_pool_size(void **state)
+{
+	return rebuild_sub_setup_common(state, REBUILD_POOL_SIZE, 3, DAOS_PROP_CO_REDUN_RF0);
+}
+
+int
 rebuild_sub_3nodes_rf0_setup(void **state)
 {
 	return rebuild_sub_setup_common(state, REBUILD_SUBTEST_POOL_SIZE, 3,

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -506,6 +506,8 @@ rebuild_small_sub_rf0_setup(void **state);
 int
 rebuild_sub_3nodes_rf0_setup(void **state);
 int
+rebuild_sub_3nodes_rf0_setup_rebuild_pool_size(void **state);
+int
 rebuild_sub_6nodes_rf1_setup(void **state);
 int
 rebuild_sub_setup_common(void **state, daos_size_t pool_size, int node_nr, uint32_t rf);


### PR DESCRIPTION
In dfs_extend_write_kill() tests, hits -DER_NOSPACE in extend_cb_internal() -> case EXTEND_UPDATE's extend_write() -> dfs_write() assert_int_equal(rc, 0);
It then cause the test case abort and do cleanup - test_teardown() -> pool_destroy_safe() -> wait_rebuild hang, as in dfs_extend_internal() it set DAOS_REBUILD_TGT_SCAN_HANG but no chance to reset it when hit DER_NOSPACE and abort.

So increase dfs_extend_write_kill/_extend()'s pool size to REBUILD_POOL_SIZE to avoid that case.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
