### PR TITLE
DAOS-19489 test: remove self.add_container* methods (#18846)

### DIFF
--- a/src/tests/ftest/aggregation/multiple_pool_cont.py
+++ b/src/tests/ftest/aggregation/multiple_pool_cont.py
@@ -83,6 +83,7 @@ class DaosAggregationMultiPoolCont(IorTestBase):
         job_manager = get_job_manager(self, subprocess=False, timeout=self.get_remaining_time())
         # Create requested pools
         self.pool = [self.get_pool(connect=False) for _ in range(total_pools)]
+        self.container = []
         start_time = time.time()
         while int(finish_time - start_time) < int(total_runtime):
             # Since the transfer size is 1M, the objects will be inserted
@@ -95,7 +96,8 @@ class DaosAggregationMultiPoolCont(IorTestBase):
                 # Disable the aggregation
                 pool.set_property("reclaim", "disabled")
                 # Create the containers requested per pool
-                self.add_container_qty(total_containers_per_pool, pool)
+                self.container.extend(
+                    self.get_container(pool) for _ in range(total_containers_per_pool))
 
             # Run ior on each container sequentially
             for idx in [1, 2]:

--- a/src/tests/ftest/container/api_basic_attribute.py
+++ b/src/tests/ftest/container/api_basic_attribute.py
@@ -115,7 +115,7 @@ class ContainerAPIBasicAttributeTest(TestWithServers):
         """Prepare variables needed for the tests.
         """
         self.pool = self.get_pool()
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
         self.container.open()
 
         expected_for_param = []

--- a/src/tests/ftest/container/destroy.py
+++ b/src/tests/ftest/container/destroy.py
@@ -66,7 +66,7 @@ class ContainerDestroyTest(TestWithServers):
 
         # Create a pool and a container.
         self.pool = self.get_pool()
-        self.add_container(pool=self.pool)
+        self.container = self.get_container(self.pool)
 
         # Open the container if required
         if open_container:

--- a/src/tests/ftest/container/full_pool_container_create.py
+++ b/src/tests/ftest/container/full_pool_container_create.py
@@ -56,7 +56,7 @@ class FullPoolContainerCreate(TestWithServers):
         self.log.info("%s query data: %s\n", str(self.pool), self.pool.query_data)
 
         # create a container
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
         self.container.open()
 
         # get free space before write

--- a/src/tests/ftest/container/open.py
+++ b/src/tests/ftest/container/open.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -90,7 +91,7 @@ class OpenContainerTest(TestWithServers):
         container_uuids = []
         for _ in range(2):
             self.pool.append(self.get_pool())
-            self.container.append(self.get_container(pool=self.pool[-1]))
+            self.container.append(self.get_container(self.pool[-1]))
             container_uuids.append(uuid.UUID(self.container[-1].uuid))
 
         # Decide which pool handle and container UUID to use. The PASS/FAIL

--- a/src/tests/ftest/container/per_server_fault_domain.py
+++ b/src/tests/ftest/container/per_server_fault_domain.py
@@ -49,7 +49,7 @@ class PerServerFaultDomainTest(IorTestBase):
         # container property.
         if create_pool:
             self.pool = self.get_pool()
-        self.container = self.get_container(pool=self.pool, properties=properties)
+        self.container = self.get_container(self.pool, properties=properties)
 
         # Run IOR to write some data to the container.
         self.ior_cmd.set_daos_params(self.pool, self.container.identifier)

--- a/src/tests/ftest/control/daos_object_query.py
+++ b/src/tests/ftest/control/daos_object_query.py
@@ -49,7 +49,7 @@ class DaosObjectQuery(TestWithServers):
         # Create a pool and a container. Specify --oclass, which will be used
         # when writing object.
         self.pool = self.get_pool()
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
         self.pool.connect()
         self.container.open(pool_handle=self.pool.pool.handle.value)
 

--- a/src/tests/ftest/control/daos_snapshot.py
+++ b/src/tests/ftest/control/daos_snapshot.py
@@ -36,7 +36,7 @@ class DaosSnapshotTest(TestWithServers):
     def prepare_pool_container(self):
         """Create a pool and a container and prepare for the test cases."""
         self.pool = self.get_pool(connect=False)
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
 
     def create_verify_snapshots(self, count):
         """Create and list to verify that the snapshots are created.

--- a/src/tests/ftest/control/dmg_telemetry_io_basic.py
+++ b/src/tests/ftest/control/dmg_telemetry_io_basic.py
@@ -95,7 +95,7 @@ class TestWithTelemetryIOBasic(IorTestBase, TestWithTelemetry):
             TelemetryUtils.ENGINE_IO_OPS_UPDATE_ACTIVE_METRICS
         loop = 0
         self.pool = self.get_pool(connect=False)
-        self.add_container(pool=self.pool)
+        self.container = self.get_container(self.pool)
         metrics_data = {}
         for block_size in block_sizes:
             for transfer_size in transfer_sizes:

--- a/src/tests/ftest/deployment/agent_failure.py
+++ b/src/tests/ftest/deployment/agent_failure.py
@@ -82,7 +82,7 @@ class AgentFailure(IorTestBase):
         """
         # 1. Create a pool and a container.
         self.pool = self.get_pool()
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
 
         # 2. Run IOR.
         ior_results = {}
@@ -175,7 +175,7 @@ class AgentFailure(IorTestBase):
         """
         # 1. Create a pool and a container.
         self.pool = self.get_pool()
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
 
         # Use the last two agent hosts, since the first is likely the test runner node
         agent_hosts = self.agent_managers[0].hosts

--- a/src/tests/ftest/deployment/network_failure.py
+++ b/src/tests/ftest/deployment/network_failure.py
@@ -185,7 +185,7 @@ class NetworkFailureTest(IorTestBase):
         self.container = []
         self.pool = self.get_pool(namespace="/run/pool_size_ratio_80/*")
         self.container.append(
-            self.get_container(pool=self.pool, namespace=container_namespace))
+            self.get_container(self.pool, namespace=container_namespace))
 
         # 2. Take down network interface of one of the engines. Use the first host.
         self.log_step("Take down network interface of one of the engines.")
@@ -250,7 +250,7 @@ class NetworkFailureTest(IorTestBase):
         # 6. To further verify the system, create another container.
         self.log_step("Create another container.")
         self.container.append(
-            self.get_container(pool=self.pool, namespace=container_namespace))
+            self.get_container(self.pool, namespace=container_namespace))
 
         # 7. Run IOR to the new container. Should work.
         self.log_step("Expect IOR to pass on the new container.")
@@ -369,7 +369,7 @@ class NetworkFailureTest(IorTestBase):
         self.log_step("Create a container without redundancy factor.")
         self.container = []
         self.container.append(
-            self.get_container(pool=self.pool, namespace="/run/container_wo_rf/*"))
+            self.get_container(self.pool, namespace="/run/container_wo_rf/*"))
 
         # 4. Take down the interface where the pool isn't created.
         self.log_step("Take down the interface where the pool isn't created.")
@@ -401,7 +401,7 @@ class NetworkFailureTest(IorTestBase):
         # 8. Create a new container on the pool and run IOR.
         self.log_step("Create a new container on the pool")
         self.container.append(
-            self.get_container(pool=self.pool, namespace="/run/container_wo_rf/*"))
+            self.get_container(self.pool, namespace="/run/container_wo_rf/*"))
 
         # Run IOR.
         self.log_step("Run IOR on the new pool/container.")

--- a/src/tests/ftest/deployment/server_rank_failure.py
+++ b/src/tests/ftest/deployment/server_rank_failure.py
@@ -135,7 +135,7 @@ class ServerRankFailure(IorTestBase):
         """
         # 1. Create a pool and a container.
         self.pool = self.get_pool(namespace="/run/pool_size_ratio_80/*")
-        self.add_container(pool=self.pool)
+        self.container = self.get_container(self.pool)
 
         # 2. Run IOR with given object class and let it run through step 7.
         ior_results = {}
@@ -307,7 +307,7 @@ class ServerRankFailure(IorTestBase):
         # 3. Create a container without redundancy factor.
         self.container = []
         self.container.append(
-            self.get_container(pool=self.pool, namespace="/run/container_wo_rf/*"))
+            self.get_container(self.pool, namespace="/run/container_wo_rf/*"))
 
         # 4. Run IOR with oclass SX.
         ior_results = {}
