### PR TITLE
DAOS-19413 cq: update githooks/get_branch to 2.6+

### DIFF
--- a/utils/githooks/get_branch
+++ b/utils/githooks/get_branch
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 # find the base branch of the current branch
-# base branches can be master, release/2.4+, release/3+
+# base branches can be master, release/2.6+, release/3+
 # or optionally branches passed into $1
 set -eu -o pipefail
 
@@ -28,7 +28,7 @@ for origin in $(git remote); do
     while IFS= read -r base; do
         builtin_bases+=("$base")
     done < <(echo "master"
-             git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[4-9]\|[3-9]\)/s/^  $origin\\///p")
+             git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[6-9]\|[3-9]\)/s/^  $origin\\///p")
     export ORIGIN="${origin}"
     export find_branches
     readarray -t branches <<< "$(find_branches)"


### PR DESCRIPTION
Update githooks/get_branch to look at 2.6+ since 2.4 is out of support.
This will speedup figuring out the release branch.

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
