### PR TITLE
DAOS-19449 dfuse: fix EOF logic to avoid corruption (#18824)

### DIFF
--- a/src/client/dfuse/ops/read.c
+++ b/src/client/dfuse/ops/read.c
@@ -73,15 +73,10 @@ readahead_actual_reply(struct active_inode *active, struct read_req *rr)
 	 * In this case do not dereference beyond the pre-read buffer.
 	 */
 	if (rr->position >= readahead_len) {
-		rr->oh->doh_linear_read_eof = true;
 		DFUSE_TRA_DEBUG(rr->oh, "%#zx-%#zx requested (EOF)", rr->position,
 				rr->position + rr->len - 1);
 		DFUSE_REPLY_BUFQ(rr->oh, rr->req, NULL, 0);
 		return;
-	}
-
-	if (rr->len >= readahead_len - rr->position) {
-		rr->oh->doh_linear_read_eof = true;
 	}
 
 	/* At this point there is a buffer of known length that contains the data, and a read
@@ -153,6 +148,14 @@ dfuse_readahead_reply(fuse_req_t req, size_t len, off_t position, struct dfuse_o
 	} else {
 		oh->doh_linear_read_pos = position + len;
 	}
+
+	size_t readahead_len = active->readahead->dra_ev->de_readahead_len;
+
+	/* eof pairs with the position just advanced; must agree with readahead_actual_reply's
+	 * truncation split.  The first arm guards the unsigned subtraction.
+	 */
+	if (position >= (off_t)readahead_len || len >= readahead_len - position)
+		oh->doh_linear_read_eof = true;
 
 	struct read_req rr;
 
@@ -486,7 +489,8 @@ dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position, struct
 
 	DFUSE_IE_STAT_ADD(oh->doh_ie, DS_READ);
 
-	if (oh->doh_linear_read_eof && position == oh->doh_linear_read_pos) {
+	/* The cached EOF is only valid while the handle is still linear */
+	if (oh->doh_linear_read && oh->doh_linear_read_eof && position == oh->doh_linear_read_pos) {
 		DFUSE_TRA_DEBUG(oh, "Returning EOF early without round trip %#zx", position);
 		oh->doh_linear_read_eof = false;
 		oh->doh_linear_read     = false;

--- a/src/tests/ftest/dfuse/read.py
+++ b/src/tests/ftest/dfuse/read.py
@@ -1,13 +1,30 @@
 """
   (C) Copyright 2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
+import os
 import time
 
 from apricot import TestWithServers
 from dfuse_utils import get_dfuse, start_dfuse
 from run_utils import run_remote
+
+
+def helper_failure(label, result):
+    """Describe a failed helper run using the helper's own error message.
+
+    Args:
+        label (str): which leg of the test failed
+        result (CommandResult): the failed run_remote result
+
+    Returns:
+        str: the label plus the helper's error output
+    """
+    data = result.output[0]
+    message = "; ".join(data.stdout + data.stderr) or f"helper exited {data.returncode}"
+    return f"{label}: {message}"
 
 
 class DFusePreReadTest(TestWithServers):
@@ -126,3 +143,133 @@ class DFusePreReadTest(TestWithServers):
         )
 
         self.assertEqual(data["inodes"], 4, "expected 4 inodes in cache")
+
+    def test_dfuse_pre_read_stale_eof(self):
+        """
+        Test Description:
+            Guard against DAOS-18683: a read drained while a pre-read RPC was in flight could
+            leave a handle claiming EOF at offset zero, so a later read there returned no data
+            (plain read) or faulted with SIGBUS (mmap).
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=dfuse
+        :avocado: tags=DFusePreReadTest,test_dfuse_pre_read_stale_eof
+        """
+        pool = self.get_pool(connect=False)
+        container = self.get_container(pool)
+
+        dfuse = get_dfuse(self, self.hostlist_clients)
+
+        cont_attrs = {}
+        cont_attrs["dfuse-data-cache"] = "1h"
+        cont_attrs["dfuse-attr-time"] = "1h"
+        cont_attrs["dfuse-dentry-time"] = "1h"
+        cont_attrs["dfuse-ndentry-time"] = "1h"
+        container.set_attr(attrs=cont_attrs)
+
+        start_dfuse(self, dfuse, pool, container)
+
+        fuse_root_dir = dfuse.mount_dir.value
+        helper = os.path.join(self.prefix, "lib/daos/TESTING/tests/preread_stale_eof")
+
+        def run_or_fail(cmd):
+            result = run_remote(self.log, self.hostlist_clients, cmd)
+            if not result.passed:
+                self.fail(f'"{cmd}" failed on {result.failed_hosts}')
+
+        def evict_and_wait(subdir, baseline):
+            # Eviction is asynchronous; a check run before the forget lands is vacuous.
+            daos_bin = os.path.join(self.prefix, "bin", "daos")
+            run_or_fail(f"{daos_bin} fs evict {subdir}")
+            for _ in range(20):
+                if dfuse.get_stats()["inodes"] <= baseline:
+                    return
+                time.sleep(0.5)
+            self.fail(f"eviction of {subdir} did not complete")
+
+        pre_read_before = dfuse.get_stats()["statistics"].get("pre_read", 0)
+
+        sizes = (4096, 65536, 131072, 1024 * 1024)
+        iterations = 4
+        failures = []
+        for itr in range(iterations):
+            for size in sizes:
+                subdir = f"{fuse_root_dir}/dir.{itr}.{size}"
+                target = f"{subdir}/target"
+                baseline = dfuse.get_stats()["inodes"]
+                run_or_fail(f"mkdir {subdir}")
+                run_or_fail(f"{helper} write {target} {size} {itr}")
+                evict_and_wait(subdir, baseline)
+
+                cmd = f"{helper} check {target} {size} {itr}"
+                result = run_remote(self.log, self.hostlist_clients, cmd)
+                if not result.passed:
+                    failures.append(helper_failure(f"iteration {itr} size {size}", result))
+
+        # Tail offsets let a read queued behind the pre-read arm EOF state; re-reads probe it.
+        for itr in range(4):
+            size = 131072
+            subdir = f"{fuse_root_dir}/race.{itr}"
+            target = f"{subdir}/target"
+            baseline = dfuse.get_stats()["inodes"]
+            run_or_fail(f"mkdir {subdir}")
+            run_or_fail(f"{helper} write {target} {size} {itr}")
+            evict_and_wait(subdir, baseline)
+
+            cmd = f"{helper} race {target} {size} {itr}"
+            result = run_remote(self.log, self.hostlist_clients, cmd)
+            if not result.passed:
+                failures.append(helper_failure(f"race {itr}", result))
+
+        pre_read_after = dfuse.get_stats()["statistics"].get("pre_read", 0)
+
+        # Guards non-engagement only; the stat cannot prove any check was actually drained.
+        self.assertGreater(
+            pre_read_after, pre_read_before, "pre-read never engaged, checks were vacuous"
+        )
+        if failures:
+            self.fail(f"{len(failures)} corrupted reads:\n" + "\n".join(failures))
+
+    def test_dfuse_stale_eof_after_append(self):
+        """
+        Test Description:
+            Guard against the early-EOF cache surviving a write: read to EOF, append through
+            the same handle, then re-read at the old EOF and expect the appended bytes.
+            Data caching is disabled so direct-io makes every read reach dfuse.
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=dfuse
+        :avocado: tags=DFusePreReadTest,test_dfuse_stale_eof_after_append
+        """
+        pool = self.get_pool(connect=False)
+        container = self.get_container(pool)
+
+        dfuse = get_dfuse(self, self.hostlist_clients)
+
+        container.set_attr(attrs={"dfuse-data-cache": "off"})
+
+        start_dfuse(self, dfuse, pool, container)
+
+        fuse_root_dir = dfuse.mount_dir.value
+        helper = os.path.join(self.prefix, "lib/daos/TESTING/tests/preread_stale_eof")
+
+        failures = []
+        for itr in range(2):
+            for size in (4096, 65536):
+                target = f"{fuse_root_dir}/append.{itr}.{size}"
+                result = run_remote(
+                    self.log, self.hostlist_clients, f"{helper} write {target} {size} {itr}"
+                )
+                if not result.passed:
+                    self.fail(f"write of {target} failed on {result.failed_hosts}")
+
+                result = run_remote(
+                    self.log, self.hostlist_clients, f"{helper} append {target} {size} {itr}"
+                )
+                if not result.passed:
+                    failures.append(helper_failure(f"iteration {itr} size {size}", result))
+
+        if failures:
+            self.fail(f"{len(failures)} corrupted reads after append:\n" + "\n".join(failures))

--- a/src/tests/ftest/dfuse/read.yaml
+++ b/src/tests/ftest/dfuse/read.yaml
@@ -2,6 +2,8 @@ hosts:
   test_servers: 1
   test_clients: 1
 timeout: 900
+timeouts:
+  test_dfuse_pre_read_stale_eof: 1200
 server_config:
   name: daos_server
   engines_per_host: 1

--- a/src/tests/ftest/dfuse/utest/SConscript
+++ b/src/tests/ftest/dfuse/utest/SConscript
@@ -1,5 +1,6 @@
 # /*
 #  * (C) Copyright 2024 Intel Corporation.
+#  * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 #  *
 #  * SPDX-License-Identifier: BSD-2-Clause-Patent
 # */
@@ -23,6 +24,11 @@ def scons():
     for test in PIL4DFS_TEST_SRC:
         test_exe = test_env.d_test_program(test)
         test_env.Install(tests_dir, test_exe)
+
+    preread_env = test_env.Clone()
+    preread_env.AppendUnique(LINKFLAGS=['-pthread'])
+    test_exe = preread_env.d_test_program('preread_stale_eof.c')
+    test_env.Install(tests_dir, test_exe)
 
 
 if __name__ == "SCons.Script":

--- a/src/tests/ftest/dfuse/utest/preread_stale_eof.c
+++ b/src/tests/ftest/dfuse/utest/preread_stale_eof.c
@@ -1,0 +1,411 @@
+/*
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/**
+ * Write/check helper for the dfuse pre-read stale-EOF ftest case (DAOS-18683)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define PATTERN_LEN 255
+
+static void
+patterned_bytes(unsigned char *buf, size_t size, unsigned int seed)
+{
+	size_t offset = seed % PATTERN_LEN;
+	size_t i;
+
+	for (i = 0; i < size; i++)
+		buf[i] = ((offset + i) % PATTERN_LEN) + 1;
+}
+
+static int
+do_write(const char *path, size_t size, unsigned int seed)
+{
+	unsigned char *buf;
+	int            fd;
+	ssize_t        written;
+	int            rc = 0;
+
+	buf = malloc(size);
+	if (buf == NULL) {
+		fprintf(stderr, "malloc(%zu) failed\n", size);
+		return 1;
+	}
+	patterned_bytes(buf, size, seed);
+
+	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (fd < 0) {
+		fprintf(stderr, "open(%s) failed: %s\n", path, strerror(errno));
+		free(buf);
+		return 1;
+	}
+
+	written = write(fd, buf, size);
+	if (written != (ssize_t)size) {
+		fprintf(stderr, "write(%s) wrote %zd bytes, expected %zu\n", path, written, size);
+		rc = 1;
+	}
+
+	/* Writeback flush errors surface at close; swallowing one here would read as corruption */
+	if (close(fd) != 0) {
+		fprintf(stderr, "close(%s) failed: %s\n", path, strerror(errno));
+		rc = 1;
+	}
+	free(buf);
+	return rc;
+}
+
+static void
+drop_cache(int fd, const char *path)
+{
+	int rc = posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+
+	if (rc != 0)
+		fprintf(stderr, "posix_fadvise(%s) failed: %s\n", path, strerror(rc));
+}
+
+/* The corruption reads back as either a short read at a valid offset or a NUL-filled buffer */
+static void
+report_bad_read(const char *what, size_t offset, ssize_t got, size_t want,
+		const unsigned char *data)
+{
+	size_t nuls = 0;
+
+	if (got != (ssize_t)want) {
+		fprintf(stderr, "%s at offset %zu returned %zd bytes, expected %zu\n", what, offset,
+			got, want);
+		return;
+	}
+	while (nuls < want && data[nuls] == 0)
+		nuls++;
+	if (nuls == want)
+		fprintf(stderr, "%s at offset %zu returned %zu NUL bytes instead of data\n", what,
+			offset, want);
+	else
+		fprintf(stderr, "%s at offset %zu returned wrong data\n", what, offset);
+}
+
+static int
+do_check(const char *path, size_t size, unsigned int seed)
+{
+	unsigned char *expected;
+	unsigned char *data;
+	size_t         total;
+	size_t         want_len;
+	ssize_t        got;
+	int            fd;
+	pid_t          child;
+	int            status;
+
+	expected = malloc(size);
+	data     = malloc(size);
+	if (expected == NULL || data == NULL) {
+		fprintf(stderr, "malloc(%zu) failed\n", size);
+		free(expected);
+		free(data);
+		return 1;
+	}
+	patterned_bytes(expected, size, seed);
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		fprintf(stderr, "open(%s) failed: %s\n", path, strerror(errno));
+		free(expected);
+		free(data);
+		return 1;
+	}
+
+	total = 0;
+	while (total < size) {
+		got = read(fd, data + total, size - total);
+		if (got <= 0)
+			break;
+		total += got;
+	}
+	if (total != size || memcmp(data, expected, size) != 0) {
+		fprintf(stderr, "sequential read-back mismatch: got %zu/%zu bytes%s\n", total, size,
+			total == size ? " (content differs)" : "");
+		close(fd);
+		free(expected);
+		free(data);
+		return 3;
+	}
+
+	drop_cache(fd, path);
+
+	want_len = size < 4096 ? size : 4096;
+
+	got = pread(fd, data, want_len, 0);
+	if (got != (ssize_t)want_len || memcmp(data, expected, want_len) != 0) {
+		report_bad_read("pread", 0, got, want_len, data);
+		close(fd);
+		free(expected);
+		free(data);
+		return 1;
+	}
+
+	/* Drop the pread's pages or the child never reaches dfuse (fallback probe) */
+	drop_cache(fd, path);
+
+	child = fork();
+	if (child == 0) {
+		void *mapped = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+
+		if (mapped == MAP_FAILED) {
+			fprintf(stderr, "mmap failed: %s\n", strerror(errno));
+			_exit(3);
+		}
+		_exit(memcmp(mapped, expected, want_len) == 0 ? 0 : 1);
+	}
+	if (child < 0) {
+		fprintf(stderr, "fork() failed: %s\n", strerror(errno));
+		close(fd);
+		free(expected);
+		free(data);
+		return 1;
+	}
+
+	if (waitpid(child, &status, 0) != child) {
+		fprintf(stderr, "waitpid() failed: %s\n", strerror(errno));
+		close(fd);
+		free(expected);
+		free(data);
+		return 1;
+	}
+
+	close(fd);
+	free(expected);
+	free(data);
+
+	if (WIFSIGNALED(status)) {
+		fprintf(stderr, "mmap child killed by %s\n", strsignal(WTERMSIG(status)));
+		return 2;
+	}
+	if (WIFEXITED(status) && WEXITSTATUS(status) == 3) {
+		fprintf(stderr, "mmap child could not map the file\n");
+		return 1;
+	}
+	if (WIFEXITED(status) && WEXITSTATUS(status) == 1) {
+		fprintf(stderr, "mmap child read wrong content at offset 0\n");
+		return 2;
+	}
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		fprintf(stderr, "mmap child exited abnormally, status 0x%x\n", status);
+		return 2;
+	}
+
+	return 0;
+}
+
+struct race_read {
+	int            fd;
+	off_t          off;
+	size_t         len;
+	unsigned char *buf;
+	ssize_t        got;
+};
+
+static void *
+race_read_fn(void *arg)
+{
+	struct race_read *rr = arg;
+
+	rr->got = pread(rr->fd, rr->buf, rr->len, rr->off);
+	return NULL;
+}
+
+/* Queued reads drain in arrival order; later wrong data means the drain armed handle state */
+static int
+do_race(const char *path, size_t size, unsigned int seed)
+{
+	unsigned char   *expected;
+	unsigned char   *data;
+	struct race_read high;
+	pthread_t        thread;
+	ssize_t          got;
+	int              fd;
+	int              rc = 0;
+
+	if (size < 8192) {
+		fprintf(stderr, "race mode needs size >= 8192\n");
+		return 1;
+	}
+
+	expected = malloc(size);
+	data     = malloc(size);
+	if (expected == NULL || data == NULL) {
+		fprintf(stderr, "malloc(%zu) failed\n", size);
+		free(expected);
+		free(data);
+		return 1;
+	}
+	patterned_bytes(expected, size, seed);
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		fprintf(stderr, "open(%s) failed: %s\n", path, strerror(errno));
+		free(expected);
+		free(data);
+		return 1;
+	}
+
+	high.fd  = fd;
+	high.off = (off_t)size - 4096;
+	high.len = 4096;
+	high.buf = data + 4096;
+	high.got = -1;
+	if (pthread_create(&thread, NULL, race_read_fn, &high) != 0) {
+		fprintf(stderr, "pthread_create failed\n");
+		close(fd);
+		free(expected);
+		free(data);
+		return 1;
+	}
+	got = pread(fd, data, 4096, size - 8192);
+	pthread_join(thread, NULL);
+
+	if (got != 4096 || high.got != 4096 || memcmp(data, expected + size - 8192, 4096) != 0 ||
+	    memcmp(data + 4096, expected + size - 4096, 4096) != 0) {
+		fprintf(stderr, "racing reads wrong: low %zd bytes, high %zd bytes\n", got,
+			high.got);
+		rc = 1;
+		goto out;
+	}
+
+	drop_cache(fd, path);
+
+	/* Probe the tail offsets and zero: a stateful drain arms EOF wherever it last wrote */
+	got = pread(fd, data, 4096, size - 8192);
+	if (got != 4096 || memcmp(data, expected + size - 8192, 4096) != 0) {
+		report_bad_read("re-read", size - 8192, got, 4096, data);
+		rc = 1;
+		goto out;
+	}
+	got = pread(fd, data, 4096, size - 4096);
+	if (got != 4096 || memcmp(data, expected + size - 4096, 4096) != 0) {
+		report_bad_read("re-read", size - 4096, got, 4096, data);
+		rc = 1;
+		goto out;
+	}
+	got = pread(fd, data, 4096, 0);
+	if (got != 4096 || memcmp(data, expected, 4096) != 0) {
+		report_bad_read("re-read", 0, got, 4096, data);
+		rc = 1;
+	}
+
+out:
+	close(fd);
+	free(expected);
+	free(data);
+	return rc;
+}
+
+#define APPEND_LEN 4096
+
+/* Reading to EOF arms the cache; the append must disarm it or the re-read sees EOF */
+static int
+do_append(const char *path, size_t size, unsigned int seed)
+{
+	unsigned char *expected;
+	unsigned char *data;
+	unsigned char *tail;
+	ssize_t        got;
+	int            fd;
+	int            rc = 0;
+
+	expected = malloc(size);
+	data     = malloc(size + APPEND_LEN);
+	tail     = malloc(APPEND_LEN);
+	if (expected == NULL || data == NULL || tail == NULL) {
+		fprintf(stderr, "malloc(%zu) failed\n", size);
+		free(expected);
+		free(data);
+		free(tail);
+		return 1;
+	}
+	patterned_bytes(expected, size, seed);
+	patterned_bytes(tail, APPEND_LEN, seed + 7);
+
+	fd = open(path, O_RDWR);
+	if (fd < 0) {
+		fprintf(stderr, "open(%s) failed: %s\n", path, strerror(errno));
+		free(expected);
+		free(data);
+		free(tail);
+		return 1;
+	}
+
+	got = read(fd, data, size + APPEND_LEN);
+	if (got != (ssize_t)size || memcmp(data, expected, size) != 0) {
+		fprintf(stderr, "read-back before append: got %zd/%zu bytes\n", got, size);
+		rc = 3;
+		goto out;
+	}
+
+	got = pwrite(fd, tail, APPEND_LEN, size);
+	if (got != APPEND_LEN) {
+		fprintf(stderr, "append pwrite returned %zd: %s\n", got, strerror(errno));
+		rc = 1;
+		goto out;
+	}
+
+	got = pread(fd, data, APPEND_LEN, size);
+	if (got != APPEND_LEN || memcmp(data, tail, APPEND_LEN) != 0) {
+		report_bad_read("re-read of appended bytes", size, got, APPEND_LEN, data);
+		rc = 1;
+	}
+
+out:
+	if (close(fd) != 0 && rc == 0) {
+		fprintf(stderr, "close(%s) failed: %s\n", path, strerror(errno));
+		rc = 1;
+	}
+	free(expected);
+	free(data);
+	free(tail);
+	return rc;
+}
+
+static void
+usage(const char *prog)
+{
+	fprintf(stderr, "usage: %s write|check|race|append <path> <size> <seed>\n", prog);
+}
+
+int
+main(int argc, char *argv[])
+{
+	size_t       size;
+	unsigned int seed;
+
+	if (argc != 5) {
+		usage(argv[0]);
+		return 1;
+	}
+
+	size = strtoul(argv[3], NULL, 10);
+	seed = strtoul(argv[4], NULL, 10);
+
+	if (strcmp(argv[1], "write") == 0)
+		return do_write(argv[2], size, seed);
+	if (strcmp(argv[1], "check") == 0)
+		return do_check(argv[2], size, seed);
+	if (strcmp(argv[1], "race") == 0)
+		return do_race(argv[2], size, seed);
+	if (strcmp(argv[1], "append") == 0)
+		return do_append(argv[2], size, seed);
+
+	usage(argv[0]);
+	return 1;
+}


### PR DESCRIPTION
The drain path for reads that raced the pre-read set the EOF flag
without updating the read position, so a later read there got an
empty reply: zero-filled files, or SIGBUS from mmap. Writes also
left the flag armed, returning stale EOF over appended data. The
flag is now set only next to the position update, and the early-EOF
reply checks doh_linear_read first.

Adds two new ftests that trigger the problems when run without
the fixes.

Signed-off-by: Michael MacDonald <github@macdonald.cx>