@@ -341,7 +341,7 @@ class ServerRankFailure(IorTestBase):
 
         # 8. Create a new container on the pool and run IOR.
         self.container.append(
-            self.get_container(pool=self.pool, namespace="/run/container_wo_rf/*"))
+            self.get_container(self.pool, namespace="/run/container_wo_rf/*"))
 
         # Run IOR and verify that it works.
         job_num = 2

--- a/src/tests/ftest/deployment/target_failure.py
+++ b/src/tests/ftest/deployment/target_failure.py
@@ -89,7 +89,7 @@ class TargetFailure(IorTestBase):
         """
         # 1. Create a pool and a container.
         self.pool = self.get_pool(namespace="/run/pool_size_ratio_80/*")
-        self.add_container(pool=self.pool, namespace="/run/container_with_rf/*")
+        self.container = self.get_container(self.pool, namespace="/run/container_with_rf/*")
 
         # 2. Run IOR with oclass RP_2G1 or EC_2P1G1.
         ior_results = {}
@@ -162,7 +162,7 @@ class TargetFailure(IorTestBase):
         self.container.destroy()
 
         # 10. Create a new container and run IOR.
-        self.add_container(pool=self.pool, namespace="/run/container_with_rf/*")
+        self.container = self.get_container(self.pool, namespace="/run/container_with_rf/*")
         ior_results = {}
         self.run_ior_report_error(
             job_num=job_num, results=ior_results, file_name="test_file_3", pool=self.pool,
@@ -203,7 +203,7 @@ class TargetFailure(IorTestBase):
         """
         # 1. Create a pool and a container.
         self.pool = self.get_pool(namespace="/run/pool_size_ratio_80/*")
