### PR TITLE
DAOS-19298 cart: fix test fini sequence (#18650)

### DIFF
--- a/src/tests/ftest/cart/iv_client.c
+++ b/src/tests/ftest/cart/iv_client.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -670,12 +671,11 @@ int main(int argc, char **argv)
 		return -1;
 	}
 
-	crt_group_detach(srv_grp);
-
 	g_do_shutdown = true;
 	pthread_join(progress_thread, NULL);
 
 	DBG_PRINT("Exiting client\n");
+	crt_group_detach(srv_grp);
 
 	if (log_file != stdout)
 		fclose(log_file);

--- a/src/tests/ftest/cart/no_pmix_launcher_client.c
+++ b/src/tests/ftest/cart/no_pmix_launcher_client.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2018-2022 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -206,6 +206,9 @@ int main(int argc, char **argv)
 		DBG_PRINT("RPC response received from rank=%d\n", rank);
 	}
 
+	g_do_shutdown = true;
+	pthread_join(progress_thread, NULL);
+
 	D_FREE(rank_list->rl_ranks);
 	D_FREE(rank_list);
 
@@ -214,9 +217,6 @@ int main(int argc, char **argv)
 		D_ERROR("crt_group_view_destroy() failed; rc=%d\n", rc);
 		assert(0);
 	}
-
-	g_do_shutdown = true;
-	pthread_join(progress_thread, NULL);
 
 	sem_destroy(&sem);
 

--- a/src/tests/ftest/cart/rpc_test_srv.c
+++ b/src/tests/ftest/cart/rpc_test_srv.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -222,15 +223,15 @@ srv_rpc_finalize(void)
 	rc = crt_group_rank(NULL, &myrank);
 	D_ASSERTF(rc == 0, "crt_group_rank failed %d\n", rc);
 
-	if (rpc_srv.target_multitier_grp != NULL) {
-		rc = crt_group_detach(rpc_srv.target_multitier_grp);
-		D_ASSERTF(rc == 0, "crt_group_detach failed %d\n", rc);
-	}
-
 	dbg("main thread wait progress thread ...\n");
 
 	if (rpc_srv.progress_thid)
 		pthread_join(rpc_srv.progress_thid, NULL);
+
+	if (rpc_srv.target_multitier_grp != NULL) {
+		rc = crt_group_detach(rpc_srv.target_multitier_grp);
+		D_ASSERTF(rc == 0, "crt_group_detach failed %d\n", rc);
+	}
 
 	rc = crt_context_destroy(rpc_srv.crt_ctx, 1);
 	D_ASSERTF(rc == 0, "crt_context_destroy failed %d\n", rc);

--- a/src/tests/ftest/cart/test_ep_cred_client.c
+++ b/src/tests/ftest/cart/test_ep_cred_client.c
@@ -149,6 +149,12 @@ test_run()
 		crtu_sem_timedwait(&test.tg_token_to_proceed, 61, __LINE__);
 	}
 
+	crtu_progress_stop();
+
+	rc = pthread_join(test.tg_tid, NULL);
+	D_ASSERTF(rc == 0, "pthread_join failed. rc: %d\n", rc);
+	DBG_PRINT("joined progress thread.\n");
+
 	d_rank_list_free(rank_list);
 	rank_list = NULL;
 
@@ -160,12 +166,6 @@ test_run()
 		D_ASSERTF(rc == 0,
 			  "crt_group_view_destroy() failed; rc=%d\n", rc);
 	}
-
-	crtu_progress_stop();
-
-	rc = pthread_join(test.tg_tid, NULL);
-	D_ASSERTF(rc == 0, "pthread_join failed. rc: %d\n", rc);
-	DBG_PRINT("joined progress thread.\n");
 
 	rc = sem_destroy(&test.tg_token_to_proceed);
 	D_ASSERTF(rc == 0, "sem_destroy() failed.\n");

--- a/src/tests/ftest/cart/test_multisend_client.c
+++ b/src/tests/ftest/cart/test_multisend_client.c
@@ -228,6 +228,13 @@ test_run()
 		}
 	}
 
