### PR TITLE
DAOS-19518 test: nvme/fault.py - Update timeout and delay

### DIFF
--- a/src/tests/ftest/nvme/fault.yaml
+++ b/src/tests/ftest/nvme/fault.yaml
@@ -1,7 +1,9 @@
 hosts:
   test_servers: 4
   test_clients: 2
+
 timeout: 3600
+
 server_config:
   name: daos_server
   engines_per_host: 1
@@ -11,18 +13,25 @@ server_config:
       storage: auto
   transport_config:
     allow_insecure: True
+
 agent_config:
   transport_config:
     allow_insecure: True
+
 dmg:
   transport_config:
     allow_insecure: True
+
 pool:
   size: 96%
+  pool_query_timeout: 330
+  pool_query_delay: 20
+
 container:
   type: POSIX
   control_method: daos
   properties: rd_fac:1
+
 ior:
   api: DFS
   client_processes:
@@ -33,6 +42,7 @@ ior:
   transfersize_blocksize:
     nvme_transfer_size: 16777216 #16M
   dfs_oclass: RP_2G1
+
 faulttests:
   pool_capacity: 15
   no_of_servers: 1

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -800,6 +800,11 @@ class TestPool(TestDaosApiBase):
             end_time = time() + self.pool_query_timeout.value
 
         while True:
+            if self.pool_query_delay.value:
+                self.log.info(
+                    "Waiting %s seconds before issuing next dmg pool query",
+                    self.pool_query_delay.value)
+                sleep(self.pool_query_delay.value)
             try:
                 return self.dmg.pool_query(self.identifier, show_enabled)
 
@@ -814,12 +819,6 @@ class TestPool(TestDaosApiBase):
                         "response. This timeout can be adjusted via the 'pool/pool_query_timeout' "
                         "test yaml parameter.".format(
                             self.pool_query_timeout.value, self.identifier)) from error
-
-                if self.pool_query_delay.value:
-                    self.log.info(
-                        "Waiting %s seconds before issuing next dmg pool query",
-                        self.pool_query_delay.value)
-                    sleep(self.pool_query_delay.value)
 
     @fail_on(CommandFailure)
     def query_targets(self, *args, **kwargs):


### PR DESCRIPTION
test_nvme_fault sets NVMe devices faulty. If the device is an sysXs device, "storage set nvme-faulty" command would fail, which is expected.

The issue is that if we call dmg pool query (to check rebuild status) immeidately after the nvme-faulty command failure, the pool query command may timeout (after 5 min.). If pool query times out, we should retry. To enable the retry, set pool_query_timeout larger than 5 min, say 330 sec.

Another way that could avoid this issue is to add some sleep between nvme-faulty and pool query. We already have a variable for this in TestPool, pool_query_delay, so set some time to it in the test yaml and move the sleep code in query() to right before calling pool query.

Skip-fault-injection-test: true
Skip-func-hw-test-large: false
Test-tag: test_nvme_fault
Test-repeat: 3

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
