### PR TITLE
DAOS-19428 test: Add build param for Functional on SLES 15

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,7 @@ void updateRunStage() {
         'Functional on EL 8',
         'Functional on EL 9',
         'Functional on Leap 15',
+        'Functional on SLES 15',
         'Functional on Ubuntu 20.04',
         'Fault injection testing',
         'Test RPMs on EL 9',
@@ -218,6 +219,7 @@ void updateRunStage() {
             'Functional on EL 8': 'Build on EL 8',
             'Functional on EL 9': 'Build on EL 9',
             'Functional on Leap 15': 'Build on Leap 15',
+            'Functional on SLES 15': 'Build on Leap 15',
             'Functional Hardware Medium': hwBuildStage,
             'Functional Hardware Medium MD on SSD': hwBuildStage,
             'Functional Hardware Medium VMD': hwBuildStage,
@@ -627,6 +629,9 @@ pipeline {
         booleanParam(name: bashName('Functional on Leap 15'),
                      defaultValue: false,
                      description: 'Run the Functional on Leap 15 stage.')
+        booleanParam(name: bashName('Functional on SLES 15'),
+                     defaultValue: false,
+                     description: 'Run the Functional on SLES 15 stage.')
         booleanParam(name: bashName('Functional on Ubuntu 20.04'),
                      defaultValue: false,
                      description: 'Run the Functional on Ubuntu 20.04 stage.')


### PR DESCRIPTION
Add missing build parameter to control running the Functional on SLES 15 stage.

Quick-functional: true
Skip-test-hardware: true
Test-tag: always_passes

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
