### PR TITLE
DAOS-19523 test: use runner as client

### DIFF
--- a/ftest.sh
+++ b/ftest.sh
@@ -23,7 +23,7 @@ NFS_SERVER=${NFS_SERVER:-${HOSTNAME%%.*}}
 trap 'echo "encountered an unchecked return code, exiting with error"' ERR
 
 IFS=" " read -r -a nodes <<< "${2//,/ }"
-TEST_NODES=$(IFS=","; echo "${nodes[*]:1}")
+TEST_NODES=$(IFS=","; echo "${nodes[*]}")
 
 # Optional arguments for launch.py
 LAUNCH_OPT_ARGS="${3:-}"
@@ -97,9 +97,8 @@ CLUSH_ARGS=($CLUSH_ARGS)
 DAOS_FTEST_VENV=${DAOS_FTEST_VENV:-"daos_ftest_venv"}
 DAOS_BASE=${SL_SRC_DIR}
 if ! clush "${CLUSH_ARGS[@]}" -B -l "${REMOTE_ACCT:-jenkins}" -R ssh -S \
-    -w "$(IFS=','; echo "${nodes[*]}")"                                 \
-    "FIRST_NODE=${nodes[0]}
-     TEST_RPMS=$TEST_RPMS
+    -w "$TEST_NODES"                                                    \
+    "TEST_RPMS=$TEST_RPMS
      DAOS_BASE=$DAOS_BASE
      SL_PREFIX=$SL_PREFIX
      TEST_TAG_DIR=$TEST_TAG_DIR
@@ -122,8 +121,7 @@ _DAOS_NO_PROXY=${DAOS_NO_PROXY:-}
 # shellcheck disable=SC2029
 # shellcheck disable=SC2086
 if ! ssh -A $SSH_KEY_ARGS ${REMOTE_ACCT:-jenkins}@"${nodes[0]}" \
-    "FIRST_NODE=\"${nodes[0]}\"
-     TEST_RPMS=\"$TEST_RPMS\"
+    "TEST_RPMS=\"$TEST_RPMS\"
      DAOS_TEST_SHARED_DIR=\"${DAOS_TEST_SHARED_DIR:-$PWD/install/tmp}\"
      DAOS_BASE=\"$DAOS_BASE\"
      TEST_TAG_DIR=\"$TEST_TAG_DIR\"

--- a/src/tests/ftest/daos_test/nvme_recovery.yaml
+++ b/src/tests/ftest/daos_test/nvme_recovery.yaml
@@ -2,6 +2,7 @@
 # required quantity is indicated by the placeholders
 hosts:
   test_servers: 2
+  test_clients: 1
 
 timeout: 600
 

--- a/src/tests/ftest/daos_test/rebuild.yaml
+++ b/src/tests/ftest/daos_test/rebuild.yaml
@@ -2,6 +2,7 @@
 # required quantity is indicated by the placeholders
 hosts:
   test_servers: 4
+  test_clients: 1
 
 timeout: 800
 timeouts:

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -2,6 +2,7 @@
 # required quantity is indicated by the placeholders
 hosts:
   test_servers: 4
+  test_clients: 1
 
 # Note that subtests below can set their own timeout so this
 # should be a general average of all tests not including outliers

--- a/src/tests/ftest/io/unaligned_io.yaml
+++ b/src/tests/ftest/io/unaligned_io.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 4
+  test_clients: 1
 
 timeout: 900
 

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -269,8 +269,13 @@ class Launch():
         # A list of server hosts is required
         if not args.test_servers and not args.list:
             return self.get_exit_status(1, "Missing required '--test_servers' argument", "Setup")
-        logger.info("Testing with hosts:       %s", args.test_servers.union(args.test_clients))
-        self.details["test hosts"] = str(args.test_servers.union(args.test_clients))
+        all_hosts = args.test_servers.union(args.test_clients)
+        logger.info("Testing with hosts:       %s", all_hosts)
+        self.details["test hosts"] = str(all_hosts)
+        if not args.list and self.local_host not in all_hosts:
+            return self.get_exit_status(
+                1, f"Local host {self.local_host} required in --test_servers or --test_clients",
+                "Setup")
 
         # Add the installed packages to the details json
         # pylint: disable=unsupported-binary-operation
