### PR TITLE
DAOS-19429 rebuild: add global EC aggregation barrier

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -63,10 +63,11 @@ agg_rate_ctl(void *arg)
 		return -1;
 
 	/*
-	 * XXX temporary workaround: EC aggregation needs to be paused during rebuilding
-	 * to avoid the race between EC rebuild and EC aggregation.
+	 * EC aggregation needs to be paused by the rebuild EC agg barrier to avoid
+	 * the race between EC rebuild and EC aggregation.
 	 **/
-	if (ds_pool_is_rebuilding(pool) && cont->sc_ec_agg_active && !param->ap_vos_agg)
+	if (!param->ap_vos_agg && cont->sc_ec_agg_active &&
+	    ds_pool_child_ec_agg_paused(cont->sc_pool))
 		return -1;
 
 	/* When system is idle or under space pressure, let aggregation run in tight mode */
@@ -207,10 +208,10 @@ cont_aggregate_runnable(struct ds_cont_child *cont, struct sched_request *req,
 		return false;
 	}
 
-	if (ds_pool_is_rebuilding(pool) && !vos_agg) {
-		D_DEBUG(DB_EPC, DF_CONT ": skip EC aggregation during rebuild %d, %d.\n",
+	if (ds_pool_child_ec_agg_paused(cont->sc_pool) && !vos_agg) {
+		D_DEBUG(DB_EPC, DF_CONT ": skip EC aggregation during pause gate %u.\n",
 			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
-			atomic_load(&pool->sp_rebuilding), atomic_load(&pool->sp_rebuild_enum));
+			atomic_load(&cont->sc_pool->spc_ec_agg_pause_gate));
 		return false;
 	}
 
@@ -511,10 +512,8 @@ next:
 		if (dss_ult_exiting(req))
 			break;
 
-		/* sleep 18 seconds for EC aggregation ULT if the pool is in rebuilding,
-		 * if no space pressure.
-		 */
-		if (ds_pool_is_rebuilding(cont->sc_pool->spc_pool) && !param->ap_vos_agg &&
+		/* Sleep longer while the rebuild EC agg barrier is active if no space pressure. */
+		if (ds_pool_child_ec_agg_paused(cont->sc_pool) && !param->ap_vos_agg &&
 		    msecs != 200)
 			msecs = 18000;
 
@@ -964,11 +963,11 @@ ds_cont_child_reset_ec_agg_eph_all(struct ds_pool_child *pool_child)
 
 #define WAIT_EC_PAUSE_MAX 600
 
-void
+int
 ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child, int wait_timeout)
 {
 	uint64_t start_time = daos_wallclock_secs();
-	int      wait_intv  = 10;
+	int      next_warn  = 60;
 	int      waited     = 0;
 
 	D_DEBUG(DB_MD, DF_UUID "[%d]: wait for pausing EC aggregation\n",
@@ -981,35 +980,31 @@ ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child, int wait_timeo
 		struct ds_cont_child *coc;
 		bool                  paused = true;
 
-		/* Wait for pausing aggregation
-		 * XXX: There is no global barrier so we always wait for at least 10 seconds to
-		 * lower the chance that remote targets are still running EC aggregation.
-		 */
-		if (wait_intv > wait_timeout - waited)
-			wait_intv = wait_timeout - waited;
+		if (!ds_pool_child_ec_agg_paused(pool_child))
+			return -DER_OP_CANCELED;
 
-		dss_sleep(wait_intv * 1000);
 		d_list_for_each_entry(coc, &pool_child->spc_cont_list, sc_link) {
 			if (ds_cont_child_ec_aggregating(coc)) {
-				/* Aggregation is active on this container */
 				paused = false;
 				break;
 			}
 		}
 		if (paused)
-			return;
+			return 0;
 
 		waited = daos_wallclock_secs() - start_time;
 		if (waited >= wait_timeout) {
 			D_WARN("can't pause EC aggregation after %d seconds\n", waited);
-			return; /* XXX what can I do? */
+			return -DER_TIMEDOUT;
 		}
 
-		if (waited % 60 == 0) {
+		if (waited >= next_warn) {
 			D_WARN(DF_UUID "[%d]: waited %d secs for EC aggregation to pause\n",
 			       DP_UUID(pool_child->spc_uuid), dss_get_module_info()->dmi_tgt_id,
 			       waited);
+			next_warn += 60;
 		}
+		dss_sleep(1000);
 	}
 }
 

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -71,7 +71,7 @@ enum daos_module_id {
 #define DAOS_POOL_VERSION     7
 #define DAOS_CONT_VERSION     9
 #define DAOS_OBJ_VERSION      10
-#define DAOS_REBUILD_VERSION  5
+#define DAOS_REBUILD_VERSION  6
 #define DAOS_RSVC_VERSION     5
 #define DAOS_RDB_VERSION      5
 #define DAOS_RDBT_VERSION     3

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -228,7 +228,7 @@ ds_cont_child_destroy(uuid_t pool_uuid, uuid_t cont_uuid);
 
 void
 ds_cont_child_reset_ec_agg_eph_all(struct ds_pool_child *pool_child);
-void
+int
      ds_cont_child_wait_ec_agg_pause(struct ds_pool_child *pool_child, int wait_timeout);
 
 /** initialize a csummer based on container properties. Will retrieve the

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -183,6 +183,10 @@ struct ds_pool_child {
 	ABT_eventual	spc_ref_eventual;
 
 	uint64_t                 spc_no_storage : 1; /* The pool shard has no storage. */
+	ATOMIC uint32_t          spc_ec_agg_pause_gate;
+	ATOMIC uint64_t          spc_ec_agg_pause_term;
+	/* Debug state set by RB_OP_REBUILD START after the global EC agg pause. */
+	ATOMIC uint64_t          spc_rebuild_ec_agg_paused_hlc;
 
 	uint32_t	spc_reint_mode;
 	uint32_t	*spc_state;	/* Pointer to ds_pool->sp_states[i] */
@@ -210,6 +214,26 @@ static inline bool
 ds_pool_is_rebuilding(struct ds_pool *pool)
 {
 	return (atomic_load(&pool->sp_rebuilding) > 0 || atomic_load(&pool->sp_rebuild_enum) > 0);
+}
+
+static inline bool
+ds_pool_child_ec_agg_paused(struct ds_pool_child *child)
+{
+	return atomic_load(&child->spc_ec_agg_pause_gate) != 0;
+}
+
+static inline bool
+ds_pool_child_rebuild_started(struct ds_pool_child *child)
+{
+	return atomic_load(&child->spc_rebuild_ec_agg_paused_hlc) != 0;
+}
+
+static inline bool
+ds_pool_child_ec_agg_token_match(struct ds_pool_child *child, uint64_t leader_term,
+				 uint32_t rebuild_gen)
+{
+	return atomic_load(&child->spc_ec_agg_pause_gate) == rebuild_gen &&
+	       atomic_load(&child->spc_ec_agg_pause_term) <= leader_term;
 }
 
 /* encode metadata RPC operation key: HLC time first, in network order, for keys sorted by time.

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -1340,7 +1340,7 @@ agg_peer_check_avail(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 	int                    i;
 	int                    rc;
 
-	if (ds_pool_is_rebuilding(agg_param->ap_cont->sc_pool->spc_pool)) {
+	if (ds_pool_child_ec_agg_paused(agg_param->ap_cont->sc_pool)) {
 		rc = -DER_OP_CANCELED;
 		/* We currently pause EC aggregation for rebuild, so just cancel the
 		 * aggregation for the current stripe. It means the following peer status
@@ -1426,8 +1426,15 @@ agg_peer_update_ult(void *arg)
 
 	if (unlikely(DAOS_FAIL_CHECK(DAOS_FORCE_EC_AGG_PEER_FAIL)))
 		D_GOTO(out, rc = -DER_TIMEDOUT);
-
 	agg_param = container_of(entry, struct ec_agg_param, ap_agg_entry);
+	D_ASSERTF(!ds_pool_child_rebuild_started(agg_param->ap_cont->sc_pool),
+		  DF_UUID " EC aggregation peer update after rebuild START: "
+			  "rank %u tgt %d " DF_UOID " stripe " DF_U64 " global_pause_done " DF_X64
+			  "\n",
+		  DP_UUID(agg_param->ap_pool_info.api_pool_uuid), dss_self_rank(),
+		  dss_get_module_info()->dmi_tgt_id, DP_UOID(entry->ae_oid),
+		  entry->ae_cur_stripe.as_stripenum,
+		  atomic_load(&agg_param->ap_cont->sc_pool->spc_rebuild_ec_agg_paused_hlc));
 	rc        = agg_peer_check_avail(agg_param, entry);
 	if (rc != 0)
 		D_GOTO(out, rc);
@@ -1939,9 +1946,10 @@ agg_process_stripe(struct ec_agg_param *agg_param, struct ec_agg_entry *entry)
 
 	/* avoid race between EC aggregation and rebuild scanner */
 	agg_param->ap_cont->sc_ec_agg_updates++;
-	if (ds_pool_is_rebuilding(agg_param->ap_cont->sc_pool->spc_pool)) {
+	if (ds_pool_child_ec_agg_paused(agg_param->ap_cont->sc_pool)) {
 		rc = -DER_OP_CANCELED;
-		DL_INFO(rc, DF_UOID " abort as rebuild started", DP_UOID(entry->ae_oid));
+		DL_INFO(rc, DF_UOID " abort as EC aggregation pause gate is set",
+			DP_UOID(entry->ae_oid));
 		update_vos = false;
 		goto out;
 	}
@@ -2366,10 +2374,10 @@ ec_aggregate_yield(struct ec_agg_param *agg_param)
 {
 	int	rc;
 
-	if (ds_pool_is_rebuilding(agg_param->ap_pool_info.api_pool)) {
-		D_INFO(DF_UUID ": abort ec aggregation, sp_rebuilding %d\n",
+	if (ds_pool_child_ec_agg_paused(agg_param->ap_cont->sc_pool)) {
+		D_INFO(DF_UUID ": abort EC aggregation, pause gate %u\n",
 		       DP_UUID(agg_param->ap_pool_info.api_pool->sp_uuid),
-		       atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding));
+		       atomic_load(&agg_param->ap_cont->sc_pool->spc_ec_agg_pause_gate));
 		return true;
 	}
 
@@ -2578,15 +2586,15 @@ agg_iterate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	D_ASSERT(agg_param->ap_initialized);
 
-	/* If rebuild started, abort it to save conflict window with rebuild
+	/* If the rebuild EC agg barrier is active, abort to save conflict window with rebuild
 	 * (see obj_inflight_io_check()).
 	 */
-	if (ds_pool_is_rebuilding(agg_param->ap_pool_info.api_pool)) {
+	if (ds_pool_child_ec_agg_paused(agg_param->ap_cont->sc_pool)) {
 		rc = -DER_OP_CANCELED;
-		DL_INFO(rc, DF_CONT " abort as rebuild started, sp_rebuilding %d.",
+		DL_INFO(rc, DF_CONT " abort as EC aggregation pause gate %u is set.",
 			DP_CONT(agg_param->ap_pool_info.api_pool_uuid,
 				agg_param->ap_pool_info.api_cont_uuid),
-			atomic_load(&agg_param->ap_pool_info.api_pool->sp_rebuilding));
+			atomic_load(&agg_param->ap_cont->sc_pool->spc_ec_agg_pause_gate));
 		return rc;
 	}
 
@@ -2887,7 +2895,7 @@ update_hae:
 	/* clear the flag before next turn's cont_aggregate_runnable(), to save conflict
 	 * window with rebuild (see obj_inflight_io_check()).
 	 */
-	if (ds_pool_is_rebuilding(cont->sc_pool->spc_pool))
+	if (ds_pool_child_ec_agg_paused(cont->sc_pool))
 		cont->sc_ec_agg_active = 0;
 
 	if (rc == 0) {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2664,6 +2664,20 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 	}
 
 	D_ASSERT(ioc.ioc_coc != NULL);
+	if (ds_pool_child_ec_agg_paused(ioc.ioc_coc->sc_pool)) {
+		rc = -DER_OP_CANCELED;
+		DL_INFO(rc, DF_CONT " reject EC aggregation update while rebuild pause gate is set",
+			DP_CONT(ioc.ioc_coc->sc_pool_uuid, ioc.ioc_coc->sc_uuid));
+		goto out;
+	}
+	D_ASSERTF(!ds_pool_child_rebuild_started(ioc.ioc_coc->sc_pool),
+		  DF_CONT " EC aggregation handler after rebuild START: "
+			  "rank %u tgt %d " DF_UOID " stripe " DF_U64 " epoch " DF_X64 "-" DF_X64
+			  " global_pause_done " DF_X64 "\n",
+		  DP_CONT(ioc.ioc_coc->sc_pool_uuid, ioc.ioc_coc->sc_uuid), dss_self_rank(),
+		  dss_get_module_info()->dmi_tgt_id, DP_UOID(oea->ea_oid), oea->ea_stripenum,
+		  oea->ea_epoch_range.epr_lo, oea->ea_epoch_range.epr_hi,
+		  atomic_load(&ioc.ioc_coc->sc_pool->spc_rebuild_ec_agg_paused_hlc));
 	ioc.ioc_coc->sc_ec_agg_updates++;
 
 	dkey = (daos_key_t *)&oea->ea_dkey;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -3538,10 +3538,9 @@ migrate_obj_ult(void *data)
 			DF_RB ": punched obj " DF_UOID " epoch " DF_U64 "/" DF_U64 "/" DF_U64 "\n",
 			DP_RB_MPT(tls), DP_UOID(arg->oid), arg->epoch, arg->punched_epoch,
 			epr.epr_hi);
-		arg->epoch = DAOS_EPOCH_MAX;
 	}
 free:
-	if (arg->epoch == DAOS_EPOCH_MAX)
+	if (rc == 0)
 		tls->mpt_obj_count++;
 
 	if (DAOS_FAIL_CHECK(DAOS_REBUILD_OBJ_FAIL) &&

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -149,8 +149,8 @@ struct rebuild_global_pool_tracker {
 
 	uint64_t	rgt_time_start;
 
-	/* Stable epoch of the rebuild, the minimum epoch from
-	 * all rebuilding targets
+	/* Leader-selected rebuild cutoff. For RB_OP_REBUILD it is not published
+	 * until all participating engines have paused EC aggregation.
 	 */
 	uint64_t	rgt_stable_epoch;
 
@@ -168,7 +168,8 @@ struct rebuild_global_pool_tracker {
 	uint32_t	rgt_opc;
 	unsigned int                    rgt_abort : 1, /* abort: kill rebuild */
 	    rgt_init_scan : 1, rgt_stop_admin : 1,     /* stop: admin has asked to kill rebuild */
-	    rgt_include_up : 1;                        /* include UP rank domain for FAIL_RECLAIM */
+	    rgt_include_up          : 1,               /* include UP rank domain for FAIL_RECLAIM */
+	    rgt_ec_agg_barrier_done : 1;
 
 	/* only valid when rgt_include_up is true (FAIL_RECLAIM), the original rebuild version */
 	uint32_t rgt_orig_rb_ver;

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -86,22 +86,28 @@ struct rebuild_tgt_pool_tracker {
 	/* new layout version for upgrade rebuild */
 	uint32_t		rt_new_layout_ver;
 
+	/* clang-format off */
 	unsigned int		rt_lead_puller_running:1,
 				rt_abort:1,
 				/* re-report #rebuilt cnt per master change */
 				rt_re_report:1,
 				rt_finishing:1,
+				rt_ec_agg_paused:1,
 				rt_scan_done:1,
 				rt_global_scan_done:1,
 				rt_global_done:1;
+	/* clang-format on */
 };
 
 struct rebuild_server_status {
 	d_rank_t	rank;
 	double          last_update;
 	uint32_t	dtx_resync_version;
-	uint32_t	scan_done:1,
+	/* clang-format off */
+	uint32_t	ec_agg_paused:1,
+			scan_done:1,
 			pull_done:1;
+	/* clang-format on */
 };
 
 /* Track the rebuild status globally */
@@ -324,11 +330,14 @@ struct rebuild_iv {
 	uint32_t        riv_master_rank;
 	uint32_t        riv_ver;
 	uint32_t        riv_rebuild_gen;
+	/* clang-format off */
 	uint32_t	riv_global_done:1,
 			riv_global_scan_done:1,
 			riv_scan_done:1,
 			riv_pull_done:1,
-			riv_sync:1;
+			riv_sync:1,
+			riv_ec_agg_paused:1;
+	/* clang-format on */
 	int32_t  riv_status;
 	uint32_t riv_bukid; /* bucket ID */
 };

--- a/src/rebuild/rpc.h
+++ b/src/rebuild/rpc.h
@@ -57,7 +57,7 @@ extern struct crt_proto_format rebuild_proto_fmt;
 	((uint32_t)		(rsi_rebuild_gen)	CRT_VAR) \
 	((uint32_t)		(rsi_layout_ver)	CRT_VAR) \
 	((uint32_t)		(rsi_phase)		CRT_VAR) \
-	((uint64_t)		(rsi_padding)		CRT_VAR)
+	((uint64_t)		(rsi_stable_epoch)	CRT_VAR)
 
 #define DAOS_OSEQ_REBUILD_SCAN	/* output fields */		 \
 	((uint64_t)		(rso_stable_epoch)	CRT_VAR) \

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -281,16 +281,21 @@ rebuild_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 static int
 rpt_wait_rebuild_epoch(struct rebuild_tgt_pool_tracker *rpt)
 {
-	int wait_cnt     = 0;
-	int wait_intv    = 200; /* milliseconds */
-	int wait_cnt_max = 180;
+	int wait_cnt = 0;
 
-	while (rpt->rt_stable_epoch == 0 && wait_cnt++ < wait_cnt_max)
-		dss_sleep(wait_intv);
+	while (rpt->rt_stable_epoch == 0 && !rpt->rt_abort && !rpt->rt_finishing &&
+	       !rpt->rt_global_done && wait_cnt++ < 180)
+		dss_sleep(200);
 
+	if (rpt->rt_abort || rpt->rt_finishing || rpt->rt_global_done)
+		return -DER_SHUTDOWN;
 	if (rpt->rt_stable_epoch != 0)
 		return 0;
 
+	D_ERROR(DF_RB " timed out waiting for stable epoch after EC aggregation paused, "
+		      "ec_agg_paused=%u global_dtx=%u rebuild_ver=%u\n",
+		DP_RB_RPT(rpt), rpt->rt_ec_agg_paused, rpt->rt_global_dtx_resync_version,
+		rpt->rt_rebuild_ver);
 	return -DER_TIMEDOUT;
 }
 
@@ -1094,6 +1099,9 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	param.ip_hdl = coh;
 	param.ip_epr.epr_lo = 0;
 	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+	/* Rebuild must not migrate updates newer than the stable epoch. */
+	if (rpt->rt_rebuild_op == RB_OP_REBUILD)
+		param.ip_epr.epr_hi = rpt->rt_stable_epoch;
 	param.ip_flags = VOS_IT_FOR_MIGRATION;
 	uuid_copy(arg->co_uuid, entry->ie_couuid);
 	arg->snapshot_cnt = snapshot_cnt;
@@ -1185,8 +1193,10 @@ rebuild_scanner(void *data)
 	child = ds_pool_child_lookup(rpt->rt_pool_uuid);
 	if (child == NULL)
 		D_GOTO(out, rc = -DER_NONEXIST);
-
-	ds_cont_child_wait_ec_agg_pause(child, rebuild_wait_ec_pause);
+	if (rpt->rt_rebuild_op == RB_OP_REBUILD) {
+		D_ASSERT(rpt->rt_stable_epoch != 0);
+		atomic_store(&child->spc_rebuild_ec_agg_paused_hlc, rpt->rt_stable_epoch);
+	}
 
 	/* There maybe orphan DTX entries after DTX resync, let's cleanup before rebuild scan. */
 	rc = dtx_cleanup_orphan(rpt->rt_pool_uuid, rpt->rt_pool->sp_dtx_resync_version);
@@ -1251,6 +1261,36 @@ out:
 	return rc;
 }
 
+static int
+rebuild_ec_agg_pause_one(void *data)
+{
+	struct rebuild_tgt_pool_tracker *rpt = data;
+	struct ds_pool_child            *child;
+	uint64_t                         current_term;
+	uint32_t                         current_gen;
+	int                              rc;
+
+	child = ds_pool_child_lookup(rpt->rt_pool_uuid);
+	if (child == NULL)
+		return -DER_NONEXIST;
+
+	current_term = atomic_load(&child->spc_ec_agg_pause_term);
+	current_gen  = atomic_load(&child->spc_ec_agg_pause_gate);
+	if (current_term > rpt->rt_leader_term ||
+	    (current_term == rpt->rt_leader_term && current_gen > rpt->rt_rebuild_gen)) {
+		ds_pool_child_put(child);
+		return -DER_STALE;
+	}
+
+	atomic_store(&child->spc_ec_agg_pause_term, rpt->rt_leader_term);
+	atomic_store(&child->spc_ec_agg_pause_gate, rpt->rt_rebuild_gen);
+	rc = ds_cont_child_wait_ec_agg_pause(child, rebuild_wait_ec_pause);
+	if (rc != 0)
+		DL_ERROR(rc, DF_RB " failed to pause EC aggregation", DP_RB_RPT(rpt));
+	ds_pool_child_put(child);
+	return rc;
+}
+
 /**
  * Wait for pool map and setup global status, then spawn scanners for all
  * service xsteams
@@ -1298,6 +1338,24 @@ rebuild_scan_leader(void *data)
 	}
 
 do_scan:
+	if (rpt->rt_rebuild_op == RB_OP_REBUILD) {
+		rc = ds_pool_thread_collective(
+		    rpt->rt_pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
+		    rebuild_ec_agg_pause_one, rpt, 0);
+		if (rc != 0) {
+			DL_ERROR(rc, DF_RB " failed to pause EC aggregation globally",
+				 DP_RB_RPT(rpt));
+			D_GOTO(out, rc);
+		}
+
+		rpt->rt_ec_agg_paused = 1;
+		rc                    = rpt_wait_rebuild_epoch(rpt);
+		if (rc != 0)
+			D_GOTO(out, rc);
+	}
+	if (rpt->rt_abort || rpt->rt_finishing || rpt->rt_global_done)
+		D_GOTO(out, rc = -DER_SHUTDOWN);
+
 	D_INFO(DF_RB " scan collective begin\n", DP_RB_RPT(rpt));
 	rc = ds_pool_thread_collective(rpt->rt_pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN |
 				       PO_COMP_ST_DOWNOUT, rebuild_scanner, rpt,
@@ -1326,7 +1384,6 @@ out:
 	DL_INFO(rc, DF_RB " scan leader done", DP_RB_RPT(rpt));
 	rpt_put(rpt);
 }
-
 /* Scan the local target and generate rebuild object list */
 void
 rebuild_tgt_scan_handler(crt_rpc_t *rpc)
@@ -1349,6 +1406,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 		DL_ERROR(rc, DF_RB " cannot find pool", DP_RB_RSI(rsi));
 		D_GOTO(out_put, rc);
 	}
+
 	atomic_fetch_add(&pool->sp_rebuilding, 1);
 
 	/* If PS leader has been changed, and rebuild version is also increased
@@ -1486,7 +1544,12 @@ out_put:
 
 	rout = crt_reply_get(rpc);
 	rout->rso_status = rc;
-	rout->rso_stable_epoch = d_hlc_get();
+	rout->rso_stable_epoch = 0;
+	if (rc == 0) {
+		D_ASSERT(rsi->rsi_rebuild_op != RB_OP_REBUILD || rsi->rsi_stable_epoch != 0);
+		rout->rso_stable_epoch =
+		    rsi->rsi_rebuild_op == RB_OP_REBUILD ? rsi->rsi_stable_epoch : d_hlc_get();
+	}
 	dss_rpc_reply(rpc, DAOS_REBUILD_DROP_SCAN);
 }
 
@@ -1494,15 +1557,23 @@ int
 rebuild_tgt_scan_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 			    void *priv)
 {
+	struct rebuild_scan_in  *src_in = crt_req_get(source);
 	struct rebuild_scan_out	*src = crt_reply_get(source);
 	struct rebuild_scan_out *dst = crt_reply_get(result);
 
 	if (dst->rso_status == 0)
 		dst->rso_status = src->rso_status;
 
-	if (src->rso_status == 0 &&
-	    dst->rso_stable_epoch < src->rso_stable_epoch)
-		dst->rso_stable_epoch = src->rso_stable_epoch;
+	if (src->rso_status == 0) {
+		if (src_in->rsi_rebuild_op == RB_OP_REBUILD) {
+			D_ASSERTF(src->rso_stable_epoch == src_in->rsi_stable_epoch,
+				  DF_X64 " != " DF_X64 "\n", src->rso_stable_epoch,
+				  src_in->rsi_stable_epoch);
+			dst->rso_stable_epoch = src_in->rsi_stable_epoch;
+		} else if (dst->rso_stable_epoch < src->rso_stable_epoch) {
+			dst->rso_stable_epoch = src->rso_stable_epoch;
+		}
+	}
 
 	return 0;
 }

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -34,6 +34,8 @@
 #define REBUILD_SEND_BATCH_MIN         (REBUILD_SEND_LIMIT / 4)
 /* Maximum seconds to wait for a batch to fill before flushing anyway. */
 #define REBUILD_SEND_BATCH_TIMEOUT_SEC 1
+/* Local EC aggregation pause can take up to 600 seconds. */
+#define REBUILD_EPOCH_WAIT_MAX_SEC     660
 
 struct rebuild_send_arg {
 	struct rebuild_tgt_pool_tracker *rpt;
@@ -284,7 +286,7 @@ rpt_wait_rebuild_epoch(struct rebuild_tgt_pool_tracker *rpt)
 	int wait_cnt = 0;
 
 	while (rpt->rt_stable_epoch == 0 && !rpt->rt_abort && !rpt->rt_finishing &&
-	       !rpt->rt_global_done && wait_cnt++ < 180)
+	       !rpt->rt_global_done && wait_cnt++ < REBUILD_EPOCH_WAIT_MAX_SEC * 5)
 		dss_sleep(200);
 
 	if (rpt->rt_abort || rpt->rt_finishing || rpt->rt_global_done)
@@ -1564,16 +1566,13 @@ rebuild_tgt_scan_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 	if (dst->rso_status == 0)
 		dst->rso_status = src->rso_status;
 
-	if (src->rso_status == 0) {
-		if (src_in->rsi_rebuild_op == RB_OP_REBUILD) {
-			D_ASSERTF(src->rso_stable_epoch == src_in->rsi_stable_epoch,
-				  DF_X64 " != " DF_X64 "\n", src->rso_stable_epoch,
-				  src_in->rsi_stable_epoch);
-			dst->rso_stable_epoch = src_in->rsi_stable_epoch;
-		} else if (dst->rso_stable_epoch < src->rso_stable_epoch) {
-			dst->rso_stable_epoch = src->rso_stable_epoch;
-		}
-	}
+	/*
+	 * RB_OP_REBUILD uses the stable epoch selected by the leader, so target
+	 * reply epochs do not need to be aggregated.
+	 */
+	if (src->rso_status == 0 && src_in->rsi_rebuild_op != RB_OP_REBUILD &&
+	    dst->rso_stable_epoch < src->rso_stable_epoch)
+		dst->rso_stable_epoch = src->rso_stable_epoch;
 
 	return 0;
 }

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -477,7 +477,7 @@ update_and_warn_for_slow_engines(struct rebuild_global_pool_tracker *rgt)
 	}
 
 	ec_paused_gl = (ec_paused_ct == rgt->rgt_servers_number);
-	if (rgt->rgt_opc == RB_OP_REBUILD && rgt->rgt_stable_epoch == 0 && !ec_paused_gl) {
+	if (rgt->rgt_opc == RB_OP_REBUILD && !rgt->rgt_ec_agg_barrier_done && !ec_paused_gl) {
 		if (do_warn) {
 			D_WARN(DF_RB ": EC aggregation pause hung? waiting for %d/%d engines:\n",
 			       DP_RB_RGT(rgt), rgt->rgt_servers_number - ec_paused_ct,
@@ -552,7 +552,12 @@ rebuild_global_status_update(struct rebuild_global_pool_tracker *rgt,
 {
 	rebuild_leader_set_update_time(rgt, iv->riv_rank);
 	if (iv->riv_stable_epoch != 0) {
-		if (rgt->rgt_stable_epoch == 0) {
+		if (rgt->rgt_opc == RB_OP_REBUILD && !rgt->rgt_ec_agg_barrier_done) {
+			rgt->rgt_stable_epoch        = iv->riv_stable_epoch;
+			rgt->rgt_ec_agg_barrier_done = 1;
+			D_INFO(DF_RB ": recovered stable epoch " DF_X64 " from rank %u\n",
+			       DP_RB_RGT(rgt), rgt->rgt_stable_epoch, iv->riv_rank);
+		} else if (rgt->rgt_stable_epoch == 0) {
 			rgt->rgt_stable_epoch = iv->riv_stable_epoch;
 			D_INFO(DF_RB ": recovered stable epoch " DF_X64 " from rank %u\n",
 			       DP_RB_RGT(rgt), rgt->rgt_stable_epoch, iv->riv_rank);
@@ -975,7 +980,8 @@ rebuild_leader_status_notify(struct rebuild_global_pool_tracker *rgt, struct ds_
 	iv.riv_leader_term	= rgt->rgt_leader_term;
 	iv.riv_rebuild_gen	= rgt->rgt_rebuild_gen;
 	iv.riv_seconds          = rgt->rgt_status.rs_seconds;
-	iv.riv_stable_epoch	= rgt->rgt_stable_epoch;
+	if (op != RB_OP_REBUILD || rgt->rgt_ec_agg_barrier_done)
+		iv.riv_stable_epoch = rgt->rgt_stable_epoch;
 	iv.riv_sync = 1;
 	rgt->rgt_dtx_resync_version = iv.riv_global_dtx_resyc_version =
 				rebuild_get_global_dtx_resync_ver(rgt);
@@ -1203,6 +1209,25 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 		}
 		ABT_rwlock_unlock(pool->sp_lock);
 		map_ranks_fini(&rank_list);
+
+		if (rgt->rgt_opc == RB_OP_REBUILD && !rgt->rgt_ec_agg_barrier_done &&
+		    !rgt->rgt_abort) {
+			bool ec_agg_paused = true;
+
+			for (i = 0; i < rgt->rgt_servers_number; i++) {
+				if (!rgt->rgt_servers[i].ec_agg_paused) {
+					ec_agg_paused = false;
+					break;
+				}
+			}
+			if (ec_agg_paused) {
+				D_ASSERT(rgt->rgt_stable_epoch != 0);
+				rgt->rgt_ec_agg_barrier_done = 1;
+				D_INFO(DF_RB ": all engines paused EC aggregation, publish stable "
+					     "epoch " DF_X64 "\n",
+				       DP_RB_RGT(rgt), rgt->rgt_stable_epoch);
+			}
+		}
 
 		/* Abort orphaned rgt if the node is no longer the leader.
 		 * After PS leader switch, this rgt becomes orphaned and should be aborted.
@@ -1555,10 +1580,17 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 		/*
 		 * Bound rebuild migration before starting target scan. Target scan waits
 		 * for DTX resync before migration, so IO at or below this cutoff is
-		 * covered by the resync, while later IO is kept outside the migration
-		 * range.
+		 * covered by the resync, while later IO is kept outside the migration range.
+		 * The leader publishes this cutoff through IV only after every participating
+		 * engine reports that EC aggregation is paused.
 		 */
-		rsi->rsi_stable_epoch = d_hlc_get();
+		if (rgt->rgt_ec_agg_barrier_done) {
+			D_ASSERT(rgt->rgt_stable_epoch != 0);
+			rsi->rsi_stable_epoch = rgt->rgt_stable_epoch;
+		} else {
+			rsi->rsi_stable_epoch = d_hlc_get();
+			rgt->rgt_stable_epoch = rsi->rsi_stable_epoch;
+		}
 	}
 	crt_group_rank(pool->sp_group,  &rsi->rsi_master_rank);
 
@@ -1567,14 +1599,14 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 		rso = crt_reply_get(rpc);
 		D_ASSERT(rso != NULL);
 		rc = rso->rso_status;
-		if (rc == 0)
+		if (rc == 0 && rebuild_op != RB_OP_REBUILD)
 			rgt->rgt_stable_epoch = rso->rso_stable_epoch;
 	} else {
 		DL_ERROR(rc, DF_RB " scan broadcast send failed.", DP_RB_RGT(rgt));
 	}
 
 	rgt->rgt_init_scan = 1;
-	DL_INFO(rc, DF_RB " got stable/reclaim epoch " DF_X64 "/" DF_X64, DP_RB_RGT(rgt),
+	DL_INFO(rc, DF_RB " selected stable/reclaim epoch " DF_X64 "/" DF_X64, DP_RB_RGT(rgt),
 		rgt->rgt_stable_epoch, rgt->rgt_reclaim_epoch);
 	crt_req_decref(rpc);
 out:
@@ -2126,7 +2158,8 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		/* Schedule fail_reclaim to clean up current op. After fail_reclaim, we may retry
 		 * original. Scheduling any retry is deferred until fail_reclaim is actually done.
 		 */
-		if (rgt->rgt_init_scan && rgt->rgt_stable_epoch != 0) {
+		if (rgt->rgt_init_scan && rgt->rgt_stable_epoch != 0 &&
+		    (rgt->rgt_opc != RB_OP_REBUILD || rgt->rgt_ec_agg_barrier_done)) {
 			/* NB: dst_reclaim_ver is the minimum rebuild target version, once rebuild
 			 * fails, it will be used to discard all of the previous rebuild data
 			 * (reclaim - 1 see obj_reclaim()), but keep the in-flight I/O data.
@@ -2162,8 +2195,8 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 			D_GOTO(complete, rc);
 		}
 		if (rgt->rgt_init_scan)
-			D_INFO(DF_RB ": skip fail_reclaim because rebuild failed before stable "
-				     "epoch was established\n",
+			D_INFO(DF_RB ": skip fail_reclaim because rebuild failed before the EC "
+				     "aggregation barrier was released\n",
 			       DP_RB_RGT(rgt));
 
 		/* With the global EC aggregation barrier, RB_OP_REBUILD publishes its stable
@@ -2174,7 +2207,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		 * the normal Fail_reclaim path above must clean up any migrated data.
 		 */
 		if (task->dst_rebuild_op == RB_OP_REBUILD && rgt->rgt_stop_admin &&
-		    rgt->rgt_init_scan && rgt->rgt_stable_epoch == 0) {
+		    rgt->rgt_init_scan && !rgt->rgt_ec_agg_barrier_done) {
 			rgt->rgt_status.rs_errno = -DER_OP_CANCELED;
 			rgt->rgt_status.rs_state = DRS_NOT_STARTED;
 			D_GOTO(complete, rc);
@@ -2188,12 +2221,14 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		if (retry_opc == RB_OP_NONE)
 			D_GOTO(complete, rc);
 
-		retry_reclaim_eph =
-		    rgt->rgt_stable_epoch != 0 ? rgt->rgt_stable_epoch : task->dst_reclaim_eph;
-		rc = ds_rebuild_schedule(
-		    pool, task->dst_map_ver, retry_reclaim_eph, task->dst_new_layout_version,
-		    &task->dst_tgts, retry_opc /* rebuild_op*/, 0 /* retry_rebuild_op */,
-		    0 /* retry_map_ver */, false /* stop_admin */, task, delay_sec);
+		retry_reclaim_eph = rgt->rgt_stable_epoch != 0 && (rgt->rgt_opc != RB_OP_REBUILD ||
+								   rgt->rgt_ec_agg_barrier_done)
+					? rgt->rgt_stable_epoch
+					: task->dst_reclaim_eph;
+		rc                = ds_rebuild_schedule(
+                    pool, task->dst_map_ver, retry_reclaim_eph, task->dst_new_layout_version,
+                    &task->dst_tgts, retry_opc /* rebuild_op*/, 0 /* retry_rebuild_op */,
+                    0 /* retry_map_ver */, false /* stop_admin */, task, delay_sec);
 		DL_CDEBUG(rc, DLOG_ERR, DLOG_INFO, rc,
 			  DF_RB ": errno " DF_RC ", schedule retry of original %u(%s)",
 			  DP_RB_RGT(rgt), DP_RC(rgt->rgt_status.rs_errno), retry_opc,

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -254,6 +254,7 @@ is_rebuild_phase_mostly_done(int engines_done_ct, int engines_total_ct)
 
 #define SCAN_DONE	0x1
 #define PULL_DONE	0x2
+#define EC_AGG_PAUSED   0x4
 
 static void
 servers_sop_swap(void *array, int a, int b)
@@ -334,6 +335,10 @@ rebuild_leader_set_status(struct rebuild_global_pool_tracker *rgt,
 	if ((flags & PULL_DONE) && !status->pull_done) {
 		D_DEBUG(DB_REBUILD, DF_RB " rank %d is pull_done", DP_RB_RGT(rgt), rank);
 		status->pull_done = 1;
+	}
+	if ((flags & EC_AGG_PAUSED) && !status->ec_agg_paused) {
+		D_DEBUG(DB_REBUILD, DF_RB " rank %d paused EC aggregation", DP_RB_RGT(rgt), rank);
+		status->ec_agg_paused = 1;
 	}
 }
 
@@ -428,10 +433,12 @@ static void
 update_and_warn_for_slow_engines(struct rebuild_global_pool_tracker *rgt)
 {
 	int    i;
+	int    ec_paused_ct = 0;
 	int    scan_ct = 0;
 	int    pull_ct = 0;
 	int    done_ct;
 	int    wait_ct;
+	bool   ec_paused_gl = false;
 	bool   scan_gl = false;
 	bool   pull_gl = false;
 	bool   do_warn = false;
@@ -447,6 +454,8 @@ update_and_warn_for_slow_engines(struct rebuild_global_pool_tracker *rgt)
 		double   tu = now - rgt->rgt_servers[i].last_update;
 		d_rank_t r  = rgt->rgt_servers[i].rank;
 
+		if (rgt->rgt_servers[i].ec_agg_paused)
+			ec_paused_ct++;
 		if (rgt->rgt_servers[i].scan_done) {
 			scan_ct++;
 			if (rgt->rgt_servers[i].pull_done) {
@@ -460,11 +469,29 @@ update_and_warn_for_slow_engines(struct rebuild_global_pool_tracker *rgt)
 
 		if (tu > 30) {
 			D_WARN(DF_RB ": no updates from rank %u in %8.3f seconds. "
-				     "scan_done=%d pull_done=%d\n",
-			       DP_RB_RGT(rgt), r, tu, rgt->rgt_servers[i].scan_done,
-			       rgt->rgt_servers[i].pull_done);
+				     "ec_agg_paused=%d scan_done=%d pull_done=%d\n",
+			       DP_RB_RGT(rgt), r, tu, rgt->rgt_servers[i].ec_agg_paused,
+			       rgt->rgt_servers[i].scan_done, rgt->rgt_servers[i].pull_done);
 			warned = true;
 		}
+	}
+
+	ec_paused_gl = (ec_paused_ct == rgt->rgt_servers_number);
+	if (rgt->rgt_opc == RB_OP_REBUILD && rgt->rgt_stable_epoch == 0 && !ec_paused_gl) {
+		if (do_warn) {
+			D_WARN(DF_RB ": EC aggregation pause hung? waiting for %d/%d engines:\n",
+			       DP_RB_RGT(rgt), rgt->rgt_servers_number - ec_paused_ct,
+			       rgt->rgt_servers_number);
+			for (i = 0; i < rgt->rgt_servers_number; i++)
+				if (!rgt->rgt_servers[i].ec_agg_paused)
+					D_WARN(DF_RB ": rank %u has not paused EC aggregation!\n",
+					       DP_RB_RGT(rgt), rgt->rgt_servers[i].rank);
+			warned = true;
+		}
+
+		if (warned)
+			rgt->rgt_last_warn_ts = now;
+		return;
 	}
 
 	scan_gl = (scan_ct == rgt->rgt_servers_number);
@@ -524,6 +551,24 @@ rebuild_global_status_update(struct rebuild_global_pool_tracker *rgt,
 			     struct rebuild_iv *iv)
 {
 	rebuild_leader_set_update_time(rgt, iv->riv_rank);
+	if (iv->riv_stable_epoch != 0) {
+		if (rgt->rgt_stable_epoch == 0) {
+			rgt->rgt_stable_epoch = iv->riv_stable_epoch;
+			D_INFO(DF_RB ": recovered stable epoch " DF_X64 " from rank %u\n",
+			       DP_RB_RGT(rgt), rgt->rgt_stable_epoch, iv->riv_rank);
+		} else if (rgt->rgt_stable_epoch != iv->riv_stable_epoch) {
+			D_ERROR(DF_RB ": stable epoch mismatch " DF_X64 "/" DF_X64
+				      " from rank %u\n",
+				DP_RB_RGT(rgt), rgt->rgt_stable_epoch, iv->riv_stable_epoch,
+				iv->riv_rank);
+			rgt->rgt_status.rs_errno     = -DER_STALE;
+			rgt->rgt_status.rs_fail_rank = iv->riv_rank;
+			rgt->rgt_abort               = 1;
+		}
+	}
+	if (iv->riv_ec_agg_paused)
+		rebuild_leader_set_status(rgt, iv->riv_rank, iv->riv_dtx_resyc_version,
+					  EC_AGG_PAUSED);
 
 	D_DEBUG(DB_REBUILD, DF_RB ": iv rank %d scan_done %d pull_done %d resync dtx %u\n",
 		DP_RB_RGT(rgt), iv->riv_rank, iv->riv_scan_done, iv->riv_pull_done,
@@ -1110,10 +1155,12 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 		}
 
 		for (i = 0; i < rank_list.rl_nr; i++) {
-			struct pool_domain *dom;
+			struct pool_domain           *dom;
+			struct rebuild_server_status *status;
 
 			dom = pool_map_find_dom_by_rank(pool->sp_map, rank_list.rl_ranks[i]);
 			D_ASSERT(dom != NULL);
+			status = rebuild_server_get_status(rgt, dom->do_comp.co_rank);
 
 			if (rgt->rgt_opc == RB_OP_REBUILD) {
 				if (dom->do_comp.co_status == PO_COMP_ST_UP) {
@@ -1138,8 +1185,9 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 			}
 
 			if (check_cnt - last_print_cnt >= log_cnt_intv)
-				D_INFO(DF_RB " rank %d, status 0x%x.\n", DP_RB_RGT(rgt),
-				       dom->do_comp.co_rank, dom->do_comp.co_status);
+				D_INFO(DF_RB " rank %d, status 0x%x, ec paused %d.\n",
+				       DP_RB_RGT(rgt), dom->do_comp.co_rank, dom->do_comp.co_status,
+				       status != NULL ? status->ec_agg_paused : 0);
 
 			/* Some engines don't participate the rebuild that will not report
 			 * progress/completion or dtx resync version through IV, mark the complete/
@@ -1151,7 +1199,7 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 			if (rgt_up_dom_included(rgt, dom) == false)
 				rebuild_leader_set_status(rgt, dom->do_comp.co_rank,
 							  RB_DTX_RESYNC_VER_SKIP,
-							  SCAN_DONE | PULL_DONE);
+							  EC_AGG_PAUSED | SCAN_DONE | PULL_DONE);
 		}
 		ABT_rwlock_unlock(pool->sp_lock);
 		map_ranks_fini(&rank_list);
@@ -1490,7 +1538,6 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 		DL_ERROR(rc, DF_RB " failed to create scan broadcast request", DP_RB_RGT(rgt));
 		D_GOTO(out, rc);
 	}
-
 	rsi = crt_req_get(rpc);
 	uuid_copy(rsi->rsi_pool_uuid, pool->sp_uuid);
 	rsi->rsi_ns_id = pool->sp_iv_ns->iv_ns_id;
@@ -1504,17 +1551,29 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 	rsi->rsi_layout_ver = layout_version;
 	rsi->rsi_tgts_num = tgts_failed->pti_number;
 	rsi->rsi_rebuild_op = rebuild_op;
+	if (rebuild_op == RB_OP_REBUILD) {
+		/*
+		 * Bound rebuild migration before starting target scan. Target scan waits
+		 * for DTX resync before migration, so IO at or below this cutoff is
+		 * covered by the resync, while later IO is kept outside the migration
+		 * range.
+		 */
+		rsi->rsi_stable_epoch = d_hlc_get();
+	}
 	crt_group_rank(pool->sp_group,  &rsi->rsi_master_rank);
 
 	rc = dss_rpc_send(rpc);
-	rso = crt_reply_get(rpc);
-	if (rc == 0)
+	if (rc == 0) {
+		rso = crt_reply_get(rpc);
+		D_ASSERT(rso != NULL);
 		rc = rso->rso_status;
-	else
+		if (rc == 0)
+			rgt->rgt_stable_epoch = rso->rso_stable_epoch;
+	} else {
 		DL_ERROR(rc, DF_RB " scan broadcast send failed.", DP_RB_RGT(rgt));
+	}
 
 	rgt->rgt_init_scan = 1;
-	rgt->rgt_stable_epoch = rso->rso_stable_epoch;
 	DL_INFO(rc, DF_RB " got stable/reclaim epoch " DF_X64 "/" DF_X64, DP_RB_RGT(rgt),
 		rgt->rgt_stable_epoch, rgt->rgt_reclaim_epoch);
 	crt_req_decref(rpc);
@@ -2034,6 +2093,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 
 	if (!is_rebuild_global_done(rgt) || rgt->rgt_status.rs_errno != 0) {
 		daos_rebuild_opc_t retry_opc = 0;
+		daos_epoch_t       retry_reclaim_eph;
 
 		/* If current job failed */
 		if ((rgt->rgt_opc == RB_OP_REBUILD) && (rgt->rgt_status.rs_errno != 0) &&
@@ -2052,7 +2112,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 			 * later successful pass still parks the original rebuild (delay=-1)
 			 */
 			rc = ds_rebuild_schedule(
-			    pool, task->dst_map_ver, rgt->rgt_stable_epoch,
+			    pool, task->dst_map_ver, rgt->rgt_reclaim_epoch,
 			    task->dst_new_layout_version, &task->dst_tgts, task->dst_rebuild_op,
 			    task->dst_retry_rebuild_op, task->dst_retry_map_ver,
 			    task->dst_stop_admin || rgt->rgt_stop_admin, task, delay_sec);
@@ -2066,7 +2126,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		/* Schedule fail_reclaim to clean up current op. After fail_reclaim, we may retry
 		 * original. Scheduling any retry is deferred until fail_reclaim is actually done.
 		 */
-		if (rgt->rgt_init_scan) {
+		if (rgt->rgt_init_scan && rgt->rgt_stable_epoch != 0) {
 			/* NB: dst_reclaim_ver is the minimum rebuild target version, once rebuild
 			 * fails, it will be used to discard all of the previous rebuild data
 			 * (reclaim - 1 see obj_reclaim()), but keep the in-flight I/O data.
@@ -2101,6 +2161,24 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 				  RB_OP_STR(RB_OP_FAIL_RECLAIM));
 			D_GOTO(complete, rc);
 		}
+		if (rgt->rgt_init_scan)
+			D_INFO(DF_RB ": skip fail_reclaim because rebuild failed before stable "
+				     "epoch was established\n",
+			       DP_RB_RGT(rgt));
+
+		/* With the global EC aggregation barrier, RB_OP_REBUILD publishes its stable
+		 * epoch only after every target has paused EC aggregation. If an admin stop
+		 * arrives after the scan RPC was broadcast but before that epoch is established,
+		 * targets have not crossed the migration cutoff yet and Fail_reclaim has no
+		 * stable boundary to use. Park the rebuild as stopped; once stable_epoch exists,
+		 * the normal Fail_reclaim path above must clean up any migrated data.
+		 */
+		if (task->dst_rebuild_op == RB_OP_REBUILD && rgt->rgt_stop_admin &&
+		    rgt->rgt_init_scan && rgt->rgt_stable_epoch == 0) {
+			rgt->rgt_status.rs_errno = -DER_OP_CANCELED;
+			rgt->rgt_status.rs_state = DRS_NOT_STARTED;
+			D_GOTO(complete, rc);
+		}
 
 		/* Determine if original rebuild needs a retry, and if so revert pool map. */
 		retry_rebuild_task(task, rgt, &retry_opc);
@@ -2110,8 +2188,10 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		if (retry_opc == RB_OP_NONE)
 			D_GOTO(complete, rc);
 
+		retry_reclaim_eph =
+		    rgt->rgt_stable_epoch != 0 ? rgt->rgt_stable_epoch : task->dst_reclaim_eph;
 		rc = ds_rebuild_schedule(
-		    pool, task->dst_map_ver, rgt->rgt_stable_epoch, task->dst_new_layout_version,
+		    pool, task->dst_map_ver, retry_reclaim_eph, task->dst_new_layout_version,
 		    &task->dst_tgts, retry_opc /* rebuild_op*/, 0 /* retry_rebuild_op */,
 		    0 /* retry_map_ver */, false /* stop_admin */, task, delay_sec);
 		DL_CDEBUG(rc, DLOG_ERR, DLOG_INFO, rc,
@@ -2972,8 +3052,7 @@ static int
 rebuild_fini_one(void *arg)
 {
 	struct rebuild_tgt_pool_tracker	*rpt = arg;
-	struct rebuild_pool_tls		*pool_tls;
-	struct ds_pool_child		*dpc;
+	struct rebuild_pool_tls         *pool_tls;
 
 	pool_tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
 					   rpt->rt_rebuild_gen);
@@ -2983,14 +3062,30 @@ rebuild_fini_one(void *arg)
 	rebuild_pool_tls_destroy(pool_tls);
 	/* close the opened local ds_cont on main XS */
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
+	return 0;
+}
 
-	dpc = ds_pool_child_lookup(rpt->rt_pool_uuid);
-	/* The ds_pool_child is already stopped */
+struct rebuild_ec_agg_fini_arg {
+	uuid_t   pool_uuid;
+	uint64_t leader_term;
+	uint32_t rebuild_gen;
+};
+
+static int
+rebuild_ec_agg_fini_one(void *arg)
+{
+	struct rebuild_ec_agg_fini_arg *fini_arg = arg;
+	struct ds_pool_child           *dpc;
+
+	dpc = ds_pool_child_lookup(fini_arg->pool_uuid);
 	if (dpc == NULL)
 		return 0;
 
-	D_DEBUG(DB_REBUILD, DF_RB ": rebuild fini for stable epoch " DF_U64 "\n", DP_RB_RPT(rpt),
-		rpt->rt_stable_epoch);
+	if (ds_pool_child_ec_agg_token_match(dpc, fini_arg->leader_term, fini_arg->rebuild_gen)) {
+		atomic_store(&dpc->spc_ec_agg_pause_gate, 0);
+		atomic_store(&dpc->spc_ec_agg_pause_term, 0);
+		atomic_store(&dpc->spc_rebuild_ec_agg_paused_hlc, 0);
+	}
 	ds_pool_child_put(dpc);
 	return 0;
 }
@@ -2999,6 +3094,7 @@ static void
 rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 {
 	struct rebuild_pool_tls	*pool_tls;
+	struct rebuild_ec_agg_fini_arg fini_arg;
 	int			 rc;
 
 	D_INFO(DF_RB " finishing rebuild rpt refcount %u, pool refcount %u\n", DP_RB_RPT(rpt),
@@ -3036,7 +3132,13 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 		DL_WARN(rc, DF_RB " rebuild fini one failed", DP_RB_RPT(rpt));
 	/* destroy the migrate_tls of 0-xstream */
 	ds_migrate_stop(rpt->rt_pool, rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
-	/* No one should access rpt after rebuild_fini_one. */
+	uuid_copy(fini_arg.pool_uuid, rpt->rt_pool_uuid);
+	fini_arg.leader_term = rpt->rt_leader_term;
+	fini_arg.rebuild_gen = rpt->rt_rebuild_gen;
+	rc                   = dss_task_collective(rebuild_ec_agg_fini_one, &fini_arg, 0);
+	if (rc != 0)
+		DL_WARN(rc, DF_RB " EC aggregation gate fini failed", DP_RB_RPT(rpt));
+	/* No one should access rpt after the final gate cleanup. */
 	D_INFO(DF_RB " Finalized rebuild\n", DP_RB_RPT(rpt));
 	rpt_delete(rpt);
 }
@@ -3105,6 +3207,8 @@ rebuild_tgt_status_check_ult(void *arg)
 					   rpt->rt_reported_size;
 		}
 		iv.riv_status = status.status;
+		iv.riv_ec_agg_paused = rpt->rt_ec_agg_paused;
+		iv.riv_stable_epoch  = rpt->rt_stable_epoch;
 		if (status.scanning == 0 || rpt->rt_abort ||
 		    status.status != 0) {
 			iv.riv_scan_done = 1;
@@ -3179,12 +3283,12 @@ rebuild_tgt_status_check_ult(void *arg)
 		if (check_cnt % log_cnt_intv == 0 || rpt->rt_global_done || rpt->rt_abort) {
 			D_INFO(DF_RB
 			       " obj " DF_U64 "/" DF_U64 " rec " DF_U64 " size " DF_U64
-			       " scan done %d pull done %d scan gl done %d gl done %d status %d "
-			       "abort %s\n",
+			       " ec paused %d scan done %d pull done %d scan gl done %d gl done "
+			       "%d status %d abort %s\n",
 			       DP_RB_RPT(rpt), iv.riv_toberb_obj_count, iv.riv_obj_count,
-			       iv.riv_rec_count, iv.riv_size, rpt->rt_scan_done, iv.riv_pull_done,
-			       rpt->rt_global_scan_done, rpt->rt_global_done, iv.riv_status,
-			       rpt->rt_abort ? "yes" : "no");
+			       iv.riv_rec_count, iv.riv_size, rpt->rt_ec_agg_paused,
+			       rpt->rt_scan_done, iv.riv_pull_done, rpt->rt_global_scan_done,
+			       rpt->rt_global_done, iv.riv_status, rpt->rt_abort ? "yes" : "no");
 			log_cnt_intv = min(log_cnt_intv * 2, (uint64_t)RBLD_LOG_INTV_CNT);
 		}
 		check_cnt++;

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -490,6 +490,137 @@ rebuild_iv_tgt_fail(void **state)
 	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
+static int
+rebuild_ec_agg_barrier_setup(test_arg_t *arg, daos_obj_id_t *oids, d_rank_t *blocked_rank)
+{
+	daos_pool_info_t pinfo        = {0};
+	d_rank_list_t   *engine_ranks = NULL;
+	d_rank_t         failed_rank  = ranks_to_kill[0];
+	int              i;
+	int              rc;
+
+	for (i = 0; i < OBJ_NR; i++) {
+		oids[i] = daos_test_oid_gen(arg->coh, DAOS_OC_R3S_SPEC_RANK, 0, 0, arg->myrank);
+		oids[i] = dts_oid_set_rank(oids[i], failed_rank);
+	}
+	rebuild_io(arg, oids, OBJ_NR);
+
+	pinfo.pi_bits = DPI_REBUILD_STATUS | DPI_ENGINES_ENABLED;
+	rc            = test_pool_get_info(arg, &pinfo, &engine_ranks);
+	if (rc != 0)
+		return rc;
+
+	*blocked_rank = -1;
+	for (i = 0; i < engine_ranks->rl_nr; i++) {
+		if (engine_ranks->rl_ranks[i] != failed_rank) {
+			*blocked_rank = engine_ranks->rl_ranks[i];
+			break;
+		}
+	}
+	d_rank_list_free(engine_ranks);
+	if (*blocked_rank == (d_rank_t)-1)
+		return -DER_NONEXIST;
+
+	arg->rebuild_pre_pool_ver = pinfo.pi_map_ver;
+	memcpy(&arg->pool.pool_info, &pinfo, sizeof(pinfo));
+	test_set_engine_fail_loc(arg, *blocked_rank,
+				 DAOS_REBUILD_TGT_IV_UPDATE_FAIL | DAOS_FAIL_ALWAYS);
+
+	rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid, arg->group, failed_rank, -1);
+	if (rc != 0) {
+		test_set_engine_fail_loc(arg, *blocked_rank, 0);
+		return rc;
+	}
+	test_rebuild_wait_to_start_next(&arg, 1);
+	return 0;
+}
+
+static bool
+rebuild_ec_agg_barrier_holds(test_arg_t *arg, int seconds)
+{
+	daos_pool_info_t pinfo = {0};
+	int              i;
+	int              rc;
+
+	for (i = 0; i < seconds; i++) {
+		pinfo.pi_bits = DPI_REBUILD_STATUS;
+		rc            = test_pool_get_info(arg, &pinfo, NULL);
+		if (rc != 0 || pinfo.pi_rebuild_st.rs_state != DRS_IN_PROGRESS ||
+		    pinfo.pi_rebuild_st.rs_errno != 0 ||
+		    pinfo.pi_rebuild_st.rs_toberb_obj_nr != 0 || pinfo.pi_rebuild_st.rs_obj_nr != 0)
+			return false;
+		sleep(1);
+	}
+	return true;
+}
+
+static void
+rebuild_ec_agg_global_barrier(void **state)
+{
+	test_arg_t   *arg = *state;
+	daos_obj_id_t oids[OBJ_NR];
+	d_rank_t      blocked_rank;
+	bool          held;
+	int           rc;
+
+	FAULT_INJECTION_REQUIRED();
+	if (!test_runable(arg, 6))
+		return;
+
+	par_barrier(PAR_COMM_WORLD);
+	if (arg->myrank != 0)
+		return;
+
+	rc = rebuild_ec_agg_barrier_setup(arg, oids, &blocked_rank);
+	if (rc != 0)
+		assert_rc_equal(rc, 0);
+
+	held = rebuild_ec_agg_barrier_holds(arg, 10);
+	test_set_engine_fail_loc(arg, blocked_rank, 0);
+	assert_true(held);
+
+	test_rebuild_wait(&arg, 1);
+	assert_int_equal(arg->pool.pool_info.pi_rebuild_st.rs_errno, 0);
+	rebuild_io_verify(arg, oids, OBJ_NR);
+
+	reintegrate_single_pool_rank(arg, ranks_to_kill[0], false);
+	rebuild_io_verify(arg, oids, OBJ_NR);
+}
+
+static void
+rebuild_stop_before_ec_agg_barrier(void **state)
+{
+	test_arg_t   *arg = *state;
+	daos_obj_id_t oids[OBJ_NR];
+	d_rank_t      blocked_rank;
+	bool          held;
+	int           rc;
+
+	FAULT_INJECTION_REQUIRED();
+	if (!test_runable(arg, 6))
+		return;
+
+	par_barrier(PAR_COMM_WORLD);
+	if (arg->myrank != 0)
+		return;
+
+	rc = rebuild_ec_agg_barrier_setup(arg, oids, &blocked_rank);
+	if (rc != 0)
+		assert_rc_equal(rc, 0);
+
+	held = rebuild_ec_agg_barrier_holds(arg, 5);
+	rc   = dmg_pool_rebuild_stop(arg->dmg_config, arg->pool.pool_uuid, arg->group, false);
+	test_set_engine_fail_loc(arg, blocked_rank, 0);
+	assert_true(held);
+	assert_rc_equal(rc, 0);
+
+	rebuild_resume_wait(arg);
+	rebuild_io_verify(arg, oids, OBJ_NR);
+
+	reintegrate_single_pool_rank(arg, ranks_to_kill[0], false);
+	rebuild_io_verify(arg, oids, OBJ_NR);
+}
+
 static void
 rebuild_tgt_start_fail(void **state)
 {
@@ -1736,6 +1867,10 @@ static const struct CMUnitTest rebuild_tests[] = {
      rebuild_sub_6nodes_rf1_setup, rebuild_sub_teardown},
     {"REBUILD37: single engine scan lengthy hang", rebuild_long_scan_hang, rebuild_sub_setup,
      rebuild_sub_teardown},
+    {"REBUILD38: EC aggregation global barrier", rebuild_ec_agg_global_barrier,
+     rebuild_small_sub_setup, rebuild_sub_teardown},
+    {"REBUILD39: stop before EC aggregation barrier", rebuild_stop_before_ec_agg_barrier,
+     rebuild_small_sub_setup, rebuild_sub_teardown},
 };
 
 /* TODO: Enable aggregation once stable view rebuild is done. */


### PR DESCRIPTION
Rebuild currently pauses EC aggregation only on each local target, without
waiting for all targets globally. In CI, EC aggregation was observed more
than 90 seconds after rebuild had started pausing it.
    
Add a global EC aggregation barrier without introducing a new rebuild
phase. Each target reports through the existing rebuild IV after its local
EC aggregation has stopped. Once all participating targets have reported,
the rebuild leader publishes the stable epoch and allows scanning to start.

Features: rebuild

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
