### PR TITLE
DAOS-19361 test: update ftest/cart to use self.log.info (#18720)

### DIFF
--- a/src/tests/ftest/cart/ctl/ctl_five_node.py
+++ b/src/tests/ftest/cart/ctl/ctl_five_node.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -27,7 +28,7 @@ class CartCtlFiveNodeTest(CartTest):
             srv_rtn = self.launch_cmd_bg(srvcmd)
         # pylint: disable=broad-except
         except Exception as error:
-            self.print("Exception in launching server : {}".format(error))
+            self.log.info("Exception in launching server : %s", error)
             self.fail("Test failed.\n")
 
         # Verify the server is still running.

--- a/src/tests/ftest/cart/ctl/ctl_one_node.py
+++ b/src/tests/ftest/cart/ctl/ctl_one_node.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -27,7 +28,7 @@ class CartCtlOneNodeTest(CartTest):
             srv_rtn = self.launch_cmd_bg(srvcmd)
         # pylint: disable=broad-except
         except Exception as error:
-            self.print("Exception in launching server : {}".format(error))
+            self.log.info("Exception in launching server : %s", error)
             self.fail("Test failed.\n")
 
         # Verify the server is still running.

--- a/src/tests/ftest/cart/iv/iv_one_node.py
+++ b/src/tests/ftest/cart/iv/iv_one_node.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -88,18 +89,18 @@ class CartIvOneNodeTest(CartTest):
     def _verify_action(self, action):
         """Verify the action."""
         if (('operation' not in action) or ('rank' not in action) or ('key' not in action)):
-            self.print("Error happened during action check")
+            self.log.info("Error happened during action check")
             raise ValueError(
                 "Each action must contain an operation, rank, and key")
 
         if len(action['key']) != 2:
-            self.print("Error key should be tuple of (rank, idx)")
+            self.log.info("Error key should be tuple of (rank, idx)")
             raise ValueError("key should be a tuple of (rank, idx)")
 
     def _verify_fetch_operation(self, action):
         """Verify the fetch operation."""
         if (('return_code' not in action) or ('expected_value' not in action)):
-            self.print("Error: fetch operation was malformed")
+            self.log.info("Error: fetch operation was malformed")
             raise ValueError("Fetch operation malformed")
 
     def _iv_test_actions(self, cmd, actions):
@@ -135,7 +136,7 @@ class CartIvOneNodeTest(CartTest):
                             log_path)
                 clicmd += command
 