-        self.add_container(pool=self.pool, namespace="/run/container_wo_rf/*")
+        self.container = self.get_container(self.pool, namespace="/run/container_wo_rf/*")
 
         # 2. Run IOR with oclass SX so that excluding one target will result in a failure.
         ior_results = {}
@@ -329,7 +329,7 @@ class TargetFailure(IorTestBase):
         self.pool.append(self.get_pool(namespace="/run/pool_size_ratio_66/*"))
         for idx in range(2):
             self.container.append(
-                self.get_container(pool=self.pool[idx], namespace="/run/container_wo_rf/*"))
+                self.get_container(self.pool[idx], namespace="/run/container_wo_rf/*"))
 
         # 2. Run IOR with oclass SX on all containers at the same time.
         ior_results = {}

--- a/src/tests/ftest/dfuse/posix_stat.py
+++ b/src/tests/ftest/dfuse/posix_stat.py
@@ -40,7 +40,7 @@ class POSIXStatTest(IorTestBase):
         error_list = []
 
         self.pool = self.get_pool(connect=False)
-        self.add_container(pool=self.pool)
+        self.container = self.get_container(self.pool)
 
         idx = 1
         for block_size in block_sizes:

--- a/src/tests/ftest/erasurecode/cell_size_property.py
+++ b/src/tests/ftest/erasurecode/cell_size_property.py
@@ -68,7 +68,7 @@ class EcodCellSizeProperty(IorTestBase):
             # Run IOR for different Transfer size and container cell size.
             for tx_size, cont_cell in product(ior_transfer_sizes, cont_cell_sizes):
                 # Initial container
