### PR TITLE
DAOS-19087 container: Remove some VOS cont creates

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -2202,13 +2202,15 @@ cont_snap_update_one(void *vin)
 	struct ds_cont_child	*cont;
 	int			 rc;
 
-	/* The container should be exist on the system at this point, if non-exist on this target
-	 * it should be the case of reintegrate the container was destroyed ahead, so just
-	 * open_create the container here.
-	 */
-	rc = ds_cont_child_open_create(args->pool_uuid, args->cont_uuid, false, &cont);
-	if (rc != 0)
+	rc = ds_cont_child_lookup(args->pool_uuid, args->cont_uuid, &cont);
+	if (rc != 0) {
+		if (rc == -DER_CONT_NONEXIST || rc == -DER_CONT_DESTROYING) {
+			D_DEBUG(DB_MD, DF_CONT ": skip: " DF_RC "\n",
+				DP_CONT(args->pool_uuid, args->cont_uuid), DP_RC(rc));
+			rc = 0;
+		}
 		return rc;
+	}
 
 	if (args->snap_count == 0) {
 		if (cont->sc_snapshots != NULL) {

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -45,10 +45,8 @@ int
 int ds_cont_filter(uuid_t pool_uuid, daos_pool_cont_filter_t *filt,
 		   struct daos_pool_cont_info2 **conts, uint64_t *ncont);
 int ds_cont_upgrade(uuid_t pool_uuid, struct cont_svc *svc);
-int ds_cont_tgt_close(uuid_t pool_uuid, uuid_t hdl_uuid);
-int ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
-		     uuid_t cont_uuid, uint64_t flags, uint64_t sec_capas,
-		     uint32_t status_pm_ver);
+int
+ds_cont_tgt_close(uuid_t pool_uuid, uuid_t hdl_uuid);
 int
 ds_cont_srv_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid);
 void

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -2580,8 +2580,7 @@ cont_discard_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	struct child_discard_arg *arg = cb_arg;
 	struct ds_cont_child	*cont = NULL;
 	vos_iter_param_t	param = { 0 };
-	struct vos_iter_anchors	anchor = { 0 };
-	daos_handle_t		coh;
+	struct vos_iter_anchors   anchor = {0};
 	struct d_backoff_seq	backoff_seq;
 	int			rc;
 
@@ -2598,18 +2597,11 @@ cont_discard_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		return rc;
 	}
 
-	rc = vos_cont_open(iter_param->ip_hdl, entry->ie_couuid, &coh);
-	if (rc != 0) {
-		D_ERROR("Open container "DF_UUID" failed: "DF_RC"\n",
-			DP_UUID(entry->ie_couuid), DP_RC(rc));
-		D_GOTO(put, rc);
-	}
-
 	rc = d_backoff_seq_init(&backoff_seq, 0 /* nzeros */, 16 /* factor */, 8 /* next (ms) */,
 				1 << 10 /* max (ms) */);
 	D_ASSERTF(rc == 0, "d_backoff_seq_init: "DF_RC"\n", DP_RC(rc));
 
-	param.ip_hdl = coh;
+	param.ip_hdl        = cont->sc_hdl;
 	param.ip_epr.epr_lo = 0;
 	param.ip_epr.epr_hi = arg->ca_epoch;
 	uuid_copy(arg->ca_co_uuid, entry->ie_couuid);
@@ -2627,19 +2619,10 @@ cont_discard_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	} while (1);
 
 	d_backoff_seq_fini(&backoff_seq);
-	vos_cont_close(coh);
 	D_DEBUG(DB_TRACE, DF_UUID "/" DF_UUID " discard cont done: " DF_RC "\n",
 		DP_UUID(arg->ca_po_uuid), DP_UUID(entry->ie_couuid), DP_RC(rc));
 
-put:
 	ds_cont_child_put(cont);
-	/* don't destroy vos container, to avoid ds_cont_tgt_refresh_agg_eph() failure,
-	 * later depend on container recovery process to handle it.
-	 */
-#if 0
-	if (rc == 0)
-		rc = ds_cont_child_destroy(arg->tgt_discard->pool_uuid, entry->ie_couuid);
-#endif
 	return rc;
 }
 


### PR DESCRIPTION
Remove VOS container create operations, except for the following cases:

  - cont_iv_ent_{fetch,update} for IV_CONT_CAPA
  - ds_pool_recov_cont_handler

Nonexistent VOS containers (i.e., container children) mean that the
container either has never been successfully opened (i.e., is emtpy) or
is being destroyed. Hence, upper layers should not have any safety issue
if they return an error or ignore the nonexistent container children,
AFAICS.

Features: rebuild

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
