### PR TITLE
DAOS-16759 test: extend_simple wait for rebuild start before FI clear…

### DIFF
--- a/src/tests/suite/daos_extend_common.c
+++ b/src/tests/suite/daos_extend_common.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -180,8 +180,13 @@ dfs_extend_internal(void **state, int opc, test_rebuild_cb_t extend_cb, bool kil
 	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 			      DAOS_REBUILD_TGT_SCAN_HANG | DAOS_FAIL_ALWAYS, 0, NULL);
 
-	arg->no_rebuild =
-	    1; /* This has no effect for RB_OP_TYPE_ADD - so can this be removed here? */
+	/*
+	 * For RB_OP_TYPE_ADD, rebuild_targets() still performs the extend and invokes
+	 * rebuild_cb, but no_rebuild=1 disables its internal waits
+	 * (test_rebuild_wait_to_start_next/test_rebuild_wait). Therefore,
+	 * extend_single_pool_rank() returns without waiting for rebuild completion.
+	 */
+	arg->no_rebuild = 1;
 	extend_single_pool_rank(arg, extend_rank);
 	arg->no_rebuild = 0;
 

--- a/src/tests/suite/daos_extend_simple.c
+++ b/src/tests/suite/daos_extend_simple.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -247,8 +247,17 @@ extend_cb_internal(void *arg)
 	int                   rc;
 	int                   i;
 
-	print_message("Extending, sleep 10, %s another rank %u, and start op %d (%s)\n", pre_op,
-		      cb_arg->rank, opc, extend_opstrs[opc]);
+	/* Wait for first extend to start (immediate return expected since it's running).
+	 * We want a post-effect: test_arg->pool.pool_info.pi_rebuild_st has the first rs_version.
+	 * Then later we can wait for the second rebuild to start with another similar call.
+	 */
+	print_message("before waiting for rebuild to start, pmap_ver=%u, rs_version=%u\n",
+		      test_arg->pool.pool_info.pi_map_ver,
+		      test_arg->pool.pool_info.pi_rebuild_st.rs_version);
+	test_rebuild_wait_to_start_next(&test_arg, 1);
+	print_message("Extending (rs_version=%u), sleep 10, %s rank %u, and start op %d (%s)\n",
+		      test_arg->pool.pool_info.pi_rebuild_st.rs_version, pre_op, cb_arg->rank, opc,
+		      extend_opstrs[opc]);
 
 	sleep(10);
 
@@ -314,7 +323,15 @@ extend_cb_internal(void *arg)
 		break;
 	}
 
-	daos_debug_set_params(test_arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
+	if (cb_arg->kill) {
+		print_message(
+		    "extend_cb_internal: waiting for next rebuild start before clearing FI\n");
+		test_rebuild_wait_to_start_next(&test_arg, 1);
+	}
+
+	print_message("extend_cb_internal: clear FI via daos_debug_set_params()\n");
+	rc = daos_debug_set_params(test_arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
+	assert_success(rc);
 
 	return 0;
 }


### PR DESCRIPTION
… (#18662)

Adjust the daos_extend_simple kill path (e.g., for EXTEND14 test) to wait for the combined extend+exclude rebuild to start before clearing the rebuild scan hang fault injection. And add debug print messages around key events in the test sequence.

Test-tag: test_daos_extend_simple
Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-test-rpms: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
