### PR TITLE
DAOS-19416 fix DAV zone0 init on pool recreate over stale SCM

### DIFF
--- a/src/common/dav_v2/dav_iface.c
+++ b/src/common/dav_v2/dav_iface.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2015-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -286,8 +286,13 @@ dav_obj_open_internal(int fd, int flags, size_t scm_sz, const char *path, struct
 			err = rc;
 			goto out5;
 		}
-		heap_zinfo_init(hdl->do_heap, false);
+		rc = heap_zinfo_init(hdl->do_heap, false);
 		lw_tx_end(hdl, NULL);
+		if (rc) {
+			D_ERROR("Failed to initialize zinfo, rc = %d", daos_errno2der(rc));
+			err = rc;
+			goto out5;
+		}
 
 		rc = heap_update_mbrt_zinfo(hdl->do_heap);
 		if (rc) {

--- a/src/common/dav_v2/heap.c
+++ b/src/common/dav_v2/heap.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2015-2024, Intel Corporation
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+/* Copyright 2015-2024 Intel Corporation.
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  */
 
 /*
@@ -194,7 +194,7 @@ heap_zinfo_get_size(uint64_t *alloc_size, uint64_t *capacity)
 	*capacity   = ZINFO_CAPACITY;
 }
 
-void
+int
 heap_zinfo_init(struct palloc_heap *heap, bool is_create)
 {
 	struct zinfo_vec *zv;
@@ -202,7 +202,19 @@ heap_zinfo_init(struct palloc_heap *heap, bool is_create)
 	uint64_t          alloc_size, capacity;
 
 	heap_zinfo_get_size(&alloc_size, &capacity);
-	D_ASSERT(z0->header.zone0_zinfo_size == alloc_size);
+	if (z0->header.zone0_zinfo_size != alloc_size) {
+		/*
+		 * On create the zinfo array was just allocated, so the size must match. On
+		 * open a mismatch means zone0 was never initialized (e.g. an empty meta blob
+		 * left behind by an NVMe device replace) or is corrupt; report it instead of
+		 * aborting the engine so the caller can treat the shard as lost and recover it
+		 * via reintegration/rebuild.
+		 */
+		D_ASSERT(!is_create);
+		D_ERROR("zone0 zinfo size mismatch: stored %lu, expected %lu\n",
+			z0->header.zone0_zinfo_size, alloc_size);
+		return ENOENT;
+	}
 
 	heap->rt->zinfo_vec      = HEAP_OFF_TO_PTR(heap, z0->header.zone0_zinfo_off);
 	heap->rt->zinfo_vec_size = z0->header.zone0_zinfo_size;
@@ -225,6 +237,8 @@ heap_zinfo_init(struct palloc_heap *heap, bool is_create)
 	heap->rt->zones_exhausted    = 1;
 	heap->rt->zones_exhausted_ne = 1;
 	heap->rt->zones_exhausted_e  = 0;
+
+	return 0;
 }
 
 static void
@@ -2213,6 +2227,14 @@ heap_init(void *heap_start, uint64_t umem_cache_size, struct umem_store *store)
 
 	nzones = heap_max_zone(heap_size);
 	meta_clear_pages(store, sizeof(struct heap_header), 4096, ZONE_MAX_SIZE, nzones);
+
+	/*
+	 * The SCM cache backing file (zone0 is mapped at heap_start) may be reused with
+	 * stale content on a fresh create, e.g. pool recreate after an NVMe device replace
+	 * where only the SSD blobs are destroyed. Clear zone0's header so the create path
+	 * doesn't mistake the previous pool's still-valid magic for an initialized zone0.
+	 */
+	memset(heap_start, 0, sizeof(struct zone_header));
 
 	if (heap_write_header(store, heap_size, umem_cache_size, nemb_pct))
 		return ENOMEM;