@@ -359,7 +364,7 @@ class Launch():
         try:
             group.update_test_yaml(
                 logger, args.scm_size, args.scm_mount, args.extra_yaml,
-                args.timeout_multiplier, args.override, args.verbose, args.include_localhost)
+                args.timeout_multiplier, args.override, args.verbose)
         except (RunException, YamlException) as e:
             message = f"Error modifying the test yaml files: {e}"
             status |= self.get_exit_status(1, message, "Setup", sys.exc_info())
@@ -565,10 +570,6 @@ def main():
         action="store_true",
         help="stop the test suite after the first failure")
     parser.add_argument(
-        "-i", "--include_localhost",
-        action="store_true",
-        help="include the local host when cleaning and archiving")
-    parser.add_argument(
         "-ins", "--insecure_mode",
         action="store_true",
         help="Launch test with insecure-mode")
@@ -735,7 +736,6 @@ def main():
     # Override arguments via the mode
     if args.mode == "ci":
         args.archive = True
-        args.include_localhost = True
         args.jenkinslog = True
         args.overwrite_config = True    # to ensure CI expected path is used for test results
         args.process_cores = True

--- a/src/tests/ftest/rebuild/inc_reint.yaml
+++ b/src/tests/ftest/rebuild/inc_reint.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 4
+  test_clients: 1
 
 timeout: 1H
 

--- a/src/tests/ftest/recovery/cat_recov_core.yaml
+++ b/src/tests/ftest/recovery/cat_recov_core.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 4
+  test_clients: 1
 
 timeout: 1H40M
 

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -26,7 +26,6 @@ class DaosCoreBase(TestWithServers):
         """Initialize the DaosCoreBase object."""
         super().__init__(*args, **kwargs)
         self.subtest_name = None
-        self.using_local_host = False
 
     def setUp(self):
         """Set up before each test."""

--- a/src/tests/ftest/util/host_utils.py
+++ b/src/tests/ftest/util/host_utils.py
@@ -1,6 +1,6 @@
 """
 (C) Copyright 2018-2024 Intel Corporation.
-(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+(C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -127,7 +127,7 @@ class HostInfo():
         log.info("mgmt_svc_replicas:   %s", self.mgmt_svc_replicas)
 
     def set_hosts(self, log, control_host, server_hosts, server_partition, server_reservation,
-                  client_hosts, client_partition, client_reservation, include_local_host=False):
+                  client_hosts, client_partition, client_reservation):
         """Set the host information.
 
         Args:
@@ -139,8 +139,6 @@ class HostInfo():
             client_hosts (object): hosts to define as clients
             client_partition (str): client partition name
             client_reservation (str): client reservation name
-            include_local_host (bool, optional): option to include the local host as a client.
-                Defaults to False.
 
         Raises:
             HostException: if there is a problem obtaining the hosts
@@ -155,11 +153,12 @@ class HostInfo():
             raise HostException("Error defining the server hosts") from error
 
         try:
+            # Always include localhost in the client list so it is setup correctly.
             self._clients = HostRole(
                 client_hosts, client_partition, client_reservation,
                 get_partition_hosts(log, control_host, client_partition),
                 get_reservation_hosts(log, control_host, client_reservation),
-                include_local_host)
+                True)
         except SlurmFailed as error:
             raise HostException("Error defining the server hosts") from error
 

--- a/src/tests/ftest/util/launch_utils.py
+++ b/src/tests/ftest/util/launch_utils.py
@@ -289,15 +289,13 @@ class TestInfo():
         """
         return self.test_file
 
-    def set_yaml_info(self, logger, include_local_host=False):
+    def set_yaml_info(self, logger):
         """Set the test yaml data from the test yaml file.
 
         Args:
             logger (Logger): logger for the messages produced by this method
-            include_local_host (bool, optional): whether or not the local host be included in the
-                set of client hosts. Defaults to False.
         """
-        self.yaml_info = {"include_local_host": include_local_host}
+        self.yaml_info = {}
         yaml_data = get_yaml_data(self.yaml_file)
         for extra_yaml in self.extra_yaml:
             yaml_data.update(get_yaml_data(extra_yaml))
@@ -330,14 +328,12 @@ class TestInfo():
             setting up a slum partition
         """
         logger.debug("Using %s to define host information", self.yaml_file)
