### PR TITLE
DAOS-XXXXX vos: keep TX alive when DTX commit blob alloc hits ENOSPC

### DIFF
--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -806,6 +806,8 @@ pmem_tx_alloc(struct umem_instance *umm, size_t size, uint64_t flags, unsigned i
 		pflags |= POBJ_FLAG_ZERO;
 	if (flags & UMEM_FLAG_NO_FLUSH)
 		pflags |= POBJ_FLAG_NO_FLUSH;
+	if (flags & UMEM_FLAG_NO_ABORT)
+		pflags |= POBJ_XALLOC_NO_ABORT;
 	return umem_id2off(umm, pmemobj_tx_xalloc(size, type_num, pflags));
 }
 
@@ -1244,6 +1246,8 @@ bmem_tx_alloc(struct umem_instance *umm, size_t size, uint64_t flags, unsigned i
 		pflags |= DAV_FLAG_ZERO;
 	if (flags & UMEM_FLAG_NO_FLUSH)
 		pflags |= DAV_FLAG_NO_FLUSH;
+	if (flags & UMEM_FLAG_NO_ABORT)
+		pflags |= DAV_XALLOC_NO_ABORT;
 	return dav_tx_xalloc(size, type_num, pflags);
 }
 
@@ -1483,6 +1487,8 @@ bmem_tx_alloc_v2(struct umem_instance *umm, size_t size, uint64_t flags, unsigne
 		pflags |= DAV_FLAG_ZERO;
 	if (flags & UMEM_FLAG_NO_FLUSH)
 		pflags |= DAV_FLAG_NO_FLUSH;
+	if (flags & UMEM_FLAG_NO_ABORT)
+		pflags |= DAV_XALLOC_NO_ABORT;
 	if (mbkt_id != 0)
 		pflags |= DAV_EZONE_ID(mbkt_id);
 	return dav_tx_alloc_v2(size, type_num, pflags);

--- a/src/common/tests/umem_test.c
+++ b/src/common/tests/umem_test.c
@@ -360,6 +360,58 @@ done:
 	assert_int_equal(rc, 0);
 }
 
