### PR TITLE
DAOS-17813 doc: Remove outdated note about system names

### DIFF
--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -12,8 +12,6 @@
 # Specify the associated DAOS systems.
 # Name must match name specified in the daos_server.yml file on the server.
 #
-# NOTE: changing the name is not supported yet, it must be daos_server
-#
 # default: daos_server
 #name: daos_server
 

--- a/utils/config/daos_control.yml
+++ b/utils/config/daos_control.yml
@@ -12,8 +12,6 @@
 # Specify the associated DAOS systems.
 # Name must match name specified in the daos_server.yml file on the server.
 #
-# NOTE: Changing the name is not supported yet, it must be daos_server
-#
 # default: daos_server
 #name: daos_server
 

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -8,9 +8,6 @@
 ## Name associated with the DAOS system.
 ## Immutable after running "dmg storage format".
 #
-## NOTE: Changing the DAOS system name is not supported yet.
-##       It must not be changed from the default "daos_server".
-#
 ## default: daos_server
 #name: daos_server
 #


### PR DESCRIPTION
Custom system names are supported. The text on the config examples was out of date.

Doc-only: true

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
