### PR TITLE
DAOS-19451 test: Add pool/container default attributes check

### DIFF
--- a/src/tests/ftest/util/pool_create_all_base.py
+++ b/src/tests/ftest/util/pool_create_all_base.py
@@ -1,6 +1,6 @@
 """
 (C) Copyright 2022-2024 Intel Corporation.
-(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+(C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -111,10 +111,11 @@ class PoolCreateAllTestBase(TestWithServers):
         pool_idx = len(self.pool) - pool_count
 
         # pylint: disable-next=logging-format-truncated
-        self.log.info("Creating a pool with all the available storage: size=100%")
-        self.pool[pool_idx].size.update("100%", "pool[{}].size".format(pool_idx))
+        self.log_step(
+            f"Creating a TestPool_{pool_idx + 1} with all the available storage: size=100%")
+        self.pool[pool_idx].size.update("100%", f"pool[{pool_idx}].size")
         if ranks is not None:
-            self.pool[pool_idx].target_list.update(ranks, "pool[{}].target_list".format(pool_idx))
+            self.pool[pool_idx].target_list.update(ranks, f"pool[{pool_idx}].target_list")
         self.pool[pool_idx].create()
         self.pool[pool_idx].get_info()
         tier_bytes = self.pool[pool_idx].info.pi_space.ps_space.s_total
@@ -125,8 +126,11 @@ class PoolCreateAllTestBase(TestWithServers):
             self.assertListEqual(
                 wait_ranks,
                 got_ranks,
-                "Pool with invalid ranks: wait={} got={}".format(wait_ranks, got_ranks))
+                f"Pool with invalid ranks: wait={wait_ranks} got={got_ranks}")
         self.log.info("Pool created: scm_size=%d, nvme_size=%d", *tier_bytes)
+        self.log_step(f"Verifying TestPool_{pool_idx + 1} default attributes")
+        self.check_pool_default_attributes(self.pool[pool_idx], label=f"TestPool_{pool_idx + 1}")
+        self.log_step(f"Destroying TestPool_{pool_idx + 1}")
         self.pool[pool_idx].destroy()
         pool_idx += 1
 
@@ -138,32 +142,33 @@ class PoolCreateAllTestBase(TestWithServers):
             nvme_delta_bytes is None,
             "Invalid function call: no NVME delta with usable NVMe storage")
 
-        self.log.info(
-            "Creating a pool with all the available storage: scm_size=%d, nvme_size=%d",
-            dmg_scm_size,
-            dmg_nvme_size)
-        self.pool[pool_idx].scm_size.update(dmg_scm_size, "pool[{}].scm_size", pool_idx)
+        self.log_step(
+            f"Creating a pool with all the available storage: scm_size={dmg_scm_size}, "
+            f"nvme_size={dmg_nvme_size}")
+        self.pool[pool_idx].scm_size.update(dmg_scm_size, f"pool[{pool_idx}].scm_size")
         if dmg_nvme_size > 0:
-            self.pool[pool_idx].nvme_size.update(dmg_nvme_size, "pool[{}].nvme_size", pool_idx)
+            self.pool[pool_idx].nvme_size.update(dmg_nvme_size, f"pool[{pool_idx}].nvme_size")
         if ranks is not None:
-            self.pool[pool_idx].target_list.update(ranks, "pool[{}].target_list".format(pool_idx))
+            self.pool[pool_idx].target_list.update(ranks, f"pool[{pool_idx}].target_list")
         self.pool[pool_idx].create()
+        self.log_step(f"Verifying TestPool_{pool_idx + 1} default attributes")
+        self.check_pool_default_attributes(self.pool[pool_idx], label=f"TestPool_{pool_idx + 1}")
+        self.log_step(f"Destroying TestPool_{pool_idx + 1}")
         self.pool[pool_idx].destroy()
         pool_idx += 1
 
-        self.log.info(
-            "Creating a pool with SCM oversubscription: scm_size=%d nvme_size=%d",
-            dmg_scm_size + scm_delta_bytes,
-            dmg_nvme_size)
+        self.log_step(
+            f"Creating a pool with SCM oversubscription: scm_size={dmg_scm_size}, "
+            f"nvme_size={dmg_nvme_size}")
         self.pool[pool_idx].scm_size.update(
             dmg_scm_size + scm_delta_bytes,
-            "pool[{}].scm_size".format(pool_idx))
+            f"pool[{pool_idx}].scm_size")
         if dmg_nvme_size > 0:
             self.pool[pool_idx].nvme_size.update(
                 dmg_nvme_size,
-                "pool[{}].nvme_size".format(pool_idx))
+                f"pool[{pool_idx}].nvme_size")
         if ranks is not None:
-            self.pool[pool_idx].target_list.update(ranks, "pool[{}].target_list".format(pool_idx))
+            self.pool[pool_idx].target_list.update(ranks, f"pool[{pool_idx}].target_list")
         error_msg = r"Pool should not be created: SCM oversubscription"
         with self.assertRaises(TestFail, msg=error_msg) as context_manager:
             self.pool[pool_idx].create()
@@ -174,18 +179,17 @@ class PoolCreateAllTestBase(TestWithServers):
         pool_idx += 1
 
         if dmg_nvme_size > 0:
-            self.log.info(
-                "Creating a pool with NVME oversubscription: scm_size=%d, nvme_size=%d",
-                dmg_scm_size,
-                dmg_nvme_size + nvme_delta_bytes)
-            self.pool[pool_idx].scm_size.update(dmg_scm_size, "pool[{}].scm_size".format(pool_idx))
+            self.log_step(
+                f"Creating a pool with NVME oversubscription: scm_size={dmg_scm_size}, "
+                f"nvme_size={dmg_nvme_size + nvme_delta_bytes}")
+            self.pool[pool_idx].scm_size.update(dmg_scm_size, f"pool[{pool_idx}].scm_size")
             self.pool[pool_idx].nvme_size.update(
                 dmg_nvme_size + nvme_delta_bytes,
-                "pool[{}].nvme_size".format(pool_idx))
+                f"pool[{pool_idx}].nvme_size")
             if ranks is not None:
                 self.pool[pool_idx].target_list.update(
                     ranks,
-                    "pool[{}].target_list".format(pool_idx))
+                    f"pool[{pool_idx}].target_list")
             error_msg = r"Pool should not be created: NVME oversubscription"
             with self.assertRaises(TestFail, msg=error_msg) as context_manager:
                 self.pool[pool_idx].create()
@@ -195,18 +199,20 @@ class PoolCreateAllTestBase(TestWithServers):
                 "Pool creation failed with invalid error message")
             pool_idx += 1
 
-        self.log.info(
-            "Creating a pool with 100%% of the available storage: scm_size=%d, nvme_size=%d",
-            dmg_scm_size,
-            dmg_nvme_size)
-        self.pool[pool_idx].scm_size.update(dmg_scm_size, "pool[{}].scm_size".format(pool_idx))
+        self.log_step(
+            f"Creating a pool with 100%% of the available storage: scm_size={dmg_scm_size}, "
+            f"nvme_size={dmg_nvme_size}")
+        self.pool[pool_idx].scm_size.update(dmg_scm_size, f"pool[{pool_idx}].scm_size")
         if dmg_nvme_size > 0:
             self.pool[pool_idx].nvme_size.update(
                 dmg_nvme_size,
-                "pool[{}].nvme_size".format(pool_idx))
+                f"pool[{pool_idx}].nvme_size")
         if ranks is not None:
-            self.pool[pool_idx].target_list.update(ranks, "pool[{}].target_list".format(pool_idx))
+            self.pool[pool_idx].target_list.update(ranks, f"pool[{pool_idx}].target_list")
         self.pool[pool_idx].create()
+        self.log_step(f"Verifying TestPool_{pool_idx + 1} default attributes")
+        self.check_pool_default_attributes(self.pool[pool_idx], label=f"TestPool_{pool_idx + 1}")
+        self.log_step(f"Destroying TestPool_{pool_idx + 1}")
         self.pool[pool_idx].destroy()
 
     def check_pool_recycling(self, pool_count, scm_delta_bytes, nvme_delta_bytes=None):
@@ -387,3 +393,36 @@ class PoolCreateAllTestBase(TestWithServers):
             pool_size[1],
             delta=nvme_delta_bytes,
             msg="Pool with invalid NVME size")
+
+    def check_pool_default_attributes(self, pool, label="TestPool_1"):
+        """Check the default attributes of a pool.
+
+        Args:
+            pool (TestPool): The pool object to check.
+            label (str, optional): The label of the pool. Defaults to "TestPool_1".
+
+        Raises:
+            TestFail: If any of the default attributes are missing or have invalid values.
+        """
+        defaults = {
+            "label": label,
+            "acl": pool.acl.value,
+            "space_rb": "5%",
+            "self_heal": pool.self_heal.value,
+            "owner": pool.owner.value,
+            "owner_group": pool.owner_group.value
+        }
+        response = pool.get_prop()['response']
+        errors = []
+        for key, value in defaults.items():
+            if key not in response:
+                errors.append(f"Missing property: {key}")
+                continue
+            if response[key] != value:
+                errors.append(
+                    f"Invalid value for property: {key}, expected: {value}, got: {response[key]}")
+        if errors:
+            self.log.error("Pool default attributes check failed:")
+            for error in errors:
+                self.log.error(f"  - {error}")
+            raise TestFail("Pool default attributes check failed")

--- a/src/tests/ftest/util/pool_create_all_base.py
+++ b/src/tests/ftest/util/pool_create_all_base.py
@@ -129,7 +129,7 @@ class PoolCreateAllTestBase(TestWithServers):
                 f"Pool with invalid ranks: wait={wait_ranks} got={got_ranks}")
         self.log.info("Pool created: scm_size=%d, nvme_size=%d", *tier_bytes)
         self.log_step(f"Verifying TestPool_{pool_idx + 1} default attributes")
-        self.check_pool_default_attributes(self.pool[pool_idx], label=f"TestPool_{pool_idx + 1}")
+        self.pool[pool_idx].verify_props()
         self.log_step(f"Destroying TestPool_{pool_idx + 1}")
         self.pool[pool_idx].destroy()
         pool_idx += 1
@@ -152,7 +152,7 @@ class PoolCreateAllTestBase(TestWithServers):
             self.pool[pool_idx].target_list.update(ranks, f"pool[{pool_idx}].target_list")
         self.pool[pool_idx].create()
         self.log_step(f"Verifying TestPool_{pool_idx + 1} default attributes")
-        self.check_pool_default_attributes(self.pool[pool_idx], label=f"TestPool_{pool_idx + 1}")
+        self.pool[pool_idx].verify_props()
         self.log_step(f"Destroying TestPool_{pool_idx + 1}")
         self.pool[pool_idx].destroy()
         pool_idx += 1
@@ -211,7 +211,7 @@ class PoolCreateAllTestBase(TestWithServers):
             self.pool[pool_idx].target_list.update(ranks, f"pool[{pool_idx}].target_list")
         self.pool[pool_idx].create()
         self.log_step(f"Verifying TestPool_{pool_idx + 1} default attributes")
-        self.check_pool_default_attributes(self.pool[pool_idx], label=f"TestPool_{pool_idx + 1}")
+        self.pool[pool_idx].verify_props()
         self.log_step(f"Destroying TestPool_{pool_idx + 1}")
         self.pool[pool_idx].destroy()
 
@@ -393,34 +393,3 @@ class PoolCreateAllTestBase(TestWithServers):
             pool_size[1],
             delta=nvme_delta_bytes,
             msg="Pool with invalid NVME size")
-
-    def check_pool_default_attributes(self, pool, label="TestPool_1"):
-        """Check the default attributes of a pool.
-
-        Args:
-            pool (TestPool): The pool object to check.
-            label (str, optional): The label of the pool. Defaults to "TestPool_1".
-
-        Raises:
-            TestFail: If any of the default attributes are missing or have invalid values.
-        """
-        defaults = {
-            "label": label,
-            "space_rb": "5%",
-            "rd_fac": "3",
-            "ec_cell_sz": "128 KiB"
-        }
-        response = pool.get_prop()['response']
-        errors = []
-        for key, value in defaults.items():
-            if key not in response:
-                errors.append(f"Missing property: {key}")
-                continue
-            if response[key] != value:
-                errors.append(
-                    f"Invalid value for property: {key}, expected: {value}, got: {response[key]}")
-        if errors:
-            self.log.error("Pool default attributes check failed:")
-            for error in errors:
-                self.log.error(f"  - {error}")
-            raise TestFail("Pool default attributes check failed")

--- a/src/tests/ftest/util/pool_create_all_base.py
+++ b/src/tests/ftest/util/pool_create_all_base.py
@@ -406,11 +406,9 @@ class PoolCreateAllTestBase(TestWithServers):
         """
         defaults = {
             "label": label,
-            "acl": pool.acl.value,
             "space_rb": "5%",
-            "self_heal": pool.self_heal.value,
-            "owner": pool.owner.value,
-            "owner_group": pool.owner_group.value
+            "rd_fac": "3",
+            "ec_cell_sz": "128 KiB"
         }
         response = pool.get_prop()['response']
         errors = []

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -21,6 +21,28 @@ from test_utils_base import LabelGenerator, TestDaosApiBase
 
 POOL_NAMESPACE = "/run/pool/*"
 POOL_TIMEOUT_INCREMENT = 200