+	crtu_progress_stop();
+
+	for (i = 0; i < test.tg_num_ctx; i++) {
+		rc = pthread_join(test.tg_tid[i], NULL);
+		D_ASSERTF(rc == 0, "pthread_join failed. rc: %d\n", rc);
+	}
+	D_DEBUG(DB_TRACE, "joined progress threads.\n");
 	d_rank_list_free(rank_list);
 	rank_list = NULL;
 
@@ -238,14 +245,6 @@ test_run()
 		rc = crt_group_view_destroy(grp);
 		D_ASSERTF(rc == 0, "crt_group_view_destroy() failed; rc=%d\n", rc);
 	}
-
-	crtu_progress_stop();
-
-	for (i = 0; i < test.tg_num_ctx; i++) {
-		rc = pthread_join(test.tg_tid[i], NULL);
-		D_ASSERTF(rc == 0, "pthread_join failed. rc: %d\n", rc);
-	}
-	D_DEBUG(DB_TRACE, "joined progress threads.\n");
 
 	rc = sem_destroy(&test.tg_token_to_proceed);
 	D_ASSERTF(rc == 0, "sem_destroy() failed.\n");

--- a/src/tests/ftest/cart/test_no_timeout.c
+++ b/src/tests/ftest/cart/test_no_timeout.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2018-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/tests/ftest/cart/test_no_timeout.c
+++ b/src/tests/ftest/cart/test_no_timeout.c
@@ -147,6 +147,13 @@ test_run(void)
 		}
 	}
 
+	crtu_progress_stop();
+
+	rc = pthread_join(test_g.t_tid[0], NULL);
+	if (rc != 0)
+		fprintf(stderr, "pthread_join failed. rc: %d\n", rc);
+	D_DEBUG(DB_TEST, "joined progress thread.\n");
+
 	d_rank_list_free(rank_list);
 	rank_list = NULL;
 
@@ -158,13 +165,6 @@ test_run(void)
 		D_ASSERTF(rc == 0,
 			  "crt_group_view_destroy() failed; rc=%d\n", rc);
 	}
-
-	crtu_progress_stop();
-
-	rc = pthread_join(test_g.t_tid[0], NULL);
-	if (rc != 0)
-		fprintf(stderr, "pthread_join failed. rc: %d\n", rc);
-	D_DEBUG(DB_TEST, "joined progress thread.\n");
 
 	rc = sem_destroy(&test_g.t_token_to_proceed);
 	D_ASSERTF(rc == 0, "sem_destroy() failed.\n");

--- a/src/tests/ftest/cart/test_proto_client.c
+++ b/src/tests/ftest/cart/test_proto_client.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2018-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/tests/ftest/cart/test_proto_client.c
+++ b/src/tests/ftest/cart/test_proto_client.c
@@ -167,6 +167,12 @@ test_run()
 		crtu_sem_timedwait(&test.tg_token_to_proceed, 61, __LINE__);
 	}
 
+	crtu_progress_stop();
+
+	rc = pthread_join(test.tg_tid, NULL);
+	D_ASSERTF(rc == 0, "pthread_join failed. rc: %d\n", rc);
+	D_DEBUG(DB_TRACE, "joined progress thread.\n");
+
 	d_rank_list_free(rank_list);
 	rank_list = NULL;
 
@@ -178,12 +184,6 @@ test_run()
 		D_ASSERTF(rc == 0,
 			  "crt_group_view_destroy() failed; rc=%d\n", rc);
 	}
-
-	crtu_progress_stop();
-
-	rc = pthread_join(test.tg_tid, NULL);
-	D_ASSERTF(rc == 0, "pthread_join failed. rc: %d\n", rc);
-	D_DEBUG(DB_TRACE, "joined progress thread.\n");
 
 	rc = sem_destroy(&test.tg_token_to_proceed);
 	D_ASSERTF(rc == 0, "sem_destroy() failed.\n");


### PR DESCRIPTION
- In number of cart clients, the group was destroyed before all the client threads joined. If during testing any RPC timed out, then the client could try to access already-destroyed group in the delayed completion callback handler, leading to a segfault.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
