### PR TITLE
DAOS-19415 test: remove self.add_pool* methods (#18795)

### DIFF
--- a/src/tests/ftest/aggregation/multiple_pool_cont.py
+++ b/src/tests/ftest/aggregation/multiple_pool_cont.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2021-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -81,7 +82,7 @@ class DaosAggregationMultiPoolCont(IorTestBase):
 
         job_manager = get_job_manager(self, subprocess=False, timeout=self.get_remaining_time())
         # Create requested pools
-        self.add_pool_qty(total_pools, connect=False)
+        self.pool = [self.get_pool(connect=False) for _ in range(total_pools)]
         start_time = time.time()
         while int(finish_time - start_time) < int(total_runtime):
             # Since the transfer size is 1M, the objects will be inserted

--- a/src/tests/ftest/aggregation/punching.py
+++ b/src/tests/ftest/aggregation/punching.py
@@ -34,7 +34,7 @@ class AggregationPunching(MdtestBase):
         :avocado: tags=AggregationPunching,test_aggregation_punching
         """
         if self.pool is None:
-            self.add_pool(connect=False)
+            self.pool = self.get_pool(connect=False)
         self.pool.connect()
 
         storage_index = 1  # SSD

--- a/src/tests/ftest/container/api_basic_attribute.py
+++ b/src/tests/ftest/container/api_basic_attribute.py
@@ -1,6 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -114,7 +114,7 @@ class ContainerAPIBasicAttributeTest(TestWithServers):
     def prepare_attribute_test(self):
         """Prepare variables needed for the tests.
         """
-        self.add_pool()
+        self.pool = self.get_pool()
         self.add_container(self.pool)
         self.container.open()
 

--- a/src/tests/ftest/container/auto_oc_selection.py
+++ b/src/tests/ftest/container/auto_oc_selection.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -33,7 +34,7 @@ class AutoOCSelectionTest(TestWithServers):
         :avocado: tags=container,dfs
         :avocado: tags=AutoOCSelectionTest,test_oc_selection
         """
-        self.add_pool()
+        self.pool = self.get_pool()
 
         # (Redundancy Factor, Object Class, Failure Expected)
         prop_oclasses = [

--- a/src/tests/ftest/container/destroy.py
+++ b/src/tests/ftest/container/destroy.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -64,7 +65,7 @@ class ContainerDestroyTest(TestWithServers):
         passed = False
 
         # Create a pool and a container.
-        self.add_pool()
+        self.pool = self.get_pool()
         self.add_container(pool=self.pool)
 
         # Open the container if required

--- a/src/tests/ftest/container/fill_destroy_loop.py
+++ b/src/tests/ftest/container/fill_destroy_loop.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2022-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -168,7 +169,7 @@ class BoundaryPoolContainerSpace(TestWithServers):
         :avocado: tags=BoundaryPoolContainerSpace,test_fill_destroy_cont_loop
         """
         # create pool
-        self.add_pool()
+        self.pool = self.get_pool()
 
         for test_loop in range(1, self.test_loop + 1):
             self.log.info("==>Starting test loop: %i ...", test_loop)

--- a/src/tests/ftest/container/full_pool_container_create.py
+++ b/src/tests/ftest/container/full_pool_container_create.py
@@ -48,7 +48,7 @@ class FullPoolContainerCreate(TestWithServers):
 
         # create pool and connect
         self.log_step("Create a pool and container")
-        self.add_pool()
+        self.pool = self.get_pool()
 
         # query the pool
         self.log.info("Pool Query before write")

--- a/src/tests/ftest/container/multiple_delete.py
+++ b/src/tests/ftest/container/multiple_delete.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -34,7 +34,7 @@ class MultipleContainerDelete(IorTestBase):
         :avocado: tags=container
         :avocado: tags=MultipleContainerDelete,test_multiple_container_delete
         """
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
 
         out = []
 

--- a/src/tests/ftest/control/daos_object_query.py
+++ b/src/tests/ftest/control/daos_object_query.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -47,7 +48,7 @@ class DaosObjectQuery(TestWithServers):
 
         # Create a pool and a container. Specify --oclass, which will be used
         # when writing object.
-        self.add_pool()
+        self.pool = self.get_pool()
         self.add_container(self.pool)
         self.pool.connect()
         self.container.open(pool_handle=self.pool.pool.handle.value)

--- a/src/tests/ftest/control/daos_snapshot.py
+++ b/src/tests/ftest/control/daos_snapshot.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -34,7 +35,7 @@ class DaosSnapshotTest(TestWithServers):
 
     def prepare_pool_container(self):
         """Create a pool and a container and prepare for the test cases."""
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
         self.add_container(self.pool)
 
     def create_verify_snapshots(self, count):

--- a/src/tests/ftest/control/dmg_pool_exclude_ranks.py
+++ b/src/tests/ftest/control/dmg_pool_exclude_ranks.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -20,7 +20,7 @@ class DmgPoolExcludeRanks(ControlTestBase):
         super().setUp()
 
         # Init the pool
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
 
     def test_pool_exclude_ranks_basic(self):
         """Test the exclusion when it break Pool RF.

--- a/src/tests/ftest/control/dmg_pool_query_ranks.py
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2022-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -24,7 +24,7 @@ class DmgPoolQueryRanks(ControlTestBase):
         super().setUp()
 
         # Init the pool
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
 
     def test_pool_query_ranks_basic(self):
         """Test the state of ranks with dmg pool query.

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -24,7 +24,7 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
         super().setUp()
 
         # Init the pool
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
 
     def test_pool_query_basic(self):
         """

--- a/src/tests/ftest/control/dmg_storage_query.py
+++ b/src/tests/ftest/control/dmg_storage_query.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -148,7 +149,7 @@ class DmgStorageQuery(ControlTestBase):
         targets = self.server_managers[-1].get_config_value('targets')
 
         # Create pool and get the storage smd information, then verify info
-        self.add_pool()
+        self.pool = self.get_pool()
         pool_info = get_storage_query_pool_info(self.dmg, verbose=True)
 
         # Check the dmg storage query list-pools output for inaccuracies

--- a/src/tests/ftest/control/dmg_telemetry_basic.py
+++ b/src/tests/ftest/control/dmg_telemetry_basic.py
@@ -1,5 +1,6 @@
 """
 (C) Copyright 2021-2023 Intel Corporation.
+(C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -96,7 +97,7 @@ class TestWithTelemetryBasic(TestWithTelemetry):
         """
         container_qty = self.params.get("container_qty", "/run/test/*", 1)
         open_close_qty = self.params.get("open_close_qty", "/run/test/*", 2)
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
         self.pool.set_query_data()
         pool_leader_rank = self.pool.query_data["response"]["svc_ldr"]
         self.pool_leader_host = self.server_managers[0].get_host(pool_leader_rank)

--- a/src/tests/ftest/control/dmg_telemetry_io_basic.py
+++ b/src/tests/ftest/control/dmg_telemetry_io_basic.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -93,7 +94,7 @@ class TestWithTelemetryIOBasic(IorTestBase, TestWithTelemetry):
             TelemetryUtils.ENGINE_IO_OPS_FETCH_ACTIVE_METRICS +\
             TelemetryUtils.ENGINE_IO_OPS_UPDATE_ACTIVE_METRICS
         loop = 0
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
         self.add_container(pool=self.pool)
         metrics_data = {}
         for block_size in block_sizes:

--- a/src/tests/ftest/control/dmg_telemetry_io_latency.py
+++ b/src/tests/ftest/control/dmg_telemetry_io_latency.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -165,7 +166,7 @@ class TestWithTelemetryIOLatency(IorTestBase, TestWithTelemetry):
 
         for transfer_size in transfer_sizes:
             ior_latency[transfer_size] = {}
-            self.add_pool(connect=False)
+            self.pool = self.get_pool(connect=False)
             self.add_containers(self.pool, oclass=self.ior_cmd.dfs_oclass.value)
             for operation in ["update", "fetch"]:
                 flags = self.params.get("F", "/run/ior/ior{}flags/".format(operation))

--- a/src/tests/ftest/control/ms_resilience.py
+++ b/src/tests/ftest/control/ms_resilience.py
@@ -1,5 +1,6 @@
 """
 (C) Copyright 2021-2024 Intel Corporation.
+(C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -68,7 +69,7 @@ class ManagementServiceResilience(TestWithServers):
 
     def create_pool(self):
         """Create a pool on the server group."""
-        self.add_pool(create=False)
+        self.pool = self.get_pool(create=False)
         self.pool.name.value = self.server_group
         self.log.info("*** creating pool")
         self.pool.create()

--- a/src/tests/ftest/deployment/agent_failure.py
+++ b/src/tests/ftest/deployment/agent_failure.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2022-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -81,7 +81,7 @@ class AgentFailure(IorTestBase):
         :avocado: tags=AgentFailure,test_agent_failure
         """
         # 1. Create a pool and a container.
-        self.add_pool()
+        self.pool = self.get_pool()
         self.add_container(self.pool)
 
         # 2. Run IOR.
@@ -174,7 +174,7 @@ class AgentFailure(IorTestBase):
         :avocado: tags=AgentFailure,test_agent_failure_isolation
         """
         # 1. Create a pool and a container.
-        self.add_pool()
+        self.pool = self.get_pool()
         self.add_container(self.pool)
 
         # Use the last two agent hosts, since the first is likely the test runner node

--- a/src/tests/ftest/deployment/ior_per_rank.py
+++ b/src/tests/ftest/deployment/ior_per_rank.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -34,7 +35,7 @@ class IorPerRank(IorTestBase):
 
         self.log.info("Running Test on rank: %s", rank)
         # create the pool on specified rank.
-        self.add_pool(connect=False, target_list=[rank])
+        self.pool = self.get_pool(connect=False, target_list=[rank])
         self.container = self.get_container(self.pool)
 
         host = self.server_managers[0].get_host(rank)

--- a/src/tests/ftest/deployment/network_failure.py
+++ b/src/tests/ftest/deployment/network_failure.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2022-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -183,7 +183,7 @@ class NetworkFailureTest(IorTestBase):
         # 1. Create a pool and a container.
         self.log_step("Create a pool and a container.")
         self.container = []
-        self.add_pool(namespace="/run/pool_size_ratio_80/*")
+        self.pool = self.get_pool(namespace="/run/pool_size_ratio_80/*")
         self.container.append(
             self.get_container(pool=self.pool, namespace=container_namespace))
 
@@ -363,7 +363,7 @@ class NetworkFailureTest(IorTestBase):
         # 2. Create a pool across the four ranks on the two nodes. Use --nsvc=3. We have
         # to provide the size because we're using --ranks.
         self.log_step("Create a pool across the four ranks on the two nodes.")
-        self.add_pool(namespace="/run/pool_size_value/*", target_list=target_list)
+        self.pool = self.get_pool(namespace="/run/pool_size_value/*", target_list=target_list)
 
         # 3. Create a container without redundancy factor.
         self.log_step("Create a container without redundancy factor.")

--- a/src/tests/ftest/deployment/server_rank_failure.py
+++ b/src/tests/ftest/deployment/server_rank_failure.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2022-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -134,7 +134,7 @@ class ServerRankFailure(IorTestBase):
             ior_namespace (str): Yaml namespace that defines the object class used for IOR.
         """
         # 1. Create a pool and a container.
-        self.add_pool(namespace="/run/pool_size_ratio_80/*")
+        self.pool = self.get_pool(namespace="/run/pool_size_ratio_80/*")
         self.add_container(pool=self.pool)
 
         # 2. Run IOR with given object class and let it run through step 7.
@@ -302,7 +302,7 @@ class ServerRankFailure(IorTestBase):
         self.log.info("engine_kill_host = %s", engine_kill_host)
 
         # 2. Create a pool across two ranks on the same node; 0 and rank_r.
-        self.add_pool(namespace="/run/pool_size_value/*", target_list=[0, rank_r])
+        self.pool = self.get_pool(namespace="/run/pool_size_value/*", target_list=[0, rank_r])
 
         # 3. Create a container without redundancy factor.
         self.container = []

--- a/src/tests/ftest/deployment/target_failure.py
+++ b/src/tests/ftest/deployment/target_failure.py
@@ -88,7 +88,7 @@ class TargetFailure(IorTestBase):
                 IOR.
         """
         # 1. Create a pool and a container.
-        self.add_pool(namespace="/run/pool_size_ratio_80/*")
+        self.pool = self.get_pool(namespace="/run/pool_size_ratio_80/*")
         self.add_container(pool=self.pool, namespace="/run/container_with_rf/*")
 
         # 2. Run IOR with oclass RP_2G1 or EC_2P1G1.
@@ -202,7 +202,7 @@ class TargetFailure(IorTestBase):
         :avocado: tags=TargetFailure,test_target_failure_wo_rf
         """
         # 1. Create a pool and a container.
-        self.add_pool(namespace="/run/pool_size_ratio_80/*")
+        self.pool = self.get_pool(namespace="/run/pool_size_ratio_80/*")
         self.add_container(pool=self.pool, namespace="/run/container_wo_rf/*")
 
         # 2. Run IOR with oclass SX so that excluding one target will result in a failure.

--- a/src/tests/ftest/dfuse/posix_stat.py
+++ b/src/tests/ftest/dfuse/posix_stat.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2018-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -39,7 +39,7 @@ class POSIXStatTest(IorTestBase):
         block_sizes = self.params.get("block_sizes", "/run/*")
         error_list = []
 
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
         self.add_container(pool=self.pool)
 
         idx = 1

--- a/src/tests/ftest/harness/advanced.py
+++ b/src/tests/ftest/harness/advanced.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2021-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -58,9 +59,9 @@ class HarnessAdvancedTest(TestWithServers):
             timeouts[key].append(get_avocado_config_value(namespace, key))
             self.log.info("    %s.%s = %s", namespace, key, timeouts[key][0])
 
-        self.add_pool(create=True, connect=True)
-        self.add_pool(create=True, connect=False)
-        self.add_pool(create=False)
+        self.pool = self.get_pool(create=True, connect=True)
+        self.pool = self.get_pool(create=True, connect=False)
+        self.pool = self.get_pool(create=False)
 
         self.log.info("After creating pools:")
         for key in sorted(timeouts):

--- a/src/tests/ftest/nvme/fault.py
+++ b/src/tests/ftest/nvme/fault.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -35,7 +36,7 @@ class NvmeFault(ServerFillUp):
 
         # Create the Pool with Maximum NVMe size
         self.log_step(f'Creating a pool using {pool_capacity}% of the free NVMe space')
-        self.add_pool()
+        self.pool = self.get_pool()
         self.result.clear()
 
         # Create the IOR threads

--- a/src/tests/ftest/nvme/fragmentation.py
+++ b/src/tests/ftest/nvme/fragmentation.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -110,7 +111,7 @@ class NvmeFragmentation(TestWithServers):
         num_repeat = self.params.get("num_repeat", '/run/ior/*')
         num_parallel_job = self.params.get("num_parallel_job", '/run/ior/*')
         # Create a pool
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
         self.pool.display_pool_daos_space("Pool space at the Beginning")
 
         # Repeat the test many times

--- a/src/tests/ftest/nvme/io_verification.py
+++ b/src/tests/ftest/nvme/io_verification.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -53,7 +53,7 @@ class NvmeIoVerification(IorTestBase):
         # Loop for every pool size
         for index in range(num_pools):
             # Create and connect to a pool with namespace
-            self.add_pool(namespace=f"/run/pool_{index}/*")
+            self.pool = self.get_pool(namespace=f"/run/pool_{index}/*")
 
             # get pool info
             self.pool.get_info()
@@ -121,7 +121,7 @@ class NvmeIoVerification(IorTestBase):
         # Loop for every pool size
         for index in range(num_pools):
             # Create and connect to a pool with namespace
-            self.add_pool(namespace="/run/pool_{}/*".format(index))
+            self.pool = self.get_pool(namespace="/run/pool_{}/*".format(index))
 
             # get pool info
             self.pool.get_info()

--- a/src/tests/ftest/pool/api_attribute.py
+++ b/src/tests/ftest/pool/api_attribute.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -108,7 +109,7 @@ class PoolAPIAttributeTest(TestWithServers):
         :avocado: tags=pool,pool_attribute
         :avocado: tags=PoolAPIAttributeTest,test_pool_large_attributes
         """
-        self.add_pool()
+        self.pool = self.get_pool()
         attr_dict = self.create_data_set()
 
         try:
@@ -137,7 +138,7 @@ class PoolAPIAttributeTest(TestWithServers):
         :avocado: tags=pool,pool_attribute
         :avocado: tags=PoolAPIAttributeTest,test_pool_attributes
         """
-        self.add_pool()
+        self.pool = self.get_pool()
         expected_for_param = []
         name = self.params.get("name", '/run/attrtests/name_handles/*/')
         expected_for_param.append(name[1])
@@ -213,7 +214,7 @@ class PoolAPIAttributeTest(TestWithServers):
         :avocado: tags=pool,pool_attribute
         :avocado: tags=PoolAPIAttributeTest,test_pool_attribute_async
         """
-        self.add_pool()
+        self.pool = self.get_pool()
 
         expected_for_param = []
 

--- a/src/tests/ftest/pool/autotest.py
+++ b/src/tests/ftest/pool/autotest.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -23,7 +24,7 @@ class PoolAutotestTest(TestWithServers):
         :avocado: tags=PoolAutotestTest,test_pool_autotest
         """
         self.log_step("Create a pool")
-        self.add_pool()
+        self.pool = self.get_pool()
         self.pool.set_query_data()
         daos_cmd = self.get_daos_command()
         self.log_step("Autotest start")

--- a/src/tests/ftest/pool/bad_connect.py
+++ b/src/tests/ftest/pool/bad_connect.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -24,7 +25,7 @@ class BadConnectTest(TestWithServers):
         :avocado: tags=pool
         :avocado: tags=BadConnectTest,test_connect
         """
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
 
         # save this uuid since we might trash it as part of the test
         original_uuid = (ctypes.c_ubyte * 16)()

--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -48,7 +49,7 @@ class PoolBadEvictTest(TestWithServers):
 
         saveduuid = None
 
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
         original_test_pool_uuid = self.pool.uuid
 
         # trash the UUID value in various ways

--- a/src/tests/ftest/pool/bad_query.py
+++ b/src/tests/ftest/pool/bad_query.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -49,7 +50,7 @@ class BadQueryTest(TestWithServers):
 
         # initialize a python pool object then create the underlying
         # daos storage
-        self.add_pool()
+        self.pool = self.get_pool()
 
         # trash the pool handle value
         handle_sav = self.pool.pool.handle

--- a/src/tests/ftest/pool/destroy.py
+++ b/src/tests/ftest/pool/destroy.py
@@ -1,5 +1,6 @@
 """
 (C) Copyright 2018-2024 Intel Corporation.
+(C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -96,7 +97,7 @@ class DestroyTests(TestWithServers):
         """
         # Create a pool
         self.log.info("Create a pool")
-        self.add_pool(create=False)
+        self.pool = self.get_pool(create=False)
         self.pool.create()
 
         # Check that the pool was created.
@@ -389,7 +390,7 @@ class DestroyTests(TestWithServers):
         # dictionary, first item is added to server_managers first, so we use index 0.
         scm_mount = self.server_managers[0].get_config_value("scm_mount")
 
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
 
         # Get dmg_c instance that uses daos_control_c.yml. Server group is b.
         cert_dir = os.path.join(os.sep, "etc", "daos", "certs")
@@ -539,7 +540,7 @@ class DestroyTests(TestWithServers):
         scm_mount = self.server_managers[0].get_config_value("scm_mount")
 
         # Create the pool
-        self.add_pool()
+        self.pool = self.get_pool()
 
         # Create pool container
         self.add_container(pool=self.pool)
@@ -584,7 +585,7 @@ class DestroyTests(TestWithServers):
         self.start_servers(self.get_group(self.server_group, hostlist_servers))
 
         # Create the pool
-        self.add_pool()
+        self.pool = self.get_pool()
 
         # Create pool container
         self.add_container(pool=self.pool)

--- a/src/tests/ftest/pool/info.py
+++ b/src/tests/ftest/pool/info.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -36,7 +37,7 @@ class InfoTests(TestWithServers):
         # pool_targets = len(self.hostlist_servers) * targets
 
         # Create a pool
-        self.add_pool()
+        self.pool = self.get_pool()
 
         # Connect to the pool
         self.pool.connect(1 << permissions)

--- a/src/tests/ftest/pool/multi_server_create_delete.py
+++ b/src/tests/ftest/pool/multi_server_create_delete.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2017-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -61,7 +62,7 @@ class MultiServerCreateDeleteTest(TestWithServers):
 
         scm_mount = self.server_managers[0].get_config_value("scm_mount")
 
-        self.add_pool(create=False)
+        self.pool = self.get_pool(create=False)
         self.pool.uid = user
         self.pool.gid = group
         self.pool.target_list.update(tgtlist)

--- a/src/tests/ftest/pool/pda.py
+++ b/src/tests/ftest/pool/pda.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2022-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -49,7 +50,7 @@ class PoolPDAProperty(TestWithServers):
         """
 
         # Create the pool with default
-        self.add_pool(namespace="/run/pool/*")
+        self.pool = self.get_pool(namespace="/run/pool/*")
 
         # Verify pool ec_pda, pool_pda is default.
         self.assertEqual(1, self.pool.get_property("ec_pda"))
@@ -59,7 +60,7 @@ class PoolPDAProperty(TestWithServers):
         self.destroy_pools(pools=self.pool)
 
         # create pool
-        self.add_pool(namespace="/run/pool_1/*")
+        self.pool = self.get_pool(namespace="/run/pool_1/*")
 
         # create container with default
         self.add_container(self.pool, create=True)

--- a/src/tests/ftest/pool/query_attribute.py
+++ b/src/tests/ftest/pool/query_attribute.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -48,7 +49,7 @@ class QueryAttributeTest(TestWithServers):
 
         # 1. Test pool query.
         expected_size = self.params.get("scm_size", "/run/pool/*")
-        self.add_pool()
+        self.pool = self.get_pool()
 
         # Call daos pool query, obtain pool UUID and SCM size, and compare
         # against those used when creating the pool.

--- a/src/tests/ftest/pool/svc.py
+++ b/src/tests/ftest/pool/svc.py
@@ -1,6 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -65,7 +65,7 @@ class PoolSvc(TestWithServers):
         # parameter used in pool create
         svc_params = self.params.get("svc_params")
         # Setup the TestPool object
-        self.add_pool(create=False)
+        self.pool = self.get_pool(create=False)
 
         # Assign the expected svcn value
         if svc_params[0] != "None":

--- a/src/tests/ftest/pool/uuid_corner_case.py
+++ b/src/tests/ftest/pool/uuid_corner_case.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -34,7 +35,7 @@ class UUIDCornerCase(TestWithServers):
         :avocado: tags=UUIDCornerCase,test_create_label_destroy_uuid
         """
         # Create with a label - Default.
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
 
         # Make self.pool use UUID.
         self.pool.use_label = False

--- a/src/tests/ftest/rebuild/no_cap.py
+++ b/src/tests/ftest/rebuild/no_cap.py
@@ -1,6 +1,6 @@
 '''
   (C) Copyright 2020-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -57,7 +57,7 @@ class RbldNoCapacity(TestWithServers):
         err_pool_full = -1007
 
         # Create a pool and container
-        self.add_pool()
+        self.pool = self.get_pool()
         self.add_container(self.pool)
         self.container.open()
 

--- a/src/tests/ftest/rebuild/widely_striped.py
+++ b/src/tests/ftest/rebuild/widely_striped.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
     SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -52,7 +52,7 @@ class RbldWidelyStriped(MdtestBase):
 
         # create pool
         self.log.info(">> Creating a pool")
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
 
         # make sure pool looks good before we start
         checks = {

--- a/src/tests/ftest/rebuild/with_io.py
+++ b/src/tests/ftest/rebuild/with_io.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2018-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -33,7 +33,7 @@ class RbldWithIO(TestWithServers):
         :avocado: tags=RbldWithIO,test_rebuild_with_io
         """
         # Get the test params
-        self.add_pool(create=False)
+        self.pool = self.get_pool(create=False)
         self.add_container(self.pool, create=False)
         targets = self.server_managers[0].get_config_value("targets")
         # data = self.params.get("datasize", "/run/testparams/*")

--- a/src/tests/ftest/scrubber/aggregation.py
+++ b/src/tests/ftest/scrubber/aggregation.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -31,7 +32,7 @@ class TestScrubberEvictWithAggregation(TestWithScrubber, TestWithTelemetry):
         """
         initial_metrics = {}
         final_metrics = {}
-        self.add_pool()
+        self.pool = self.get_pool()
         # Disable the aggregation on the pool.
         self.pool.set_property("reclaim", "disabled")
         self.add_container(self.pool)

--- a/src/tests/ftest/scrubber/basic.py
+++ b/src/tests/ftest/scrubber/basic.py
@@ -52,7 +52,7 @@ class TestWithScrubberBasic(TestWithScrubber):
         """
         other_properties = self.params.get("other_properties", '/run/pool/*')
 
-        self.add_pool()
+        self.pool = self.get_pool()
         for prop_val in other_properties.split(","):
             if prop_val is not None:
                 value = prop_val.split(":")
@@ -79,7 +79,7 @@ class TestWithScrubberBasic(TestWithScrubber):
         pool_properties = self.params.get("properties", '/run/pool/*')
         other_properties = self.params.get("other_properties", '/run/pool/*')
 
-        self.add_pool(properties=f"{pool_properties},{other_properties}")
+        self.pool = self.get_pool(properties=f"{pool_properties},{other_properties}")
         self.add_container(pool=self.pool)
 
         self.run_scrubber_basic()

--- a/src/tests/ftest/security/cont_acl.py
+++ b/src/tests/ftest/security/cont_acl.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -89,7 +89,7 @@ class DaosContainerSecurityTest(ContSecurityTestBase, PoolSecurityTestBase):
         # (2)Create pool and container with acl
         self.log.info("(2)==>Create a pool and a container with acl\n"
                       "   base_acl_entries= %s\n", base_acl_entries)
-        self.add_pool()
+        self.pool = self.get_pool()
         secTestBase.create_acl_file(acl_file_name, base_acl_entries)
         self.container = self.create_container_with_daos(self.pool, None, acl_file_name)
 

--- a/src/tests/ftest/security/cont_owner.py
+++ b/src/tests/ftest/security/cont_owner.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -26,7 +27,7 @@ class DaosContainerOwnerTest(ContSecurityTestBase, PoolSecurityTestBase):
         secTestBase.create_acl_file(acl_file_name, acl_entries)
 
         # Set up the pool and container.
-        self.add_pool()
+        self.pool = self.get_pool()
         self.container = self.create_container_with_daos(self.pool, acl_file=acl_file_name,
                                                          cont_type=cont_type)
 

--- a/src/tests/ftest/security/pool_connect_init.py
+++ b/src/tests/ftest/security/pool_connect_init.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -38,7 +39,7 @@ class PoolSecurityTest(TestWithServers):
         user_uid = os.geteuid()
         user_gid = os.getegid()
 
-        self.add_pool(create=False)
+        self.pool = self.get_pool(create=False)
 
         uid, gid, expected = self.params.get("ids", "/run/pool/tests/*")
 

--- a/src/tests/ftest/server/dynamic_start_stop.py
+++ b/src/tests/ftest/server/dynamic_start_stop.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -80,7 +81,7 @@ class DynamicStartStop(TestWithServers):
         :avocado: tags=server
         :avocado: tags=DynamicStartStop,test_dynamic_server_addition
         """
-        self.add_pool()
+        self.pool = self.get_pool()
 
         extra_servers = self.get_hosts_from_yaml(
             "test_servers", "server_partition", "server_reservation", "/run/extra_servers/*")

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -78,11 +78,11 @@ class ObjectMetadata(TestWithServers):
 
         """
         if svc_ops_enabled:
-            self.add_pool()
+            self.pool = self.get_pool()
         else:
             params = {}
             params['properties'] = "rd_fac:0,space_rb:0,svc_ops_enabled:0"
-            self.add_pool(**params)
+            self.pool = self.get_pool(**params)
         self.log.info("Created %s: svc ranks:", str(self.pool))
         for index, rank in enumerate(self.pool.svc_ranks):
             self.log.info("[%d]: %d", index, rank)

--- a/src/tests/ftest/server/multiengine_persocket.py
+++ b/src/tests/ftest/server/multiengine_persocket.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -221,7 +222,7 @@ class MultiEnginesPerSocketTest(IorTestBase, MdtestBase):
 
         # Create a pool
         self.log_step("Create a pool")
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
 
         # (6) Container create and attributes test
         self.log_step("Create a container and verify the attributes")

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -137,7 +138,7 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
         """
 
         # create pool and container
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
         self.pool.set_property("reclaim", "disabled")
         self.add_container(pool=self.pool)
 
@@ -209,7 +210,7 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
         :avocado: tags=TelemetryPoolMetrics,test_telemetry_pool_metrics_sanity_check
         """
         # Create a Pool
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
         # Get all the default Pool Metrics and check for any errors.
         # If errors are noticed, get_pool_metrics will report them and
         # fail the test.

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -1726,53 +1726,6 @@ class TestWithServers(TestWithoutServers):
         """
         return add_pool(self, namespace, create, connect, dmg, **params)
 
-    def add_pool(self, namespace=POOL_NAMESPACE, create=True, connect=True, dmg=None, **params):
-        """Add a pool to the test case.
-
-        This method defines the common test pool creation sequence.
-
-        Args:
-            namespace (str, optional): namespace for TestPool parameters in the
-                test yaml file. Defaults to POOL_NAMESPACE.
-            create (bool, optional): should the pool be created. Defaults to
-                True.
-            connect (bool, optional): should the pool be connected. Defaults to
-                True.
-            dmg (DmgCommand, optional): dmg command used to create the pool. Defaults to None, which
-                calls test.get_dmg_command().
-            params (dict): name/value of attributes for which to call update(value, name).
-                See TestPool for available attributes.
-        """
-        self.pool = self.get_pool(namespace, create, connect, dmg, **params)
-
-    def add_pool_qty(self, quantity, namespace=POOL_NAMESPACE, create=True, connect=True, dmg=None):
-        """Add multiple pools to the test case.
-
-        This method requires self.pool to be defined as a list.  If self.pool is
-        undefined it will define it as a list.
-
-        Args:
-            quantity (int): number of pools to create
-            namespace (str, optional): namespace for TestPool parameters in the
-                test yaml file. Defaults to POOL_NAMESPACE.
-            create (bool, optional): should the pool be created. Defaults to
-                True.
-            connect (bool, optional): should the pool be connected. Defaults to
-                True.
-            dmg (DmgCommand, optional): dmg command used to create the pool. Defaults to None, which
-                calls test.get_dmg_command().
-
-        Raises:
-            TestFail: if self.pool is defined, but not as a list object.
-
-        """
-        if self.pool is None:
-            self.pool = []
-        if not isinstance(self.pool, list):
-            self.fail("add_pool_qty(): self.pool must be a list: {}".format(type(self.pool)))
-        for _ in range(quantity):
-            self.pool.append(self.get_pool(namespace, create, connect, dmg))
-
     def get_container(self, pool, namespace=CONT_NAMESPACE, create=True, daos=None, **params):
         """Create a TestContainer object.
 

--- a/src/tests/ftest/util/daos_io_conf.py
+++ b/src/tests/ftest/util/daos_io_conf.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -136,7 +136,7 @@ class IoConfTestBase(TestWithServers):
 
     def setup_test_pool(self):
         """Define a TestPool object."""
-        self.add_pool(create=False)
+        self.pool = self.get_pool(create=False)
         avocado_tmp_dir = os.environ['AVOCADO_TESTS_COMMON_TMPDIR']
         self.testfile = os.path.join(avocado_tmp_dir, 'testfile')
         self.dmg = self.get_dmg_command()

--- a/src/tests/ftest/util/daos_perf_base.py
+++ b/src/tests/ftest/util/daos_perf_base.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -23,7 +24,7 @@ class DaosPerfBase(TestWithServers):
     def run_daos_perf(self):
         """Run the daos_perf command."""
         # Create pool
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
         # Create container
         self.add_container(self.pool)
         # Obtain the number of processes listed with the daos_perf options

--- a/src/tests/ftest/util/ec_utils.py
+++ b/src/tests/ftest/util/ec_utils.py
@@ -269,7 +269,7 @@ class ErasureCodeSingle(TestWithServers):
         self.server_count = len(self.hostlist_servers) * engine_count
         self.obj_class = self.params.get("dfs_oclass_list", '/run/objectclass/*')
         self.singledata_set = self.params.get("single_data_set", '/run/container/*')
-        self.add_pool()
+        self.pool = self.get_pool()
         self.out_queue = queue.Queue()
 
     def ec_container_create(self, oclass):
@@ -417,7 +417,7 @@ class ErasureCodeMdtest(MdtestBase):
         """Set up each test case."""
         super().setUp()
         # Create Pool
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
         self.container = None
         self.out_queue = queue.Queue()
 

--- a/src/tests/ftest/util/file_count_test_base.py
+++ b/src/tests/ftest/util/file_count_test_base.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -78,7 +79,7 @@ class FileCountTestBase(IorTestBase, MdtestBase):
         mdtest_oclass = self.params.get("mdtest_oclass", '/run/largefilecount/object_class/*')
 
         # create pool
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
 
         for api in apis:
             self.ior_cmd.api.update(api)

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -1,5 +1,6 @@
 """
 (C) Copyright 2018-2024 Intel Corporation.
+(C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -56,7 +57,7 @@ class IorTestBase(TestWithServers):
     def create_pool(self):
         """Create a TestPool object to use with ior."""
         # Get the pool params and create a pool
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
 
     def create_cont(self):
         """Create a TestContainer object to be used to create container.

--- a/src/tests/ftest/util/mdtest_test_base.py
+++ b/src/tests/ftest/util/mdtest_test_base.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -83,7 +83,7 @@ class MdtestBase(TestWithServers):
         """
         # Create a pool if one does not already exist
         if self.pool is None:
-            self.add_pool(connect=False)
+            self.pool = self.get_pool(connect=False)
         # create container
         if self.container is None:
             self.container = self.get_mdtest_container(self.pool)

--- a/src/tests/ftest/util/mpiio_test_base.py
+++ b/src/tests/ftest/util/mpiio_test_base.py
@@ -1,5 +1,6 @@
 """
     (C) Copyright 2020-2023 Intel Corporation.
+    (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
     SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -43,7 +44,7 @@ class MpiioTests(TestWithServers):
         client_processes = self.params.get("np", '/run/client_processes/')
 
         # Create pool
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
 
         # create container
         self.add_container(self.pool)

--- a/src/tests/ftest/util/nvme_utils.py
+++ b/src/tests/ftest/util/nvme_utils.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -301,7 +301,7 @@ class ServerFillUp(IorTestBase):
               pool. Replace with dmg options in future when it's available.
         """
         # Create a pool
-        self.add_pool(create=False)
+        self.pool = self.get_pool(create=False)
 
         if nvme or scm:
             sizes = self.get_max_storage_sizes(percentage)

--- a/src/tests/ftest/util/pool_create_all_base.py
+++ b/src/tests/ftest/util/pool_create_all_base.py
@@ -1,6 +1,6 @@
 """
 (C) Copyright 2022-2024 Intel Corporation.
-(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+(C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -107,7 +107,9 @@ class PoolCreateAllTestBase(TestWithServers):
             ranks (list, optional): List of rank used for creating pools.  Defaults to None.
         """
         pool_count = 4 if nvme_delta_bytes is None else 5
-        self.add_pool_qty(pool_count, create=False)
+        if self.pool is None:
+            self.pool = []
+        self.pool.extend(self.get_pool(create=False) for _ in range(pool_count))
         pool_idx = len(self.pool) - pool_count
 
         # pylint: disable-next=logging-format-truncated
@@ -221,7 +223,10 @@ class PoolCreateAllTestBase(TestWithServers):
             nvme_delta_bytes (int, optional): Allowed difference of the NVMe pool storage.  Defaults
                 to None.
         """
-        self.add_pool_qty(pool_count, namespace="/run/pool/*", create=False)
+        if self.pool is None:
+            self.pool = []
+        self.pool.extend(
+            self.get_pool(namespace="/run/pool/*", create=False) for _ in range(pool_count))
 
         first_pool_size = None
         for index in range(pool_count):
@@ -359,7 +364,9 @@ class PoolCreateAllTestBase(TestWithServers):
             scm_delta_bytes (int): Allowed difference of the SCM pool storage.
             nvme_delta_bytes (int): Allowed difference of the NVMe pool storage.
         """
-        self.add_pool_qty(1, namespace="/run/pool/*", create=False)
+        if self.pool is None:
+            self.pool = []
+        self.pool.append(self.get_pool(namespace="/run/pool/*", create=False))
 
         usable_bytes = self.get_usable_bytes()
         self.log.info("Usable bytes: scm_size=%d, nvme_size=%d", *usable_bytes)

--- a/src/tests/ftest/util/rebuild_test_base.py
+++ b/src/tests/ftest/util/rebuild_test_base.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -49,7 +49,7 @@ class RebuildTestBase(TestWithServers):
 
     def setup_test_pool(self):
         """Define a TestPool object."""
-        self.add_pool(create=False)
+        self.pool = self.get_pool(create=False)
 
     def setup_test_container(self):
         """Define a TestContainer object."""

--- a/src/tests/ftest/util/scrubber_test_base.py
+++ b/src/tests/ftest/util/scrubber_test_base.py
@@ -1,6 +1,6 @@
 """
 (C) Copyright 2021-2024 Intel Corporation.
-(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+(C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -70,10 +70,10 @@ class TestWithScrubber(IorTestBase):
         # and update them at runtime.
         if pool_prop is None:
             # Create without properties and set at runtime below
-            self.add_pool(properties=None)
+            self.pool = self.get_pool(properties=None)
         else:
             # Create with properties
-            self.add_pool()
+            self.pool = self.get_pool()
         if pool_prop is None:
             pool_prop = "scrub:timed,scrub_freq:1"
         for prop_val in pool_prop.split(","):

--- a/src/tests/ftest/vmd/fault_reintegration.py
+++ b/src/tests/ftest/vmd/fault_reintegration.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2023-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -126,7 +127,7 @@ class NvmeFaultReintegrate(TestWithServers):
 
         # 3.
         self.log_step("Creating a pool and container with RF and starting IOR in a thread")
-        self.add_pool(connect=False)
+        self.pool = self.get_pool(connect=False)
         self.add_container(self.pool)
 
         job_manager = get_job_manager(self, subprocess=None, timeout=120)


### PR DESCRIPTION
Replace self.add_pool* with self.get_pool.
Delete self.add_pool* definitions.

Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