-                self.add_container(self.pool, create=False)
+                self.container = self.get_container(self.pool, create=False)
 
                 # Use the default pool property for container and do not update
                 if cont_cell != pool_prop_expected:

--- a/src/tests/ftest/io/parallel_io.py
+++ b/src/tests/ftest/io/parallel_io.py
@@ -140,7 +140,7 @@ class ParallelIo(FioBase, IorTestBase):
         start_dfuse(self, dfuse, self.pool[0])
 
         # create multiple containers
-        self.add_container_qty(self.cont_count, self.pool[0])
+        self.container = [self.get_container(self.pool[0]) for _ in range(self.cont_count)]
 
         # check if all the created containers can be accessed and perform
         # io on each container using fio in parallel
@@ -234,8 +234,9 @@ class ParallelIo(FioBase, IorTestBase):
         # different times and get appended in the self.container variable in
         # unordered manner, causing problems during the write process.
         self.log_step("Create 10 containers for each pool.")
+        self.container = []
         for _, pool in enumerate(self.pool):
-            self.add_container_qty(self.cont_count, pool)
+            self.container.extend([self.get_container(pool) for _ in range(self.cont_count)])
 
         # Try to access each dfuse mounted container using ls. Once it is
         # accessed successfully, go ahead and perform io on that location

--- a/src/tests/ftest/nvme/pool_exclude.py
+++ b/src/tests/ftest/nvme/pool_exclude.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -70,7 +70,7 @@ class NvmePoolExclude(OSAUtils):
         thread_queue = Queue()
         for val in range(0, num_pool):
             self.pool = pool[val]
-            self.add_container(self.pool)
+            self.container = self.get_container(self.pool)
             self.cont_list.append(self.container)
             rf = ''.join(self.container.properties.value.split(":"))
             rf_num = int(re.search(r"rd_fac([0-9]+)", rf).group(1))

--- a/src/tests/ftest/pool/destroy.py
+++ b/src/tests/ftest/pool/destroy.py
@@ -543,7 +543,7 @@ class DestroyTests(TestWithServers):
         self.pool = self.get_pool()
 
         # Create pool container
-        self.add_container(pool=self.pool)
+        self.container = self.get_container(self.pool)
 
         # Destroy pool with recursive unset
         self.log.info("Attempting to destroy a pool with containers")
@@ -588,7 +588,7 @@ class DestroyTests(TestWithServers):
         self.pool = self.get_pool()
 
         # Create pool container
-        self.add_container(pool=self.pool)
+        self.container = self.get_container(self.pool)
 
         # Destroy pool with recursive set
         self.log.info("Attempting to recursively destroy a pool with containers")

--- a/src/tests/ftest/pool/pda.py
+++ b/src/tests/ftest/pool/pda.py
@@ -63,7 +63,7 @@ class PoolPDAProperty(TestWithServers):
         self.pool = self.get_pool(namespace="/run/pool_1/*")
 
         # create container with default
-        self.add_container(self.pool, create=True)
+        self.container = self.get_container(self.pool, create=True)
         ec_pda = self.pool.get_property("ec_pda")
         rp_pda = self.pool.get_property("rp_pda")
 
@@ -76,7 +76,7 @@ class PoolPDAProperty(TestWithServers):
         self.container.destroy()
 
         ec_pda, rp_pda = self.params.get("pda_properties", '/run/container_1/*')
-        self.add_container(self.pool, namespace="/run/container_1/*", create=False)
+        self.container = self.get_container(self.pool, namespace="/run/container_1/*", create=False)
         self.container.properties.update("ec_pda:{},rp_pda:{}".format(ec_pda, rp_pda))
 
         # Create the container

