### PR TITLE
DAOS-19406 test: Add testing for daos container del-attr

### DIFF
--- a/src/tests/ftest/container/query_attribute.py
+++ b/src/tests/ftest/container/query_attribute.py
@@ -1,11 +1,13 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import base64
 
 from apricot import TestWithServers
+from exception_utils import CommandFailure
 from general_utils import report_errors
 
 # Test container set-attr, get-attr, and list-attrs with different
@@ -39,43 +41,44 @@ class ContainerQueryAttributeTest(TestWithServers):
     """Test class for daos container query and attribute tests.
 
     Test Class Description:
-        Query test: Create a pool, create a container, and call daos container
-        query. From the output, verify the pool/container UUID matches the one
-        that was returned when creating the pool/container.
+        Query test: Create a pool, create a container, and call daos container query. From the
+        output, verify the pool/container UUID matches the one that was returned when creating the
+        pool/container.
 
         Attribute test:
-        1. Prepare 7 types of strings; alphabets, numbers, special characters,
-        etc.
-        2. Create attributes with each of these 7 types in attr and value;
-        i.e., 14 total attributes are created.
-        3. Call get-attr for each of the 14 attrs and verify the returned
-        values.
-        4. Call list-attrs and verify the returned attrs.
+        1. Prepare 7 types of strings; alphabets, numbers, special characters, etc.
+        2. Create attributes with each of these 7 types in attr and value; i.e., 14 total attributes
+        are created.
+        3. Call get-attr for each of the 14 attrs and verify the returned values.
+        4. Added by DAOS-19406: Call del-attr for each of the 14 attrs and verify that it's deleted.
+        5. Call list-attrs and verify the returned attrs.
+        6. Added by DAOS-19406: Delete all attributes at once and call list-attrs and verify that
+        the returned list is empty.
 
     :avocado: recursive
     """
 
     def test_container_query_attr(self):
-        """JIRA ID: DAOS-4640
-
-        Test Description:
-            Test daos container query and attribute commands as described
-            above.
+        """Test daos container query and attribute commands as described above.
 
         Use Cases:
-            Test container query, set-attr, get-attr, and list-attrs.
+            Test container query, set-attr, get-attr, list-attrs, and del-attr.
+
+        Original Jira: DAOS-4640
+        Adding delete test Jira: DAOS-19406
 
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container,daos_cmd
         :avocado: tags=ContainerQueryAttributeTest,test_container_query_attr
         """
-        # Create a pool and a container.
-        pool = self.get_pool()
+        self.log_step("Create a pool and a container.")
+        pool = self.get_pool(connect=False)
         container = self.get_container(pool)
 
         # Call daos container query, obtain pool and container UUID, and
         # compare against those used when creating the pool and the container.
+        self.log_step("Query container and verify pool and container UUID.")
         data = container.query()['response']
         actual_pool_uuid = data['pool_uuid']
         actual_cont_uuid = data['container_uuid']
@@ -98,11 +101,12 @@ class ContainerQueryAttributeTest(TestWithServers):
                     attr_values.append([test_string, "attr" + str(attr_idx)])
                 attr_idx += 1
 
-        # Set and verify get-attr.
+        self.log_step("Set attribute and verify with get-attr.")
         errors = []
         expected_attrs = []
 
         for attr_value in attr_values:
+            self.log.info("attr_value to set and get = {}".format(attr_value))
             container.set_attr(attrs={attr_value[0]: attr_value[1]})
 
             data = container.get_attr(attr_value[0])['response']
@@ -128,10 +132,27 @@ class ContainerQueryAttributeTest(TestWithServers):
 
         report_errors(self, errors)
 
-        # Verify that attr-lists works with test_strings.
+        self.log_step("Verify that list-attrs works with test_strings.")
         expected_attrs.sort()
         actual_attrs = sorted(list(container.list_attrs()['response']))
         self.assertEqual(actual_attrs, expected_attrs, 'list-attrs does not match set-attr')
+
+        # For each attribute, delete it and check with list-attrs and get-attr that it was deleted.
+        self.log_step("Delete check.")
+        for attr_value in attr_values:
+            container.del_attr(key=attr_value[0])
+            try:
+                container.get_attr(attr_value[0])
+                self.fail(f"get-attr with deleted attribute ({attr_value[0]}) worked!")
+            except CommandFailure as error:
+                msg = (f"get-attr with deleted attribute ({attr_value[0]}) failed as expected. "
+                       f"{error}")
+                self.log.info(msg)
+            attr_list = container.list_attrs()['response']
+            self.log.info("attr_list after deleting one attr = {}".format(attr_list))
+            if attr_value[0] in attr_list:
+                msg = f"Deleted attr ({attr_value[0]}) is in the list {attr_list}!"
+                self.fail(msg)
 
     def test_container_query_attrs(self):
         """JIRA ID: DAOS-4640
@@ -209,28 +230,42 @@ class ContainerQueryAttributeTest(TestWithServers):
         report_errors(self, errors)
 
     def test_list_attrs_long(self):
-        """JIRA ID: DAOS-4640
-
-        Test Description:
-            Set many attributes and verify list-attrs works.
+        """Set many attributes and verify list-attrs works. Delete all attributes at once and check
+        that list-attrs returns empty list.
 
         Use Cases:
             Test daos container list-attrs with 50 attributes.