+DEFAULT_POOL_PROPS = {
+    "checkpoint": "timed",
+    "checkpoint_freq": 50,
+    "data_thresh": 4096,
+    "ec_cell_sz": 131072,   # 128 KiB
+    "ec_pda": 1,
+    "global_version": 4,
+    "perf_domain": "root",
+    "rd_fac": 3,
+    "reclaim": "lazy",
+    "reintegration": "data_sync",
+    "rp_pda": 4294967295,
+    "scrub": "off",
+    "scrub_freq": 604800,
+    "scrub_thresh": 0,
+    "self_heal": "exclude;rebuild",
+    "space_rb": 5,
+    "svc_ops_enabled": 1,
+    "svc_ops_entry_age": 300,
+    "svc_rf": 2,
+    "upgrade_status": "not started"
+}
 
 
 def add_pools(dmg, add_pool_kwargs, error_handler=None):
@@ -1648,3 +1670,43 @@ class TestPool(TestDaosApiBase):
                     raise AssertionError(
                         f'Expected target {target} to be in state {expected_target_state}, '
                         f'but current state is {info["target_state"]}')
+
+        # pylint: disable=dangerous-default-value
+    def verify_props(self, expected=DEFAULT_POOL_PROPS):
+        """Verify pool properties match expected values.
+
+        Args:
+            expected (dict): Expected key/value pairs from pool properties.
+                Can be a subset of the full properties, where only expected keys are verified.
+                Defaults to DEFAULT_POOL_PROPS.
+
+        Raises:
+            TestFail: If any of the default properties are missing or have invalid values.
+        """
+        errors = {
+            "types": set(),
+            "details": []
+        }
+
+        try:
+            data = {}
+            for entry in self.get_prop()['response']:
+                data[entry['name']] = entry['value']
+            for key, value in expected.items():
+                if key not in data:
+                    errors["types"].add("missing property")
+                    errors["details"].append(f"Missing property: {key}")
+                    continue
+                if data[key] != value:
+                    errors["types"].add("property value")
+                    errors["details"].append(
+                        f"Invalid value for property: {key}, expected: {value}, got: {data[key]}")
+        except TestFail as error:
+            errors["types"].add("retrieval error")
+            errors["details"].append(f"Error retrieving pool properties: {str(error)}")
+
+        if errors["types"]:
+            self.log.error("Errors detected verifying pool properties:")
+            for error in errors["details"]:
+                self.log.error(f"  - {error}")
+            raise TestFail(f'Pool properties check failed - {", ".join(errors["types"])}')


### PR DESCRIPTION
Add checking the default pool and container default attributes.

Quick-functional: true
Test-tag: test_one_pool_hw test_two_pools_hw test_one_pool_vm test_rank_filter test_two_pools_vm

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
