### PR TITLE
DAOS-19453 test: Update aggregation test yaml files

### DIFF
--- a/src/tests/ftest/aggregation/dfuse_space_check.yaml
+++ b/src/tests/ftest/aggregation/dfuse_space_check.yaml
@@ -15,10 +15,11 @@ server_config:
 pool:
   scm_size: 200MB
   nvme_size: 1GiB  # Minimum for 1 target
+  properties: "rd_fac:0,space_rb:0"
 
 container:
   type: POSIX
-  control_method: daos
+  properties: "cksum:off,srv_cksum:off"
 
 dfuse_space_check:
   block_size: 2097152  # 2M

--- a/src/tests/ftest/aggregation/io_small.yaml
+++ b/src/tests/ftest/aggregation/io_small.yaml
@@ -1,7 +1,9 @@
 hosts:
   test_servers: 2
   test_clients: 2
+
 timeout: 600
+
 server_config:
   name: daos_server
   engines_per_host: 1
@@ -13,9 +15,12 @@ pool:
   scm_size: 10000000000
   nvme_size: 10000000000
   svcn: 1
+  properties: "rd_fac:0,space_rb:0"
+
 container:
   type: POSIX
-  control_method: daos
+  properties: "cksum:off,srv_cksum:off"
+
 ior:
   client_processes:
     np: 12

--- a/src/tests/ftest/aggregation/multiple_pool_cont.yaml
+++ b/src/tests/ftest/aggregation/multiple_pool_cont.yaml
@@ -33,10 +33,11 @@ server_config:
 pool:
   size: 40%
   svcn: 1
+  properties: "rd_fac:0,space_rb:0"
 
 container:
   type: POSIX
-  control_method: daos
+  properties: "cksum:off,srv_cksum:off"
 
 ior:
   client_processes:

--- a/src/tests/ftest/aggregation/shutdown_restart.yaml
+++ b/src/tests/ftest/aggregation/shutdown_restart.yaml
@@ -1,7 +1,9 @@
 hosts:
   test_servers: 3
   test_clients: 1
+
 timeout: 600
+
 server_config:
   name: daos_server
   engines_per_host: 1
@@ -12,9 +14,12 @@ server_config:
 pool:
   size: 50%
   svcn: 1
+  properties: "rd_fac:0,space_rb:0"
+
 container:
   type: POSIX
-  control_method: daos
+  properties: "cksum:off,srv_cksum:off"
+
 ior:
   api: "DFS"
   client_processes:

--- a/src/tests/ftest/aggregation/throttling.yaml
+++ b/src/tests/ftest/aggregation/throttling.yaml
@@ -1,7 +1,9 @@
 hosts:
   test_servers: 2
   test_clients: 2
+
 timeout: 2400
+
 server_config:
   name: daos_server
   engines_per_host: 1
@@ -9,13 +11,17 @@ server_config:
     0:
       log_mask: INFO
       storage: auto
+
 pool:
   scm_size: 20000000000
   nvme_size: 50000000000
   svcn: 1
+  properties: "rd_fac:0,space_rb:0"
+
 container:
   type: POSIX
-  control_method: daos
+  properties: "cksum:off,srv_cksum:off"
+
 ior:
   client_processes:
     np: 12


### PR DESCRIPTION
Some of the ftest/aggregation tests will fail using pools and containers created with their current default properties.  Update these tests to override their default pool/container properties so that they will pass when all tests are updated to use the new defaults.

Quick-functional: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
