### PR TITLE
DAOS-19494 cq: fix commit_pragma_mapping.yaml regex

### DIFF
--- a/ci/commit_pragma_mapping.yaml
+++ b/ci/commit_pragma_mapping.yaml
@@ -24,157 +24,157 @@ src/tests/ftest/cart/.*\.[ch]$:
   <<: *ftest-only
 
 # Special handling for ftest, defaulting to pr
-src/tests/ftest*:
+src/tests/ftest/:
   <<: *ftest-only
   test-tag:
     handler: FtestTagMap
     tags: pr
 
-src/tests/suite/daos_aggregate_ec.c:
+src/tests/suite/daos_aggregate_ec\.c$:
   test-tag: test_daos_aggregate_ec
   <<: *ftest-only
 
-src/tests/suite/daos_array.c:
+src/tests/suite/daos_array\.c$:
   test-tag: test_daos_array
   <<: *ftest-only
 
-src/tests/suite/daos_base_tx.c:
+src/tests/suite/daos_base_tx\.c$:
   test-tag: test_daos_single_rdg_tx
   <<: *ftest-only
 
-src/tests/suite/daos_capa.c:
+src/tests/suite/daos_capa\.c$:
   test-tag: test_daos_capability
   <<: *ftest-only
 
-src/tests/suite/daos_checksum.c:
+src/tests/suite/daos_checksum\.c$:
   test-tag: test_daos_checksum
   <<: *ftest-only
 
-src/tests/suite/daos_container.c:
+src/tests/suite/daos_container\.c$:
   test-tag: test_daos_container
   <<: *ftest-only
 
-src/tests/suite/daos_cr.c:
+src/tests/suite/daos_cr\.c$:
   test-tag: test_daos_cat_recov_core
   <<: *ftest-only
 
-src/tests/suite/daos_dedup.c:
+src/tests/suite/daos_dedup\.c$:
   test-tag: test_daos_dedup
   <<: *ftest-only
 
-src/tests/suite/daos_degraded.c:
+src/tests/suite/daos_degraded\.c$:
   test-tag: test_daos_degraded_mode
   <<: *ftest-only
 
-src/tests/suite/daos_degrade_ec.c:
+src/tests/suite/daos_degrade_ec\.c$:
   test-tag: test_daos_degraded_ec
   <<: *ftest-only
 
-src/tests/suite/daos_dist_tx.c:
+src/tests/suite/daos_dist_tx\.c$:
   test-tag: test_daos_distributed_tx
   <<: *ftest-only
 
-src/tests/suite/daos_drain_simple.c:
+src/tests/suite/daos_drain_simple\.c$:
   test-tag: test_daos_drain_simple
   <<: *ftest-only
 
-src/tests/suite/daos_epoch.c:
+src/tests/suite/daos_epoch\.c$:
   test-tag: test_daos_epoch
   <<: *ftest-only
 
-src/tests/suite/daos_epoch_recovery.c:
+src/tests/suite/daos_epoch_recovery\.c$:
   test-tag: test_daos_epoch_recovery
   <<: *ftest-only
 
-src/tests/suite/daos_extend_simple.c:
+src/tests/suite/daos_extend_simple\.c$:
   test-tag: test_daos_extend_simple
   <<: *ftest-only
 
-src/tests/suite/daos_inc_reint.c:
+src/tests/suite/daos_inc_reint\.c$:
   test-tag: test_daos_inc_reint_cont_recov
   <<: *ftest-only
 
-src/tests/suite/daos_kv.c:
+src/tests/suite/daos_kv\.c$:
   test-tag: test_daos_kv
   <<: *ftest-only
 
-src/tests/suite/daos_md_replication.c:
+src/tests/suite/daos_md_replication\.c$:
   test-tag: test_daos_md_replication
   <<: *ftest-only
 
-src/tests/suite/daos_mgmt.c:
+src/tests/suite/daos_mgmt\.c$:
   test-tag: test_daos_management
   <<: *ftest-only
 
-src/tests/suite/daos_nvme_recovery.c:
+src/tests/suite/daos_nvme_recovery\.c$:
   test-tag: DaosCoreTestNvme
   <<: *ftest-only
 
-src/tests/suite/daos_obj_array.c:
+src/tests/suite/daos_obj_array\.c$:
   test-tag: test_daos_object_array
   <<: *ftest-only
 
-src/tests/suite/daos_obj.c:
+src/tests/suite/daos_obj\.c$:
   test-tag: test_daos_io test_daos_ec_io
   <<: *ftest-only
 
-src/tests/suite/daos_obj_ec.c:
+src/tests/suite/daos_obj_ec\.c$:
   test-tag: test_daos_ec_obj
   <<: *ftest-only
 
-src/tests/suite/daos_oid_alloc.c:
+src/tests/suite/daos_oid_alloc\.c$:
   test-tag: test_daos_oid_allocator
   <<: *ftest-only
 
-src/tests/suite/daos_pipeline.c:
+src/tests/suite/daos_pipeline\.c$:
   test-tag: test_daos_pipeline
   <<: *ftest-only
 
-src/tests/suite/daos_pool.c:
+src/tests/suite/daos_pool\.c$:
   test-tag: test_daos_pool
   <<: *ftest-only
 
-src/tests/suite/daos_rebuild.c:
+src/tests/suite/daos_rebuild\.c$:
   test-tag: DaosCoreTestRebuild
   <<: *ftest-only
 
-src/tests/suite/daos_rebuild_ec.c:
+src/tests/suite/daos_rebuild_ec\.c$:
   test-tag: test_daos_rebuild_ec
   <<: *ftest-only
 
-src/tests/suite/daos_rebuild_interactive.c:
+src/tests/suite/daos_rebuild_interactive\.c$:
   test-tag: test_daos_rebuild_interactive
   <<: *ftest-only
 
-src/tests/suite/daos_rebuild_simple.c:
+src/tests/suite/daos_rebuild_simple\.c$:
   test-tag: test_daos_rebuild_simple
   <<: *ftest-only
 
-src/tests/suite/daos_upgrade.c:
+src/tests/suite/daos_upgrade\.c$:
   test-tag: test_daos_upgrade
   <<: *ftest-only
 
-src/tests/suite/daos_verify_consistency.c:
+src/tests/suite/daos_verify_consistency\.c$:
   test-tag: test_daos_verify_consistency
   <<: *ftest-only
 
-src/tests/suite/dfs_par_test.c:
+src/tests/suite/dfs_par_test\.c$:
   test-tag: test_daos_dfs_parallel
   <<: *ftest-only
 
-src/tests/suite/dfs_sys_unit_test.c:
+src/tests/suite/dfs_sys_unit_test\.c$:
   test-tag: test_daos_dfs_sys
   <<: *ftest-only
 
-src/tests/suite/dfs_test.c:
+src/tests/suite/dfs_test\.c$:
   test-tag: dfs_test
   <<: *ftest-only
 
-src/tests/suite/dfs_unit_test.c:
+src/tests/suite/dfs_unit_test\.c$:
   test-tag: test_daos_dfs_unit
   <<: *ftest-only
 
-src/tests/suite/dfuse_test.c:
+src/tests/suite/dfuse_test\.c$:
   test-tag: DaosCoreTestDfuse
   <<: *ftest-only
 
@@ -185,7 +185,7 @@ src/tests/suite/:
 
 
 # Individual code areas
-src/cart:
+src/cart/:
   test-tag: cart
 
 src/client/dfs/:


### PR DESCRIPTION
Fix the regex in commit_pragma_mapping.yaml to user literal "." and "$" when needed.

Doc-only: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
