### PR TITLE
DAOS-19396 pool: mind pool_discard() dss_rpc_send() errors

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7626,6 +7626,12 @@ pool_discard(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr_li
 	ptdi_in->ptdi_addrs.ca_count = list->pta_number;
 	uuid_copy(ptdi_in->ptdi_uuid, svc->ps_pool->sp_uuid);
 	rc = dss_rpc_send(rpc);
+	/* No corpc aggregation callback is registered, so ptdo_rc cannot report a send error. */
+	if (rc != 0) {
+		DL_ERROR(rc, DF_UUID ": dss_rpc_send POOL_TGT_DISCARD",
+			 DP_UUID(svc->ps_pool->sp_uuid));
+		D_GOTO(decref, rc);
+	}
 
 	ptdi_out = crt_reply_get(rpc);
 	D_ASSERT(ptdi_out != NULL);
@@ -7634,6 +7640,7 @@ pool_discard(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr_li
 		D_ERROR(DF_UUID": pool discard failed: rc: %d\n",
 			DP_UUID(svc->ps_pool->sp_uuid), rc);
 
+decref:
 	crt_req_decref(rpc);
 
 out:

--- a/src/tests/ftest/daos_test/suite.py
+++ b/src/tests/ftest/daos_test/suite.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -378,6 +379,22 @@ class DaosCoreTest(DaosCoreBase):
         :avocado: tags=hw,medium,provider
         :avocado: tags=daos_test,daos_core_test
         :avocado: tags=DaosCoreTest,test_daos_rebuild_ec
+        """
+        self.run_subtest()
+
+    def test_daos_rebuild_ec_subtest9(self):
+        """Jira ID: DAOS-1568
+
+        Test Description:
+            Run daos_test -S --subtests="9"
+
+        Use cases:
+            Core tests for daos_test
+
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=hw,medium,provider
+        :avocado: tags=daos_test,daos_core_test
+        :avocado: tags=DaosCoreTest,test_daos_rebuild_ec_subtest9
         """
         self.run_subtest()
 

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -29,6 +29,7 @@ timeouts:
   test_daos_oid_allocator: 640
   test_daos_checksum: 500
   test_daos_rebuild_ec: 7200
+  test_daos_rebuild_ec_subtest9: 600
   test_daos_aggregate_ec: 200
   test_daos_degraded_ec: 1900
   test_daos_dedup: 220
@@ -109,6 +110,7 @@ daos_tests:
     test_daos_oid_allocator: 1
     test_daos_checksum: 1
     test_daos_rebuild_ec: 1
+    test_daos_rebuild_ec_subtest9: 1
     test_daos_aggregate_ec: 1
     test_daos_degraded_ec: 1
     test_daos_dedup: 1
@@ -137,6 +139,7 @@ daos_tests:
     test_daos_oid_allocator: DAOS_OID_Allocator
     test_daos_checksum: DAOS_Checksum
     test_daos_rebuild_ec: DAOS_Rebuild_EC
+    test_daos_rebuild_ec_subtest9: DAOS_Rebuild_EC_Subtest9
     test_daos_aggregate_ec: DAOS_Aggregate_EC
     test_daos_degraded_ec: DAOS_Degraded_EC
     test_daos_dedup: DAOS_Dedup
@@ -167,6 +170,7 @@ daos_tests:
     test_daos_oid_allocator: O
     test_daos_checksum: z
     test_daos_rebuild_ec: S
+    test_daos_rebuild_ec_subtest9: S
     test_daos_aggregate_ec: Z
     test_daos_degraded_ec: X
     test_daos_dedup: U
@@ -175,6 +179,7 @@ daos_tests:
   args:
     test_daos_ec_io: -l"EC_4P2G1"
     test_daos_rebuild_ec: -s5
+    test_daos_rebuild_ec_subtest9: -s5  --subtests="9"
     test_daos_md_replication: -s5
     test_daos_degraded_mode: -s7
     test_daos_drain_simple: -s3


### PR DESCRIPTION
Experimental product code change on release/2.6 branch to *not* proceed to pool map update step of ds_pool_update_handler() for reintegration operations when the previous pool_discard() step got an error in dss_rpc_send() (e.g., a -DER_TIMEDOUT failure).

This gives retries either by the MS host daos_engine dsc_pool_client or by the test program itself (re-issuing the dmg pool reintegrate command) a chance to wait out and possibly recover from whatever communication failures are occurring among some engines and the reintegrating engine.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
