### PR TITLE
DAOS-19412 mgmt: avoid engine abort on NVMe hot-remove

### DIFF
--- a/src/mgmt/srv_query.c
+++ b/src/mgmt/srv_query.c
@@ -303,8 +303,11 @@ copy_str2ctrlr(char **dst, const char *src)
 {
 	int len;
 
-	D_ASSERT(src != NULL);
 	D_ASSERT(dst != NULL);
+	if (src == NULL) {
+		D_ERROR("source string is NULL\n");
+		return -DER_INVAL;
+	}
 
 	if ((*dst != NULL) && (strnlen(*dst, NVME_DETAIL_BUFLEN) != 0)) {
 		D_ERROR("attempting to copy to non-empty destination");
@@ -414,6 +417,26 @@ add_ctrlr_details(Ctl__NvmeController *ctrlr, struct bio_dev_info *dev_info)
 	return 0;
 }
 
+static int
+add_unplugged_ctrlr_details(Ctl__NvmeController *ctrlr, struct bio_dev_info *dev_info)
+{
+	int rc;
+
+	if (dev_info->bdi_ctrlr == NULL)
+		return 0;
+
+	if (dev_info->bdi_ctrlr->model != NULL) {
+		rc = copy_str2ctrlr(&ctrlr->model, dev_info->bdi_ctrlr->model);
+		if (rc != 0)
+			return rc;
+	}
+
+	if (dev_info->bdi_ctrlr->serial != NULL)
+		return copy_str2ctrlr(&ctrlr->serial, dev_info->bdi_ctrlr->serial);
+
+	return 0;
+}
+
 int
 ds_mgmt_smd_list_devs(Ctl__SmdDevResp *resp)
 {
@@ -484,6 +507,14 @@ ds_mgmt_smd_list_devs(Ctl__SmdDevResp *resp)
 		/* Set string fields to NULL to allow D_FREE to work as expected on cleanup */
 		ctrlr_reset_str_fields(resp->devices[i]->ctrlr);
 
+		if ((dev_info->bdi_flags & NVME_DEV_FL_PLUGGED) == 0) {
+			rc = add_unplugged_ctrlr_details(resp->devices[i]->ctrlr, dev_info);
+			if (rc != 0)
+				break;
+			resp->devices[i]->ctrlr->dev_state = CTL__NVME_DEV_STATE__UNPLUGGED;
+			goto next_dev;
+		}
+
 		if (dev_info->bdi_ctrlr != NULL) {
 			rc = add_ctrlr_details(resp->devices[i]->ctrlr, dev_info);
 			if (rc != 0)
@@ -495,10 +526,6 @@ ds_mgmt_smd_list_devs(Ctl__SmdDevResp *resp)
 
 		/* Populate NVMe device state */
 
-		if ((dev_info->bdi_flags & NVME_DEV_FL_PLUGGED) == 0) {
-			resp->devices[i]->ctrlr->dev_state = CTL__NVME_DEV_STATE__UNPLUGGED;
-			goto next_dev;
-		}
 		if ((dev_info->bdi_flags & NVME_DEV_FL_FAULTY) != 0)
 			resp->devices[i]->ctrlr->dev_state = CTL__NVME_DEV_STATE__EVICTED;
 		else if ((dev_info->bdi_flags & NVME_DEV_FL_INUSE) == 0)


### PR DESCRIPTION
An unplugged NVMe device may have a partial controller object restored from SMD containing only its model and serial number. The SMD device query treated any controller object as complete and asserted while copying the missing PCI address.

Handle unplugged devices before serializing live controller details. Preserve the SMD-backed model and serial number, report the device as unplugged, and return an error instead of asserting on a missing source string.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
