### PR TITLE
DAOS-19496 control: remove per-engine sysdb on format replace

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -1134,12 +1134,14 @@ DAOS I/O Engines will be started, and all DAOS pools will have been removed.
 
 ### Storage Format Replace
 
-If storage metadata for a rank is lost, for example after losing PMem contents after NVDIMM failure,
-storage for that rank will need to be formatted and rank metadata regenerated. If other hardware on
-the storage server has not changed the old rank can be "reused" by formatting using the
-`dmg storage format --replace` option.
+If storage metadata for a rank is lost, for example after losing PMem contents after NVDIMM failure
+or after an SSD failure in MD-on-SSD mode, storage for that rank will need to be formatted and rank
+metadata regenerated. If other hardware on the storage server has not changed, the old rank can be
+"reused" by formatting using the `dmg storage format --replace` option.
 
-An examples workflow would be:
+#### PMem (DCPM) Failure Recovery Workflow
+
+An example workflow for PMem failure would be:
 
 1. `daos_server` is running and PMem NVDIMM fails causing an engine to enter excluded state.
 2. `daos_server` is stopped, storage server powered down, faulty PMem NVDIMM is replaced.
@@ -1150,6 +1152,116 @@ An examples workflow would be:
 7. Run `dmg storage format --replace` to rejoin with existing rank (if --replace isn't used, a new
    rank will be created).
 8. Formatted engine will join using the existing (old) rank which is mapped to the engine's hardware.