-                self.print("\nClient cmd : %s\n" % clicmd)
+                self.log.info("Client cmd : %s", clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -153,11 +154,11 @@ class CartIvOneNodeTest(CartTest):
                 # codecs.open(log_file, "w", "unicode").write('')
 
                 # DEBUGGING: dump contents of JSON file to screen
-                with open(log_path, 'r') as file:
-                    print(file.read())
+                with open(log_path, 'r', encoding='utf-8') as file:
+                    self.log.info(file.read())
 
                 # Read the result into test_result and remove the temp file
-                with open(log_path, 'r') as log_file:
+                with open(log_path, 'r', encoding='utf-8') as log_file:
                     test_result = json.load(log_file)
 
                 os.close(log_fd)
@@ -197,7 +198,7 @@ class CartIvOneNodeTest(CartTest):
 
                 clicmd += command
 
-                self.print("\nClient cmd : %s\n" % clicmd)
+                self.log.info("Client cmd : %s", clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -214,7 +215,7 @@ class CartIvOneNodeTest(CartTest):
                     command = "{!s} -s '{!s}'".format(command, "none")
                 clicmd += command
 
-                self.print("\nClient cmd : %s\n" % clicmd)
+                self.log.info("Client cmd : %s", clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -234,7 +235,7 @@ class CartIvOneNodeTest(CartTest):
                         .format(command, 0)
                 clicmd += command
 
-                self.print("\nClient cmd : %s\n" % clicmd)
+                self.log.info("Client cmd : %s", clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -246,7 +247,7 @@ class CartIvOneNodeTest(CartTest):
                 command = " {!s} -o '{!s}' -r '{!s}' ".format(command, operation, rank)
                 clicmd += command
 
-                self.print("\nClient cmd : %s\n" % clicmd)
+                self.log.info("Client cmd : %s", clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -268,7 +269,7 @@ class CartIvOneNodeTest(CartTest):
             srv_rtn = self.launch_cmd_bg(srvcmd)
         # pylint: disable=broad-except
         except Exception as error:
-            self.print("Exception in launching server : {}".format(error))
+            self.log.info("Exception in launching server : %s", error)
             self.fail("Test failed.\n")
 
         # Verify the server is still running.
@@ -481,7 +482,7 @@ class CartIvOneNodeTest(CartTest):
         except ValueError as exception:
             failed = True
             traceback.print_stack()
-            self.print("TEST FAILED: %s" % str(exception))
+            self.log.info("TEST FAILED: %s", exception)
 
         # Shutdown Servers
 
@@ -493,25 +494,25 @@ class CartIvOneNodeTest(CartTest):
         # Request each server shut down gracefully
         for rank in reversed(list(range(1, int(srv_ppn) * num_servers))):
             clicmdt = clicmd + " -o shutdown -r " + str(rank)
-            self.print("\nClient cmd : {}\n".format(clicmdt))
+            self.log.info("Client cmd : %s", clicmdt)
             try:
                 subprocess.call(shlex.split(clicmdt))
             # pylint: disable=broad-except
             except Exception as error:
                 failed = True
-                self.print("Exception in launching client : {}".format(error))
+                self.log.info("Exception in launching client : %s", error)
 
         time.sleep(1)
 
         # Shutdown rank 0 separately
         clicmd += " -o shutdown -r 0"
-        self.print("\nClient cmd : {}\n".format(clicmd))
+        self.log.info("Client cmd : %s", clicmd)
         try:
             subprocess.call(shlex.split(clicmd))
         # pylint: disable=broad-except
         except Exception as error:
             failed = True
-            self.print("Exception in launching client : {}".format(error))
+            self.log.info("Exception in launching client : %s", error)
 
         # wait for servers to finish shutting down
         time.sleep(2)

--- a/src/tests/ftest/cart/iv/iv_two_node.py
+++ b/src/tests/ftest/cart/iv/iv_two_node.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -74,18 +75,18 @@ class CartIvTwoNodeTest(CartTest):
     def _verify_action(self, action):
         """Verify the action."""
         if (('operation' not in action) or ('rank' not in action) or ('key' not in action)):
-            self.print("Error happened during action check")
+            self.log.info("Error happened during action check")
             raise ValueError(
                 "Each action must contain an operation, rank, and key")
 
         if len(action['key']) != 2:
-            self.print("Error key should be tuple of (rank, idx)")
+            self.log.info("Error key should be tuple of (rank, idx)")
             raise ValueError("key should be a tuple of (rank, idx)")
 
     def _verify_fetch_operation(self, action):
         """Verify fetch operation."""
         if (('return_code' not in action) or ('expected_value' not in action)):
-            self.print("Error: fetch operation was malformed")
+            self.log.info("Error: fetch operation was malformed")
             raise ValueError("Fetch operation malformed")
 
     def _iv_test_actions(self, cmd, actions):
@@ -118,7 +119,7 @@ class CartIvTwoNodeTest(CartTest):
                             log_path)
                 clicmd += command
 
-                self.print("\nClient cmd : %s\n" % clicmd)
+                self.log.info("Client cmd : %s", clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -161,7 +162,7 @@ class CartIvTwoNodeTest(CartTest):
                         action['value'])
                 clicmd += command
 
-                self.print("\nClient cmd : %s\n" % clicmd)
+                self.log.info("Client cmd : %s", clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -174,7 +175,7 @@ class CartIvTwoNodeTest(CartTest):
                     command, operation, rank, key_rank, key_idx)
                 clicmd += command
 
-                self.print("\nClient cmd : %s\n" % clicmd)
+                self.log.info("Client cmd : %s", clicmd)
                 cli_rtn = subprocess.call(shlex.split(clicmd))
 
                 if cli_rtn != 0:
@@ -197,7 +198,7 @@ class CartIvTwoNodeTest(CartTest):
             srv_rtn = self.launch_cmd_bg(srvcmd)
         # pylint: disable=broad-except
         except Exception as error:
-            self.print("Exception in launching server : {}".format(error))
+            self.log.info("Exception in launching server : %s", error)
             self.fail("Test failed.\n")
 
         # Verify the server is still running.
@@ -237,7 +238,7 @@ class CartIvTwoNodeTest(CartTest):
             self._iv_test_actions(clicmd, actions)
         except ValueError as exception:
             failed = True
-            self.print("TEST FAILED: {}".format(exception))
+            self.log.info("TEST FAILED: %s", exception)
 
         # Shutdown Servers
         num_servers = 2
@@ -248,25 +249,25 @@ class CartIvTwoNodeTest(CartTest):
         # Request each server shut down gracefully
         for rank in reversed(list(range(1, int(srv_ppn) * num_servers))):
             clicmdt = clicmd + " -o shutdown -r " + str(rank)
-            self.print("\nClient cmd : {}\n".format(clicmdt))
+            self.log.info("Client cmd : %s", clicmdt)
             try:
                 subprocess.call(shlex.split(clicmdt))
             # pylint: disable=broad-except
             except Exception as error:
                 failed = True
-                self.print("Exception in launching client : {}".format(error))
+                self.log.info("Exception in launching client : %s", error)
 
         time.sleep(1)
 
         # Shutdown rank 0 separately
         clicmd += " -o shutdown -r 0"
-        self.print("\nClient cmd : {}\n".format(clicmd))
+        self.log.info("Client cmd : %s", clicmd)
         try:
             subprocess.call(shlex.split(clicmd))
         # pylint: disable=broad-except
         except Exception as error:
             failed = True
-            self.print("Exception in launching client : {}".format(error))
+            self.log.info("Exception in launching client : %s", error)
 
         # Give some time for completion before forcing servers shut down
         time.sleep(2)

--- a/src/tests/ftest/cart/no_pmix/multictx_one_node.py
+++ b/src/tests/ftest/cart/no_pmix/multictx_one_node.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -25,14 +26,14 @@ class CartNoPmixOneNodeTest(CartTest):
         """
         cmd = self.params.get("tst_bin", '/run/tests/*/')
 
-        self.print("\nTest cmd : {}\n".format(cmd))
+        self.log.info("Test cmd : %s", cmd)
 
         with subprocess.Popen([cmd], stdout=subprocess.PIPE) as proc:
 
             rc = self.wait_process(proc, 30)
             if rc != 0:
-                self.print("Error waiting for process.")
-                self.print("returning {}".format(rc))
+                self.log.info("Error waiting for process.")
+                self.log.info("returning %s", rc)
                 self.fail("Test failed.\n")
 
-            self.print("Finished waiting for {}".format(proc))
+            self.log.info("Finished waiting for %s", proc)

--- a/src/tests/ftest/cart/rpc/swim_notification.py
+++ b/src/tests/ftest/cart/rpc/swim_notification.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -29,7 +30,7 @@ class CartRpcOneNodeSwimNotificationOnRankEvictionTest(CartTest):
             srv_rtn = self.launch_cmd_bg(srvcmd)
         # pylint: disable=broad-except
         except Exception as error:
-            self.print("Exception in launching server : {}".format(error))
+            self.log.info("Exception in launching server : %s", error)
             self.fail("Test failed.\n")
 
         # Verify the server is still running.
@@ -51,8 +52,6 @@ class CartRpcOneNodeSwimNotificationOnRankEvictionTest(CartTest):
 
         # Verify the server(s) exited gracefully
         if not self.check_files(glob_pat, count=3, retries=4):
-            self.print("Didn't find completion file(s): '{}'. "
-                       "This indicates not all CaRT binaries exited "
-                       "gracefully. "
-                       "Marking test pass while DAOS-7892 remains "
-                       "unresolved.\n".format(glob_pat))
+            self.log.error("Didn't find completion file(s): '%s'.", glob_pat)
+            self.log.error("This indicates not all CaRT binaries exited gracefully.")
+            self.fail("Not all CaRT binaries exited gracefully")

--- a/src/tests/ftest/cart/selftest/selftest_three_node.py
+++ b/src/tests/ftest/cart/selftest/selftest_three_node.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -27,7 +28,7 @@ class CartSelfThreeNodeTest(CartTest):
             srv_rtn = self.launch_cmd_bg(srvcmd)
         # pylint: disable=broad-except
         except Exception as error:
-            self.print("Exception in launching server : {}".format(error))
+            self.log.info("Exception in launching server : %s", error)
             self.fail("Test failed.\n")
 
         # Verify the server is still running.

--- a/src/tests/ftest/cart/util/cart_utils.py
+++ b/src/tests/ftest/cart/util/cart_utils.py
@@ -1,10 +1,10 @@
 '''
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 import glob
-import logging
 import os
 import re
 import shlex
@@ -27,8 +27,6 @@ class CartTest(TestWithoutServers):
     def __init__(self, *args, **kwargs):
         """Initialize a CartTest object."""
         super().__init__(*args, **kwargs)
-        self.stdout = logging.getLogger('avocado.test.stdout')
-        self.progress_log = logging.getLogger("progress")
         self.module_init = False
         self.module = lambda *x: False
         self.supp_file = "/etc/daos/memcheck-cart.supp"
@@ -48,7 +46,7 @@ class CartTest(TestWithoutServers):
 
         for file in filtered:
             to_del = os.path.join(self.attach_dir, file)
-            print("WARN: stale file {} found, deleting...\n".format(to_del))
+            self.log.info("WARN: stale file %s found, deleting...", to_del)
             os.remove(to_del)
 
         # Add test binaries and daos binaries to PATH
@@ -63,21 +61,22 @@ class CartTest(TestWithoutServers):
                 if os.path.basename(path_dirname) == "TESTING":
                     added_path = os.path.join(path_dirname, test_dirs["TESTING"])
                     os.environ["PATH"] += os.pathsep + added_path
-                    self.print("\nAdding {} to PATH\n".format(added_path))
+                    self.log.info("Adding %s to PATH", added_path)
                     found_path = True
                 elif os.path.basename(path_dirname) == "install":
                     self.supp_file = path_dirname + "/etc/memcheck-cart.supp"
                     added_path = os.path.join(path_dirname, test_dirs["install"])
                     if os.path.isdir(added_path):
                         os.environ["PATH"] += os.pathsep + added_path
-                        self.print("\nAdding {} to PATH\n".format(added_path))
+                        self.log.info("Adding %s to PATH", added_path)
                         found_path = True
                     else:
-                        print("ERROR: Directory does not exist: " + added_path)
+                        self.log.info("ERROR: Directory does not exist: %s", added_path)
                 elif re.match(r"^\s*\/+\s*$", path_dirname) is not None:
                     if not found_path:
-                        print("ERROR: Couldn't find a directory named 'TESTING' or 'install' "
-                              + "to add to your PATH.\n")
+                        self.log.info(
+                            "ERROR: Couldn't find a directory named 'TESTING' or 'install' to add "
+                            "to your PATH.")
                     break
 
                 path_dirname = os.path.dirname(path_dirname)
@@ -89,8 +88,8 @@ class CartTest(TestWithoutServers):
             if os.path.isdir(tests_dir):
                 os.environ["PATH"] += os.pathsep + tests_dir
             else:
-                print("WARNING: I didn't find the daos tests directory. "
-                      + "No test directories have been added to your PATH..\n")
+                self.log.warning("Did not find the daos tests directory. "
+                                 "No test directories have been added to your PATH.")
 
     def tearDown(self):
         """Tear down the test case."""
@@ -129,8 +128,7 @@ class CartTest(TestWithoutServers):
             retry += 1
             file_list = glob.glob(glob_pattern)
 
-            self.log.info("Found completion files: [%s]\n",
-                          ", ".join(file_list))
+            self.log.info("Found completion files: [%s]", ", ".join(file_list))
 
             if len(file_list) == count:
                 found_files = True
@@ -139,8 +137,7 @@ class CartTest(TestWithoutServers):
             time.sleep(1)
 
         if not found_files:
-            self.log.info("Expected %d completion files, ", count)
-            self.log.info("but only found %d.\n", len(file_list))
+            self.log.info("Expected %d completion files, but only found %d.", count, len(file_list))
 
         # Clean up completion file(s) for next test for next run
         for _file in file_list:
@@ -356,13 +353,14 @@ class CartTest(TestWithoutServers):
         job.hostfile.update(hostfile)
         job.pprnode.update(tst_ppn)
         job.processes.update(tst_processes)
+
         return str(job)
 
     def convert_xml(self, xml_file):
         """Modify the xml file"""
 
-        with open(xml_file, 'r') as fd:
-            with open('{}.xml'.format(xml_file), 'w') as ofd:
+        with open(xml_file, 'r', encoding='utf-8') as fd:
+            with open('{}.xml'.format(xml_file), 'w', encoding='utf-8') as ofd:
                 for line in fd:
                     if self.src_dir in line:
                         ofd.write(re.sub(r'<dir>\/*' + self.src_dir + r'\/*', r'<dir>', line))
@@ -398,15 +396,13 @@ class CartTest(TestWithoutServers):
         # Verify the server is still running.
         if not self.check_process(srv_rtn):
             procrtn = self.stop_process(srv_rtn)
-            self.fail("Server did not launch, return code {}".format(procrtn))
+            self.fail(f"Server did not launch, return code {procrtn}")
 
         cli_rtn = self.launch_test(clicmd, srv_rtn)
         srv_rtn = self.stop_process(srv_rtn)
 
         if srv_rtn:
-            self.fail(
-                "Failed, return codes client {} server {}".format(
-                    cli_rtn, srv_rtn))
+            self.fail(f"Failed, return codes client {cli_rtn} server {srv_rtn}")
 
         self.convert_xml_files()
 
@@ -414,8 +410,8 @@ class CartTest(TestWithoutServers):
 
     def launch_test(self, cmd, srv1=None, srv2=None):
         """Launch a test."""
-        self.print("\nCMD : {}\n".format(cmd))
-        self.print("\nENV : {}\n".format(os.environ))
+        self.log.info("CMD : %s", cmd)
+        self.log.info("ENV : %s", os.environ)
 
         cmd = shlex.split(cmd)
         rtn = subprocess.call(cmd)
@@ -425,7 +421,7 @@ class CartTest(TestWithoutServers):
                 self.stop_process(srv1)
             if srv2 is not None:
                 self.stop_process(srv2)
-            self.fail("Failed, return codes {}".format(rtn))
+            self.fail(f"Failed, return codes {rtn}")
 
         self.convert_xml_files()
 
@@ -433,11 +429,11 @@ class CartTest(TestWithoutServers):
 
     def launch_cmd_bg(self, cmd):
         """Launch the given cmd in background."""
-        self.print("\nCMD : {}\n".format(cmd))
+        self.log.info("CMD : %s", cmd)
 
         cmd = shlex.split(cmd)
         # pylint: disable-next=consider-using-with
-        rtn = subprocess.Popen(cmd)
+        rtn = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
         if rtn is None:
             self.fail("Failed to start command\n")
@@ -446,12 +442,6 @@ class CartTest(TestWithoutServers):
         self.convert_xml_files()
 
         return rtn
-
-    def print(self, cmd):
-        """Print the given cmd at runtime and stdout."""
-        self.log.info(cmd)
-        self.stdout.info(cmd)
-        self.progress_log.info(cmd)
 
     def log_check(self):
         """Check log files for consistency."""


### PR DESCRIPTION
Update ftest/cart tests to use self.log.info instead of print so logging goes to the log instead of stdout.

Test-tag: cart
Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
