### PR TITLE
DAOS-19439 test: only keep NLT logs that have findings

### DIFF
--- a/src/tests/nlt/README.md
+++ b/src/tests/nlt/README.md
@@ -67,6 +67,10 @@ The machine-readable artifacts are still produced for the Jenkins plugins:
 | `dnt.*.memcheck.xml`     | valgrind output                                      |
 | `nlt_logs/<class>/`      | raw `dnt*.log` DAOS/DFuse logs                        |
 
+By default only logs that produced a finding are kept (and fault-injection keeps only the
+iterations that crashed or reported something); the many clean per-command, DFuse and
+fault-location logs are dropped after analysis. Pass `--keep-logs` to retain every log.
+
 ## Package layout
 
 The former ~7k-line script is split into a dependency-ordered package (low level first):

--- a/src/tests/nlt/cli.py
+++ b/src/tests/nlt/cli.py
@@ -59,6 +59,8 @@ def main():
                              '(default nlt-summary[-<class-name>].md, "" to disable)')
     parser.add_argument('--suite', default='ci', choices=['ci', 'manual', 'all'],
                         help='which test suite to run: ci (default), manual (long/opt-in), or all')
+    parser.add_argument('--keep-logs', action='store_true',
+                        help='keep every log; by default only logs with findings are retained')
     parser.add_argument('--perf-check', action='store_true')
     parser.add_argument('--log-usage-import')
     parser.add_argument('--log-usage-export')

--- a/src/tests/nlt/fault_injection.py
+++ b/src/tests/nlt/fault_injection.py
@@ -75,6 +75,7 @@ class AllocFailTestRun():
         self._stderr = None
         self._fi_loc = None
         self._cwd = cwd
+        self._issues_before = 0
 
         if loc:
             prefix = f'dnt_{loc:04d}_'
@@ -164,7 +165,65 @@ class AllocFailTestRun():
 
         self._post(self._sp.wait())
 
+    def _significant_issues(self, wf):
+        """Count findings that warrant keeping this iteration's log.
+
+        Injecting a fault legitimately makes the code log the allocation failure next to the
+        fault site, which cart_logtest reports as 'Logging allocation failure' plus a 'Fault
+        injection location' summary.  Those are expected consequences, not defects, so they are
+        still reported but do not by themselves retain the log.  Every other finding (leaks,
+        strict-mode warnings/errors, ...) does.
+        """
+        total = 0
+        for issue in wf.issues:
+            if issue.get('description') == 'Logging allocation failure':
+                continue
+            if issue.get('category') == 'Fault injection location':
+                continue
+            total += 1
+        return total
+
+    def _issue_total(self):
+        """Number of significant findings so far, used to tell if this iteration is of interest."""
+        total = self._significant_issues(self._aft.conf.wf)
+        if self._aft.wf is not self._aft.conf.wf:
+            total += self._significant_issues(self._aft.wf)
+        return total
+
+    def _prune_log(self, force_keep=False):
+        """Keep this iteration's log only if it is interesting; most fault locations are not.
+
+        A run is interesting if it crashed, if a check raised, or if it produced a finding.  A
+        clean run - including one where the fault was simply not injected (e.g. the reference run
+        and the many boundary iterations past the last allocation) - has no debugging value.
+        """
+        if self.returncode is None:
+            return
+        conf = self._aft.conf
+        interesting = force_keep or self.returncode < 0 \
+            or self._issue_total() > self._issues_before
+        if getattr(conf.args, 'keep_logs', False) or interesting:
+            conf.compress_file(self.log_file)
+        else:
+            try:
+                os.unlink(self.log_file)
+            except FileNotFoundError:
+                pass
+
     def _post(self, rc):
