### PR TITLE
DAOS-19360 test: Handle abrupt EOF

### DIFF
--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -489,6 +489,9 @@ class LogIter():
         self.file_corrupt = False
 
         self.bz2 = False
+        # Track whether the logfile ended without a trailing newline.
+        # This is common when a process is terminated abruptly (e.g. SIGKILL).
+        self.truncated_eof = False
 
         # Force check encoding for smaller files.
         stbuf = os.stat(fname)
@@ -552,6 +555,7 @@ class LogIter():
         index = 0
         for line in self._fd:
             index += 1
+            self.truncated_eof = not line.endswith('\n')
             if not LogLine.is_valid(line):
                 self._data.append(LogRaw(line))
             else:
@@ -573,6 +577,7 @@ class LogIter():
         position = 0
         for line in self._fd:
             index += 1
+            self.truncated_eof = not line.endswith('\n')
             if not LogLine.is_valid(line):
                 position += len(line)
                 continue

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -340,7 +340,7 @@ class LogTest():
         warnings_strict = False
         warnings_mode = False
         server_shutdown = False
-        abrupt_eof = getattr(self._li, 'truncated_eof', False)
+        abrupt_eof = self._li.truncated_eof
 
         error_files = set()
 

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -340,6 +340,7 @@ class LogTest():
         warnings_strict = False
         warnings_mode = False
         server_shutdown = False
+        abrupt_eof = getattr(self._li, 'truncated_eof', False)
 
         error_files = set()
 
@@ -540,7 +541,10 @@ class LogTest():
         if active_desc:
             for (_, line) in list(active_desc.items()):
                 show_line(line, 'NORMAL', 'desc not deregistered', custom=leak_wf)
-            raise ActiveDescriptors()
+            if abrupt_eof:
+                print('WARNING: log ended abruptly; skipping descriptor leak failure')
+            else:
+                raise ActiveDescriptors()
 
         if active_rpcs:
             for (_, line) in list(active_rpcs.items()):
@@ -548,7 +552,10 @@ class LogTest():
         if error_files or err_count:
             raise LogError()
         if not self.ftest_mode and mem_r.lost_memory:
-            raise NotAllFreed()
+            if abrupt_eof:
+                print('WARNING: log ended abruptly; skipping memory leak failure')
+            else:
+                raise NotAllFreed()
         if warnings_strict:
             raise WarningStrict()
         if warnings_mode:


### PR DESCRIPTION
- Handle abrupt EOF in logs; happens if server is SIGKILL-ed

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
