### PR TITLE
DAOS-19491 cq: auto-run dfuse tests for dfuse changes

### DIFF
--- a/ci/commit_pragma_mapping.yaml
+++ b/ci/commit_pragma_mapping.yaml
@@ -191,6 +191,10 @@ src/cart:
 src/client/dfs/:
   test-tag: dfs
 
+# It is not ideal to exclude the build tests but they are currently unstable
+src/client/dfuse/:
+  test-tag: dfuse,-DaosBuild,-DaosBuildVM
+
 src/client/pydaos/torch/:
   test-tag: pytorch
 

--- a/ci/commit_pragma_mapping.yaml
+++ b/ci/commit_pragma_mapping.yaml
@@ -191,9 +191,8 @@ src/cart:
 src/client/dfs/:
   test-tag: dfs
 
-# It is not ideal to exclude the build tests but they are currently unstable
 src/client/dfuse/:
-  test-tag: dfuse,-DaosBuild,-DaosBuildVM
+  test-tag: dfuse
 
 src/client/pydaos/torch/:
   test-tag: pytorch


### PR DESCRIPTION
Run dfuse tests by default when dfuse source is modified.
Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
