### PR TITLE
SRE-3954 testing a dfuse deadlock fix

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -1189,6 +1189,13 @@ ival_drop_inode(struct dfuse_inode_entry *inode);
 int
 ival_update_inode(struct dfuse_inode_entry *inode, double timeout);
 
+/* Queue a dentry for invalidation by the invalidation thread.  Request handlers must use this
+ * rather than calling fuse_lowlevel_notify_inval_entry() directly, which deadlocks against a
+ * client holding the parent inode lock.
+ */
+int
+ival_dentry_invalidate(fuse_ino_t parent, const char *name);
+
 int
 ival_init(struct dfuse_info *dfuse_info);
 

--- a/src/client/dfuse/inval.c
+++ b/src/client/dfuse/inval.c
@@ -113,6 +113,27 @@ struct inode_core {
  */
 #define EVICT_COUNT 8
 
+/* A dentry queued for immediate invalidation.
+ *
+ * fuse_lowlevel_notify_inval_entry() blocks in the kernel whilst it acquires the parent inode
+ * lock, so it must never be called from a fuse service thread.  A client performing any
+ * operation which takes that same lock (mkdir, rename, unlink, ...) holds it whilst waiting for
+ * dfuse to reply, so a service thread which blocks on it can never make progress.  With enough
+ * concurrency every service thread ends up blocked this way and the whole daemon deadlocks.
+ *
+ * Request handlers therefore queue the invalidation here and the invalidation thread performs
+ * the notify.  The invalidation becomes asynchronous, so a lookup racing with it may briefly
+ * still see the old dentry, but the queue is drained immediately on wakeup so the window is
+ * very small - and a stale dentry expires on its own, whereas the deadlock does not.
+ */
+struct ival_now_entry {
+	d_list_t   ine_list;
+	fuse_ino_t ine_parent;
+	char       ine_name[NAME_MAX + 1];
+};
+
+static D_LIST_HEAD(ival_now_list);
+
 static pthread_mutex_t   ival_lock = PTHREAD_MUTEX_INITIALIZER;
 static bool              ival_stop;
 static pthread_t         ival_thread;
@@ -200,6 +221,68 @@ out:
 	return (idx == EVICT_COUNT);
 }
 
+/* Queue a dentry for invalidation by the invalidation thread.
+ *
+ * Safe to call from a fuse request handler - see struct ival_now_entry above for why calling
+ * fuse_lowlevel_notify_inval_entry() directly from one is not.
+ */
+int
+ival_dentry_invalidate(fuse_ino_t parent, const char *name)
+{
+	struct ival_now_entry *ine;
+
+	D_ALLOC_PTR(ine);
+	if (ine == NULL)
+		return ENOMEM;
+
+	ine->ine_parent = parent;
+	strncpy(ine->ine_name, name, NAME_MAX + 1);
+	ine->ine_name[NAME_MAX] = '\0';
+
+	D_MUTEX_LOCK(&ival_lock);
+	d_list_add_tail(&ine->ine_list, &ival_now_list);
+	D_MUTEX_UNLOCK(&ival_lock);
+
+	sem_post(&ival_sem);
+
+	return 0;
+}
+
+/* Perform any queued immediate invalidations.  Runs on the invalidation thread only. */
+static void
+ival_drain_now_list(void)
+{
+	while (1) {
+		struct ival_now_entry *ine;
+		int                    rc;
+
+		D_MUTEX_LOCK(&ival_lock);
+		ine = d_list_pop_entry(&ival_now_list, struct ival_now_entry, ine_list);
+		D_MUTEX_UNLOCK(&ival_lock);
+
+		if (ine == NULL)
+			return;
+
+		if (ival_data.session_dead) {
+			D_FREE(ine);
+			continue;
+		}
+
+		DFUSE_TRA_DEBUG(&ival_data, "Invalidating entry %#lx " DF_DE, ine->ine_parent,
+				DP_DE(ine->ine_name));
+
+		rc = fuse_lowlevel_notify_inval_entry(ival_data.session, ine->ine_parent,
+						      ine->ine_name,
+						      strnlen(ine->ine_name, NAME_MAX));
+		if (rc && rc != -ENOENT && rc != -EBADF)
+			DHS_ERROR(&ival_data, -rc, "notify_inval_entry() failed");
+		if (rc == -EBADF)
+			ival_data.session_dead = true;
+
+		D_FREE(ine);
+	}
+}
+
 /* Main loop for eviction thread.  Spins until ready for exit waking after one second and iterates
  * over all newly expired dentries.
  */
@@ -226,6 +309,8 @@ ival_thread_fn(void *arg)
 			if (errno != ETIMEDOUT)
 				DS_ERROR(rc, "sem_wait");
 		}
+
+		ival_drain_now_list();
 
 		while (ival_loop(&sleep_time))
 			;
@@ -320,6 +405,13 @@ void
 ival_fini()
 {
 	struct dfuse_time_entry *dte, *dtep;
+	struct ival_now_entry   *ine;
+
+	/* Discard anything still queued for immediate invalidation.  The thread has stopped by
+	 * this point so there is nothing left to perform these.
+	 */
+	while ((ine = d_list_pop_entry(&ival_now_list, struct ival_now_entry, ine_list)) != NULL)
+		D_FREE(ine);
 
 	/* Walk the list, oldest first */
 	d_list_for_each_entry_safe(dte, dtep, &ival_data.time_entry_list, dte_list) {

--- a/src/client/dfuse/ops/setxattr.c
+++ b/src/client/dfuse/ops/setxattr.c
@@ -50,18 +50,21 @@ dfuse_cb_setxattr(fuse_req_t req, struct dfuse_inode_entry *inode,
 		 * If the xattr is to set a UNS entry point, and dentry_dir
 		 * caching is enabled then invalidate the dentry here, to force
 		 * a lookup which will check the xattr and return the linked
-		 * container.  The fuse header says this potentially deadlocks
-		 * however it does appear to work, and calling this after the
-		 * reply will introduce a race condition that future lookups
-		 * will be skipped.
+		 * container.
+		 *
+		 * This must not call fuse_lowlevel_notify_inval_entry() directly: it blocks in
+		 * the kernel taking the parent inode lock, which a concurrent mkdir/rename in
+		 * that directory holds whilst waiting for dfuse to reply.  Doing so from this
+		 * service thread deadlocks the whole daemon once every service thread is stuck
+		 * this way, which is exactly what concurrent UNS container creates into one
+		 * directory produce.  Queue it for the invalidation thread instead.
 		 */
 		if (duns_attr && inode->ie_dfs->dfc_dentry_dir_timeout > 0) {
-			struct dfuse_info *dfuse_info = fuse_req_userdata(req);
+			int rcq;
 
-			rc = fuse_lowlevel_notify_inval_entry(dfuse_info->di_session,
-							      inode->ie_parent, inode->ie_name,
-							      strnlen(inode->ie_name, NAME_MAX));
-			DFUSE_TRA_INFO(inode, "inval_entry() rc is %d", rc);
+			rcq = ival_dentry_invalidate(inode->ie_parent, inode->ie_name);
+			if (rcq != 0)
+				DHS_ERROR(inode, rcq, "Unable to queue dentry invalidation");
 		}
 		DFUSE_REPLY_ZERO(inode, req);
 		return;


### PR DESCRIPTION
Cancel-prev-build: false

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