-        if self.yaml_info["include_local_host"]:
-            logger.debug("  Adding the localhost to the clients: %s", get_local_host())
         try:
             self.host_info.set_hosts(
                 logger, control_node, self.yaml_info[self.YAML_INFO_KEYS[0]],
                 self.yaml_info[self.YAML_INFO_KEYS[1]], self.yaml_info[self.YAML_INFO_KEYS[2]],
                 self.yaml_info[self.YAML_INFO_KEYS[3]], self.yaml_info[self.YAML_INFO_KEYS[4]],
-                self.yaml_info[self.YAML_INFO_KEYS[5]], self.yaml_info["include_local_host"])
+                self.yaml_info[self.YAML_INFO_KEYS[5]])
         except HostException as error:
             raise LaunchException("Error getting hosts from {self.yaml_file}") from error
 
@@ -1023,7 +1019,7 @@ class TestGroup():
                             file_name, class_name, method_name, ','.join(tags))
 
     def update_test_yaml(self, logger, scm_size, scm_mount, extra_yaml, multiplier, override,
-                         verbose, include_localhost):
+                         verbose):
         """Update each test yaml file.
 
         Args:
@@ -1034,7 +1030,6 @@ class TestGroup():
             multiplier (int): multiplier to apply to any timeouts specified in the test yaml
             override (bool): whether or not to override the number of hosts for the test
             verbose (int): level of verbosity
-            include_localhost (bool): whether or not to include the local host with the client hosts
 
         Raises:
             RunException: if there is an error modifying the test yaml files
@@ -1109,7 +1104,7 @@ class TestGroup():
                 raise RunException(f"Error listing test variants for {test.yaml_file}")
 
             # Collect the host information from the updated test yaml
-            test.set_yaml_info(logger, include_localhost)
+            test.set_yaml_info(logger)
 
     def _add_auto_storage_yaml(self, logger, storage_info, yaml_dir, tier_0_type, scm_size,
                                scm_mount, max_nvme_tiers, control_metadata):

--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2022-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -465,6 +465,10 @@ def run_remote(log, hosts, command, verbose=True, timeout=120, task_debug=False,
     Returns:
         CommandResult: groups of command results from the same hosts with the same return status
     """
+    if hosts is None:
+        raise ValueError("No hosts specified for run_remote()")
+    if command is None:
+        raise ValueError("No command specified for run_remote()")
     task = task_self()
     task.set_info('debug', task_debug)
     task.set_default("stderr", stderr)

--- a/src/tests/ftest/util/yaml_utils.py
+++ b/src/tests/ftest/util/yaml_utils.py
@@ -14,8 +14,10 @@ from ClusterShell.NodeSet import NodeSet
 # pylint: disable=import-error,no-name-in-module
 try:
     from util.data_utils import dict_extract_values, list_flatten, list_unique
+    from util.host_utils import get_local_host
 except (ImportError, ModuleNotFoundError):
     from data_utils import dict_extract_values, list_flatten, list_unique
+    from host_utils import get_local_host
 
 
 class YamlException(BaseException):
@@ -128,6 +130,7 @@ class YamlUpdater():
             clients (NodeSet): set of hosts to use as clients in the test yaml
             storage (str): updated storage information to apply to the test yaml
             timeout (int): multiplier to apply to any timeouts specified in the test yaml
+            override (bool): whether to override the test yaml values with user-specified values
             verbose (int): verbosity level
         """
         self.log = logger
@@ -219,6 +222,16 @@ class YamlUpdater():
             if key == "test_clients" and not replacement:
                 replacement = replacement_data["test_servers"]
 
+            # localhost is preferred as a client over a server,
+            # so put localhost last for servers and first for clients.
+            # It will only be used as a server if it is the last available node.
+            if key == "test_servers":
+                replacement.sort(key=lambda x: x == str(get_local_host()))
+                self.log.debug("replacing test_servers with sorted list: %s", replacement)
+            if key == "test_clients":
+                replacement.sort(key=lambda x: x != str(get_local_host()))
+                self.log.debug("replacing test_clients with sorted list: %s", replacement)
+
             if key not in placeholder_data:
                 if self._verbose > 1:
                     self.log.debug("  - No '%s' placeholder specified in the test yaml", key)
@@ -234,7 +247,7 @@ class YamlUpdater():
             # Replace test yaml keys that were:
             #   - found in the test yaml
             #   - have a user-specified replacement
-            if key.startswith("test_"):
+            if key in ("test_servers", "test_clients"):
                 # The entire server/client test yaml list entry is replaced by a new test yaml list
                 # entry, e.g.
                 #   '  test_servers: server-[1-2]' --> '  test_servers: wolf-[10-11]'
@@ -260,14 +273,14 @@ class YamlUpdater():
 
         return replacements
 
-    def _get_host_replacement(self, replacements, placeholder_data, key, replacement, node_mapping):
+    def _get_host_replacement(self, replacements, placeholder_data, key, available, node_mapping):
         """Replace the server or client placeholders.
 
         Args:
             replacements (dict): dictionary in which to add replacements for test yaml entries
             placeholder_data (dict): test yaml values requesting replacements