+            Test daos container del-attr with 50 attributes.
+
+        Original Jira: DAOS-4640
+        Adding delete test Jira: DAOS-19406
 
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container,daos_cmd
         :avocado: tags=ContainerQueryAttributeTest,test_list_attrs_long
         """
-        # Create a pool and a container.
-        pool = self.get_pool()
+        self.log_step("Create a pool and a container.")
+        pool = self.get_pool(connect=False)
         container = self.get_container(pool)
 
         expected_attrs = {"attr" + str(idx): "val" + str(idx) for idx in range(50)}
 
+        self.log_step("Set the 50 attributes.")
         container.set_attr(attrs=expected_attrs)
 
+        self.log_step("List the 50 attributes and verify.")
         actual_attr_names = sorted(list(container.list_attrs()['response']))
         expected_attr_names = sorted(expected_attrs.keys())
         self.assertEqual(
             actual_attr_names, expected_attr_names, "Unexpected output from list_attrs")
+
+        self.log_step("Delete all attributes at once and check that list_attrs returns empty list.")
+        attr_list = ",".join(expected_attrs.keys())
+        container.del_attr(key=attr_list)
+        attr_list = container.list_attrs()['response']
+        self.log.info("attr_list after delete = {}".format(attr_list))
+        if attr_list:
+            self.fail(
+                "All attrs should have been deleted, but returned list is non-empty! {}".format(
+                    attr_list))

--- a/src/tests/ftest/container/query_attribute.py
+++ b/src/tests/ftest/container/query_attribute.py
@@ -106,7 +106,7 @@ class ContainerQueryAttributeTest(TestWithServers):
         expected_attrs = []
 
         for attr_value in attr_values:
-            self.log.info("attr_value to set and get = {}".format(attr_value))
+            self.log.info("attr_value to set and get = %s", attr_value)
             container.set_attr(attrs={attr_value[0]: attr_value[1]})
 
             data = container.get_attr(attr_value[0])['response']
@@ -149,7 +149,7 @@ class ContainerQueryAttributeTest(TestWithServers):
                        f"{error}")
                 self.log.info(msg)
             attr_list = container.list_attrs()['response']
-            self.log.info("attr_list after deleting one attr = {}".format(attr_list))
+            self.log.info("attr_list after deleting one attr = %s", attr_list)
             if attr_value[0] in attr_list:
                 msg = f"Deleted attr ({attr_value[0]}) is in the list {attr_list}!"
                 self.fail(msg)
@@ -264,7 +264,7 @@ class ContainerQueryAttributeTest(TestWithServers):
         attr_list = ",".join(expected_attrs.keys())
         container.del_attr(key=attr_list)
         attr_list = container.list_attrs()['response']
-        self.log.info("attr_list after delete = {}".format(attr_list))
+        self.log.info("attr_list after delete = %s", attr_list)
         if attr_list:
             self.fail(
                 "All attrs should have been deleted, but returned list is non-empty! {}".format(

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -735,6 +735,19 @@ class DaosCommand(DaosCommandBase):
         return self._get_json_result(
             ("container", "list-attrs"), pool=pool, cont=cont, sys_name=sys_name, verbose=verbose)
 
+    def container_del_attr(self, pool, cont, key, sys_name=None):
+        """Call daos container del-attr.
+
+        Args:
+            pool (str): Pool UUID or label.
+            cont (str): Container UUID or label.
+            key (str): Attribute to delete. If deleting multiple attributes, separate them with
+            comma.
+            sys_name (str, optional): DAOS system name context for servers. Defaults to None.
+        """
+        return self._get_result(
+            ("container", "del-attr"), pool=pool, cont=cont, key=key, sys_name=sys_name)
+
     def container_list_objects(self, pool, cont, sys_name=None):
         """Call daos container list-objects.
 

--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -314,12 +314,12 @@ class DaosCommandBase(CommandWithSubCommand):
                 self.snap = FormattedParameter("--snap={}")
 
         class DelAttrSubCommand(CommonContainerSubCommand):
-            """Defines an object for the daos container del-attrs command."""
+            """Defines an object for the daos container del-attr command."""
 
             def __init__(self):
-                """Create a daos container del-attrs command object."""
+                """Create a daos container del-attr command object."""
                 super().__init__("del-attr")
-                self.attr = BasicParameter(None, position=3)
+                self.key = BasicParameter(None, position=3)
 
         class DeleteAclSubCommand(CommonContainerSubCommand):
             """Defines an object for the daos container delete-acl command."""

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -1183,3 +1183,19 @@ class TestContainer(TestDaosApiBase):  # pylint: disable=too-many-public-methods
         """
         return self.daos.container_update_acl(
             pool=self.pool.identifier, cont=self.identifier, *args, **kwargs)
+
+    def del_attr(self, *args, **kwargs):
+        """Call daos container del-attr.
+
+        Args:
+            args (tuple, optional): args to pass to container_del_attr
+            kwargs (dict, optional): keyword args to pass to container_del_attr
+
+        Returns:
+            str: JSON output of daos container get-attr.
+
+        Raises:
+            CommandFailure: Raised from the daos command call.
+        """
+        return self.daos.container_del_attr(
+            pool=self.pool.identifier, cont=self.identifier, *args, **kwargs)


### PR DESCRIPTION
In test_container_query_attr, add steps to delete an attribute and check that get-attr to it fails. Then call list-attrs to check that the deleted attribute doesn't appear in the list.

In test_list_attrs_long, add steps to delete all attributes at once and call list-attr to check that it returns an empty list.

Add del-attr support to daos_utils.py, test_utils_container.py, and daos_utils_base.py.

Skip-fault-injection-test: true
Skip-func-hw-test-medium: false
Test-tag: test_container_query_attr test_list_attrs_long

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