+        """Run the completion checks, then keep or drop this iteration's log."""
+        self._issues_before = self._issue_total()
+        keep = False
+        try:
+            self._post_checks(rc)
+        except Exception:
+            # A check raised (unexpected output/return code); keep the log for debugging.
+            keep = True
+            raise
+        finally:
+            self._prune_log(force_keep=keep)
+
+    def _post_checks(self, rc):
         """Helper function, called once after command is complete.
 
         This is where all the checks are performed.
@@ -217,7 +276,8 @@ class AllocFailTestRun():
                                     ignore_busy=self._aft.ignore_busy,
                                     quiet=True,
                                     skip_fi=True,
-                                    leak_wf=wf)
+                                    leak_wf=wf,
+                                    defer_prune=True)
             self.fault_injected = True
             assert self._fi_loc
         except NLTestNoFi:

--- a/src/tests/nlt/logging_utils.py
+++ b/src/tests/nlt/logging_utils.py
@@ -161,7 +161,8 @@ def log_test(conf,
              ignore_busy=False,
              check_read=False,
              check_write=False,
-             check_fstat=False):
+             check_fstat=False,
+             defer_prune=False):
     """Run the log checker on filename, logging to stdout"""
     # pylint: disable=too-many-arguments
 
@@ -189,10 +190,6 @@ def log_test(conf,
 
     log_iter = nlt_lp.LogIter(filename)
 
-    # LogIter will have opened the file and seek through it as required, so start a background
-    # process to compress it in parallel with the log tracing.
-    conf.compress_file(filename)
-
     lto = nlt_lt.LogTest(log_iter, quiet=quiet)
 
     # Add the code coverage tracer.
@@ -207,36 +204,59 @@ def log_test(conf,
     if ignore_busy:
         lto.skip_suffixes.append(" DER_BUSY(-1012): 'Device or resource busy'")
 
+    def _issue_total():
+        """Findings recorded so far, used to tell whether this log produced any."""
+        total = len(conf.wf.issues) if conf.wf else 0
+        if leak_wf is not None and leak_wf is not conf.wf:
+            total += len(leak_wf.issues)
+        return total
+
+    issues_before = _issue_total()
+    keep = getattr(conf.args, 'keep_logs', False)
     try:
-        lto.check_log_file(abort_on_warning=True,
-                           show_memleaks=show_memleaks,
-                           leak_wf=leak_wf)
-    except nlt_lt.LogCheckError:
-        pass
+        try:
+            lto.check_log_file(abort_on_warning=True,
+                               show_memleaks=show_memleaks,
+                               leak_wf=leak_wf)
+        except nlt_lt.LogCheckError:
+            pass
 
-    if skip_fi:
-        if not lto.fi_triggered:
-            raise NLTestNoFi
+        if skip_fi:
+            if not lto.fi_triggered:
+                raise NLTestNoFi
 
-    if check_read or check_write or check_fstat:
-        for line in log_iter.new_iter():
-            if line.function != "ioil_show_summary":
-                continue
-            print(line.get_msg())
+        if check_read or check_write or check_fstat:
+            for line in log_iter.new_iter():
+                if line.function != "ioil_show_summary":
+                    continue
+                print(line.get_msg())
 
-            # These numbers match the D_INFO log line in the ioil_show_summary function.
-            if check_read and int(line.get_field(3)) == 0:
-                raise NLTestIlZeroCall('read')
+                # These numbers match the D_INFO log line in the ioil_show_summary function.
+                if check_read and int(line.get_field(3)) == 0:
+                    raise NLTestIlZeroCall('read')
 
-            if check_write and int(line.get_field(5)) == 0:
-                raise NLTestIlZeroCall('write')
+                if check_write and int(line.get_field(5)) == 0:
+                    raise NLTestIlZeroCall('write')
 
-            if check_fstat and int(line.get_field(8)) == 0:
-                raise NLTestIlZeroCall('fstat')
+                if check_fstat and int(line.get_field(8)) == 0:
+                    raise NLTestIlZeroCall('fstat')
 
-    if conf.max_log_size and fstat.st_size > conf.max_log_size:
-        message = (f'Max log size exceeded, {sizeof_fmt(fstat.st_size)} > '
-                   + sizeof_fmt(conf.max_log_size))
-        conf.wf.add_test_case('logfile_size', failure=message)
+        if conf.max_log_size and fstat.st_size > conf.max_log_size:
+            message = (f'Max log size exceeded, {sizeof_fmt(fstat.st_size)} > '
+                       + sizeof_fmt(conf.max_log_size))
+            conf.wf.add_test_case('logfile_size', failure=message)
+    except Exception:  # pylint: disable=broad-exception-caught
+        # Preserve the log on any error/abort path (fault not injected, IL check, etc.).
+        keep = True
+        raise
+    finally:
+        # Keep a log only if it produced a finding (or --keep-logs).  Fault-injection logs are
+        # pruned by the fault-injection framework instead, once it knows if the run was of
+        # interest, so leave those untouched here.
+        if not defer_prune:
+            if keep or _issue_total() > issues_before:
+                conf.compress_file(filename)
+            else:
+                os.unlink(filename)
 
     return lto.fi_location

--- a/src/tests/nlt/server.py
+++ b/src/tests/nlt/server.py
@@ -448,10 +448,15 @@ class DaosServer():
 
         self.conf.compress_file(self.agent_log.name)
         self.conf.compress_file(self.control_log.name)
+        self.conf.compress_file(self.helper_log.name)
 
+        # Always keep the shared server logs; analyze the engine log for findings but do not let
+        # log_test prune it.  Only the client logs (per-command/dfuse/FI) are pruned when clean.
         for log in self.server_logs:
-            log_test(self.conf, log.name, leak_wf=wf, skip_fi=self._fi)
-            self.server_logs.remove(log)
+            log_test(self.conf, log.name, leak_wf=wf, skip_fi=self._fi, defer_prune=True)
+            if os.path.exists(log.name):
+                self.conf.compress_file(log.name)
+        self.server_logs = []
         self.running = False
         return ret
 


### PR DESCRIPTION
NLT kept a compressed copy of every log it analyzed, so a CI run archived thousands of dnt_*.log.bz2 files (one per daos command, per DFuse mount, and per fault-injection location), making the artifacts very hard to navigate. The vast majority are from work that passed and contain nothing of interest.

log_test() now decides retention after analysis: a log is kept (and compressed) only if it produced a finding, otherwise it is deleted. Any error/abort path still preserves the log. This is safe under the parallel POSIX test threads because findings only ever add to the count, so the worst case is keeping an extra clean log, never dropping one that had a finding.

Fault injection prunes per iteration: an AllocFailTestRun log is kept only when the run is interesting (the process crashed, the fault was not injected, or it reported a finding); the many clean fault-location logs are dropped. FI calls log_test(defer_prune=True) so log_test leaves FI logs alone and the framework owns their retention, avoiding compress-then-delete work. A separate defer_prune flag is used rather than the existing skip_fi, which is also used to hide FI calls during server-log analysis and would otherwise leave FI-enabled server logs uncompressed.

Add --keep-logs to retain every log for deep local debugging, and document the behavior in utils/nlt/README.md.

Skip-unit-test: true
skip-unit-test-memcheck: true
skip-unit-test-bdev: true
skip-functional: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