+/* A failed allocation with UMEM_FLAG_NO_ABORT must leave the transaction
+ * alive so in-tx fallbacks (e.g. vos_dtx_reuse_cmt_blob) keep working;
+ * without the flag the failure aborts the TX and any further tx_add is a
+ * fatal usage error in the allocator.
+ */
+static void
+test_alloc_no_abort(void **state)
+{
+	struct test_arg		*arg = *state;
+	struct umem_instance	*umm = utest_utx2umm(arg->ta_utx);
+	int			*value;
+	umem_off_t		 umoff = 0;
+	umem_off_t		 huge;
+	int			 rc;
+
+	rc = utest_tx_begin(arg->ta_utx);
+	if (rc != 0)
+		goto done;
+
+	/* Larger than the pool: must fail, but must NOT abort the TX */
+	huge = umem_alloc_verb(umm, UMEM_FLAG_ZERO | UMEM_FLAG_NO_ABORT,
+			       POOL_SIZE, UMEM_DEFAULT_MBKT_ID);
+	if (!UMOFF_IS_NULL(huge)) {
+		print_message("huge allocation unexpectedly succeeded\n");
+		rc = 1;
+		goto end;
+	}
+
+	/* TX still alive: alloc + snapshot + write must all work */
+	umoff = umem_zalloc(umm, 4);
+	if (UMOFF_IS_NULL(umoff)) {
+		print_message("small alloc failed after NO_ABORT failure\n");
+		rc = 1;
+		goto end;
+	}
+
+	value = umem_off2ptr(umm, umoff);
+	rc = umem_tx_add_ptr(umm, value, 4);
+	if (rc != 0) {
+		print_message("tx_add_ptr failed after NO_ABORT failure\n");
+		rc = 1;
+		goto end;
+	}
+	*value = 42;
+
+	rc = umem_free(umm, umoff);
+end:
+	rc = utest_tx_end(arg->ta_utx, rc);
+done:
+	assert_int_equal(rc, 0);
+}
+
 static int
 flush_prep(struct umem_store *store, struct umem_store_iod *iod, daos_handle_t *fh)
 {
@@ -757,6 +809,7 @@ main(int argc, char **argv)
 	    {"UMEM002: Test null flags vmem", test_invalid_flags, setup_vmem, teardown_vmem},
 	    {"UMEM003: Test alloc pmem", test_alloc, setup_pmem, teardown_pmem},
 	    {"UMEM004: Test alloc vmem", test_alloc, setup_vmem, teardown_vmem},
+	    {"UMEM010: Test alloc NO_ABORT pmem", test_alloc_no_abort, setup_pmem, teardown_pmem},
 	    {"UMEM005: Test page cache", test_page_cache, NULL, NULL},
 	    {"UMEM006: Test page cache many pages", test_many_pages, NULL, NULL},
 	    {"UMEM007: Test page cache many writes", test_many_writes, NULL, NULL},

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -681,6 +681,10 @@ struct umem_instance;
 #define UMEM_FLAG_ZERO		(((uint64_t)1) << 0)
 #define UMEM_FLAG_NO_FLUSH	(((uint64_t)1) << 1)
 #define UMEM_XADD_NO_SNAPSHOT	(((uint64_t)1) << 2)
+/* On allocation failure, return UMOFF_NULL without aborting the current
+ * transaction, so the caller can fall back to another strategy in-tx.
+ */
+#define UMEM_FLAG_NO_ABORT	(((uint64_t)1) << 3)
 
 /* Macros associated with Memory buckets */
 #define	UMEM_DEFAULT_MBKT_ID	0

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1293,8 +1293,14 @@ vos_dtx_extend_cmt_table(struct vos_container *cont)
 	umem_off_t              dbd_off = UMOFF_NULL;
 	int                     rc;
 
+	/* NO_ABORT: on ENOSPC the fallback below (vos_dtx_reuse_cmt_blob)
+	 * keeps working inside the same transaction; a plain alloc failure
+	 * would have aborted the tx and any further tx_add would be a fatal
+	 * usage error in the allocator (engine abort).
+	 */
 	if (!DAOS_FAIL_CHECK(DAOS_DTX_NOSPACE_NOREFRESH))
-		dbd_off = umem_zalloc(umm, DTX_CMT_BLOB_SIZE);
+		dbd_off = umem_alloc_verb(umm, UMEM_FLAG_ZERO | UMEM_FLAG_NO_ABORT,
+					  DTX_CMT_BLOB_SIZE, UMEM_DEFAULT_MBKT_ID);
 
 	if (UMOFF_IS_NULL(dbd_off))
 		return vos_dtx_reuse_cmt_blob(cont);


### PR DESCRIPTION
## Problem

`vos_dtx_extend_cmt_table()` allocates a new committed-DTX blob and, on failure, falls back to `vos_dtx_reuse_cmt_blob()` **inside the same transaction**:

```c
if (!DAOS_FAIL_CHECK(DAOS_DTX_NOSPACE_NOREFRESH))
        dbd_off = umem_zalloc(umm, DTX_CMT_BLOB_SIZE);

if (UMOFF_IS_NULL(dbd_off))
        return vos_dtx_reuse_cmt_blob(cont);
```

`umem_zalloc()` is a plain in-transaction allocation, so its **default failure behaviour aborts the transaction** — both PMDK and DAV abort unless `POBJ_XALLOC_NO_ABORT` / `DAV_XALLOC_NO_ABORT` is passed. `dav_v2.h` documents this explicitly:

> `POBJ_XALLOC_NO_ABORT` - if the function does not end successfully, do not abort the transaction and return the error number.

So on a real ENOSPC the TX is already dead when the fallback runs, and the `tx_add_range_direct()` it performs is a fatal usage error in the allocator — **the engine takes SIGABRT**.

## Why testing does not catch it

The only coverage is the `DAOS_DTX_NOSPACE_NOREFRESH` fault injection, and that check **skips the allocation entirely**:

```c
if (!DAOS_FAIL_CHECK(DAOS_DTX_NOSPACE_NOREFRESH))
        dbd_off = umem_zalloc(...);          // not executed under fault injection
```

With the fault injected the TX stays alive and the fallback behaves as intended. Only a genuine out-of-space allocation reaches the crash path.

## Fix

- Add `UMEM_FLAG_NO_ABORT` (`1 << 3`, distinct from `UMEM_XADD_NO_SNAPSHOT` `1 << 2`)
- Plumb it through the three allocator backends: `pmem_tx_alloc`, `bmem_tx_alloc`, `bmem_tx_alloc_v2`
- Use it for the blob allocation in `vos_dtx_extend_cmt_table()`

The allocation can then fail without killing the transaction, the fallback works as designed, and the operation returns `-DER_NOSPACE` instead of aborting the engine.

## Test

`UMEM010` added to `umem_test`: a `NO_ABORT` allocation larger than the pool must fail, and `alloc` / `tx_add_ptr` / write / commit must still succeed in the same transaction.

## Reproduction

MD-on-SSD engine, 400 MiB tmpfs SCM pool:

1. Fill the pool to ENOSPC
2. Run a create/unlink storm (1000 iterations) with mixed I/O

Before: engine takes SIGABRT with `vos_dtx_commit_internal()` in the backtrace.
After: engine survives, callers get `-DER_NOSPACE`.

## Notes

- **Draft**: the commit uses a `DAOS-XXXXX` placeholder. A Jira ticket needs to be filed per `CONTRIBUTING.md` before this is ready for review — happy to refile the commit once a number is assigned.
- Branched from a slightly older `master` (fork sync is blocked by a token scope limitation on this side). The four touched files are **unchanged** between that base and current `master`, so the patch applies identically — I can rebase on request.
