### PR TITLE
DAOS-19493 test: remove control_method daos (#18850)

### DIFF
--- a/src/tests/ftest/aggregation/continuous_write.yaml
+++ b/src/tests/ftest/aggregation/continuous_write.yaml
@@ -20,7 +20,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   flags: -w

--- a/src/tests/ftest/aggregation/dfuse_space_check.yaml
+++ b/src/tests/ftest/aggregation/dfuse_space_check.yaml
@@ -18,7 +18,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 dfuse_space_check:
   block_size: 2097152  # 2M

--- a/src/tests/ftest/aggregation/io_small.yaml
+++ b/src/tests/ftest/aggregation/io_small.yaml
@@ -15,7 +15,6 @@ pool:
   svcn: 1
 container:
   type: POSIX
-  control_method: daos
 ior:
   client_processes:
     np: 12

--- a/src/tests/ftest/aggregation/multiple_pool_cont.yaml
+++ b/src/tests/ftest/aggregation/multiple_pool_cont.yaml
@@ -36,7 +36,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   client_processes:

--- a/src/tests/ftest/aggregation/punching.yaml
+++ b/src/tests/ftest/aggregation/punching.yaml
@@ -22,7 +22,6 @@ pool: !mux
     mem_ratio: 25
 container:
   type: POSIX
-  control_method: daos
 mdtest:
   client_processes:
     np: 2

--- a/src/tests/ftest/aggregation/shutdown_restart.yaml
+++ b/src/tests/ftest/aggregation/shutdown_restart.yaml
@@ -14,7 +14,6 @@ pool:
   svcn: 1
 container:
   type: POSIX
-  control_method: daos
 ior:
   api: "DFS"
   client_processes:

--- a/src/tests/ftest/aggregation/space_rb.yaml
+++ b/src/tests/ftest/aggregation/space_rb.yaml
@@ -20,7 +20,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior: &ior_base
   flags: -w

--- a/src/tests/ftest/aggregation/throttling.yaml
+++ b/src/tests/ftest/aggregation/throttling.yaml
@@ -15,7 +15,6 @@ pool:
   svcn: 1
 container:
   type: POSIX
-  control_method: daos
 ior:
   client_processes:
     np: 12

--- a/src/tests/ftest/container/auto_oc_selection.yaml
+++ b/src/tests/ftest/container/auto_oc_selection.yaml
@@ -17,5 +17,4 @@ server_config:
 pool:
   scm_size: 1G
 container:
-  control_method: daos
   type: POSIX

--- a/src/tests/ftest/container/fill_destroy_loop.yaml
+++ b/src/tests/ftest/container/fill_destroy_loop.yaml
@@ -24,7 +24,6 @@ pool:
     - "time"
 
 container:
-  control_method: daos
   oclass: SX
   type: POSIX
   object_qty: 1

--- a/src/tests/ftest/container/full_pool_container_create.yaml
+++ b/src/tests/ftest/container/full_pool_container_create.yaml
@@ -14,6 +14,3 @@ timeout: 900
 pool:
   size: 20G
   threshold_percent: 0.1  # 10%
-
-container:
-  control_method: daos

--- a/src/tests/ftest/container/label.yaml
+++ b/src/tests/ftest/container/label.yaml
@@ -20,5 +20,3 @@ server_config:
   system_ram_reserved: 1
 pool:
   size: 1G
-container:
-  control_method: daos

--- a/src/tests/ftest/container/multiple_delete.yaml
+++ b/src/tests/ftest/container/multiple_delete.yaml
@@ -26,7 +26,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   client_processes:

--- a/src/tests/ftest/container/open.yaml
+++ b/src/tests/ftest/container/open.yaml
@@ -16,8 +16,6 @@ server_config:
   system_ram_reserved: 1
 pool:
   scm_size: 1G
-container:
-  control_method: daos
 uuid_poh: !mux
   good_uuid_good_poh:
     uuid: PASS

--- a/src/tests/ftest/container/per_server_fault_domain.yaml
+++ b/src/tests/ftest/container/per_server_fault_domain.yaml
@@ -25,7 +25,6 @@ pool:
   properties: space_rb:5
 
 container:
-  control_method: daos
   type: POSIX
 
 ior:

--- a/src/tests/ftest/container/rf_enforcement.yaml
+++ b/src/tests/ftest/container/rf_enforcement.yaml
@@ -19,7 +19,6 @@ pool:
   svcn: 3
   pool_query_timeout: 30
 container:
-  control_method: daos
   akey_size: 5
   dkey_size: 5
   data_size: 5

--- a/src/tests/ftest/container/snapshot_aggregation.yaml
+++ b/src/tests/ftest/container/snapshot_aggregation.yaml
@@ -27,7 +27,6 @@ pool:
   target_list: [0, 1]
 
 container:
-  control_method: daos
   type: POSIX
 
 ior:

--- a/src/tests/ftest/control/daos_object_query.yaml
+++ b/src/tests/ftest/control/daos_object_query.yaml
@@ -17,7 +17,6 @@ server_config:
 pool:
   scm_size: 3G
 container:
-  control_method: daos
   type: POSIX
   class_names: !mux
     oclass_s1:

--- a/src/tests/ftest/control/daos_snapshot.yaml
+++ b/src/tests/ftest/control/daos_snapshot.yaml
@@ -16,8 +16,6 @@ server_config:
   system_ram_reserved: 1
 pool:
   scm_size: 1G
-container:
-  control_method: daos
 stress_test: !mux
   small:
     snapshot_count: 5

--- a/src/tests/ftest/control/dmg_pool_query_test.yaml
+++ b/src/tests/ftest/control/dmg_pool_query_test.yaml
@@ -16,7 +16,6 @@ pool:
   nvme_size: 32GB
 container:
   type: POSIX
-  control_method: daos
 ior:
   flags: "-k -w -r"
   transfer_size: "64M"

--- a/src/tests/ftest/control/dmg_telemetry_basic.yaml
+++ b/src/tests/ftest/control/dmg_telemetry_basic.yaml
@@ -18,8 +18,6 @@ server_config:
   system_ram_reserved: 1
 pool:
   scm_size: 2G
-container:
-  control_method: daos
 test:
   container_qty: 5
   open_close_qty: 3

--- a/src/tests/ftest/control/dmg_telemetry_io_basic.yaml
+++ b/src/tests/ftest/control/dmg_telemetry_io_basic.yaml
@@ -24,7 +24,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 block_sizes: [10M, 500M]
 transfer_sizes: [256K, 1M]

--- a/src/tests/ftest/control/dmg_telemetry_io_latency.yaml
+++ b/src/tests/ftest/control/dmg_telemetry_io_latency.yaml
@@ -17,7 +17,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   block_size: 8M

--- a/src/tests/ftest/control/log_entry.yaml
+++ b/src/tests/ftest/control/log_entry.yaml
@@ -22,5 +22,4 @@ pool:
   svcn: 5
 
 container:
-  control_method: daos
   type: POSIX

--- a/src/tests/ftest/daos_perf/small.yaml
+++ b/src/tests/ftest/daos_perf/small.yaml
@@ -14,7 +14,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 server_config:
   name: daos_server

--- a/src/tests/ftest/daos_test/dfuse.yaml
+++ b/src/tests/ftest/daos_test/dfuse.yaml
@@ -18,7 +18,6 @@ server_config:
   system_ram_reserved: 1
 container:
   type: POSIX
-  control_method: daos
 dfuse: !mux
   writeback:
     # File metadata is incorrect after write with writeback caching and IL.

--- a/src/tests/ftest/daos_vol/bigio.yaml
+++ b/src/tests/ftest/daos_vol/bigio.yaml
@@ -33,7 +33,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 daos_vol_tests:
   testname: h5_partest_t_bigio

--- a/src/tests/ftest/daos_vol/h5_suite.yaml
+++ b/src/tests/ftest/daos_vol/h5_suite.yaml
@@ -16,7 +16,6 @@ pool:
   nvme_size: 100G
 container:
   type: POSIX
-  control_method: daos
 daos_vol_tests: !mux
   test1:
     testname: h5_partest_t_shapesame

--- a/src/tests/ftest/datamover/copy_procs.yaml
+++ b/src/tests/ftest/datamover/copy_procs.yaml
@@ -16,7 +16,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   api: 'DFS'

--- a/src/tests/ftest/datamover/dst_create.yaml
+++ b/src/tests/ftest/datamover/dst_create.yaml
@@ -17,7 +17,6 @@ server_config:
 pool:
   size: 1G
 container:
-  control_method: daos
   properties: compression:lz4
 ior:
   client_processes:

--- a/src/tests/ftest/datamover/large_file.yaml
+++ b/src/tests/ftest/datamover/large_file.yaml
@@ -27,7 +27,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   client_ppn:

--- a/src/tests/ftest/datamover/negative.yaml
+++ b/src/tests/ftest/datamover/negative.yaml
@@ -18,7 +18,6 @@ pool:
   scm_size: 5.1G
 container:
   type: POSIX
-  control_method: daos
 ior:
   client_processes:
     np: 1

--- a/src/tests/ftest/datamover/negative_space.yaml
+++ b/src/tests/ftest/datamover/negative_space.yaml
@@ -20,7 +20,6 @@ pool_small:
   size: 64M
 container:
   type: POSIX
-  control_method: daos
 ior:
   client_processes:
     np: 1

--- a/src/tests/ftest/datamover/obj_large_posix.yaml
+++ b/src/tests/ftest/datamover/obj_large_posix.yaml
@@ -26,7 +26,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 mdtest:
   client_processes:

--- a/src/tests/ftest/datamover/posix_meta_entry.yaml
+++ b/src/tests/ftest/datamover/posix_meta_entry.yaml
@@ -18,7 +18,6 @@ pool:
   scm_size: 1G
 container:
   type: POSIX
-  control_method: daos
 dcp:
   env_vars:
     - D_LOG_MASK=INFO,DFS=DEBUG

--- a/src/tests/ftest/datamover/posix_preserve_props.yaml
+++ b/src/tests/ftest/datamover/posix_preserve_props.yaml
@@ -18,7 +18,6 @@ pool:
   scm_size: 1G
 container:
   type: POSIX
-  control_method: daos
   properties: compression:lz4
 ior:
   client_processes:

--- a/src/tests/ftest/datamover/posix_subsets.yaml
+++ b/src/tests/ftest/datamover/posix_subsets.yaml
@@ -18,7 +18,6 @@ pool:
   scm_size: 1G
 container:
   type: POSIX
-  control_method: daos
 ior:
   client_processes:
     np: 1

--- a/src/tests/ftest/datamover/posix_symlinks.yaml
+++ b/src/tests/ftest/datamover/posix_symlinks.yaml
@@ -18,7 +18,6 @@ pool:
   scm_size: 1G
 container:
   type: POSIX
-  control_method: daos
 dcp:
   client_processes:
     np: 1

--- a/src/tests/ftest/datamover/posix_types.yaml
+++ b/src/tests/ftest/datamover/posix_types.yaml
@@ -18,7 +18,6 @@ pool:
   scm_size: 1G
 container:
   type: POSIX
-  control_method: daos
 ior:
   client_processes:
     np: 1

--- a/src/tests/ftest/datamover/serial_large_posix.yaml
+++ b/src/tests/ftest/datamover/serial_large_posix.yaml
@@ -26,7 +26,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 mdtest:
   client_processes:

--- a/src/tests/ftest/dbench/dbench.yaml
+++ b/src/tests/ftest/dbench/dbench.yaml
@@ -17,7 +17,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 dbench:
   loadfile: /usr/share/dbench/client.txt  # writes about 25M and perform 500 thousand operations

--- a/src/tests/ftest/deployment/agent_failure.yaml
+++ b/src/tests/ftest/deployment/agent_failure.yaml
@@ -30,7 +30,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior: &ior_base
   client_processes:

--- a/src/tests/ftest/deployment/disk_failure.yaml
+++ b/src/tests/ftest/deployment/disk_failure.yaml
@@ -30,7 +30,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_2GX
   properties: "cksum:crc16,rf:1"
 

--- a/src/tests/ftest/deployment/ior_per_rank.yaml
+++ b/src/tests/ftest/deployment/ior_per_rank.yaml
@@ -27,7 +27,6 @@ pool:
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
-  control_method: daos
   oclass: SX
 
 ior:

--- a/src/tests/ftest/deployment/network_failure.yaml
+++ b/src/tests/ftest/deployment/network_failure.yaml
@@ -31,10 +31,8 @@ pool_size_value:
 
 container_wo_rf:
   type: POSIX
-  control_method: daos
 container_with_rf:
   type: POSIX
-  control_method: daos
   properties: rd_fac:1
 
 ior: &ior_base

--- a/src/tests/ftest/deployment/server_rank_failure.yaml
+++ b/src/tests/ftest/deployment/server_rank_failure.yaml
@@ -39,11 +39,9 @@ pool_size_value:
 
 container:
   type: POSIX
-  control_method: daos
   properties: rd_fac:2
 container_wo_rf:
   type: POSIX
-  control_method: daos
 
 ior: &ior_base
   client_processes:

--- a/src/tests/ftest/deployment/target_failure.yaml
+++ b/src/tests/ftest/deployment/target_failure.yaml
@@ -28,10 +28,8 @@ pool_size_ratio_66:
 
 container_wo_rf:
   type: POSIX
-  control_method: daos
 container_with_rf:
   type: POSIX
-  control_method: daos
   properties: rd_fac:1
 
 ior: &ior_base

--- a/src/tests/ftest/dfuse/bash.yaml
+++ b/src/tests/ftest/dfuse/bash.yaml
@@ -18,4 +18,3 @@ pool:
   scm_size: 1000000000
 container:
   type: POSIX
-  control_method: daos

--- a/src/tests/ftest/dfuse/bash_dcache.yaml
+++ b/src/tests/ftest/dfuse/bash_dcache.yaml
@@ -18,4 +18,3 @@ pool:
   scm_size: 1G
 container:
   type: POSIX
-  control_method: daos

--- a/src/tests/ftest/dfuse/bash_fd.yaml
+++ b/src/tests/ftest/dfuse/bash_fd.yaml
@@ -18,4 +18,3 @@ pool:
   scm_size: 1G
 container:
   type: POSIX
-  control_method: daos

--- a/src/tests/ftest/dfuse/container_attrs.yaml
+++ b/src/tests/ftest/dfuse/container_attrs.yaml
@@ -27,21 +27,16 @@ pool:
 container_01:
   type: POSIX
   attrs: dfuse-attr-time:666,dfuse-dentry-time:999
-  control_method: daos
 
 container_02:
   type: POSIX
-  control_method: daos
 
 container_03:
   type: POSIX
   attrs: dfuse-attr-time:42,dfuse-dentry-time:404
-  control_method: daos
 
 container_04:
   type: POSIX
-  control_method: daos
 
 container_05:
   type: POSIX
-  control_method: daos

--- a/src/tests/ftest/dfuse/container_type.yaml
+++ b/src/tests/ftest/dfuse/container_type.yaml
@@ -20,4 +20,3 @@ container:
   cont_types:
     - ""
     - "POSIX"
-  control_method: daos

--- a/src/tests/ftest/dfuse/daos_build.yaml
+++ b/src/tests/ftest/dfuse/daos_build.yaml
@@ -22,7 +22,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 dfuse:
   cores: '0-17'

--- a/src/tests/ftest/dfuse/daos_build_vm.yaml
+++ b/src/tests/ftest/dfuse/daos_build_vm.yaml
@@ -26,7 +26,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 dfuse:
   cores: '0-17'

--- a/src/tests/ftest/dfuse/enospace.yaml
+++ b/src/tests/ftest/dfuse/enospace.yaml
@@ -18,6 +18,5 @@ pool:
   size: 128MiB
 container:
   type: POSIX
-  control_method: daos
 dfuse:
   disable_caching: true

--- a/src/tests/ftest/dfuse/find.yaml
+++ b/src/tests/ftest/dfuse/find.yaml
@@ -17,7 +17,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   cont_count: 5
 
 find_cmd:

--- a/src/tests/ftest/dfuse/il_whitelist.yaml
+++ b/src/tests/ftest/dfuse/il_whitelist.yaml
@@ -18,4 +18,3 @@ pool:
   scm_size: 1000000000
 container:
   type: POSIX
-  control_method: daos

--- a/src/tests/ftest/dfuse/ioctl_pool_handles.yaml
+++ b/src/tests/ftest/dfuse/ioctl_pool_handles.yaml
@@ -23,7 +23,6 @@ pool:
   size: 10GB
 
 container:
-  control_method: daos
   type: POSIX
 
 ior_write:

--- a/src/tests/ftest/dfuse/mu_mount.yaml
+++ b/src/tests/ftest/dfuse/mu_mount.yaml
@@ -18,4 +18,3 @@ pool:
   size: 1GiB
 container:
   type: POSIX
-  control_method: daos

--- a/src/tests/ftest/dfuse/mu_perms.yaml
+++ b/src/tests/ftest/dfuse/mu_perms.yaml
@@ -17,7 +17,6 @@ server_config:
 pool:
   size: 1G
 container:
-  control_method: daos
   type: POSIX
 dfuse:
   disable_caching: true

--- a/src/tests/ftest/dfuse/pil4dfs_dcache.yaml
+++ b/src/tests/ftest/dfuse/pil4dfs_dcache.yaml
@@ -22,4 +22,3 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos

--- a/src/tests/ftest/dfuse/pil4dfs_fio.yaml
+++ b/src/tests/ftest/dfuse/pil4dfs_fio.yaml
@@ -24,7 +24,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 test_pil4dfs_vs_dfs:
   bw_deltas:

--- a/src/tests/ftest/dfuse/pil4dfs_many_mounts.yaml
+++ b/src/tests/ftest/dfuse/pil4dfs_many_mounts.yaml
@@ -18,7 +18,6 @@ pool:
   size: 1GiB
 container:
   type: POSIX
-  control_method: daos
 test:
   # Mount counts at/below MAX_DAOS_MT for which libpil4dfs enables interception.
   intercept_mount_counts:

--- a/src/tests/ftest/dfuse/posix_stat.yaml
+++ b/src/tests/ftest/dfuse/posix_stat.yaml
@@ -18,7 +18,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 block_sizes: [1M, 10M, 100M, 500M]
 

--- a/src/tests/ftest/dfuse/read.yaml
+++ b/src/tests/ftest/dfuse/read.yaml
@@ -20,6 +20,5 @@ pool:
   size: 1G
 container:
   type: POSIX
-  control_method: daos
 dfuse:
   disable_wb_cache: false

--- a/src/tests/ftest/dfuse/root_container.yaml
+++ b/src/tests/ftest/dfuse/root_container.yaml
@@ -18,7 +18,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   cont_count: 10
   tmp_file_name: test_file
   tmp_file_count: 2

--- a/src/tests/ftest/dfuse/simul.yaml
+++ b/src/tests/ftest/dfuse/simul.yaml
@@ -16,7 +16,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 mpi:
   mpi_type: mpich

--- a/src/tests/ftest/dfuse/sparse_file.yaml
+++ b/src/tests/ftest/dfuse/sparse_file.yaml
@@ -14,4 +14,3 @@ pool:
   nvme_size: 1073741824
 container:
   type: POSIX
-  control_method: daos

--- a/src/tests/ftest/erasurecode/aggregation.yaml
+++ b/src/tests/ftest/erasurecode/aggregation.yaml
@@ -31,7 +31,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   api: "DFS"

--- a/src/tests/ftest/erasurecode/multiple_rank_failure.yaml
+++ b/src/tests/ftest/erasurecode/multiple_rank_failure.yaml
@@ -29,7 +29,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
 
 ior:

--- a/src/tests/ftest/erasurecode/multiple_target_failure.yaml
+++ b/src/tests/ftest/erasurecode/multiple_target_failure.yaml
@@ -29,7 +29,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
 
 ior:

--- a/src/tests/ftest/erasurecode/offline_rebuild.yaml
+++ b/src/tests/ftest/erasurecode/offline_rebuild.yaml
@@ -36,7 +36,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   api: "DFS"

--- a/src/tests/ftest/erasurecode/offline_rebuild_aggregation.yaml
+++ b/src/tests/ftest/erasurecode/offline_rebuild_aggregation.yaml
@@ -29,7 +29,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   api: "DFS"

--- a/src/tests/ftest/erasurecode/online_rebuild.yaml
+++ b/src/tests/ftest/erasurecode/online_rebuild.yaml
@@ -38,7 +38,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 daos:
   container:

--- a/src/tests/ftest/erasurecode/online_rebuild_mdtest.yaml
+++ b/src/tests/ftest/erasurecode/online_rebuild_mdtest.yaml
@@ -45,7 +45,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   properties: rd_fac:2
 
 mdtest:

--- a/src/tests/ftest/erasurecode/rebuild_disabled.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled.yaml
@@ -36,7 +36,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   api: "DFS"

--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
@@ -37,7 +37,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   single_data_set:
     # [object_qty, record_qty, dkey, akey, data_size]
     - [1, 1, 1, 1, 4194304]

--- a/src/tests/ftest/erasurecode/rebuild_fio.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_fio.yaml
@@ -40,7 +40,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   rf_properties: !mux
     rf1:
       properties: rd_fac:1

--- a/src/tests/ftest/erasurecode/restart.yaml
+++ b/src/tests/ftest/erasurecode/restart.yaml
@@ -32,7 +32,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   api: "DFS"

--- a/src/tests/ftest/erasurecode/space_usage.yaml
+++ b/src/tests/ftest/erasurecode/space_usage.yaml
@@ -27,7 +27,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior: &ior_base
   client_processes:

--- a/src/tests/ftest/erasurecode/truncate.yaml
+++ b/src/tests/ftest/erasurecode/truncate.yaml
@@ -36,7 +36,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   rf_properties: !mux
     rf1:
       properties: rd_fac:1

--- a/src/tests/ftest/fault_injection/ec.yaml
+++ b/src/tests/ftest/fault_injection/ec.yaml
@@ -29,7 +29,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:2
 
 ior:

--- a/src/tests/ftest/fault_injection/pool.yaml
+++ b/src/tests/ftest/fault_injection/pool.yaml
@@ -34,7 +34,6 @@ container:
   akey_size: 10
   dkey_size: 10
   data_array: 10
-  control_method: daos
 
 object_class: OC_RP_3G1
 

--- a/src/tests/ftest/harness/advanced.yaml
+++ b/src/tests/ftest/harness/advanced.yaml
@@ -15,4 +15,3 @@ pool:
   size: 2G
 container:
   type: POSIX
-  control_method: daos

--- a/src/tests/ftest/harness/coverage.yaml
+++ b/src/tests/ftest/harness/coverage.yaml
@@ -21,7 +21,6 @@ pool:
   size: 2G
 
 container:
-  control_method: daos
   type: POSIX
 
 ior: &ior_base

--- a/src/tests/ftest/io/macsio_test.yaml
+++ b/src/tests/ftest/io/macsio_test.yaml
@@ -24,7 +24,6 @@ pool:
   nvme_size: 10G
 
 container:
-  control_method: daos
   type: POSIX
 
 macsio:

--- a/src/tests/ftest/io/parallel_io.yaml
+++ b/src/tests/ftest/io/parallel_io.yaml
@@ -17,7 +17,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   cont_count: 10
 
 fio:

--- a/src/tests/ftest/io/seg_count.yaml
+++ b/src/tests/ftest/io/seg_count.yaml
@@ -24,7 +24,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   client_processes: !mux

--- a/src/tests/ftest/io/small_file_count.yaml
+++ b/src/tests/ftest/io/small_file_count.yaml
@@ -25,7 +25,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 largefilecount:
   api:

--- a/src/tests/ftest/ior/crash.yaml
+++ b/src/tests/ftest/ior/crash.yaml
@@ -26,7 +26,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   api: "DFS"

--- a/src/tests/ftest/ior/hard.yaml
+++ b/src/tests/ftest/ior/hard.yaml
@@ -34,7 +34,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   properties: dedup:memcmp
 
 ior:

--- a/src/tests/ftest/ior/hard_rebuild.yaml
+++ b/src/tests/ftest/ior/hard_rebuild.yaml
@@ -36,7 +36,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   api: "DFS"

--- a/src/tests/ftest/ior/intercept_messages.yaml
+++ b/src/tests/ftest/ior/intercept_messages.yaml
@@ -15,7 +15,6 @@ pool:
   svcn: 1
 container:
   type: POSIX
-  control_method: daos
 ior:
   env_vars:
     - D_LOG_MASK=INFO

--- a/src/tests/ftest/ior/intercept_messages_pil4dfs.yaml
+++ b/src/tests/ftest/ior/intercept_messages_pil4dfs.yaml
@@ -15,7 +15,6 @@ pool:
   svcn: 1
 container:
   type: POSIX
-  control_method: daos
 ior:
   env_vars:
     - D_LOG_MASK=INFO

--- a/src/tests/ftest/mpiio/hdf5.yaml
+++ b/src/tests/ftest/mpiio/hdf5.yaml
@@ -23,7 +23,6 @@ pool:
   svcn: 1
 container:
   type: POSIX
-  control_method: daos
 client_processes:
   np: 6
 test_repo:

--- a/src/tests/ftest/mpiio/llnl_mpi4py.yaml
+++ b/src/tests/ftest/mpiio/llnl_mpi4py.yaml
@@ -18,7 +18,6 @@ pool:
   scm_size: 1000000000
 container:
   type: POSIX
-  control_method: daos
 client_processes:
   np: 8
 test_repo:

--- a/src/tests/ftest/mpiio/romio.yaml
+++ b/src/tests/ftest/mpiio/romio.yaml
@@ -16,6 +16,5 @@ pool:
   svcn: 1
 container:
   type: POSIX
-  control_method: daos
 romio:
   romio_repo: "romio/test/"

--- a/src/tests/ftest/nvme/enospace.yaml
+++ b/src/tests/ftest/nvme/enospace.yaml
@@ -41,7 +41,6 @@ pool:
   usage_min_nvme: 96
 
 container:
-  control_method: daos
   register_cleanup: False  # Skip teardown destroy. Test manually destroys containers.
   type: POSIX
 

--- a/src/tests/ftest/nvme/fault.yaml
+++ b/src/tests/ftest/nvme/fault.yaml
@@ -21,7 +21,6 @@ pool:
   size: 96%
 container:
   type: POSIX
-  control_method: daos
   properties: rd_fac:1
 ior:
   api: DFS

--- a/src/tests/ftest/nvme/fragmentation.yaml
+++ b/src/tests/ftest/nvme/fragmentation.yaml
@@ -24,7 +24,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   num_repeat: 30

--- a/src/tests/ftest/nvme/io_verification.yaml
+++ b/src/tests/ftest/nvme/io_verification.yaml
@@ -36,7 +36,6 @@ pool_3:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   client_processes:

--- a/src/tests/ftest/nvme/pool_capacity.yaml
+++ b/src/tests/ftest/nvme/pool_capacity.yaml
@@ -34,7 +34,6 @@ pool_qty_10:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   no_parallel_job: 10

--- a/src/tests/ftest/nvme/pool_exclude.yaml
+++ b/src/tests/ftest/nvme/pool_exclude.yaml
@@ -37,7 +37,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:2
 
 ior_flags_common: &ior_flags_common

--- a/src/tests/ftest/nvme/pool_extend.yaml
+++ b/src/tests/ftest/nvme/pool_extend.yaml
@@ -45,7 +45,6 @@ pool_qty_3:
 
 container:
   type: POSIX
-  control_method: daos
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
 
 ior_flags_common: &ior_flags_common

--- a/src/tests/ftest/object/same_key_different_value.yaml
+++ b/src/tests/ftest/object/same_key_different_value.yaml
@@ -16,5 +16,3 @@ server_config:
   system_ram_reserved: 1
 pool:
   scm_size: 160000000
-container:
-  control_method: daos

--- a/src/tests/ftest/osa/offline_drain.yaml
+++ b/src/tests/ftest/osa/offline_drain.yaml
@@ -39,7 +39,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_3G6
   properties: cksum:crc64,cksum_size:16384,srv_cksum:on,rd_fac:2
 

--- a/src/tests/ftest/osa/offline_extend.yaml
+++ b/src/tests/ftest/osa/offline_extend.yaml
@@ -41,7 +41,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_2G1
   properties: cksum:crc64,cksum_size:16384,srv_cksum:on,rd_fac:1
 

--- a/src/tests/ftest/osa/offline_parallel_test.yaml
+++ b/src/tests/ftest/osa/offline_parallel_test.yaml
@@ -40,7 +40,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_2G8
   properties: cksum:crc64,cksum_size:16384,srv_cksum:on,rd_fac:1
 

--- a/src/tests/ftest/osa/offline_reintegration.yaml
+++ b/src/tests/ftest/osa/offline_reintegration.yaml
@@ -53,7 +53,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_3G6
   properties: cksum:crc64,cksum_size:16384,srv_cksum:on,rd_fac:2
 

--- a/src/tests/ftest/osa/online_drain.yaml
+++ b/src/tests/ftest/osa/online_drain.yaml
@@ -39,7 +39,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
   oclass: RP_2G4
 

--- a/src/tests/ftest/osa/online_extend.yaml
+++ b/src/tests/ftest/osa/online_extend.yaml
@@ -50,7 +50,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
   oclass: RP_2G1
 

--- a/src/tests/ftest/osa/online_parallel_test.yaml
+++ b/src/tests/ftest/osa/online_parallel_test.yaml
@@ -37,7 +37,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
   oclass: RP_2G1
 

--- a/src/tests/ftest/osa/online_reintegration.yaml
+++ b/src/tests/ftest/osa/online_reintegration.yaml
@@ -40,7 +40,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
   oclass: RP_2G1
 

--- a/src/tests/ftest/performance/ior_easy.yaml
+++ b/src/tests/ftest/performance/ior_easy.yaml
@@ -28,7 +28,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior: &ior_base
   client_processes:

--- a/src/tests/ftest/performance/ior_hard.yaml
+++ b/src/tests/ftest/performance/ior_hard.yaml
@@ -28,7 +28,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior: &ior_base
   client_processes:

--- a/src/tests/ftest/performance/mdtest_easy.yaml
+++ b/src/tests/ftest/performance/mdtest_easy.yaml
@@ -28,7 +28,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 mdtest: &mdtest_base
   client_processes:

--- a/src/tests/ftest/performance/mdtest_hard.yaml
+++ b/src/tests/ftest/performance/mdtest_hard.yaml
@@ -28,7 +28,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 mdtest: &mdtest_base
   client_processes:

--- a/src/tests/ftest/pool/destroy.yaml
+++ b/src/tests/ftest/pool/destroy.yaml
@@ -25,7 +25,6 @@ container:
   akey_size: 4
   dkey_size: 4
   data_size: 9
-  control_method: daos
 setnames:
   validsetname:
     setname: daos_server

--- a/src/tests/ftest/pool/list_verbose.yaml
+++ b/src/tests/ftest/pool/list_verbose.yaml
@@ -32,7 +32,6 @@ pool_scm_only:
   target_list: [0]
 
 container:
-  control_method: daos
   type: POSIX
   oclass: S1
 

--- a/src/tests/ftest/pool/pda.yaml
+++ b/src/tests/ftest/pool/pda.yaml
@@ -21,10 +21,8 @@ pool_1:
   properties: rd_fac:0,space_rb:0,ec_pda:2,rp_pda:4
 container:
   type: POSIX
-  control_method: daos
 container_1:
   type: POSIX
   pda_properties:
     - 3       # ec_pda
     - 5       # rp_pda
-  control_method: daos

--- a/src/tests/ftest/pool/target_query.yaml
+++ b/src/tests/ftest/pool/target_query.yaml
@@ -28,7 +28,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   api: "DFS"

--- a/src/tests/ftest/pool/verify_space.yaml
+++ b/src/tests/ftest/pool/verify_space.yaml
@@ -38,7 +38,6 @@ pool_rank_0_1_2:
 
 container:
   type: POSIX
-  control_method: daos
   register_cleanup: False
 
 ior:

--- a/src/tests/ftest/pytorch/checkpoint.yaml
+++ b/src/tests/ftest/pytorch/checkpoint.yaml
@@ -17,7 +17,6 @@ pool:
   size: 8G
 container:
   type: POSIX
-  control_method: daos
 
 timeout: 2000
 

--- a/src/tests/ftest/pytorch/dataset.yaml
+++ b/src/tests/ftest/pytorch/dataset.yaml
@@ -17,7 +17,6 @@ pool:
   size: 8G
 container:
   type: POSIX
-  control_method: daos
   dir_oclass: SX
 
 timeout: 270

--- a/src/tests/ftest/rebuild/container_create_race.yaml
+++ b/src/tests/ftest/rebuild/container_create_race.yaml
@@ -32,7 +32,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 io:
   object_qty: 8

--- a/src/tests/ftest/rebuild/container_rf.yaml
+++ b/src/tests/ftest/rebuild/container_rf.yaml
@@ -20,7 +20,6 @@ pool:
   svcn: 7  # To match number of servers
   pool_query_timeout: 30
 container:
-  control_method: daos
   cont_prop: !mux
     rf_1:
       properties: rd_fac:1

--- a/src/tests/ftest/rebuild/continues_after_stop.yaml
+++ b/src/tests/ftest/rebuild/continues_after_stop.yaml
@@ -27,7 +27,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 ior:
   flags: -w

--- a/src/tests/ftest/rebuild/mdtest.yaml
+++ b/src/tests/ftest/rebuild/mdtest.yaml
@@ -31,7 +31,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 mpirun:
   args: "--bind-to hwthread --map-by socket"

--- a/src/tests/ftest/rebuild/no_cap.yaml
+++ b/src/tests/ftest/rebuild/no_cap.yaml
@@ -27,7 +27,6 @@ server_config:
       storage: auto
 
 container:
-  control_method: daos
   properties: "rd_fac:1"
 
 pool:

--- a/src/tests/ftest/rebuild/pool_destroy_race.yaml
+++ b/src/tests/ftest/rebuild/pool_destroy_race.yaml
@@ -35,7 +35,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_2GX
 
 ior_write:

--- a/src/tests/ftest/rebuild/widely_striped.yaml
+++ b/src/tests/ftest/rebuild/widely_striped.yaml
@@ -26,7 +26,6 @@ pool:
   properties: rd_fac:2
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_3G1
   properties: rd_fac:2
 mdtest:

--- a/src/tests/ftest/rebuild/with_io.yaml
+++ b/src/tests/ftest/rebuild/with_io.yaml
@@ -19,7 +19,6 @@ pool:
   pool_query_timeout: 30
 container:
   properties: rd_fac:2
-  control_method: daos
   akey_size: 5
   dkey_size: 5
   data_size: 256

--- a/src/tests/ftest/rebuild/with_ior.yaml
+++ b/src/tests/ftest/rebuild/with_ior.yaml
@@ -35,7 +35,6 @@ pool:
 container:
   type: POSIX
   properties: rd_fac:1
-  control_method: daos
 
 ior:
   ior_timeout: 120

--- a/src/tests/ftest/recovery/check_policy.yaml
+++ b/src/tests/ftest/recovery/check_policy.yaml
@@ -18,6 +18,3 @@ server_config:
 
 pool:
   size: 60G
-
-container:
-  control_method: daos

--- a/src/tests/ftest/recovery/check_start_corner_case.yaml
+++ b/src/tests/ftest/recovery/check_start_corner_case.yaml
@@ -22,4 +22,3 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos

--- a/src/tests/ftest/recovery/check_start_options.yaml
+++ b/src/tests/ftest/recovery/check_start_options.yaml
@@ -17,6 +17,3 @@ server_config:
 
 pool:
   size: 60G
-
-container:
-  control_method: daos

--- a/src/tests/ftest/recovery/check_stop.yaml
+++ b/src/tests/ftest/recovery/check_stop.yaml
@@ -22,4 +22,3 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos

--- a/src/tests/ftest/recovery/container_cleanup.yaml
+++ b/src/tests/ftest/recovery/container_cleanup.yaml
@@ -18,4 +18,3 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos

--- a/src/tests/ftest/recovery/container_list_consolidation.yaml
+++ b/src/tests/ftest/recovery/container_list_consolidation.yaml
@@ -18,4 +18,3 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos

--- a/src/tests/ftest/recovery/pool_list_consolidation.yaml
+++ b/src/tests/ftest/recovery/pool_list_consolidation.yaml
@@ -24,6 +24,3 @@ setup:
 
 pool:
   size: 100G
-
-container:
-  control_method: daos

--- a/src/tests/ftest/recovery/pool_membership.yaml
+++ b/src/tests/ftest/recovery/pool_membership.yaml
@@ -22,7 +22,6 @@ pool:
   size: 100G
 
 container:
-  control_method: daos
   type: POSIX
 
 ior:

--- a/src/tests/ftest/scrubber/aggregation.yaml
+++ b/src/tests/ftest/scrubber/aggregation.yaml
@@ -38,7 +38,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   properties: "cksum:sha512,rd_fac:1"
 
 ior: &ior_base

--- a/src/tests/ftest/scrubber/basic.yaml
+++ b/src/tests/ftest/scrubber/basic.yaml
@@ -49,7 +49,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_2G1
   properties: cksum:crc16
 

--- a/src/tests/ftest/scrubber/check_csum_metrics_mdtest.yaml
+++ b/src/tests/ftest/scrubber/check_csum_metrics_mdtest.yaml
@@ -34,7 +34,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_2G1
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
 

--- a/src/tests/ftest/scrubber/csum_fault.yaml
+++ b/src/tests/ftest/scrubber/csum_fault.yaml
@@ -50,7 +50,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_2GX
   properties: "cksum:crc16"
 

--- a/src/tests/ftest/scrubber/frequency.yaml
+++ b/src/tests/ftest/scrubber/frequency.yaml
@@ -38,7 +38,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_2G1
 
 ior:

--- a/src/tests/ftest/scrubber/rebuild.yaml
+++ b/src/tests/ftest/scrubber/rebuild.yaml
@@ -40,7 +40,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_2GX
   properties: "cksum:sha256,rd_fac:1"
 

--- a/src/tests/ftest/scrubber/snapshot.yaml
+++ b/src/tests/ftest/scrubber/snapshot.yaml
@@ -40,7 +40,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_2GX
   properties: "cksum:crc64,rd_fac:1"
 

--- a/src/tests/ftest/scrubber/target_auto_eviction.yaml
+++ b/src/tests/ftest/scrubber/target_auto_eviction.yaml
@@ -50,7 +50,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   oclass: RP_2GX
   properties: "cksum:crc16"
 

--- a/src/tests/ftest/security/cont_acl.yaml
+++ b/src/tests/ftest/security/cont_acl.yaml
@@ -20,8 +20,6 @@ server_config:
   system_ram_reserved: 1
 pool:
   scm_size: 138374182
-container:
-  control_method: daos
 container_acl:
   acl_file_name: cont_test_acl1.txt
   new_user: root

--- a/src/tests/ftest/security/cont_create_acl.yaml
+++ b/src/tests/ftest/security/cont_create_acl.yaml
@@ -17,5 +17,3 @@ server_config:
   system_ram_reserved: 1
 pool:
   scm_size: 1073741824
-container:
-  control_method: daos

--- a/src/tests/ftest/security/cont_delete_acl.yaml
+++ b/src/tests/ftest/security/cont_delete_acl.yaml
@@ -19,7 +19,6 @@ server_config:
 pool:
   scm_size: 2G
 container:
-  control_method: daos
   type: POSIX
 
 invalid_principals:

--- a/src/tests/ftest/security/cont_get_acl.yaml
+++ b/src/tests/ftest/security/cont_get_acl.yaml
@@ -20,7 +20,6 @@ server_config:
 pool:
   scm_size: 2G
 container:
-  control_method: daos
   type: POSIX
 
 valid_out_filename:

--- a/src/tests/ftest/security/cont_overwrite_acl.yaml
+++ b/src/tests/ftest/security/cont_overwrite_acl.yaml
@@ -20,7 +20,6 @@ server_config:
 pool:
   scm_size: 1G
 container:
-  control_method: daos
   type: POSIX
 
 invalid_acl_filename:

--- a/src/tests/ftest/security/cont_owner.yaml
+++ b/src/tests/ftest/security/cont_owner.yaml
@@ -18,5 +18,3 @@ server_config:
   system_ram_reserved: 1
 pool:
   size: 1G
-container:
-  control_method: daos

--- a/src/tests/ftest/security/cont_update_acl.yaml
+++ b/src/tests/ftest/security/cont_update_acl.yaml
@@ -20,7 +20,6 @@ server_config:
 pool:
   scm_size: 1G
 container:
-  control_method: daos
   type: POSIX
 
 invalid_acl_entries:

--- a/src/tests/ftest/security/pool_acl.yaml
+++ b/src/tests/ftest/security/pool_acl.yaml
@@ -27,8 +27,6 @@ server_config:
 # dmg:
 #   transport_config:
 #     allow_insecure: False
-container:
-  control_method: daos
 pool_acl:
   scm_size: 134217728
   user_prefix: daos_ci

--- a/src/tests/ftest/security/pool_groups.yaml
+++ b/src/tests/ftest/security/pool_groups.yaml
@@ -16,8 +16,6 @@ server_config:
           scm_mount: /mnt/daos
           scm_size: 4
   system_ram_reserved: 1
-container:
-  control_method: daos
 pool_acl:
   scm_size: 134217728
   user_prefix: daos_ci

--- a/src/tests/ftest/server/cpu_usage.yaml
+++ b/src/tests/ftest/server/cpu_usage.yaml
@@ -25,6 +25,5 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
 
 usage_limit: 200

--- a/src/tests/ftest/server/daos_server_restart.yaml
+++ b/src/tests/ftest/server/daos_server_restart.yaml
@@ -29,6 +29,3 @@ server:
 
 pool:
   size: 100GB
-
-container:
-  control_method: daos

--- a/src/tests/ftest/server/multiengine_persocket.yaml
+++ b/src/tests/ftest/server/multiengine_persocket.yaml
@@ -88,7 +88,6 @@ pool:
   name: daos_server
 
 container:
-  control_method: daos
   type: POSIX
   properties: rf:0
   num_attributes: 20

--- a/src/tests/ftest/soak/faults.yaml
+++ b/src/tests/ftest/soak/faults.yaml
@@ -43,13 +43,11 @@ pool_reserved:
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
-  control_method: daos
 container_reserved:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
   file_oclass: EC_2P1GX
   dir_oclass: RP_2GX
-  control_method: daos
 faults:
   fault_list:
     # - DAOS_DTX_LOST_RPC_REQUEST

--- a/src/tests/ftest/soak/harassers.yaml
+++ b/src/tests/ftest/soak/harassers.yaml
@@ -49,14 +49,12 @@ pool_reserved:
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
-  control_method: daos
   daos_timeout: 30
 container_reserved:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:2
   file_oclass: EC_2P2GX
   dir_oclass: RP_3GX
-  control_method: daos
   daos_timeout: 30
 # test_params - Defines the type of test to run and how long it runs
 #               It also defines how many pools and jobs to create

--- a/src/tests/ftest/soak/smoke.yaml
+++ b/src/tests/ftest/soak/smoke.yaml
@@ -47,13 +47,11 @@ pool_racer:
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
-  control_method: daos
 container_reserved:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
   file_oclass: EC_2P1GX
   dir_oclass: RP_2GX
-  control_method: daos
 # test_params - Defines the type of test to run and how long it runs
 #               It also defines how many pools and jobs to create
 #               name:                The name of the Avocado testcase

--- a/src/tests/ftest/soak/stress.yaml
+++ b/src/tests/ftest/soak/stress.yaml
@@ -52,13 +52,11 @@ pool_racer:
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
-  control_method: daos
 container_reserved:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
   file_oclass: EC_2P1GX
   dir_oclass: RP_2GX
-  control_method: daos
 # test_params - Defines the type of test to run and how long it runs
 #               It also defines how many pools and jobs to create
 #               name:                The name of the Avocado testcase

--- a/src/tests/ftest/soak/stress_2h.yaml
+++ b/src/tests/ftest/soak/stress_2h.yaml
@@ -38,13 +38,11 @@ pool_reserved:
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
-  control_method: daos
 container_reserved:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
   file_oclass: SX
   dir_oclass: SX
-  control_method: daos
   daos_timeout: 30
 # test_params - Defines the type of test to run and how long it runs
 #               It also defines how many pools and jobs to create

--- a/src/tests/ftest/telemetry/basic_client_telemetry.yaml
+++ b/src/tests/ftest/telemetry/basic_client_telemetry.yaml
@@ -27,7 +27,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   dfs_oclass: SX
 
 ior: &ior_base

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
@@ -18,7 +18,6 @@ pool:
   scm_size: 5G
 container:
   type: POSIX
-  control_method: daos
   replication: !mux
     rf0:
       properties: rd_fac:0

--- a/src/tests/ftest/telemetry/wal_metrics.yaml
+++ b/src/tests/ftest/telemetry/wal_metrics.yaml
@@ -14,7 +14,6 @@ pool:
   size: 40G
 
 container:
-  control_method: daos
   type: POSIX
   dfs_oclass: SX
 

--- a/src/tests/ftest/vmd/fault_reintegration.yaml
+++ b/src/tests/ftest/vmd/fault_reintegration.yaml
@@ -30,7 +30,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:2
   file_oclass: RP_3G1
   dir_oclass: RP_3G1

--- a/src/tests/ftest/vmd/led.yaml
+++ b/src/tests/ftest/vmd/led.yaml
@@ -44,7 +44,6 @@ pool:
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
-  control_method: daos
 
 dfuse:
   disable_caching: True


### PR DESCRIPTION
Remove control_method: daos from test configs since that is the default.

Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