+
+#### SSD Failure Recovery in MD-on-SSD Mode
+
+In MD-on-SSD mode, when an SSD fails, the recovery process depends on which SSD failed and what
+data was stored on it. The control_metadata can be stored on any persistent local path (a dedicated
+SSD, shared storage device, or any mounted filesystem), and it stores critical engine metadata
+including superblocks separately from the data/meta/wal SSDs used for pool storage.
+
+!!! warning
+    This workflow is intended for offline device replacement scenarios where the storage server must
+    be powered down to replace the failed SSD. For SSD failures that support online replacement, use
+    the online device replacement procedures documented in the [SSD Management](#ssd-management)
+    section (see `dmg storage set nvme-faulty` and `dmg storage replace nvme`). Only use the
+    `dmg storage format --replace` workflow when hot-plug or online replacement is not available or
+    not suitable for the failure scenario.
+
+**Key Improvement**: The `dmg storage format --replace` command now safely handles control metadata
+formatting in MD-on-SSD mode. When an engine's data/meta/wal SSD fails and is replaced offline,
+the administrator must manually remove the engine's superblock before restarting the server to 
+trigger a format request. The command then selectively removes only the failed engine's 
+control_metadata subdirectory, preserving healthy engines' metadata on the same host.
+
+An example workflow for SSD failure in MD-on-SSD mode would be:
+
+1. `daos_server` is running and an SSD (data/meta/wal role) fails, causing one or more engines to become excluded.
+2. `daos_server` is stopped on the affected storage server.
+3. Storage server is powered down and the faulty SSD is physically replaced.
+4. After powering up storage server, prepare the new SSD (partition, filesystem if needed).
+5. Update server configuration if the SSD device path changed.
+6. For a host with multiple engines where only one engine's storage was lost:
+   - Both engines will be excluded (server was powered down)
+   - The control_metadata path (on any persistent local storage) remains intact with both engines' metadata
+   - **Before restarting the server, manually remove the failed engine's superblock** to trigger a format request
+     (e.g., `rm /path/to/control_metadata/daos_control/engine0/superblock`)
+   - Only the engine whose data/meta/wal SSD failed needs to be reformatted
+   - The healthy engine's control_metadata subdirectory should be preserved (do not remove its superblock)
+7. Start `daos_server` again. The engine with the removed superblock will now prompt for format.
+8. Run `dmg storage format --replace` to format only the affected engine(s).
+   - The command automatically identifies which engines need formatting based on missing superblocks
+   - If control_metadata path is intact: selectively removes subdirectories for engines with missing superblocks only
+   - If control_metadata path itself is inaccessible: the entire directory must be recreated (all engines on that path need formatting)
+9. Formatted engine(s) will rejoin using their existing rank(s) mapped to the server's hardware.
+
+**Example Scenario 1**: Server with two engines where a data SSD fails:
+- Engine 0 (rank 2): Data SSD fails, making the engine invalid
+- Engine 1 (rank 3): All storage healthy
+- Control_metadata path: Intact with both engines' metadata (stored on any persistent local storage)
+- Server is powered down for SSD replacement
+- Both rank 2 and rank 3 become excluded (server offline)
+- After powering up with new data SSD:
+  - Engine 0: Still has superblock in control_metadata, but data SSD is new/empty
+  - Engine 1: Healthy, superblock intact in control_metadata
+- **Before starting the server, administrator manually removes engine 0's superblock**: 
+  `rm /path/to/control_metadata/daos_control/engine0/superblock`
+- Start `daos_server` and engine 0 detects missing superblock and prompts for format
+- Attempting to format without `--replace` flag will fail:
+  ```bash
+  $ dmg storage format -l storage-server-16
+  ERROR: Errors:
+    Hosts              Error
+    -----              -----
+    storage-server-16  engine metadata directories or superblocks are missing for engines [0]; 
+                       running format with missing subdirectories or superblocks is not supported
+  ```
+- `dmg storage format --replace` will succeed:
+  ```bash
+  $ dmg storage format -l storage-server-16 --replace
+  Format Summary:
+    Hosts              SCM Devices NVMe Devices
+    -----              ----------- ------------
+    storage-server-16  2           2
+  ```
+- The command will:
+  - Detect engine 0 needs formatting (no superblock)
+  - Remove only `/path/to/control_metadata/daos_control/engine0/` subdirectory
+  - Preserve `/path/to/control_metadata/daos_control/engine1/` subdirectory
+  - Reinitialize engine 0's metadata with the old rank (rank 2)
+  - Engine 0 rejoins with rank 2, engine 1 with rank 3
+- Verify both engines rejoin the system:
+  ```bash
+  $ dmg system query -v
+  Rank UUID                                 Control Address      Fault Domain                State   Reason
+  ----  ----                                ---------------      ------------                -----   ------
+  0     bc5c3554-78a9-407d-87e6-f2ed9157752a 10.8.1.13:10001     /storage-server-13          Joined
+  1     94bb94a7-1aed-4e2c-98fd-049088ce3e27 10.8.1.16:10001     /storage-server-16          Joined
+  2     b72d6ac6-7805-4f1c-a408-adb1be3b2c39 10.8.1.15:10001     /storage-server-15          Joined
+  3     fc53495f-53cb-4c43-b26e-aec6cca17574 10.8.1.14:10001     /storage-server-14          Joined
+  ```
+
+**Example Scenario 2**: Server where the control_metadata storage path itself becomes inaccessible:
+- The storage hosting control_metadata path (e.g., `/mnt/control_metadata/daos_control/`) becomes inaccessible
+- All engines lose access to their superblocks and metadata
+- After resolving the storage issue (or changing control_metadata path): the control_metadata directory doesn't exist
+- `dmg storage format --replace` will:
+  - Create the control_metadata directory structure
+  - Format all engines that were stored on that path
+  - All engines rejoin with their previous ranks
+
+!!! note
+    In MD-on-SSD mode, the control_metadata path stores critical rank metadata including superblocks.
+    This path can be on any persistent local storage (dedicated SSD, shared device, or any mounted
+    filesystem) and is separate from the data/meta/wal SSDs used for pool storage. When an engine's
+    data/meta/wal SSD fails and is replaced offline, the administrator must manually remove the
+    failed engine's superblock **before restarting the server** to trigger a format request. This 
+    manual step allows `dmg storage format --replace` to reinitialize that engine's metadata and 
+    restore it with the old rank. If only a data/meta/wal SSD fails, the control_metadata path 
+    remains intact and the command will selectively remove only the subdirectories for engines with 
+    missing superblocks (i.e., only those where the administrator removed the superblock before 
+    server restart). If the control_metadata storage path itself becomes inaccessible, all engine 
+    metadata is lost and must be recreated during format replace.
 
 !!! note
     `dmg storage format --replace` can not be used to replace a rank in `AdminExcluded` state. An

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -233,6 +233,7 @@ const (
 const (
 	ControlMetadataUnknown Code = iota + 1000
 	ControlMetadataBadFilesystem
+	ControlMetadataIncomplete
 )
 
 // System Checker codes

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -837,13 +837,16 @@ func (cs *ControlService) formatMetadata(instances []Engine, reformat, replace b
 			}
 		}
 
-		if len(needFormatIdxs) > 0 {
-			cs.log.Debugf("formatting control metadata storage for engines %v (--replace)", needFormatIdxs)
-			if err := cs.storage.FormatControlMetadata(needFormatIdxs); err != nil {
-				return false, errors.Wrap(err, "formatting control metadata storage")
-			}
-			return true, nil
+		if len(needFormatIdxs) == 0 {
+			return false, errors.New("format replace option only valid if at least one " +
+				"engine requires metadata format but currently no engines need metadata format")
 		}
+
+		cs.log.Debugf("formatting control metadata storage for engines %v (--replace)", needFormatIdxs)
+		if err := cs.storage.FormatControlMetadata(needFormatIdxs); err != nil {
+			return false, errors.Wrap(err, "formatting control metadata storage")
+		}
+		return true, nil
 	}
 
 	cs.log.Debug("no control metadata format needed")

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -28,6 +28,7 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
+	"github.com/daos-stack/daos/src/control/server/storage/metadata"
 )
 
 const (
@@ -803,6 +804,12 @@ func (cs *ControlService) StorageScan(ctx context.Context, req *ctlpb.StorageSca
 }
 
 func (cs *ControlService) formatMetadata(instances []Engine, reformat, replace bool) (bool, error) {
+	// Exit early if not using MD-on-SSD mode (legacy PMem mode)
+	if !cs.storage.ControlMetadataPathConfigured() {
+		cs.log.Debug("control metadata path not configured, skipping metadata format (legacy PMem mode)")
+		return false, nil
+	}
+
 	// Format control metadata first, if needed
 	if needs, err := cs.storage.ControlMetadataNeedsFormat(); err != nil {
 		return false, errors.Wrap(err, "detecting if metadata format is needed")
@@ -819,34 +826,36 @@ func (cs *ControlService) formatMetadata(instances []Engine, reformat, replace b
 		}
 
 		return true, nil
-	} else if replace {
-		// Selective format: only format engines with missing metadata directories
-		var needFormatIdxs []uint
-		for _, eng := range instances {
-			engIdx := uint(eng.Index())
+	}
 
-			// Check if engine's metadata directory is missing
-			needsFormat, err := eng.GetStorage().ControlMetadataEngineNeedsFormat()
-			if err != nil {
-				return false, errors.Wrapf(err, "checking if engine %d metadata needs format", engIdx)
+	// Check for engines with missing metadata directories
+	var needFormatIdxs []uint
+	for _, eng := range instances {
+		engIdx := uint(eng.Index())
+
+		// Check if engine's metadata directory is missing
+		needsFormat, err := eng.GetStorage().ControlMetadataEngineNeedsFormat()
+		if err != nil {
+			return false, errors.Wrapf(err, "checking if engine %d metadata needs format", engIdx)
+		}
+
+		if needsFormat {
+			cs.log.Debugf("engine %d metadata needs format", engIdx)
+			needFormatIdxs = append(needFormatIdxs, engIdx)
+		}
+	}
+
+	if len(needFormatIdxs) > 0 {
+		if replace {
+			// In replace mode, format only the engines that need it
+			cs.log.Debugf("formatting control metadata storage for engines %v (--replace)", needFormatIdxs)
+			if err := cs.storage.FormatControlMetadata(needFormatIdxs); err != nil {
+				return false, errors.Wrap(err, "formatting control metadata storage")
 			}
-
-			if needsFormat {
-				cs.log.Debugf("engine %d metadata needs format", engIdx)
-				needFormatIdxs = append(needFormatIdxs, engIdx)
-			}
+			return true, nil
 		}
-
-		if len(needFormatIdxs) == 0 {
-			return false, errors.New("format replace option only valid if at least one " +
-				"engine requires metadata format but currently no engines need metadata format")
-		}
-
-		cs.log.Debugf("formatting control metadata storage for engines %v (--replace)", needFormatIdxs)
-		if err := cs.storage.FormatControlMetadata(needFormatIdxs); err != nil {
-			return false, errors.Wrap(err, "formatting control metadata storage")
-		}
-		return true, nil
+		// Not in replace mode, but some engines need format - return fault
+		return false, metadata.FaultIncompleteFormat(needFormatIdxs)
 	}
 
 	cs.log.Debug("no control metadata format needed")

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -802,22 +802,48 @@ func (cs *ControlService) StorageScan(ctx context.Context, req *ctlpb.StorageSca
 	return resp, nil
 }
 
-func (cs *ControlService) formatMetadata(instances []Engine, reformat bool) (bool, error) {
+func (cs *ControlService) formatMetadata(instances []Engine, reformat, replace bool) (bool, error) {
 	// Format control metadata first, if needed
 	if needs, err := cs.storage.ControlMetadataNeedsFormat(); err != nil {
 		return false, errors.Wrap(err, "detecting if metadata format is needed")
 	} else if needs || reformat {
+		// Full format needed
 		engineIdxs := make([]uint, len(instances))
 		for i, eng := range instances {
 			engineIdxs[i] = uint(eng.Index())
 		}
 
-		cs.log.Debug("formatting control metadata storage")
+		cs.log.Debug("formatting control metadata storage (all engines)")
 		if err := cs.storage.FormatControlMetadata(engineIdxs); err != nil {
 			return false, errors.Wrap(err, "formatting control metadata storage")
 		}
 
 		return true, nil
+	} else if replace {
+		// Selective format: only format engines with missing metadata directories
+		var needFormatIdxs []uint
+		for _, eng := range instances {
+			engIdx := uint(eng.Index())
+
+			// Check if engine's metadata directory is missing
+			needsFormat, err := eng.GetStorage().ControlMetadataEngineNeedsFormat()
+			if err != nil {
+				return false, errors.Wrapf(err, "checking if engine %d metadata needs format", engIdx)
+			}
+
+			if needsFormat {
+				cs.log.Debugf("engine %d metadata needs format", engIdx)
+				needFormatIdxs = append(needFormatIdxs, engIdx)
+			}
+		}
+
+		if len(needFormatIdxs) > 0 {
+			cs.log.Debugf("formatting control metadata storage for engines %v (--replace)", needFormatIdxs)
+			if err := cs.storage.FormatControlMetadata(needFormatIdxs); err != nil {
+				return false, errors.Wrap(err, "formatting control metadata storage")
+			}
+			return true, nil
+		}
 	}
 
 	cs.log.Debug("no control metadata format needed")
@@ -1059,10 +1085,11 @@ func (cs *ControlService) StorageFormat(ctx context.Context, req *ctlpb.StorageF
 		return resp, nil
 	}
 
-	// DAOS-15947: control_metadata format is valid in --replace case where multiple engines
-	// require replacement or format on the same host. No need to handle independently for
-	// individual engine as if control_metadata is missing then it needs to be created.
-	mdFormatted, err := cs.formatMetadata(instances, req.Reformat)
+	// DAOS-15947, DAOS-19385: control_metadata format is required in --replace case
+	// to ensure old rank metadata is cleared. Only engines with missing metadata
+	// directories will have their control_metadata subdirectories reformatted,
+	// preserving healthy engines. SCM formatting is handled separately.
+	mdFormatted, err := cs.formatMetadata(instances, req.Reformat, req.Replace)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -918,12 +918,6 @@ func formatScm(ctx context.Context, req formatScmReq, resp *ctlpb.StorageFormatR
 		}
 	}
 
-	if req.replace && len(needScmFormat) == 0 {
-		// Only valid if at least one engine requires format.
-		return nil, nil, errors.New("format replace option only valid if at least one " +
-			"engine requires scm-format but currently no engines need scm-format")
-	}
-
 	if allNeedScmFormat {
 		// Check available RAM is sufficient before formatting SCM on engines.
 		if err := checkTmpfsMem(req.log, scmCfgs, req.getSysMemInfo); err != nil {

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -2345,7 +2345,7 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 				},
 			},
 		},
-		"dcpm already mounted no reformat; replace fails": {
+		"dcpm already mounted no reformat; replace succeeds": {
 			scmMounted: true,
 			sMounts:    []string{"/mnt/daos"},
 			sClass:     storage.ClassDcpm,
@@ -2360,7 +2360,6 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 					},
 				},
 			},
-			expErr: errors.New("only valid if at least one engine requires scm-format"),
 			expResp: &ctlpb.StorageFormatResp{
 				Crets: []*ctlpb.NvmeControllerResult{
 					{

--- a/src/control/server/storage/metadata/faults.go
+++ b/src/control/server/storage/metadata/faults.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -34,6 +35,16 @@ func FaultBadFilesystem(fs *system.FsType) *fault.Fault {
 		code.ControlMetadataBadFilesystem,
 		fmt.Sprintf("%q%s is not usable for the control metadata storage directory", fs.Name, noSUIDStr),
 		"Configure the control_metadata path to a directory that is not on a networked or nosuid filesystem",
+	)
+}
+
+// FaultIncompleteFormat is an error that occurs when engine metadata directories or superblocks
+// are missing but format was not run with the --replace flag.
+func FaultIncompleteFormat(engineIdxs []uint) *fault.Fault {
+	return metadataFault(
+		code.ControlMetadataIncomplete,
+		fmt.Sprintf("engine metadata directories or superblocks are missing for engines %v; running format with missing subdirectories or superblocks is not supported", engineIdxs),
+		"remove the control_metadata directory entirely before running format again, or use the --replace flag to format only the missing engines",
 	)
 }
 

--- a/src/control/server/storage/metadata/provider.go
+++ b/src/control/server/storage/metadata/provider.go
@@ -198,52 +198,36 @@ func (p *Provider) isUsableFS(fs *system.FsType, path string) bool {
 func (p *Provider) setupDataDir(req storage.MetadataFormatRequest) error {
 	perms := os.FileMode(0775)
 
-	// If specific engine indices are provided and DataPath exists, only delete those engines
-	if len(req.EngineIdxs) > 0 {
-		if _, err := p.sys.Stat(req.DataPath); err == nil {
-			// DataPath exists, selectively remove only specified engine directories
-			p.log.Debugf("selectively removing control metadata for engines %v", req.EngineIdxs)
-			for _, idx := range req.EngineIdxs {
-				engPath := storage.ControlMetadataEngineDir(req.DataPath, idx)
-				if err := p.sys.RemoveAll(engPath); err != nil {
-					return errors.Wrapf(err, "removing control metadata for engine %d", idx)
-				}
-			}
-		} else if !os.IsNotExist(err) {
-			return errors.Wrap(err, "checking control metadata subdirectory")
-		} else {
-			// DataPath doesn't exist, create it
-			p.log.Debugf("creating control metadata subdirectory %q", req.DataPath)
-			if err := p.sys.Mkdir(req.DataPath, perms); err != nil {
-				return errors.Wrap(err, "creating control metadata subdirectory")
-			}
-			if err := p.sys.Chown(req.DataPath, req.OwnerUID, req.OwnerGID); err != nil {
-				return errors.Wrapf(err, "setting ownership of control metadata subdirectory to %d/%d", req.OwnerUID, req.OwnerGID)
-			}
+	// Helper to create directory with ownership
+	createDirWithOwner := func(path string) error {
+		if err := p.sys.Mkdir(path, perms); err != nil {
+			return errors.Wrapf(err, "creating directory %s", path)
 		}
-	} else {
-		// No specific engines, remove everything (legacy behavior)
-		p.log.Debugf("removing entire control metadata subdirectory %q", req.DataPath)
-		if err := p.sys.RemoveAll(req.DataPath); err != nil {
-			return errors.Wrap(err, "removing old control metadata subdirectory")
+		if err := p.sys.Chown(path, req.OwnerUID, req.OwnerGID); err != nil {
+			return errors.Wrapf(err, "setting ownership of %s to %d/%d", path, req.OwnerUID, req.OwnerGID)
 		}
-		if err := p.sys.Mkdir(req.DataPath, perms); err != nil {
-			return errors.Wrap(err, "creating control metadata subdirectory")
-		}
-		if err := p.sys.Chown(req.DataPath, req.OwnerUID, req.OwnerGID); err != nil {
-			return errors.Wrapf(err, "setting ownership of control metadata subdirectory to %d/%d", req.OwnerUID, req.OwnerGID)
-		}
+		return nil
 	}
 
-	// Create engine subdirectories for specified engines
+	// Ensure DataPath exists
+	if _, err := p.sys.Stat(req.DataPath); os.IsNotExist(err) {
+		p.log.Debugf("creating control metadata subdirectory %q", req.DataPath)
+		if err := createDirWithOwner(req.DataPath); err != nil {
+			return errors.Wrap(err, "creating control metadata subdirectory")
+		}
+	} else if err != nil {
+		return errors.Wrap(err, "checking control metadata subdirectory")
+	}
+
+	// Selectively remove and recreate engine directories
+	p.log.Debugf("formatting control metadata for engines %v", req.EngineIdxs)
 	for _, idx := range req.EngineIdxs {
 		engPath := storage.ControlMetadataEngineDir(req.DataPath, idx)
-		if err := p.sys.Mkdir(engPath, perms); err != nil {
-			return errors.Wrapf(err, "creating control metadata engine %d subdirectory", idx)
+		if err := p.sys.RemoveAll(engPath); err != nil {
+			return errors.Wrapf(err, "removing control metadata for engine %d", idx)
 		}
-
-		if err := p.sys.Chown(engPath, req.OwnerUID, req.OwnerGID); err != nil {
-			return errors.Wrapf(err, "setting ownership of control metadata engine %d subdirectory to %d/%d", idx, req.OwnerUID, req.OwnerGID)
+		if err := createDirWithOwner(engPath); err != nil {
+			return errors.Wrapf(err, "control metadata engine %d subdirectory", idx)
 		}
 	}
 

--- a/src/control/server/storage/metadata/provider.go
+++ b/src/control/server/storage/metadata/provider.go
@@ -198,18 +198,44 @@ func (p *Provider) isUsableFS(fs *system.FsType, path string) bool {
 func (p *Provider) setupDataDir(req storage.MetadataFormatRequest) error {
 	perms := os.FileMode(0775)
 
-	if err := p.sys.RemoveAll(req.DataPath); err != nil {
-		return errors.Wrap(err, "removing old control metadata subdirectory")
+	// If specific engine indices are provided and DataPath exists, only delete those engines
+	if len(req.EngineIdxs) > 0 {
+		if _, err := p.sys.Stat(req.DataPath); err == nil {
+			// DataPath exists, selectively remove only specified engine directories
+			p.log.Debugf("selectively removing control metadata for engines %v", req.EngineIdxs)
+			for _, idx := range req.EngineIdxs {
+				engPath := storage.ControlMetadataEngineDir(req.DataPath, idx)
+				if err := p.sys.RemoveAll(engPath); err != nil {
+					return errors.Wrapf(err, "removing control metadata for engine %d", idx)
+				}
+			}
+		} else if !os.IsNotExist(err) {
+			return errors.Wrap(err, "checking control metadata subdirectory")
+		} else {
+			// DataPath doesn't exist, create it
+			p.log.Debugf("creating control metadata subdirectory %q", req.DataPath)
+			if err := p.sys.Mkdir(req.DataPath, perms); err != nil {
+				return errors.Wrap(err, "creating control metadata subdirectory")
+			}
+			if err := p.sys.Chown(req.DataPath, req.OwnerUID, req.OwnerGID); err != nil {
+				return errors.Wrapf(err, "setting ownership of control metadata subdirectory to %d/%d", req.OwnerUID, req.OwnerGID)
+			}
+		}
+	} else {
+		// No specific engines, remove everything (legacy behavior)
+		p.log.Debugf("removing entire control metadata subdirectory %q", req.DataPath)
+		if err := p.sys.RemoveAll(req.DataPath); err != nil {
+			return errors.Wrap(err, "removing old control metadata subdirectory")
+		}
+		if err := p.sys.Mkdir(req.DataPath, perms); err != nil {
+			return errors.Wrap(err, "creating control metadata subdirectory")
+		}
+		if err := p.sys.Chown(req.DataPath, req.OwnerUID, req.OwnerGID); err != nil {
+			return errors.Wrapf(err, "setting ownership of control metadata subdirectory to %d/%d", req.OwnerUID, req.OwnerGID)
+		}
 	}
 
-	if err := p.sys.Mkdir(req.DataPath, perms); err != nil {
-		return errors.Wrap(err, "creating control metadata subdirectory")
-	}
-
-	if err := p.sys.Chown(req.DataPath, req.OwnerUID, req.OwnerGID); err != nil {
-		return errors.Wrapf(err, "setting ownership of control metadata subdirectory to %d/%d", req.OwnerUID, req.OwnerGID)
-	}
-
+	// Create engine subdirectories for specified engines
 	for _, idx := range req.EngineIdxs {
 		engPath := storage.ControlMetadataEngineDir(req.DataPath, idx)
 		if err := p.sys.Mkdir(engPath, perms); err != nil {

--- a/src/control/server/storage/metadata/provider_test.go
+++ b/src/control/server/storage/metadata/provider_test.go
@@ -159,7 +159,7 @@ func TestMetadata_Provider_Format(t *testing.T) {
 			expMkfsOpts: []string{"-q"},
 			expMkfs:     true,
 		},
-		"remove old data dir fails": {
+		"remove old data dir fails with permission denied": {
 			req: deviceReq,
 			setup: func(t *testing.T, root string) func() {
 				t.Helper()
@@ -175,7 +175,7 @@ func TestMetadata_Provider_Format(t *testing.T) {
 					}
 				}
 			},
-			expErr:      errors.New("removing old control metadata subdirectory"),
+			expErr:      errors.New("permission denied"),
 			expMkfsOpts: []string{"-q"},
 			expMkfs:     true,
 		},
@@ -231,7 +231,7 @@ func TestMetadata_Provider_Format(t *testing.T) {
 			expMkfsOpts: []string{"-q", "-L", "old_label"},
 			expMkfs:     true,
 		},
-		"path only doesn't attempt device format": {
+		"path only; doesn't attempt device format": {
 			req: pathReq,
 			sysCfg: &system.MockSysConfig{
 				MkfsErr:      errors.New("mkfs was called!"),
@@ -642,6 +642,192 @@ func TestMetadata_Provider_Unmount(t *testing.T) {
 
 			if diff := cmp.Diff(tc.expResp, resp); diff != "" {
 				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+// TestMetadata_Provider_setupDataDir_SelectiveEngineDelete tests the new selective
+// engine directory deletion feature for DAOS-19385.
+func TestMetadata_Provider_setupDataDir_SelectiveEngineDelete(t *testing.T) {
+	for name, tc := range map[string]struct {
+		setupExisting func(t *testing.T, dataPath string)
+		req           storage.MetadataFormatRequest
+		sysCfg        *system.MockSysConfig
+		expErr        error
+		expExist      []uint
+		expNotExist   []uint
+	}{
+		"selective delete: engines 0 and 2 when datapath exists": {
+			setupExisting: func(t *testing.T, dataPath string) {
+				// Create the data directory and subdirectories for engines 0, 1, 2
+				if err := os.MkdirAll(dataPath, 0775); err != nil {
+					t.Fatal(err)
+				}
+				for _, idx := range []uint{0, 1, 2} {
+					engPath := storage.ControlMetadataEngineDir(dataPath, idx)
+					if err := os.MkdirAll(engPath, 0775); err != nil {
+						t.Fatal(err)
+					}
+					testFile := filepath.Join(engPath, "test.dat")
+					if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+			req: storage.MetadataFormatRequest{
+				RootPath:   "/test_root",
+				DataPath:   "/test_root/data",
+				OwnerUID:   100,
+				OwnerGID:   200,
+				EngineIdxs: []uint{0, 2},
+			},
+			expExist:    []uint{1},
+			expNotExist: []uint{},
+		},
+		"selective delete: single engine when others exist": {
+			setupExisting: func(t *testing.T, dataPath string) {
+				if err := os.MkdirAll(dataPath, 0775); err != nil {
+					t.Fatal(err)
+				}
+				for _, idx := range []uint{0, 1, 2, 3} {
+					engPath := storage.ControlMetadataEngineDir(dataPath, idx)
+					if err := os.MkdirAll(engPath, 0775); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+			req: storage.MetadataFormatRequest{
+				RootPath:   "/test_root",
+				DataPath:   "/test_root/data",
+				OwnerUID:   100,
+				OwnerGID:   200,
+				EngineIdxs: []uint{1},
+			},
+			expExist:    []uint{0, 2, 3},
+			expNotExist: []uint{},
+		},
+		"datapath doesn't exist: create with specific engines": {
+			setupExisting: func(t *testing.T, dataPath string) {
+				// Don't create anything
+			},
+			req: storage.MetadataFormatRequest{
+				RootPath:   "/test_root",
+				DataPath:   "/test_root/data",
+				OwnerUID:   100,
+				OwnerGID:   200,
+				EngineIdxs: []uint{0, 2},
+			},
+			expExist:    []uint{},
+			expNotExist: []uint{1, 3},
+		},
+		"empty engine list: remove all (legacy behavior)": {
+			setupExisting: func(t *testing.T, dataPath string) {
+				if err := os.MkdirAll(dataPath, 0775); err != nil {
+					t.Fatal(err)
+				}
+				for _, idx := range []uint{0, 1, 2} {
+					engPath := storage.ControlMetadataEngineDir(dataPath, idx)
+					if err := os.MkdirAll(engPath, 0775); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+			req: storage.MetadataFormatRequest{
+				RootPath:   "/test_root",
+				DataPath:   "/test_root/data",
+				OwnerUID:   100,
+				OwnerGID:   200,
+				EngineIdxs: []uint{},
+			},
+			expExist:    []uint{},
+			expNotExist: []uint{0, 1, 2},
+		},
+		"stat error on datapath": {
+			setupExisting: func(t *testing.T, dataPath string) {
+				// Setup doesn't matter
+			},
+			req: storage.MetadataFormatRequest{
+				RootPath:   "/test_root",
+				DataPath:   "/test_root/data",
+				OwnerUID:   100,
+				OwnerGID:   200,
+				EngineIdxs: []uint{0, 1},
+			},
+			sysCfg: &system.MockSysConfig{
+				StatErrors: map[string]error{
+					"/test_root/data": errors.New("mock stat error"),
+				},
+			},
+			expErr: errors.New("mock stat error"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			testDir, cleanupTestDir := test.CreateTestDir(t)
+			defer cleanupTestDir()
+
+			oldDataPath := tc.req.DataPath
+			tc.req.RootPath = filepath.Join(testDir, tc.req.RootPath)
+			tc.req.DataPath = filepath.Join(testDir, tc.req.DataPath)
+
+			if tc.sysCfg == nil {
+				tc.sysCfg = &system.MockSysConfig{}
+			}
+			// Enable real file operations for testing (unless StatErrors configured)
+			if tc.sysCfg.StatErrors == nil {
+				tc.sysCfg.RealStat = true
+			}
+			tc.sysCfg.RealMkdir = true
+			tc.sysCfg.RealRemoveAll = true
+
+			if tc.sysCfg.StatErrors != nil {
+				if statErr, exists := tc.sysCfg.StatErrors[oldDataPath]; exists {
+					tc.sysCfg.StatErrors[tc.req.DataPath] = statErr
+				}
+			}
+
+			if tc.setupExisting != nil {
+				tc.setupExisting(t, tc.req.DataPath)
+			}
+
+			// Ensure parent directory exists for tests where DataPath doesn't exist
+			if tc.req.RootPath != "" {
+				if err := os.MkdirAll(tc.req.RootPath, 0775); err != nil && !os.IsExist(err) {
+					t.Fatal(err)
+				}
+			}
+
+			p := NewProvider(log, system.NewMockSysProvider(log, tc.sysCfg), nil)
+
+			err := p.setupDataDir(tc.req)
+
+			test.CmpErr(t, tc.expErr, err)
+			if tc.expErr != nil {
+				return
+			}
+
+			for _, idx := range tc.expExist {
+				engPath := storage.ControlMetadataEngineDir(tc.req.DataPath, idx)
+				if _, err := os.Stat(engPath); os.IsNotExist(err) {
+					t.Errorf("expected engine %d directory to exist at %s", idx, engPath)
+				}
+			}
+
+			for _, idx := range tc.expNotExist {
+				engPath := storage.ControlMetadataEngineDir(tc.req.DataPath, idx)
+				if _, err := os.Stat(engPath); err == nil {
+					t.Errorf("expected engine %d directory NOT to exist at %s", idx, engPath)
+				}
+			}
+
+			for _, idx := range tc.req.EngineIdxs {
+				engPath := storage.ControlMetadataEngineDir(tc.req.DataPath, idx)
+				if _, err := os.Stat(engPath); os.IsNotExist(err) {
+					t.Errorf("expected engine %d directory created at %s", idx, engPath)
+				}
 			}
 		})
 	}

--- a/src/control/server/storage/metadata/provider_test.go
+++ b/src/control/server/storage/metadata/provider_test.go
@@ -721,28 +721,6 @@ func TestMetadata_Provider_setupDataDir_SelectiveEngineDelete(t *testing.T) {
 			expExist:    []uint{},
 			expNotExist: []uint{1, 3},
 		},
-		"empty engine list: remove all (legacy behavior)": {
-			setupExisting: func(t *testing.T, dataPath string) {
-				if err := os.MkdirAll(dataPath, 0775); err != nil {
-					t.Fatal(err)
-				}
-				for _, idx := range []uint{0, 1, 2} {
-					engPath := storage.ControlMetadataEngineDir(dataPath, idx)
-					if err := os.MkdirAll(engPath, 0775); err != nil {
-						t.Fatal(err)
-					}
-				}
-			},
-			req: storage.MetadataFormatRequest{
-				RootPath:   "/test_root",
-				DataPath:   "/test_root/data",
-				OwnerUID:   100,
-				OwnerGID:   200,
-				EngineIdxs: []uint{},
-			},
-			expExist:    []uint{},
-			expNotExist: []uint{0, 1, 2},
-		},
 		"stat error on datapath": {
 			setupExisting: func(t *testing.T, dataPath string) {
 				// Setup doesn't matter

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/dustin/go-humanize"
@@ -27,7 +28,8 @@ import (
 
 const defaultMetadataPath = "/mnt/daos"
 
-// SystemProvider provides operating system capabilities.
+// SystemProvider provides a limited set of operating system capabilities. Not all of the
+// capabilities in src/control/provider/system are exposed via the storage provider.
 type SystemProvider interface {
 	system.IsMountedProvider
 	GetfsUsage(string) (uint64, uint64, error)
@@ -113,6 +115,30 @@ func (p *Provider) ControlMetadataPathConfigured() bool {
 		return true
 	}
 	return false
+}
+
+// ControlMetadataEngineNeedsFormat checks if this engine's superblock exists.
+// This is distinct from ControlMetadataNeedsFormat which checks the host-level DataPath.
+func (p *Provider) ControlMetadataEngineNeedsFormat() (bool, error) {
+	if p == nil {
+		return false, errors.New("nil provider")
+	}
+
+	if !p.engineStorage.ControlMetadata.HasPath() {
+		// No metadata section defined, metadata stored on SCM
+		return false, nil
+	}
+
+	superblockPath := filepath.Join(p.ControlMetadataEnginePath(), "superblock")
+
+	if _, err := p.Sys.ReadFile(superblockPath); os.IsNotExist(err) {
+		p.log.Debugf("engine %d superblock missing: %s", p.engineIndex, superblockPath)
+		return true, nil
+	} else if err != nil {
+		return false, errors.Wrapf(err, "checking engine %d superblock", p.engineIndex)
+	}
+
+	return false, nil
 }
 
 // ControlMetadataPath returns the path where control plane metadata is stored.
@@ -316,6 +342,10 @@ func (p *Provider) MountScm() error {
 
 // UnmountTmpfs unmounts SCM based on provider config.
 func (p *Provider) UnmountTmpfs() error {
+	if p == nil {
+		return errors.New("nil provider")
+	}
+
 	cfg, err := p.GetScmConfig()
 	if err != nil {
 		return err

--- a/src/control/server/storage/provider_test.go
+++ b/src/control/server/storage/provider_test.go
@@ -503,6 +503,12 @@ func TestStorage_ControlMetadataEngineNeedsFormat(t *testing.T) {
 			expResult:    true,
 		},
 		"engine directory exists": {},
+		"engine 1 directory exists": {
+			eIdx: 1,
+		},
+		"engine 2 directory exists": {
+			eIdx: 2,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(name)

--- a/src/control/server/storage/provider_test.go
+++ b/src/control/server/storage/provider_test.go
@@ -9,7 +9,9 @@
 package storage
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -468,6 +470,88 @@ func TestStorage_ControlMetadataNeedsFormat(t *testing.T) {
 	}
 }
 
+func TestStorage_ControlMetadataEngineNeedsFormat(t *testing.T) {
+	for name, tc := range map[string]struct {
+		eIdx         int
+		noPath       bool
+		noParentDir  bool
+		noEngineDir  bool
+		noSuperblock bool
+		nilProv      bool
+		expResult    bool
+		expErr       error
+	}{
+		"nil": {
+			nilProv: true,
+			expErr:  errors.New("nil"),
+		},
+		"no control metadata cfg": {
+			noPath:    true,
+			expResult: false, // metadata on SCM, not separate device
+		},
+		"no control metadata directory": {
+			noParentDir: true,
+			expResult:   true,
+		},
+		"no control metadata engine directory": {
+			noEngineDir:  true,
+			noSuperblock: true,
+			expResult:    true,
+		},
+		"engine directory exists; no superblock": {
+			noSuperblock: true,
+			expResult:    true,
+		},
+		"engine directory exists": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(name)
+			defer test.ShowBufferOnFailure(t, buf)
+
+			testDir := t.TempDir()
+			if tc.noParentDir {
+				os.RemoveAll(testDir)
+			} else {
+				engineDir := filepath.Join(testDir, "daos_control", fmt.Sprintf("engine%d", tc.eIdx))
+				if !tc.noEngineDir {
+					if err := os.MkdirAll(engineDir, 0755); err != nil {
+						t.Fatal(err)
+					}
+					if !tc.noSuperblock {
+						t.Logf("writing %s", engineDir)
+						if _, err := os.Create(filepath.Join(engineDir, "superblock")); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+			}
+
+			cfg := &Config{}
+			if !tc.noPath {
+				cfg.ControlMetadata = ControlMetadata{
+					Path: testDir,
+				}
+			}
+
+			// The storage package SystemProvider exposes ReadFile but not Stat
+			var p *Provider
+			if !tc.nilProv {
+				msc := &system.MockSysConfig{
+					RealReadFile: true,
+				}
+				sp := system.NewMockSysProvider(log, msc)
+				p = NewProvider(log, 0, cfg, sp, nil, nil, nil)
+				p.engineIndex = tc.eIdx
+			}
+
+			result, err := p.ControlMetadataEngineNeedsFormat()
+
+			test.CmpErr(t, tc.expErr, err)
+			test.AssertEqual(t, tc.expResult, result, "")
+		})
+	}
+}
+
 func TestStorage_MountControlMetadata(t *testing.T) {
 	for name, tc := range map[string]struct {
 		nilProv      bool
@@ -763,6 +847,91 @@ func TestStorage_ControlMetadataEnginePath(t *testing.T) {
 			}
 
 			test.AssertEqual(t, tc.expResult, p.ControlMetadataEnginePath(), "")
+		})
+	}
+}
+
+func TestStorage_UnmountTmpfs(t *testing.T) {
+	for name, tc := range map[string]struct {
+		nilProv bool
+		cfg     *Config
+		scmProv *MockScmProvider
+		expErr  error
+	}{
+		"nil provider": {
+			nilProv: true,
+			expErr:  errors.New("nil"),
+		},
+		"no scm config": {
+			cfg:    &Config{},
+			expErr: errors.New("expected exactly 1 SCM tier"),
+		},
+		"RAM class success": {
+			cfg: &Config{
+				Tiers: TierConfigs{
+					{
+						Class: ClassRam,
+						Scm: ScmConfig{
+							MountPoint: "/mnt/daos0",
+						},
+					},
+				},
+			},
+			scmProv: &MockScmProvider{
+				UnmountRes: &MountResponse{
+					Target:  "/mnt/daos0",
+					Mounted: false,
+				},
+			},
+		},
+		"RAM class failure": {
+			cfg: &Config{
+				Tiers: TierConfigs{
+					{
+						Class: ClassRam,
+						Scm: ScmConfig{
+							MountPoint: "/mnt/daos0",
+						},
+					},
+				},
+			},
+			scmProv: &MockScmProvider{
+				UnmountErr: errors.New("unmount fail"),
+			},
+			expErr: errors.New("unmount fail"),
+		},
+		"DCPM class skips failure": {
+			cfg: &Config{
+				Tiers: TierConfigs{
+					{
+						Class: ClassDcpm,
+						Scm: ScmConfig{
+							MountPoint: "/mnt/daos0",
+							DeviceList: []string{"/dev/pmem0"},
+						},
+					},
+				},
+			},
+			scmProv: &MockScmProvider{
+				UnmountErr: errors.New("unmount fail"),
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(name)
+			defer test.ShowBufferOnFailure(t, buf)
+
+			var p *Provider
+			if !tc.nilProv {
+				if tc.scmProv == nil {
+					tc.scmProv = &MockScmProvider{}
+				}
+				p = NewProvider(log, 0, tc.cfg, nil, tc.scmProv, nil, nil)
+			}
+
+			err := p.UnmountTmpfs()
+
+			test.CmpErr(t, tc.expErr, err)
 		})
 	}
 }


### PR DESCRIPTION
     Allow selective per-engine control metadata formatting during storage
     format --replace operations. Previously, --replace would skip control
     metadata formatting entirely or format all engines. Now only engines
     with missing metadata superblocks have their control_metadata
     subdirectories reformatted, preserving healthy engine's metadata while
     clearing old rank metadata from replaced engines.

     Features: control
  
### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
