### PR TITLE
DAOS-19456 test: add pool properties in snapshot

### DIFF
--- a/src/tests/ftest/container/basic_snapshot.yaml
+++ b/src/tests/ftest/container/basic_snapshot.yaml
@@ -16,6 +16,7 @@ server_config:
   system_ram_reserved: 1
 pool:
   name: daos_server
+  properties: "rd_fac:0,space_rb:0"
   scm_size_mux: !mux
     size1gb:
       scm_size: 1G

--- a/src/tests/ftest/container/snapshot.yaml
+++ b/src/tests/ftest/container/snapshot.yaml
@@ -19,6 +19,7 @@ server_config:
   system_ram_reserved: 1
 pool:
   scm_size: 5G
+  properties: "rd_fac:0,space_rb:0"
 snapshot:
   dkey: "dkey"
   akey: "akey"


### PR DESCRIPTION
We will run tests with the default pool and container properties but some tests will fail with these default properties. Add pool properties to snapshot tests that fail with the default properties.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