--- a/src/common/dav_v2/heap.h
+++ b/src/common/dav_v2/heap.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2015-2024, Intel Corporation */
-/* (C) Copyright 2025 Hewlett Packard Enterprise Development LP */
+/*
+ * Copyright 2015-2024 Intel Corporation.
+ */
+/* (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP */
 
 /*
  * heap.h -- internal definitions for heap
@@ -70,7 +72,7 @@ int
 heap_update_mbrt_zinfo(struct palloc_heap *heap);
 void
 heap_zinfo_get_size(uint64_t *alloc_size, uint64_t *capacity);
-void
+int
 heap_zinfo_init(struct palloc_heap *heap, bool is_create);
 
 struct alloc_class *

--- a/src/mgmt/srv_query.c
+++ b/src/mgmt/srv_query.c
@@ -303,8 +303,11 @@ copy_str2ctrlr(char **dst, const char *src)
 {
 	int len;
 
-	D_ASSERT(src != NULL);
 	D_ASSERT(dst != NULL);
+	if (src == NULL) {
+		D_ERROR("source string is NULL\n");
+		return -DER_INVAL;
+	}
 
 	if ((*dst != NULL) && (strnlen(*dst, NVME_DETAIL_BUFLEN) != 0)) {
 		D_ERROR("attempting to copy to non-empty destination");
@@ -414,6 +417,26 @@ add_ctrlr_details(Ctl__NvmeController *ctrlr, struct bio_dev_info *dev_info)
 	return 0;
 }
 
+static int
+add_unplugged_ctrlr_details(Ctl__NvmeController *ctrlr, struct bio_dev_info *dev_info)
+{
+	int rc;
+
+	if (dev_info->bdi_ctrlr == NULL)
+		return 0;
+
+	if (dev_info->bdi_ctrlr->model != NULL) {
+		rc = copy_str2ctrlr(&ctrlr->model, dev_info->bdi_ctrlr->model);
+		if (rc != 0)
+			return rc;
+	}
+
+	if (dev_info->bdi_ctrlr->serial != NULL)
+		return copy_str2ctrlr(&ctrlr->serial, dev_info->bdi_ctrlr->serial);
+
+	return 0;
+}
+
 int
 ds_mgmt_smd_list_devs(Ctl__SmdDevResp *resp)
 {
@@ -484,6 +507,14 @@ ds_mgmt_smd_list_devs(Ctl__SmdDevResp *resp)
 		/* Set string fields to NULL to allow D_FREE to work as expected on cleanup */
 		ctrlr_reset_str_fields(resp->devices[i]->ctrlr);
 
+		if ((dev_info->bdi_flags & NVME_DEV_FL_PLUGGED) == 0) {
+			rc = add_unplugged_ctrlr_details(resp->devices[i]->ctrlr, dev_info);
+			if (rc != 0)
+				break;
+			resp->devices[i]->ctrlr->dev_state = CTL__NVME_DEV_STATE__UNPLUGGED;
+			goto next_dev;
+		}
+
 		if (dev_info->bdi_ctrlr != NULL) {
 			rc = add_ctrlr_details(resp->devices[i]->ctrlr, dev_info);
 			if (rc != 0)
@@ -495,10 +526,6 @@ ds_mgmt_smd_list_devs(Ctl__SmdDevResp *resp)
 
 		/* Populate NVMe device state */
 
-		if ((dev_info->bdi_flags & NVME_DEV_FL_PLUGGED) == 0) {
-			resp->devices[i]->ctrlr->dev_state = CTL__NVME_DEV_STATE__UNPLUGGED;
-			goto next_dev;
-		}
 		if ((dev_info->bdi_flags & NVME_DEV_FL_FAULTY) != 0)
 			resp->devices[i]->ctrlr->dev_state = CTL__NVME_DEV_STATE__EVICTED;
 		else if ((dev_info->bdi_flags & NVME_DEV_FL_INUSE) == 0)


### PR DESCRIPTION
When a VOS pool is recreated in place (e.g. reintegration after an NVMe device replace), vos_pool_kill destroys only the SSD blobs and the SCM cache backing file is reused. pool_reset_header skips MD-on-SSD and heap_init clears only the blob, so the tmpfs file still holds the previous pool's zone0 with a valid magic. heap_ensure_zone0_initialized then treats zone0 as already initialized and skips heap_populate_bucket, leaving zone0's page unmapped in the umem cache. The following obj_realloc touches the unmapped page and aborts the engine in cache_off2page (offset reads back as the 0x0f ptr2off poison).

Clear zone0's header in the SCM cache during heap_init so a fresh create never mistakes stale content for an initialized zone0. This is a no-op for a normal create where the backing file is already zeroed.

Also harden the open path: heap_zinfo_init now returns an error instead of asserting when zone0's zinfo size is unexpected, so an uninitialized/corrupt shard is reported as lost (-DER_NONEXIST) rather than aborting the whole engine.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
