### PR TITLE
DAOS-19116 object: drop reference when fail in obj_ioc_begin_lite - b26

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2271,6 +2271,9 @@ obj_ioc_fini(struct obj_io_context *ioc, int err)
 	}
 }
 
+static void
+obj_ioc_end(struct obj_io_context *ioc, int err);
+
 /* Setup lite IO context, it is only for compound RPC so far:
  * - no associated object yet
  * - no permission check (not sure it's read/write)
@@ -2374,6 +2377,10 @@ out:
 	d_tm_inc_gauge(tls->ot_op_active[opc_get(rpc->cr_opc)], 1);
 	ioc->ioc_start_time = daos_get_ntime();
 	ioc->ioc_began = 1;
+
+	if (rc != 0)
+		obj_ioc_end(ioc, rc);
+
 	return rc;
 }
 


### PR DESCRIPTION
It is possible that obj_ioc_begin_lite() maybe failed because of empty or stale pool map on server. At that time, the logic has already held reference against the container open handle. Under such case, directly returning error# to the caller may cause reference leak as to such container cannot be properly stopped in subsequent operations.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
