### PR TITLE
SRE-3965 tests: Refine medium MD on SSD stages for cb test tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,10 @@ void updateRunStage() {
         'Functional Hardware Medium TCP Provider MD on SSD',
         'Functional Hardware Large TCP MD on SSD',
         'Functional Hardware Medium Verbs MD on SSD',
-        'Functional Hardware Large Verbs MD on SSD'
+        'Functional Hardware Large Verbs MD on SSD',
+        'Functional Cluster Box Medium MD on SSD',
+        'Functional Cluster Box Medium TCP MD on SSD',
+        'Functional Cluster Box Medium Verbs MD on SSD'
     ]
 
     // Initialize the run state of each stage using the parameter stage keys
@@ -384,6 +387,15 @@ pipeline {
         booleanParam(name: bashName('Functional Hardware Large Verbs MD on SSD'),
                      defaultValue: true,
                      description: 'Run the Functional Hardware Large Verbs MD on SSD stage.')
+        booleanParam(name: bashName('Functional Cluster Box Medium MD on SSD'),
+                     defaultValue: true,
+                     description: 'Run the Functional Cluster Box Medium MD on SSD stage.')
+        booleanParam(name: bashName('Functional Cluster Box Medium TCP MD on SSD'),
+                     defaultValue: true,
+                     description: 'Run the Functional Cluster Box Medium TCP MD on SSD stage.')
+        booleanParam(name: bashName('Functional Cluster Box Medium Verbs MD on SSD'),
+                     defaultValue: true,
+                     description: 'Run the Functional Cluster Box Medium Verbs MD on SSD stage.')
         string(name: 'FUNCTIONAL_VM_LABEL',
                defaultValue: 'ci_vm9',
                description: 'Label to use for 9 VM functional tests')
@@ -417,6 +429,9 @@ pipeline {
         string(name: 'FUNCTIONAL_HARDWARE_LARGE_VERBS_MD_ON_SSD_LABEL',
                defaultValue: 'ci_ofed9',
                description: 'Label to use for 9 node Functional Hardware Large Verbs MD on SSD stage')
+        string(name: 'FUNCTIONAL_CLUSTER_BOX_LABEL',
+               defaultValue: 'cluster_box',
+               description: 'Label to use for the Functional Cluster Box Medium MD on SSD stages')
         string(name: 'CI_BUILD_DESCRIPTION',
                defaultValue: '',
                description: 'A description of the build')
@@ -545,7 +560,7 @@ pipeline {
                             label: params.FUNCTIONAL_HARDWARE_MEDIUM_MD_ON_SSD_LABEL,
                             next_version: params.BaseBranch,
                             other_packages: 'mercury-libfabric mercury-ucx',
-                            stage_tags: 'hw,medium,-provider',
+                            stage_tags: 'hw,medium,-provider,-cb',
                             default_tags: defaultTags('full_regression'),
                             nvme: 'auto_md_on_ssd',
                             job_status: job_status_internal
@@ -598,7 +613,7 @@ pipeline {
                             label: params.FUNCTIONAL_HARDWARE_MEDIUM_TCP_MD_ON_SSD_LABEL,
                             next_version: params.BaseBranch,
                             other_packages: 'mercury-libfabric',
-                            stage_tags: 'hw,medium,-provider',
+                            stage_tags: 'hw,medium,-provider,-cb',
                             default_tags: defaultTags('pr daily_regression'),
                             nvme: 'auto_md_on_ssd',
                             provider: 'ofi+tcp',
@@ -612,7 +627,7 @@ pipeline {
                             label: params.FUNCTIONAL_HARDWARE_MEDIUM_TCP_PROVIDER_MD_ON_SSD_LABEL,
                             next_version: params.BaseBranch,
                             other_packages: 'mercury-libfabric',
-                            stage_tags: 'hw,medium,provider',
+                            stage_tags: 'hw,medium,provider,-cb',
                             default_tags: defaultTags('pr daily_regression'),
                             nvme: 'auto_md_on_ssd',
                             provider: 'ofi+tcp',
@@ -640,7 +655,7 @@ pipeline {
                             label: params.FUNCTIONAL_HARDWARE_MEDIUM_VERBS_MD_ON_SSD_LABEL,
                             next_version: params.BaseBranch,
                             other_packages: 'mercury-libfabric',
-                            stage_tags: 'hw,medium,-provider',
+                            stage_tags: 'hw,medium,-provider,-cb',
                             default_tags: defaultTags('pr daily_regression'),
                             nvme: 'auto_md_on_ssd',
                             provider: 'ofi+verbs;ofi_rxm',
@@ -658,6 +673,50 @@ pipeline {
                             default_tags: defaultTags('pr daily_regression'),
                             nvme: 'auto_md_on_ssd',
                             provider: 'ofi+verbs;ofi_rxm',
+                            job_status: job_status_internal
+                        ),
+                        'Functional Cluster Box Medium MD on SSD': getFunctionalTestStage(
+                            name: 'Functional Cluster Box Medium MD on SSD',
+                            runStage: shouldStageRun('Functional Cluster Box Medium MD on SSD'),
+                            pragma_suffix: '-cb-medium-md-on-ssd',
+                            base_branch: params.BaseBranch,
+                            label: params.FUNCTIONAL_CLUSTER_BOX_LABEL,
+                            next_version: params.BaseBranch,
+                            other_packages: 'mercury-libfabric mercury-ucx',
+                            stage_tags: 'cb,medium,-provider',
+                            default_tags: defaultTags('pr daily_regression'),
+                            nvme: 'auto_md_on_ssd',
+                            node_count: 5,
+                            job_status: job_status_internal
+                        ),
+                        'Functional Cluster Box Medium TCP MD on SSD': getFunctionalTestStage(
+                            name: 'Functional Cluster Box Medium TCP MD on SSD',
+                            runStage: shouldStageRun('Functional Cluster Box Medium TCP MD on SSD'),
+                            pragma_suffix: '-cb-medium-tcp-md-on-ssd',
+                            base_branch: params.BaseBranch,
+                            label: params.FUNCTIONAL_CLUSTER_BOX_LABEL,
+                            next_version: params.BaseBranch,
+                            other_packages: 'mercury-libfabric',
+                            stage_tags: 'cb,medium',
+                            default_tags: defaultTags('pr daily_regression'),
+                            nvme: 'auto_md_on_ssd',
+                            provider: 'ofi+tcp',
+                            node_count: 5,
+                            job_status: job_status_internal
+                        ),
+                        'Functional Cluster Box Medium Verbs MD on SSD': getFunctionalTestStage(
+                            name: 'Functional Cluster Box Medium Verbs MD on SSD',
+                            runStage: shouldStageRun('Functional Cluster Box Medium Verbs MD on SSD'),
+                            pragma_suffix: '-cb-medium-verbs-md-on-ssd',
+                            base_branch: params.BaseBranch,
+                            label: params.FUNCTIONAL_CLUSTER_BOX_LABEL,
+                            next_version: params.BaseBranch,
+                            other_packages: 'mercury-libfabric',
+                            stage_tags: 'cb,medium,-provider',
+                            default_tags: defaultTags('pr daily_regression'),
+                            nvme: 'auto_md_on_ssd',
+                            provider: 'ofi+verbs;ofi_rxm',
+                            node_count: 5,
                             job_status: job_status_internal
                         )
                     )


### PR DESCRIPTION
Cluster box capable tests now carry both the `cb` and `hw` tags so that they run on the PMEM hardware stages as well as the cluster box. The line is drawn at MD on SSD: the medium MD on SSD hardware stages exclude `cb` tests, and each provider used by those stages gets an associated cluster box stage.

- Add `-cb` to `Functional Hardware Medium MD on SSD`, `Medium TCP MD on SSD`, `Medium TCP Provider MD on SSD` and `Medium Verbs MD on SSD`.
- Add `Functional Cluster Box Medium MD on SSD` (default provider, `cb,medium,-provider`), `Functional Cluster Box Medium TCP MD on SSD` (`ofi+tcp`, unfiltered `cb,medium` since it stands in for both the TCP and TCP Provider hardware stages) and `Functional Cluster Box Medium Verbs MD on SSD` (`ofi+verbs;ofi_rxm`, `cb,medium,-provider`).
- Add the `FUNCTIONAL_CLUSTER_BOX_LABEL` parameter used by those stages.

Large MD on SSD stages are unchanged as no `cb` tagged test is large.

Companion PRs: #18810 (master), #18811 (daily-testing).

Ticket: SRE-3965
