### PR TITLE
DAOS-19121 tests: increase timeout for verify_dtx

### DIFF
--- a/src/tests/ftest/pool/verify_dtx.yaml
+++ b/src/tests/ftest/pool/verify_dtx.yaml
@@ -5,7 +5,7 @@ hosts:
   test_servers: 5
   test_clients: 3
 
-timeout: 600
+timeout: 800
 
 server_config:
   name: daos_server


### PR DESCRIPTION
The test verifies DTX metrics with mdtest against kinds of object classes. During the test, some factors may cause test to be slow, such as (VOS/EC) aggregation, backend TX overhead under md-on-ssd mode, network congestion, and so on. Anyway, performance is not the test purpose. So increasing the max allowed test time from 600 to 800 seconds to avoid unexpected timeout.

Test-tag-hw-large: test_verify_dtx_metrics

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