-            key (str): test yaml entry key
-            replacement (list): available values to use as replacements for the test yaml entries
+            key (str): test yaml entry key. E.g. test_servers or test_clients
+            available (list): available values to use as replacements for the test yaml entries
             node_mapping (dict): dictionary of nodes and their replacement values
 
         Raises:
@@ -279,55 +292,62 @@ class YamlUpdater():
 
         for placeholder in placeholder_data[key]:
             replacement_nodes = NodeSet()
+            quantity = None
+            placeholder_nodeset = None
             try:
+                quantity = int(placeholder)
+            except ValueError:
+                pass
+            try:
+                placeholder_nodeset = NodeSet(placeholder)
+            except TypeError:
+                pass
+
+            if quantity is not None:
                 # Replace integer placeholders with the number of nodes from the user provided list
                 # equal to the quantity requested by the test yaml
-                quantity = int(placeholder)
                 if self._override and self._clients:
                     # When individual lists of server and client nodes are provided with the
                     # override flag set use the full list of nodes specified by the
                     # test_server/test_client arguments
-                    quantity = len(replacement)
+                    quantity = len(available)
                 elif self._override:
                     self.log.warning(
                         "Warning: In order to override the node quantity a "
                         "'--test_clients' argument must be specified: %s: %s",
                         key, placeholder)
+                if len(available) < quantity:
+                    message = f"Not enough '{key}' placeholder replacements specified"
+                    self.log.error("  - %s; required: %s", message, quantity)
+                    raise YamlException(message)
                 for _ in range(quantity):
-                    try:
-                        replacement_nodes.add(replacement.pop(0))
-                    except IndexError as error:
-                        # Not enough nodes provided for the replacement
-                        message = f"Not enough '{key}' placeholder replacements specified"
-                        self.log.error("  - %s; required: %s", message, quantity)
-                        raise YamlException(message) from error
+                    replacement_nodes.add(available.pop(0))
 
-            except ValueError:
-                try:
-                    # Replace clush-style placeholders with nodes from the user provided list using
-                    # a mapping so that values used more than once yield the same replacement
-                    for node in NodeSet(placeholder):
-                        if node not in node_mapping:
-                            try:
-                                node_mapping[node] = replacement.pop(0)
-                            except IndexError as error:
-                                # Not enough nodes provided for the replacement
-                                if not self._override:
-                                    message = f"Not enough '{key}' placeholder replacements remain"
-                                    self.log.error(
-                                        "  - %s; required: %s", message, NodeSet(placeholder))
-                                    raise YamlException(message) from error
-                                break
-                            self.log.debug(
-                                "  - %s replacement node mapping: %s -> %s",
-                                key, node, node_mapping[node])
-                        replacement_nodes.add(node_mapping[node])
+            elif placeholder_nodeset is not None:
+                # Replace clush-style placeholders with nodes from the user provided list using
+                # a mapping so that values used more than once yield the same replacement
+                for node in placeholder_nodeset:
+                    if node not in node_mapping:
+                        try:
+                            node_mapping[node] = available.pop(0)
+                        except IndexError as error:
+                            # Not enough nodes provided for the replacement
+                            if not self._override:
+                                message = f"Not enough '{key}' placeholder replacements remain"
+                                self.log.error(
+                                    "  - %s; required: %s", message, NodeSet(placeholder))
+                                raise YamlException(message) from error
+                            break
+                        self.log.debug(
+                            "  - %s replacement node mapping: %s -> %s",
+                            key, node, node_mapping[node])
+                    replacement_nodes.add(node_mapping[node])
 
-                except TypeError as error:
-                    # Unsupported format
-                    message = f"Unsupported placeholder format: {placeholder}"
-                    self.log.error(message)
-                    raise YamlException(message) from error
+            else:
+                # Unsupported format
+                message = f"Unsupported placeholder format: {placeholder}"
+                self.log.error(message)
+                raise YamlException(message)
 
             hosts_key = r":\s+".join([key, str(placeholder)])
             hosts_key = hosts_key.replace("[", r"\[")


### PR DESCRIPTION
Use localhost as a proper client since it has always been setup as
a client anyway.
In launch.py, require localhost to be in the server or client list.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