--- a/src/tests/ftest/pool/rf.py
+++ b/src/tests/ftest/pool/rf.py
@@ -1,6 +1,6 @@
 '''
   (C) Copyright 2022-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -40,7 +40,7 @@ class PoolRedunFacProperty(IorTestBase):
         """
         for cont_rf in cont_rfs:
             # Create container
-            self.add_container(pool, create=False)
+            self.container = self.get_container(pool, create=False)
 
             # Use the default pool property for container and do not update
             if cont_rf != pool_prop_expected:

--- a/src/tests/ftest/rebuild/no_cap.py
+++ b/src/tests/ftest/rebuild/no_cap.py
@@ -58,7 +58,7 @@ class RbldNoCapacity(TestWithServers):
 
         # Create a pool and container
         self.pool = self.get_pool()
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
         self.container.open()
 
         # make sure pool looks good before we start

--- a/src/tests/ftest/rebuild/widely_striped.py
+++ b/src/tests/ftest/rebuild/widely_striped.py
@@ -70,7 +70,7 @@ class RbldWidelyStriped(MdtestBase):
 
         # create 1st container
         self.log.info(">> Creating the first container")
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
 
         # start 1st mdtest run and let it complete
         self.log.info(">> Running mdtest to completion")
@@ -86,7 +86,7 @@ class RbldWidelyStriped(MdtestBase):
 
         # create 2nd container
         self.log.info(">> Creating the second container")
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
 
         # start 2nd mdtest job in the background
         self.log.info(">> Running the first mdtest job in the background")
@@ -110,7 +110,7 @@ class RbldWidelyStriped(MdtestBase):
 
         # create 3rd container
         self.log.info(">> Creating the third container")
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
 
         # start 3rd mdtest job in the background
         self.log.info(">> Running a second mdtest job in the background")

--- a/src/tests/ftest/rebuild/with_io.py
+++ b/src/tests/ftest/rebuild/with_io.py
@@ -34,7 +34,7 @@ class RbldWithIO(TestWithServers):
         """
         # Get the test params
         self.pool = self.get_pool(create=False)
-        self.add_container(self.pool, create=False)
+        self.container = self.get_container(self.pool, create=False)
         targets = self.server_managers[0].get_config_value("targets")
         # data = self.params.get("datasize", "/run/testparams/*")
         rank = self.params.get("rank", "/run/testparams/*")

--- a/src/tests/ftest/recovery/pool_membership.py
+++ b/src/tests/ftest/recovery/pool_membership.py
@@ -325,7 +325,7 @@ class PoolMembershipTest(IorTestBase):
 
         self.log_step("Create a pool and a container.")
         self.pool = self.get_pool(connect=False)
-        self.container = self.get_container(pool=self.pool)
+        self.container = self.get_container(self.pool)
 
         self.log_step("Write some data with IOR.")
         self.ior_cmd.set_daos_params(self.pool, self.container.identifier)

--- a/src/tests/ftest/scrubber/aggregation.py
+++ b/src/tests/ftest/scrubber/aggregation.py
@@ -35,7 +35,7 @@ class TestScrubberEvictWithAggregation(TestWithScrubber, TestWithTelemetry):
         self.pool = self.get_pool()
         # Disable the aggregation on the pool.
         self.pool.set_property("reclaim", "disabled")
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
         # Pool and Containers are already created. Just run the IOR.
         # Run the initial IOR with a small block size.
         self.ior_cmd.namespace = "/run/ior_small_block_size/*"

--- a/src/tests/ftest/scrubber/basic.py
+++ b/src/tests/ftest/scrubber/basic.py
@@ -57,7 +57,7 @@ class TestWithScrubberBasic(TestWithScrubber):
             if prop_val is not None:
                 value = prop_val.split(":")
                 self.pool.set_property(value[0], value[1])
-        self.add_container(pool=self.pool)
+        self.container = self.get_container(self.pool)
 
         self.run_scrubber_basic()
 
@@ -80,6 +80,6 @@ class TestWithScrubberBasic(TestWithScrubber):
         other_properties = self.params.get("other_properties", '/run/pool/*')
 
         self.pool = self.get_pool(properties=f"{pool_properties},{other_properties}")
-        self.add_container(pool=self.pool)
+        self.container = self.get_container(self.pool)
 
         self.run_scrubber_basic()

--- a/src/tests/ftest/server/multiengine_persocket.py
+++ b/src/tests/ftest/server/multiengine_persocket.py
@@ -226,7 +226,7 @@ class MultiEnginesPerSocketTest(IorTestBase, MdtestBase):
 
         # (6) Container create and attributes test
         self.log_step("Create a container and verify the attributes")
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
         self.container.open()
         attr_dict = self.create_data_set(num_attributes)
         try:

--- a/src/tests/ftest/telemetry/pool_space_metrics.py
+++ b/src/tests/ftest/telemetry/pool_space_metrics.py
@@ -94,7 +94,7 @@ class TelemetryPoolSpaceMetrics(IorTestBase, TestWithTelemetry):
             self.log_step(f"Starting test {test_name} with pool namespace {namespace}")
             self.pool = self.get_pool(namespace=namespace, connect=False)
             self.pool.disable_aggregation()
-            self.container = self.get_container(pool=self.pool)
+            self.container = self.get_container(self.pool)
 
             self.log_step("Run IOR to write data to the container")
             self.update_ior_cmd_with_pool(create_cont=False)

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -140,7 +140,7 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
         # create pool and container
         self.pool = self.get_pool(connect=False)
         self.pool.set_property("reclaim", "disabled")
-        self.add_container(pool=self.pool)
+        self.container = self.get_container(self.pool)
 
         # collect first set of pool metric data before read/write
         metric_names = [

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -1743,50 +1743,6 @@ class TestWithServers(TestWithoutServers):
         """
         return add_container(self, pool, namespace, create, daos, **params)
 
-    def add_container(self, pool, namespace=CONT_NAMESPACE, create=True, daos=None, **params):
-        """Add a container to the test case.
-
-        This method defines the common test container creation sequence.
-
-        Args:
-            pool (TestPool): pool in which to create the container.
-            namespace (str, optional): namespace for TestContainer parameters in the test yaml file.
-                Defaults to CONT_NAMESPACE.
-            create (bool, optional): should the container be created. Defaults to True.
-            daos (DaosCommand, optional): daos command object. Defaults to self.get_daos_command()
-            params (dict): name/value of attributes for which to call update(value, name).
-                See TestContainer for available attributes.
-        """
-        self.container = self.get_container(pool, namespace, create, daos, **params)
-
-    def add_container_qty(self, quantity, pool, namespace=CONT_NAMESPACE, create=True):
-        """Add multiple containers to the test case.
-
-        This method requires self.container to be defined as a list.
-        If self.container is undefined it will define it as a list.
-
-        Args:
-            quantity (int): number of containers to create
-            namespace (str, optional): namespace for TestContainer parameters in the
-                test yaml file. Defaults to None.
-            pool (TestPool): Pool object
-            create (bool, optional): should the container be created. Defaults to
-                True.
-
-        Raises:
-            TestFail: if self.pool is defined, but not as a list object.
-
-        """
-        if self.container is None:
-            self.container = []
-        if not isinstance(self.container, list):
-            self.fail(
-                "add_container_qty(): self.container must be a list: {}".format(
-                    type(self.container)))
-        for _ in range(quantity):
-            self.container.append(
-                self.get_container(pool=pool, namespace=namespace, create=create))
-
     def start_additional_servers(self, additional_servers, index=0, mgmt_svc_replicas=None):
         """Start additional servers.
 

--- a/src/tests/ftest/util/daos_perf_base.py
+++ b/src/tests/ftest/util/daos_perf_base.py
@@ -26,7 +26,7 @@ class DaosPerfBase(TestWithServers):
         # Create pool
         self.pool = self.get_pool(connect=False)
         # Create container
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
         # Obtain the number of processes listed with the daos_perf options
         processes = self.params.get("processes", "/run/daos_perf/*")
         # Use the dmg_control yaml

--- a/src/tests/ftest/util/mpiio_test_base.py
+++ b/src/tests/ftest/util/mpiio_test_base.py
@@ -47,7 +47,7 @@ class MpiioTests(TestWithServers):
         self.pool = self.get_pool(connect=False)
 
         # create container
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
 
         # Pass pool and container information to the commands
         env = EnvironmentVariables()

--- a/src/tests/ftest/util/osa_utils.py
+++ b/src/tests/ftest/util/osa_utils.py
@@ -190,7 +190,7 @@ class OSAUtils(MdtestBase, IorTestBase):
         #                 pool B : containerA, Updated,
         #                          containerB, None]}
         if self.pool_cont_dict[self.pool][0] is None:
-            self.add_container(self.pool, create=False)
+            self.container = self.get_container(self.pool, create=False)
             self.set_cont_class_properties(oclass)
             if self.test_with_checksum is False:
                 tmp = self.get_object_replica_value(oclass)
@@ -205,7 +205,7 @@ class OSAUtils(MdtestBase, IorTestBase):
                     and (self.pool_cont_dict[self.pool][3] is None)
                     and ("-w" in flags)):
                 # Write to the second container
-                self.add_container(self.pool, create=False)
+                self.container = self.get_container(self.pool, create=False)
                 self.set_cont_class_properties(oclass)
                 if self.test_with_checksum is False:
                     tmp = self.get_object_replica_value(oclass)
@@ -438,7 +438,7 @@ class OSAUtils(MdtestBase, IorTestBase):
         self.mdtest_cmd.dfs_destroy.update(False)
         create_container = 0
         if self.container is None:
-            self.add_container(self.pool, create=False)
+            self.container = self.get_container(self.pool, create=False)
             create_container = 1
         self.mdtest_cmd.dfs_oclass.update(oclass)
         self.set_cont_class_properties(oclass)

--- a/src/tests/ftest/util/rebuild_test_base.py
+++ b/src/tests/ftest/util/rebuild_test_base.py
@@ -53,7 +53,7 @@ class RebuildTestBase(TestWithServers):
 
     def setup_test_container(self):
         """Define a TestContainer object."""
-        self.add_container(self.pool, create=False)
+        self.container = self.get_container(self.pool, create=False)
 
     def setup_pool_verify(self):
         """Set up pool verification initial expected values."""

--- a/src/tests/ftest/util/scrubber_test_base.py
+++ b/src/tests/ftest/util/scrubber_test_base.py
@@ -82,7 +82,7 @@ class TestWithScrubber(IorTestBase):
                 self.pool.set_property(value[0], value[1])
         if cont_prop is None:
             cont_prop = "cksum:crc16"
-        self.add_container(pool=self.pool, properties=cont_prop)
+        self.container = self.get_container(self.pool, properties=cont_prop)
 
     def run_ior_and_check_scrubber_status(self, pool, cont):
         """Run IOR and get scrubber metrics

--- a/src/tests/ftest/vmd/fault_reintegration.py
+++ b/src/tests/ftest/vmd/fault_reintegration.py
@@ -128,7 +128,7 @@ class NvmeFaultReintegrate(TestWithServers):
         # 3.
         self.log_step("Creating a pool and container with RF and starting IOR in a thread")
         self.pool = self.get_pool(connect=False)
-        self.add_container(self.pool)
+        self.container = self.get_container(self.pool)
 
         job_manager = get_job_manager(self, subprocess=None, timeout=120)
         thread_queue = Queue()


### PR DESCRIPTION
Replace self.add_container* with self.get_container. Delete self.add_container* definitions.

Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
