### PR TITLE
DAOS-19439 test: some nlt cleanup and fix

### DIFF
--- a/src/tests/nlt/client.py
+++ b/src/tests/nlt/client.py
@@ -15,6 +15,7 @@ import re
 import subprocess  # nosec
 import tempfile
 from os.path import join
+from types import NoneType
 
 from .base import get_inc_id
 from .config import get_base_env
@@ -68,11 +69,11 @@ class DaosCont():
     """Class to store data about daos containers"""
 
     def __init__(self, cont_uuid, label, pool):
+        if not isinstance(pool, (DaosPool, NoneType)):
+            raise ValueError('pool must be DaosPool or None')
         self.uuid = cont_uuid
         self.label = label
         self.pool = pool
-        if pool is not None:
-            assert isinstance(self.pool, DaosPool)
 
     # pylint: disable-next=invalid-name
     def id(self):
@@ -183,10 +184,7 @@ class ValgrindHelper():
         with open(self._xml_file, 'r') as fd:
             with open(f'{self._xml_file}.xml', 'w') as ofd:
                 for line in fd:
-                    if self.src_dir in line:
-                        ofd.write(line.replace(self.src_dir, ''))
-                    else:
-                        ofd.write(line)
+                    ofd.write(line.replace(self.src_dir, ''))
         os.unlink(self._xml_file)
 
 
@@ -358,11 +356,17 @@ def create_cont(conf, pool=None, ctype=None, label=None, path=None, oclass=None,
 
     Returns:
         DaosCont: Newly created container as DaosCont object.
+
+    Raises:
+        ValueError: on invalid inputs
     """
     cmd = ['container', 'create']
 
-    if not path:
-        assert isinstance(pool, DaosPool)
+    if not isinstance(pool, (DaosPool, NoneType)):
+        raise ValueError('pool must be DaosPool or None')
+
+    if not path and not pool:
+        raise ValueError('pool or path is required')
 
     if pool:
         cmd.append(pool.id())

--- a/src/tests/nlt/dfuse.py
+++ b/src/tests/nlt/dfuse.py
@@ -44,6 +44,9 @@ class DFuse():
             self.pool = pool.id()
         if isinstance(container, DaosCont):
             self.container = container.id()
+            if self.pool and self.pool != container.pool.id():
+                raise ValueError(
+                    f'container.pool.id() = {container.pool.id()} but self.pool = {self.pool}')
             self.pool = container.pool.id()
         self.conf = conf
         self.multi_user = multi_user
@@ -62,8 +65,7 @@ class DFuse():
         self.file_h = file_h
 
         self.valgrind = None
-        if not os.path.exists(self.dir):
-            os.mkdir(self.dir)
+        os.makedirs(self.dir, exist_ok=True)
 
     def __str__(self):
 
@@ -503,8 +505,7 @@ class needs_dfuse_with_opt():
     @staticmethod
     def parse_test_name(name):
         """Convert a string name for a parameterized test to a parameterized tuple"""
-        if not name.endswith('_caching_on') and not name.endswith('_caching_off'):
+        match = re.match(r'(.+)_(caching_on|caching_off)$', name)
+        if not match:
             return (name, None)
-
-        match = re.match(r'(.+)_(caching_on|caching_off)', name)
         return (match.group(1), match.group(2) == 'caching_on')

--- a/src/tests/nlt/logging_utils.py
+++ b/src/tests/nlt/logging_utils.py
@@ -21,8 +21,9 @@ class NltStdoutWrapper():
 
     def __init__(self):
         self._stdout = sys.stdout
-        self._outputs = {}
+        self._original_stdout = sys.stdout
         sys.stdout = self
+        self._outputs = {}
 
     def write(self, value):
         """Print to stdout.  If this is the main thread then print it, always save it"""
@@ -49,7 +50,8 @@ class NltStdoutWrapper():
         self._stdout.flush()
 
     def __del__(self):
-        sys.stdout = self._stdout
+        """Restore original stream."""
+        sys.stdout = self._original_stdout
 
 
 class NltStderrWrapper():
@@ -57,8 +59,9 @@ class NltStderrWrapper():
 
     def __init__(self):
         self._stderr = sys.stderr
+        self._original_stderr = sys.stderr
+        sys.stdout = self
         self._outputs = {}
-        sys.stderr = self
 
     def write(self, value):
         """Print to stderr.  Always print it, always save it"""
@@ -80,7 +83,8 @@ class NltStderrWrapper():
         self._stderr.flush()
 
     def __del__(self):
-        sys.stderr = self._stderr
+        """Restore original stream."""
+        sys.stderr = self._original_stderr
 
 
 nlt_lp = None  # pylint: disable=invalid-name

--- a/src/tests/nlt/server.py
+++ b/src/tests/nlt/server.py
@@ -76,9 +76,7 @@ class DaosServer():
         if self.valgrind:
             self.__process_name = 'memcheck-amd64-'
 
-        socket_dir = '/tmp/dnt_sockets'
-        if not os.path.exists(socket_dir):
-            os.mkdir(socket_dir)
+        os.makedirs('/tmp/dnt_sockets', exist_ok=True)
 
         self.agent_dir = tempfile.mkdtemp(prefix='dnt_agent_')
 
@@ -392,7 +390,7 @@ class DaosServer():
             with open(status_file, 'r') as fd:
                 for line in fd.readlines():
                     try:
-                        key, raw = line.split(':', maxsplit=2)
+                        key, raw = line.split(':', maxsplit=1)
                     except ValueError:
                         continue
                     value = raw.strip()


### PR DESCRIPTION
- Replace some asserts with more clear ValueError
- Simplify some function calls
- Fix NltStdoutWrapper and NltStderrWrapper to properly restore the original streams.
- Fix a str.split to use maxsplit=1

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
