### PR TITLE
SRE-3976 build: exclude leap 15.6 RPMs from build

### DIFF
--- a/utils/rpms/packaging/rpm_chrootbuild
+++ b/utils/rpms/packaging/rpm_chrootbuild
@@ -49,19 +49,17 @@ best=0
 """
 EOF
 
-# Leap 15.5 and Leap 15.6 DAOS packages can coexist in a single Artifactory
-# repository path. During mock/dnf dependency resolution for a Leap 15.5
-# chroot, dnf may prefer newer *.suse.lp156* (Leap 15.6) package candidates.
+# Leap 15.5 and Leap 15.6 DAOS packages COEXIST in a single Artifactory
+# repository path. During dependency resolution for Leap 15.5, dnf prefers
+# .suse.lp156 package candidates because string lp156 > lp155 from
+# the string-comparison point of view.
 #
-# This leads to 15.5 builds pulling 15.6-built packages and their dependency
-# chain (for example libpmemobj and related libraries). Those dependencies are
-# not fully ABI-compatible across these releases, especially around libc/glibc:
-# 15.6-built packages may require GLIBC_2.34 symbols, while Leap 15.5 provides
-# glibc up to 2.31.
+# This leads to 15.5 builds pulling 15.6-built packages where these packages
+# are not compatible with the Leap 15.5 system e.g. 15.6-built packages
+# require GLIBC_2.34 symbols, while Leap 15.5 provides glibc up to 2.31.
 #
-# The result can be dependency installation failures inside the Leap 15.5 root.
-# Therefore we apply a chroot-level repository filter in mock dnf.conf (exclude
-# *.suse.lp156*) instead of changing DAOS spec dependencies.
+# The result is an installation failure for Leap 15.5. Therefore we apply
+# a repository filter in dnf.conf (exclude .lp156).
 if [[ "$CHROOT_NAME" == *opensuse-leap-15.5* ]]; then
     cat <<'EOF' >> mock.cfg
 config_opts['dnf.conf'] += """

--- a/utils/rpms/packaging/rpm_chrootbuild
+++ b/utils/rpms/packaging/rpm_chrootbuild
@@ -49,6 +49,15 @@ best=0
 """
 EOF
 
+if [[ "$CHROOT_NAME" == *opensuse-leap-15.5* ]]; then
+    cat <<'EOF' >> mock.cfg
+config_opts['dnf.conf'] += """
+[main]
+exclude=*.suse.lp156*
+"""
+EOF
+fi
+
 # shellcheck disable=SC2153
 repo_adds=()
 repo_dels=()

--- a/utils/rpms/packaging/rpm_chrootbuild
+++ b/utils/rpms/packaging/rpm_chrootbuild
@@ -49,11 +49,24 @@ best=0
 """
 EOF
 
+# Leap 15.5 and Leap 15.6 DAOS packages can coexist in a single Artifactory
+# repository path. During mock/dnf dependency resolution for a Leap 15.5
+# chroot, dnf may prefer newer *.suse.lp156* (Leap 15.6) package candidates.
+#
+# This leads to 15.5 builds pulling 15.6-built packages and their dependency
+# chain (for example libpmemobj and related libraries). Those dependencies are
+# not fully ABI-compatible across these releases, especially around libc/glibc:
+# 15.6-built packages may require GLIBC_2.34 symbols, while Leap 15.5 provides
+# glibc up to 2.31.
+#
+# The result can be dependency installation failures inside the Leap 15.5 root.
+# Therefore we apply a chroot-level repository filter in mock dnf.conf (exclude
+# *.suse.lp156*) instead of changing DAOS spec dependencies.
 if [[ "$CHROOT_NAME" == *opensuse-leap-15.5* ]]; then
     cat <<'EOF' >> mock.cfg
 config_opts['dnf.conf'] += """
 [main]
-exclude=*.suse.lp156*
+exclude=*.lp156*
 """
 EOF
 fi


### PR DESCRIPTION
### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
