### PR TITLE
DAOS-19521 test: fix stale RF2 EC oclass thresholds in dfs oclass hin…

### DIFF
--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -2258,8 +2258,20 @@ compare_oclass(daos_handle_t coh, daos_oclass_id_t acid, daos_oclass_id_t ecid)
 
 	if (acid == ecid || acid == normalized_ecid)
 		return 0;
-	else
-		return 1;
+
+	{
+		char aname[24] = "?";
+		char ename[24] = "?";
+		char nname[24] = "?";
+
+		daos_oclass_id2name(acid, aname);
+		daos_oclass_id2name(ecid, ename);
+		daos_oclass_id2name(normalized_ecid, nname);
+		print_message(
+		    "oclass mismatch: actual=%s(%u) expected=%s(%u) GX-normalized=%s(%u)\n", aname,
+		    acid, ename, ecid, nname, normalized_ecid);
+	}
+	return 1;
 }
 
 static daos_oclass_id_t
@@ -2469,12 +2481,12 @@ dfs_test_oclass_hints(void **state)
 	rc = dfs_cont_create_with_label(arg->pool.poh, "oc_cont2", &dattr, NULL, &coh, &dfs_l);
 	assert_int_equal(rc, 0);
 
-	/** set the expect EC object class ID based on domain nr */
-	if (attr.pa_domain_nr >= 18)
+	/** expected max EC class per domain count; thresholds must match dc_set_oclass() RF2 */
+	if (attr.pa_domain_nr >= 20)
 		ecidx = OC_EC_16P2GX;
-	else if (attr.pa_domain_nr >= 10)
+	else if (attr.pa_domain_nr >= 12)
 		ecidx = OC_EC_8P2GX;
-	else if (attr.pa_domain_nr >= 6)
+	else if (attr.pa_domain_nr >= 8)
 		ecidx = OC_EC_4P2GX;
 	else
 		ecidx = OC_EC_2P2GX;


### PR DESCRIPTION
…ts (#18873)

The RF2 expected max-EC table in dfs_test_oclass_hints reused RF1's domain-count thresholds, so it expected EC_4P2/8P2/16P2 two domains too early. dc_set_oclass() needs domain_nr >= 8/12/20 for those (RF2 has two parity cells), so on a pool whose domain count lands in the gap the test picked a wider EC class than the library grants and failed. Align the thresholds with dc_set_oclass(); also print the actual/expected/normalized classes on a compare_oclass() mismatch.

Test-tag: test_daos_dfs_unit
Quick-Functional: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
