### PR TITLE
SRE-3842 build: post-provision diagnostics fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 #!/usr/bin/groovy
+/* groovylint-disable DuplicateListLiteral */
 /* groovylint-disable-next-line LineLength */
 /* groovylint-disable DuplicateMapLiteral, DuplicateNumberLiteral */
 /* groovylint-disable DuplicateStringLiteral, NestedBlockDepth */
@@ -316,7 +317,6 @@ List<String> getStageNameSkipPragmas(String stageName) {
         }
         // Add skip pragma for this stage
         pragmas.add(stagePragma)
-
     } else if (stageName.contains('Hardware')) {
         // Add skip pragma for parent stage
         if (stageName != 'Test Hardware') {
@@ -887,7 +887,7 @@ pipeline {
                                                                 deps_build: false) +
                                                 ' --build-arg DAOS_PACKAGES_BUILD=no ' +
                                                 ' --build-arg DAOS_KEEP_SRC=yes ' +
-                                                " -t ${sanitized_JOB_NAME()}-leap15" + 
+                                                " -t ${sanitized_JOB_NAME()}-leap15" +
                                                 ' --target build-ci' +
                                                 ' --build-arg POINT_RELEASE=.6' +
                                                 " --build-arg PYTHON_VERSION=${env.PYTHON_VERSION}"
@@ -1233,7 +1233,7 @@ pipeline {
                 }
             }
         } // stage('Test')
-        stage('Test Storage Prep on EL 9.7') {
+        stage('Test Storage Prep on EL 9') {
             when {
                 beforeAgent true
                 expression { params.CI_STORAGE_PREP_LABEL != '' }
@@ -1375,6 +1375,11 @@ pipeline {
         }
         unsuccessful {
             notifyBrokenBranch branches: target_branch
+        }
+        cleanup {
+            // Need to clean the workspace to reduce disk space usage on
+            // Jenkins build agents
+            cleanWs()
         }
     } // post
 }

--- a/ci/functional/test_main.sh
+++ b/ci/functional/test_main.sh
@@ -27,11 +27,21 @@ first_node=${NODELIST%%,*}
 hardware_ok=false
 
 cluster_reboot () {
-    # shellcheck disable=SC2029,SC2089
-    clush -B -S -o '-i ci_key' -l root -w "${tnodes}" reboot || true
+    if [ -z "$tnodes" ]; then
+        echo "ERROR: cluster_reboot called without reboot targets"
+        return 1
+    fi
+
+    if [ "$tnodes" = "localhost" ]; then
+        echo "WARNING: localhost is the only reboot target; skipping reboot"
+        return 0
+    fi
 
     # shellcheck disable=SC2029,SC2089
-    poll_cmd=( clush -B -S -o "-i ci_key" -l root -w "${tnodes}" )
+    clush -B -S -o '-i ci_key' -l root -w "$tnodes" reboot || true
+
+    # shellcheck disable=SC2029,SC2089
+    poll_cmd=( clush -B -S -o "-i ci_key" -l root -w "$tnodes" )
     poll_cmd+=( cat /etc/os-release )
     # 20 minutes, HPE systems may take more than 15 minutes.
     reboot_timeout=1200
@@ -99,8 +109,15 @@ trap 'clush -B -S -o "-i ci_key" -l root -w "${tnodes}" '\
 # Setup the Jenkins build artifacts directory before running the tests to ensure
 # there is enough disk space to report the results.
 # Even though STAGE_NAME forced to be set, shellcheck wants this syntax.
-rm -rf "${STAGE_NAME:?ERROR: STAGE_NAME is not defined}/"
-mkdir "${STAGE_NAME:?ERROR: STAGE_NAME is not defined}/"
+mkdir -p "${STAGE_NAME:?ERROR: STAGE_NAME is not defined}/"
+stage_dir="${STAGE_NAME:?ERROR: STAGE_NAME is not defined}/"
+
+find "$stage_dir" -mindepth 1 -maxdepth 2 \
+    ! -wholename "*/framework/*.xml" \
+    ! -name "framework" \
+    -exec rm -rf {} +
+# The framework directory holds JUnit results from the post-provisioning script
+# and must be preserved when the workspace is reused across stages.
 
 # set DAOS_TARGET_OVERSUBSCRIBE env here
 export DAOS_TARGET_OVERSUBSCRIBE=1
@@ -136,4 +153,5 @@ for node in ${tnodes//,/ }; do
         mv "$old_name" "$new_name"
     fi
 done
+
 "$hardware_ok"

--- a/ci/functional/test_main_prep_node.sh
+++ b/ci/functional/test_main_prep_node.sh
@@ -205,6 +205,138 @@ function check_ib_devices {
     done
 }
 
+function apply_network_alias_rules {
+    local query_script="/var/tmp/query_node_interfaces.sh"
+    local alias_csv="/var/tmp/daos_ftest_iface_aliases.csv"
+    local rules_file="/etc/udev/rules.d/99-daos-interface-alias.rules"
+    local tmp_rules_file
+    local iface_data
+    local letters="abcdefghijklmnopqrstuvwxyz"
+    local net_index=0
+    local ib_index=0
+    local node_num
+
+    declare -A subnet_label_map
+    declare -A subnet_iface_count
+    declare -A numa_seen
+
+    if [ ! -f "$query_script" ]; then
+        echo "ERROR: Missing $query_script"
+        return 1
+    fi
+
+    if [ ! -x "$query_script" ]; then
+        if ! chmod +x "$query_script"; then
+            echo "ERROR: Failed to make $query_script executable"
+            return 1
+        fi
+    fi
+
+    iface_data="$($query_script 2>/dev/null || true)"
+    if [ -z "$iface_data" ]; then
+        echo "ERROR: Empty interface data from $query_script"
+        return 1
+    fi
+
+    if ! node_num=$(printf "%03d" "$mynodenum"); then
+        node_num="000"
+    fi
+
+    while IFS='|' read -r _ip _iface iface_type subnet _numa _mac; do
+        [ -n "$iface_type" ] || continue
+        [ "$iface_type" = "primary" ] && continue
+        [ -n "$subnet" ] || continue
+        key="$iface_type|$subnet"
+        [ -z "${subnet_label_map[$key]:-}" ] || continue
+        if [ "$iface_type" = "private" ]; then
+            subnet_label_map[$key]="${letters:$net_index:1}"
+            net_index=$((net_index + 1))
+        elif [ "$iface_type" = "infiniband" ]; then
+            subnet_label_map[$key]="${letters:$ib_index:1}"
+            ib_index=$((ib_index + 1))
+        fi
+    done <<< "$(printf "%s\n" "$iface_data" | sort -t'|' -k3,3 -k4,4)"
+
+    while IFS='|' read -r _ip _iface iface_type subnet _numa _mac; do
+        [ -n "$iface_type" ] || continue
+        [ "$iface_type" = "primary" ] && continue
+        group="$iface_type|$subnet"
+        subnet_iface_count[$group]=$(( ${subnet_iface_count[$group]:-0} + 1 ))
+    done <<< "$iface_data"
+
+    tmp_rules_file=$(mktemp)
+    echo "# Managed by ci/functional/test_main_prep_node.sh" > "$tmp_rules_file"
+    echo "# Persistent DAOS interface aliases" >> "$tmp_rules_file"
+    echo "node,node_num,ip,iface,type,subnet,numa,mac,alias" > "$alias_csv"
+
+    while IFS='|' read -r ip iface iface_type subnet numa mac; do
+        [ -n "$ip" ] || continue
+        alias_name=""
+
+        if [ "$iface_type" = "primary" ]; then
+            alias_name="e_daos_mgmt"
+        else
+            key="$iface_type|$subnet"
+            letter="${subnet_label_map[$key]:-a}"
+            group="$iface_type|$subnet"
+            group_count="${subnet_iface_count[$group]:-1}"
+            suffix="00"
+
+            if [ "$group_count" -gt 1 ]; then
+                numa_digit="$numa"
+                if [ -z "$numa_digit" ] || [ "$numa_digit" -lt 0 ]; then
+                    numa_digit=0
+                fi
+                idx_key="$group|$numa_digit"
+                idx="${numa_seen[$idx_key]:-0}"
+                suffix="${numa_digit}${idx}"
+                numa_seen[$idx_key]=$((idx + 1))
+            fi
+
+            if [ "$iface_type" = "private" ]; then
+                alias_name="e_daos_net_${letter}_${suffix}"
+            elif [ "$iface_type" = "infiniband" ]; then
+                alias_name="ib_daos_${letter}_${suffix}"
+            fi
+        fi
+
+        [ -n "$alias_name" ] || continue
+
+        if ! ip -d link show dev "$iface" |
+             grep -q " altname $alias_name"; then
+            if ! ip link property add dev "$iface" altname "$alias_name"; then
+                echo "ERROR: Failed to add altname $alias_name to $iface"
+                return 1
+            fi
+        fi
+
+        echo "${HOSTNAME%%.*},$node_num,$ip,$iface,$iface_type,$subnet,$numa,$mac,$alias_name" \
+            >> "$alias_csv"
+
+        if [ -n "$mac" ]; then
+            rule="SUBSYSTEM==\"net\", ACTION==\"add\", "
+            rule+="ATTR{address}==\"$mac\", NAME=\"$alias_name\""
+            echo "$rule" >> "$tmp_rules_file"
+        fi
+    done <<< "$(printf "%s\n" "$iface_data" |
+              sort -t'|' -k3,3 -k4,4 -k5,5n -k6,6)"
+
+    if ! cp "$tmp_rules_file" "$rules_file"; then
+        rm -f "$tmp_rules_file"
+        echo "ERROR: Failed to install $rules_file"
+        return 1
+    fi
+    rm -f "$tmp_rules_file"
+
+    if ! udevadm control --reload-rules; then
+        echo "ERROR: Failed to reload udev rules for interface aliases"
+        return 1
+    fi
+
+    echo "Updated interface alias rules in $rules_file"
+    return 0
+}
+
 # First check for InfiniBand devices
 if [ "$ib_count" -gt 0 ]; then
     if do_wait_for_ib; then
@@ -216,6 +348,8 @@ if [ "$ib_count" -gt 0 ]; then
         check_ib_devices "${ib_list[@]}"
     fi
 fi
+
+apply_network_alias_rules
 
 # having -x just makes the console log harder to read.
 # set +x
@@ -329,7 +463,10 @@ fi
 # Additional information if any check failed
 if [ "$result" -ne 0 ]; then
     sys_message="$({
-        ls -l /etc/sysconfig/network-scripts/ifcfg-* || true
+        find /etc -name 'ifcfg-*' -type f -print -exec ls -l {} \; || true
+        if command -v nmcli >/dev/null 2>&1; then  # New RHEL
+            nmcli connection show || true
+        fi
         ip link show|| true
         systemctl status || true
         systemctl --failed || true
@@ -367,8 +504,8 @@ fi
 # testsuite name, in which case the package name is the part before
 # the last dot in the testsuite name.
 pn="Hardware"
-tf="failures=\"$testfails\""
-te="errors=\"0\""
+tf="failures=\"0\""
+te="errors=\"$testfails\""
 tc="tests=\"$testruns\""
 
 junit_xml="<testsuite name=\"${pn}.${cn}\" skipped=\"0\" $tf $te $tc>$nl

--- a/ci/gha_functions.sh
+++ b/ci/gha_functions.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+#
+#  Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
 # TODO: this should produce a JUnit result
 error_exit() {
     echo "$1"

--- a/ci/junit.sh
+++ b/ci/junit.sh
@@ -1,50 +1,303 @@
 #!/bin/bash
 
+#
+#  Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
 set -eux
+
+: "${STAGE_NAME:=junit_file_create}"
+
+junit_results_file() {
+    echo "${JUNIT_RESULTS_FILE:-results.xml}"
+}
+
+junit_sanitized_stage() {
+    local stage="${STAGE_NAME}"
+
+    stage="$(echo "$stage" | sed 's/[^a-zA-Z0-9_]/_/g' | sed 's/__*/_/g')"
+    echo "${stage:-unknown_stage}"
+}
+
+junit_classname() {
+    # Keep package stable and class readable for Jenkins views.
+    echo "infrastructure.$(junit_sanitized_stage)"
+}
 
 junit_result() {
     local name="$1"
     local msg="$2"
-    local stacktrace="${3:-$(stacktrace "Called from" 1)}"
+    local stacktrace="${3:-}"
+    local classname
+    classname="$(junit_classname)"
+    if [ -z "$stacktrace" ] && declare -F stacktrace > /dev/null; then
+        stacktrace="$(stacktrace "Called from" 1 || true)"
+    fi
 
     echo -e "$msg"
 
-    cat <<EOF > results.xml
-  <testcase classname="$HOSTNAME" name="$name" time="0">
-    <failure message="$msg" type="TestFail"><![CDATA[$stacktrace]]></failure>
+    cat <<EOF > "$(junit_results_file)"
+    <testcase classname="$classname" name="$name" time="0">
+        <error message="$msg" type="InfrastructureError">
+            <![CDATA[$stacktrace]]>
+        </error>
   </testcase>
 EOF
+}
+
+junit_pass_result() {
+    local name="$1"
+    local msg="${2:-success}"
+        local classname
+        classname="$(junit_classname)"
+
+    echo -e "$msg"
+
+        cat <<EOF > "$(junit_results_file)"
+    <testcase classname="$classname" name="$name" time="0">
+    <system-out><![CDATA[$msg]]></system-out>
+  </testcase>
+EOF
+}
+
+junit_on_error() {
+    local rc="${1:-1}"
+
+    # Prevent recursive ERR trap loops while collecting error diagnostics.
+    trap - ERR
+    set +e
+
+    local step="${DAOS_FAILURE_STEP:-unknown}"
+    local cmd="${BASH_COMMAND:-unknown}"
+    local msg="Unhandled error in ${STAGE_NAME} step=${step} rc=${rc}"
+    local test_name="${JUNIT_TESTCASE_NAME:-UnhandledError}"
+    local trace
+
+    trace="Failing command: ${cmd}"
+    if declare -F stacktrace > /dev/null; then
+        trace+=$'\n'
+        trace+="$(stacktrace "Called from" 1 || true)"
+    fi
+
+    junit_result "$test_name" "$msg" "$trace" || true
+}
+
+expand_junit_nodes() {
+    local nodes="$1"
+    local expanded=""
+
+    if command -v nodeset > /dev/null 2>&1; then
+        expanded="$(nodeset -e "$nodes" 2>/dev/null || true)"
+    fi
+
+    if [ -n "$expanded" ]; then
+        tr ' ' '\n' <<< "$expanded" | sed '/^$/d'
+        return
+    fi
+
+    tr ',' '\n' <<< "$nodes" | sed '/^$/d'
+}
+
+compute_node_position() {
+    local nodelist="$1"
+    local target_node="$2"
+    local pos=0
+
+    for node in ${nodelist//,/ }; do
+        ((pos++)) || true
+        if [ "$node" = "$target_node" ]; then
+            echo "$pos"
+            return 0
+        fi
+    done
+    echo "0"
+    return 1
+}
+
+count_xml_tag() {
+    local tag="$1"
+    shift
+
+    # grep exits 1 on no matches; force a zero count instead of
+    # triggering ERR trap.
+    (grep -Eho "<${tag}([[:space:]>])" "$@" || true) | wc -l
 }
 
 report_junit() {
     local name="$1"
     local results="$2"
     local nodes="$3"
-
-    clush -o '-i ci_key' -l root -w "$nodes" --rcopy "$results"
+    local node_results_root="${JUNIT_NODE_RESULTS_ROOT:-}"
+    local node_results_prefix="${JUNIT_NODE_RESULTS_NODE_PREFIX:-}"
+    local rcopy_rc=0
+    local artifacts_rc=0
+    local missing_results=0
+    local tests=0
+    local failures=0
+    local errors=0
+    local skipped=0
 
     local results_files
+    local expected_nodes
+    local node
+    local short_node
+    local file
+    local result_node
+    local existing_node_results=0
+    local class_name
+    local test_name_base
+    local node_dir
+    local node_file
+    local copied_node_results=0
+
+    class_name="$(junit_classname)"
+    test_name_base="${JUNIT_TESTCASE_BASE:-$name}"
+
+    # Capture clush return code while preserving failure for set -e.
+    # With set -e, we use || to capture $? immediately after the command fails.
+    clush -o '-i ci_key' -l root -w "$nodes" --rcopy "$results" || rcopy_rc=$?
+    if [ $rcopy_rc -ne 0 ]; then
+        echo "ERROR: Failed to copy $results from nodes=$nodes rc=$rcopy_rc"
+    fi
+
     readarray -t results_files < <(find . -maxdepth 1 -name "$results.*")
+    readarray -t expected_nodes < <(expand_junit_nodes "$nodes")
+
+    declare -A node_has_result=()
+    for file in "${results_files[@]}"; do
+        result_node="$(basename "$file")"
+        result_node="${result_node#"$results."}"
+        node_has_result["$result_node"]=1
+        node_has_result["${result_node%%.*}"]=1
+    done
+
+    local node_pos=0
+    for node in "${expected_nodes[@]}"; do
+        ((node_pos++)) || true
+        short_node="${node%%.*}"
+        if [ -n "${node_has_result[$node]:-}" ] || [ -n "${node_has_result[$short_node]:-}" ]; then
+            ((existing_node_results++)) || true
+            continue
+        fi
+
+        missing_results=1
+        file="./${results}.${node}"
+        cat <<EOF > "$file"
+    <testcase classname="$class_name" name="$test_name_base Node $node_pos" time="0">
+    <error message="Missing node JUnit results" type="InfrastructureError"><![CDATA[Unable to retrieve $results from node=$node]]></error>
+  </testcase>
+EOF
+        results_files+=("$file")
+    done
 
     if [ ${#results_files[@]} -eq 0 ]; then
-        echo "No results found to report as JUnit results"
-        ls -l
-        return
+        missing_results=1
+        file="./${results}.unknown"
+        cat <<EOF > "$file"
+    <testcase classname="$class_name" name="$test_name_base" time="0">
+    <error message="No JUnit results were generated" type="InfrastructureError"><![CDATA[nodes=${nodes} results=${results}]]></error>
+  </testcase>
+EOF
+        results_files+=("$file")
+    fi
+
+    if [ -n "$node_results_root" ]; then
+        mkdir -p "$node_results_root"
+        for node in "${expected_nodes[@]}"; do
+            short_node="${node%%.*}"
+            node_file=""
+            for file in "${results_files[@]}"; do
+                result_node="$(basename "$file")"
+                result_node="${result_node#"$results."}"
+                if [ "$result_node" = "$node" ] ||
+                   [ "$result_node" = "$short_node" ] ||
+                   [ "${result_node%%.*}" = "$short_node" ]; then
+                    node_file="$file"
+                    break
+                fi
+            done
+            if [ -z "$node_file" ]; then
+                continue
+            fi
+            node_dir="$node_results_root/${node_results_prefix}${node}"
+            mkdir -p "$node_dir"
+            cp "$node_file" "$node_dir/results.xml"
+            ((copied_node_results++)) || true
+        done
+
+        # Fallback: if expected node expansion did not match copied files,
+        # export directly from collected results fragments.
+        if [ "$copied_node_results" -eq 0 ]; then
+            for file in "${results_files[@]}"; do
+                result_node="$(basename "$file")"
+                result_node="${result_node#"$results."}"
+                [ -n "$result_node" ] || result_node="unknown"
+                node_dir="$node_results_root/"
+                node_dir+="${node_results_prefix}${result_node}"
+                mkdir -p "$node_dir"
+                cp "$file" "$node_dir/results.xml"
+            done
+        fi
+    fi
+
+    tests=$(count_xml_tag testcase "${results_files[@]}")
+    failures=$(count_xml_tag failure "${results_files[@]}")
+    errors=$(count_xml_tag error "${results_files[@]}")
+    skipped=$(count_xml_tag skipped "${results_files[@]}")
+
+    if [ "$tests" -eq 0 ]; then
+        tests=${#expected_nodes[@]}
+        if [ "$tests" -eq 0 ]; then
+            tests=${#results_files[@]}
+        fi
     fi
 
     mkdir -p "$STAGE_NAME"/framework/
 
     cat <<EOF > "$STAGE_NAME"/framework/framework_results.xml
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite errors="${#results_files[@]}" failures="0" name="$name" skipped="0"
-           tests="${#results_files[@]}" time="0" timestamp="$(date +%FT%T)">
+<testsuite errors="$errors" failures="$failures" name="$name" skipped="$skipped"
+           tests="$tests" time="0" timestamp="$(date +%FT%T)">
 $(cat "${results_files[@]}")
 </testsuite>
 EOF
 
-    clush -o '-i ci_key' -l root -w "$nodes" --rcopy /var/tmp/artifacts \
-                                             --dest "$STAGE_NAME"/framework/
+    # Compatibility output for publishers that glob only */results.xml.
+    cp "$STAGE_NAME"/framework/framework_results.xml \
+       "$STAGE_NAME"/framework/results.xml
 
+    # Capture clush return code while preserving failure for set -e.
+    # With set -e, we use || to capture $? immediately after the command fails.
+    clush -o '-i ci_key' -l root -w "$nodes" --rcopy /var/tmp/artifacts \
+                       --dest "$STAGE_NAME"/framework/ || artifacts_rc=$?
+    if [ $artifacts_rc -ne 0 ]; then
+        echo "WARNING: Failed to copy /var/tmp/artifacts from nodes=$nodes rc=$artifacts_rc"
+    fi
+
+    # Send mail notification for infrastructure errors
+    if [ "$rcopy_rc" -ne 0 ] || [ "$missing_results" -ne 0 ]; then
+        local mail_msg="Infrastructure error in ${STAGE_NAME}\n"
+        if [ "$rcopy_rc" -ne 0 ]; then
+            mail_msg+="Failed to copy results from nodes. rc=$rcopy_rc\n"
+        fi
+        if [ "$missing_results" -ne 0 ]; then
+            mail_msg+="Missing or incomplete JUnit results: $results\n"
+            mail_msg+="Nodes: $nodes\n"
+            mail_msg+="Results collected from $existing_node_results of ${#expected_nodes[@]} nodes\n"
+        fi
+        mail_msg+="See Jenkins console: ${BUILD_URL:-}\n"
+        if declare -F send_mail > /dev/null; then
+            send_mail "Infrastructure error in $STAGE_NAME" "$mail_msg" || true
+        fi
+    fi
+
+    if [ "$rcopy_rc" -ne 0 ]; then
+        return 1
+    fi
+
+    return 0
 }
 
 # create this dir so that the remote copy doesn't fail if nothing actually populates it
@@ -54,4 +307,4 @@ mkdir -p /var/tmp/artifacts
 set -E
 
 # set an error trap to create a junit result for any unhandled error
-trap 'junit_result "UnhandledError" "Unhandled error in ${STAGE_NAME} Post Restore Script step"' ERR
+trap 'junit_on_error $?' ERR

--- a/ci/provisioning/post_provision_config.sh
+++ b/ci/provisioning/post_provision_config.sh
@@ -23,6 +23,8 @@ EOF
 # shellcheck disable=SC1091
 source ci/provisioning/post_provision_config_common_functions.sh
 # shellcheck disable=SC1091
+source ci/stacktrace.sh
+# shellcheck disable=SC1091
 source ci/junit.sh
 
 # This script needs to be able to run outside of CI for testing.
@@ -64,6 +66,7 @@ FAMILY="${DISTRO%%_*}"
 # NODELIST is all the nodes in a CI cluster comma separated - do not use here.
 # NODESTRING is only the nodes in the requested CI cluster.
 : "${NODESTRING:=localhost}"
+ORDERED_NODES="$NODESTRING"
 
 : "${COMMIT_MESSAGE:=$(git log -1 --pretty=%B)}"
 : "${ARTIFACTORY_URL:=}"
@@ -71,49 +74,143 @@ FAMILY="${DISTRO%%_*}"
 if [ -n "$ARTIFACTORY_URL" ] && [ -z "$REPO_FILE_URL" ]; then
     REPO_FILE_URL="$ARTIFACTORY_URL/repo-files/"
 fi
+# This is an NFS share for looking up current test information.
+: "${DAOS_CI_INFO_DIR:=}"
+: "${JUNIT_NODE_RESULTS_ROOT:=${STAGE_NAME}/hardware_prep}"
+: "${JUNIT_NODE_RESULTS_NODE_PREFIX:=post_provision_}"
 
 # CI user can be any user that is not expected to be on the test systems.
 : "${CI_USER:=jenkins}"
 
+: "${DAOS_FAILURE_STEP:=startup}"
+
+DAOS_FAILURE_STEP="copy_ci_keys"
 retry_cmd 300 clush -B -S -l root -w "$NODESTRING" -c ci_key* --dest=/tmp/
 
-function create_host_file() {
-        local node_string="$1"
-        local output_file="${2:-./hosts}"
-        local input_file="${3:-}"
-        rm -rf "$output_file" 2>/dev/null
-        if [ -n "$input_file" ]; then
-                cp "$input_file" "$output_file"
-        fi
-        IFS=',' read -ra NODES <<< "$node_string"
-        for node in "${NODES[@]}"; do
-                ip_address=$(nslookup "$node" 2>/dev/null | awk '/^Address: / {print $2}' | head -n 1)
-                long_name=$(nslookup "$node" 2>/dev/null | awk '/^Name:/ {print $2}' | head -n 1)
-                if [ -n "$ip_address" ] && [ -n "$long_name" ]; then
-                        echo "$ip_address $long_name $node" >> "$output_file"
-                else
-                        echo "ERROR: Could not resolve $node"
-                        return 1
-                fi
-        done
+DAOS_FAILURE_STEP="copy_query_node_interfaces"
+retry_cmd 300 clush -B -S -l root -w "$NODESTRING" \
+                    -c ci/provisioning/query_node_interfaces.sh --dest=/var/tmp/
+retry_cmd 300 clush -B -S -l root -w "$NODESTRING" \
+                    chmod +x /var/tmp/query_node_interfaces.sh
+
+function resolve_host_ip() {
+    local hostname="$1"
+
+    if command -v getent >/dev/null 2>&1; then
+        getent ahostsv4 "$hostname" | awk 'NF { print $1; exit }'
         return 0
+    fi
+
+    if command -v dig >/dev/null 2>&1; then
+        dig +short A "$hostname" | awk 'NF { print; exit }'
+        return 0
+    fi
+
+    return 1
+}
+
+function create_host_file() {
+    local node_string="$1"
+    local output_file="${2:-./hosts}"
+    local NODES
+
+    rm -rf "$output_file" 2>/dev/null
+
+    # Parse node list as comma-separated hostnames in preserved cluster order.
+    if ! IFS=',' read -ra NODES <<< "$node_string"; then
+        echo "ERROR: Failed to parse node string: $node_string"
+        return "$ERROR_FATAL"
+    fi
+
+    local node_index=0
+    for node in "${NODES[@]}"; do
+        node_index=$((node_index + 1))
+        local node_num
+        if ! node_num=$(printf "%03d" "$node_index"); then
+            echo "ERROR: Failed to format node index '$node_index'"
+            return "$ERROR_FATAL"
+        fi
+
+        local node_ip
+        node_ip=$(resolve_host_ip "$node" 2>/dev/null || true)
+        if [ -z "$node_ip" ]; then
+            echo "ERROR: Could not resolve host '$node'"
+            return "$ERROR_FATAL"
+        fi
+
+        local short_node
+        short_node="${node%%.*}"
+        if [ "$short_node" = "$node" ]; then
+            echo "$node_ip $node test-$node_num" >> "$output_file"
+        else
+            echo "$node_ip $node $short_node test-$node_num" >> "$output_file"
+        fi
+    done
+
+    # Resolve REPOSITORY_URL and ARTIFACTORY_URL
+    local repo_host
+    local artifactory_host
+
+    if [ -n "${REPOSITORY_URL:-}" ]; then
+        repo_host=$(echo "$REPOSITORY_URL" | sed -E 's|^[^:]+://([^/]+).*|\1|')
+        local repo_ip
+        repo_ip=$(resolve_host_ip "$repo_host" 2>/dev/null || true)
+        if [ -n "$repo_ip" ]; then
+            echo "$repo_ip $repo_host" >> "$output_file"
+        fi
+    fi
+
+    if [ -n "${ARTIFACTORY_URL:-}" ]; then
+        artifactory_host=$(echo "$ARTIFACTORY_URL" |
+            sed -E 's|^[^:]+://([^/]+).*|\1|')
+        local artifactory_ip
+        artifactory_ip=$(
+            resolve_host_ip "$artifactory_host" 2>/dev/null || true)
+        if [ -n "$artifactory_ip" ]; then
+            echo "$artifactory_ip $artifactory_host" >> "$output_file"
+        fi
+    fi
+
+    return 0
 }
 
 if [ "$NODESTRING" != "localhost" ]; then
-    if create_host_file "$NODESTRING" "./hosts" "/etc/hosts"; then
-        retry_cmd 300 clush -B -S -l root -w "$NODESTRING" \
-                            -c ./hosts --dest=/etc/hosts
-    else
+    DAOS_FAILURE_STEP="update_hosts_file"
+    if ! create_host_file "$ORDERED_NODES" "./hosts"; then
+        # Fatal error - exit immediately
         echo "ERROR: Failed to create host file"
+        exit "$ERROR_FATAL"
     fi
+    # Distribute generated hosts block and merge with stock /etc/hosts.
+    retry_cmd 300 clush -B -S -l root -w "$NODESTRING" \
+                        -c ci/provisioning/update_daos_hosts_block.sh \
+                        --dest=/var/tmp/
+    retry_cmd 300 clush -B -S -l root -w "$NODESTRING" \
+                        chmod +x /var/tmp/update_daos_hosts_block.sh
+    retry_cmd 300 clush -B -S -l root -w "$NODESTRING" \
+                        -c ./hosts --dest=/var/tmp/daos_hosts.generated
+    update_hosts_cmd="/var/tmp/update_daos_hosts_block.sh"
+    update_hosts_cmd+=" /var/tmp/daos_hosts.generated"
+    retry_cmd 300 clush -B -S -l root -w "$NODESTRING" \
+                        "$update_hosts_cmd"
 fi
 
 
-# shellcheck disable=SC2001
-sanitized_commit_message="$(echo "$COMMIT_MESSAGE" | sed -e 's/\(["\$]\)/\\\1/g')"
+sanitized_commit_message="${COMMIT_MESSAGE//\"/\\\"}"
+sanitized_commit_message="${sanitized_commit_message//\$/\\\$}"
 
-if ! retry_cmd 2400 clush -B -S -l root -w "$NODESTRING" \
-           "export PS4='$PS4'
+build_remote_post_provision_payload() {
+    local script_path
+    local remote_script_files=(
+        "ci/stacktrace.sh"
+        "ci/junit.sh"
+        "ci/provisioning/post_provision_config_common_functions.sh"
+        "ci/provisioning/post_provision_config_common.sh"
+        "ci/provisioning/post_provision_config_nodes_${FAMILY}.sh"
+        "ci/provisioning/post_provision_config_nodes.sh"
+    )
+
+    REMOTE_POST_PROVISION_PAYLOAD="export PS4='$PS4'
            MY_UID=$(id -u)
            CI_USER=\"${CI_USER}\"
            CONFIG_POWER_ONLY=${CONFIG_POWER_ONLY:-}
@@ -129,6 +226,8 @@ if ! retry_cmd 2400 clush -B -S -l root -w "$NODESTRING" \
            BUILD_URL=\"${BUILD_URL:-}\"
            STAGE_NAME=\"${STAGE_NAME:-}\"
            OPERATIONS_EMAIL=\"${OPERATIONS_EMAIL:-}\"
+           DAOS_SMTP_RELAY=\"${DAOS_SMTP_RELAY:-}\"
+           NODELIST=\"${ORDERED_NODES:-}\"
            COMMIT_MESSAGE=\"$sanitized_commit_message\"
            REPO_FILE_URL=\"$REPO_FILE_URL\"
            ARTIFACTORY_URL=\"${ARTIFACTORY_URL}\"
@@ -140,23 +239,55 @@ if ! retry_cmd 2400 clush -B -S -l root -w "$NODESTRING" \
            REPO_PATH=\"${REPO_PATH:-}\"
            ARTIFACTS_URL=\"${ARTIFACTS_URL:-}\"
            COVFN_DISABLED=\"${COVFN_DISABLED:-true}\"
-           DAOS_CI_INFO_DIR=\"${DAOS_CI_INFO_DIR:?DAOS_CI_INFO_DIR is missing. Can not continue with node(s) provisioning process}\"
+           DAOS_CI_INFO_DIR=\"${DAOS_CI_INFO_DIR}\"
            CI_SCONS_ARGS=\"${CI_SCONS_ARGS:-}\"
-           PYTHON_VERSION=\"${PYTHON_VERSION}\"
-           $(cat ci/stacktrace.sh)
-           $(cat ci/junit.sh)
-           $(cat ci/provisioning/post_provision_config_common_functions.sh)
-           $(cat ci/provisioning/post_provision_config_common.sh)
-           $(cat ci/provisioning/post_provision_config_nodes_"$FAMILY".sh)
-           $(cat ci/provisioning/post_provision_config_nodes.sh)"; then
-    report_junit post_provision_config.sh results.xml "$NODESTRING"
+           PYTHON_VERSION=\"${PYTHON_VERSION}\""
+
+    for script_path in "${remote_script_files[@]}"; do
+        if [ ! -r "$script_path" ]; then
+            echo "ERROR: Missing remote payload file: $script_path"
+            return 2
+        fi
+        if ! bash -n "$script_path"; then
+            echo "ERROR: Syntax check failed for remote payload file: $script_path"
+            return 2
+        fi
+        REMOTE_POST_PROVISION_PAYLOAD+=$'\n'
+        REMOTE_POST_PROVISION_PAYLOAD+="$(<"$script_path")"
+    done
+
+    return 0
+}
+
+DAOS_FAILURE_STEP="remote_payload_build"
+if ! build_remote_post_provision_payload; then
+    junit_result "remote_payload_build" "Failed to build remote post-provision payload"
+    report_junit post_provision_config.sh \
+                 post_provision_results.xml "$ORDERED_NODES" || true
     exit 1
 fi
 
+DAOS_FAILURE_STEP="remote_post_provision"
+if ! retry_cmd 2400 clush -B -S -l root -w "$NODESTRING" \
+           "$REMOTE_POST_PROVISION_PAYLOAD"; then
+    report_junit post_provision_config.sh \
+                 post_provision_results.xml "$ORDERED_NODES"
+    exit 1
+fi
+
+DAOS_FAILURE_STEP="report_junit"
+if ! report_junit post_provision_config.sh \
+                 post_provision_results.xml "$ORDERED_NODES"; then
+    echo "ERROR: Failed to collect node JUnit results"
+    exit 1
+fi
+
+DAOS_FAILURE_STEP="publish_commit_metadata"
 git log --format=%B -n 1 HEAD | sed -ne '1s/^\([A-Z][A-Z]*-[0-9][0-9]*\) .*/\1/p' \
                                      -e '/^Fixes:/{s/^Fixes: *//;s/ /\
 /g;p}' | \
-  retry_cmd 60 ssh -i ci_key -l "$CI_USER" "${NODESTRING%%,*}" \
+    retry_cmd 60 ssh -i ci_key -l "$CI_USER" "${ORDERED_NODES%%,*}" \
                                      "cat >/tmp/commit_fixes"
 git log --pretty=format:%h --abbrev-commit --abbrev=7 |
-  retry_cmd 60 ssh -i ci_key -l "$CI_USER" "${NODESTRING%%,*}" "cat >/tmp/commit_list"
+    retry_cmd 60 ssh -i ci_key -l "$CI_USER" "${ORDERED_NODES%%,*}" \
+        "cat >/tmp/commit_list"

--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -11,14 +11,26 @@ set -eux
 : "${DAOS_STACK_RETRY_DELAY_SECONDS:=60}"
 : "${DAOS_STACK_RETRY_COUNT:=3}"
 : "${DAOS_STACK_MONITOR_SECONDS:=600}"
+: "${DAOS_STACK_NON_RETRY_EXIT_CODES:=2 126 127}"
 : "${BUILD_URL:=Not_in_jenkins}"
-: "${STAGE_NAME:=Unknown_Stage}"
+: "${STAGE_NAME:=post_provision_config}"
 : "${OPERATIONS_EMAIL:=$USER@localhost}"
 : "${JENKINS_URL:=https://jenkins.example.com}"
 domain1="${JENKINS_URL#https://}"
 mail_domain="${domain1%%/*}"
 : "${EMAIL_DOMAIN:=$mail_domain}"
 : "${DAOS_DEVOPS_EMAIL:="$HOSTNAME"@"$EMAIL_DOMAIN"}"
+: "${DAOS_SMTP_RELAY:=}"
+
+# Global error-code constants used by provisioning scripts.
+# These are used for to for nested retry loops to be aborted when
+# a fatal error is encountered.
+ERROR_FATAL=2
+ERROR_RETRY=1
+
+# Needed to keep the shellcheck happy.
+export ERROR_FATAL
+export ERROR_RETRY
 
 # functions common to more than one distro specific provisioning
 url_to_repo() {
@@ -80,6 +92,58 @@ dump_repos() {
         cat "$file"
     done
 }
+
+configure_postfix_relay() {
+    # Enable and start postfix on all distros that have it.
+    # This is done unconditionally so mail delivery works on LEAP/SLES as
+    # well as EL without requiring distro-specific bootstrap hooks.
+    local postfix_start_exit=0
+    if command -v systemctl >/dev/null 2>&1 && command -v postfix >/dev/null 2>&1; then
+        systemctl enable postfix.service 2>/dev/null || true
+        systemctl start postfix.service 2>/dev/null || postfix_start_exit=$?
+        if [ $postfix_start_exit -ne 0 ]; then
+            echo "WARNING: Postfix not started: $postfix_start_exit"
+            systemctl status postfix.service || true
+        fi
+    fi
+
+    # Apply optional site-specific relay override.
+    local relay="${DAOS_SMTP_RELAY:-}"
+    local normalized=""
+    local host=""
+    local port=""
+
+    relay="${relay//[[:space:]]/}"
+    if [ -z "$relay" ]; then
+        return 0
+    fi
+
+    if ! command -v postconf >/dev/null 2>&1; then
+        echo "WARNING: DAOS_SMTP_RELAY is set, but postconf is not available"
+        return 0
+    fi
+
+    # Normalize relayhost format for Postfix direct host relay.
+    if [[ "$relay" == \[*\] ]] || [[ "$relay" == \[*\]:* ]]; then
+        normalized="$relay"
+    elif [[ "$relay" == *:* ]] && [[ "$relay" != *:*:* ]] && [[ "${relay#*:}" =~ ^[0-9]+$ ]]; then
+        host="${relay%%:*}"
+        port="${relay##*:}"
+        normalized="[$host]:$port"
+    else
+        normalized="[$relay]"
+    fi
+
+    echo "INFO: Setting postfix relayhost from DAOS_SMTP_RELAY to '$normalized'"
+    postconf -e "relayhost = $normalized"
+    # Reload so the running daemon picks up the new relayhost.
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl reload postfix.service 2>/dev/null || \
+            systemctl restart postfix.service 2>/dev/null || true
+    fi
+    postconf -nh relayhost || true
+}
+
 retry_dnf() {
     local monitor_threshold="$1"
     shift
@@ -88,7 +152,9 @@ retry_dnf() {
     local attempt=0
     local rc=0
     while [ $attempt -lt "${RETRY_COUNT:-$DAOS_STACK_RETRY_COUNT}" ]; do
-        if monitor_cmd "$monitor_threshold" "${args[@]}"; then
+        rc=0
+        monitor_cmd "$monitor_threshold" "${args[@]}" || rc=$?
+        if [ "$rc" -eq 0 ]; then
             # Command succeeded, return with success
             if [ $attempt -gt 0 ]; then
                 # shellcheck disable=SC2154
@@ -107,7 +173,6 @@ retry_dnf() {
             return 0
         fi
         # Command failed, retry
-        rc=${PIPESTATUS[0]}
         (( attempt++ )) || true
         if [ "$attempt" -gt 0 ]; then
             # shellcheck disable=SC2154
@@ -177,8 +242,11 @@ retry_cmd() {
 
     local attempt=0
     local rc=0
+    local non_retry_codes=" ${DAOS_STACK_NON_RETRY_EXIT_CODES} "
     while [ $attempt -lt "${RETRY_COUNT:-$DAOS_STACK_RETRY_COUNT}" ]; do
-        if monitor_cmd "$monitor_threshold" "$@"; then
+        rc=0
+        monitor_cmd "$monitor_threshold" "$@" || rc=$?
+        if [ "$rc" -eq 0 ]; then
             # Command succeeded, return with success
             if [ $attempt -gt 0 ]; then
                 send_mail "Command retry successful in $STAGE_NAME after $attempt attempts" \
@@ -186,8 +254,10 @@ retry_cmd() {
             fi
             return 0
         fi
-        # Command failed, retry
-        rc=${PIPESTATUS[0]}
+        if [[ "$non_retry_codes" == *" $rc "* ]]; then
+            echo "Command retry aborted for non-retryable exit status: $rc"
+            break
+        fi
         (( attempt++ )) || true
         if [ "$attempt" -gt 0 ]; then
             sleep "${RETRY_DELAY_SECONDS:-$DAOS_STACK_RETRY_DELAY_SECONDS}"
@@ -211,7 +281,9 @@ timeout_cmd() {
     local attempt=0
     local rc=1
     while [ $attempt -lt "${RETRY_COUNT:-$DAOS_STACK_RETRY_COUNT}" ]; do
-        if monitor_cmd "$DAOS_STACK_MONITOR_SECONDS" timeout "$timeout" "$@"; then
+        rc=0
+        monitor_cmd "$DAOS_STACK_MONITOR_SECONDS" timeout "$timeout" "$@" || rc=$?
+        if [ "$rc" -eq 0 ]; then
             # Command succeeded, return with success
             if [ $attempt -gt 0 ]; then
                 send_mail "Command timeout successful in $STAGE_NAME after $attempt attempts" \
@@ -219,7 +291,6 @@ timeout_cmd() {
             fi
             return 0
         fi
-        rc=${PIPESTATUS[0]}
         if [ "$rc" = "124" ]; then
             # Command timed out, try again
             (( attempt++ )) || true

--- a/ci/provisioning/post_provision_config_nodes.sh
+++ b/ci/provisioning/post_provision_config_nodes.sh
@@ -8,6 +8,21 @@
 set -eux
 
 env > /root/last_run-env.txt
+: "${JUNIT_RESULTS_FILE:=post_provision_results.xml}"
+
+# Compute node position in cluster for stable JUnit naming (matches functional tests)
+myhost="${HOSTNAME%%.*}"
+: "${NODELIST:=$myhost}"
+mynodenum=0
+for node in ${NODELIST//,/ }; do
+    ((mynodenum++)) || true
+    if [ "$node" = "$myhost" ]; then break; fi
+done
+export mynodenum
+
+if ! node_alias=$(printf "test-%03d" "$mynodenum"); then
+  node_alias="test-000"
+fi
 
 # Need this fix earlier
 # For some reason sssd_common must be reinstalled
@@ -15,6 +30,9 @@ env > /root/last_run-env.txt
 if command -v dnf; then
     bootstrap_dnf
 fi
+
+# Apply optional site-specific SMTP relay override across all distro paths.
+configure_postfix_relay
 
 # If in CI use made up user "Jenkins" with UID that the build agent is
 # currently using.   Not sure that the UID is actually important any more
@@ -63,10 +81,13 @@ fi
 
 # defined in ci/functional/post_provision_config_nodes_<distro>.sh
 # and catted to the remote node along with this script
-if ! post_provision_config_nodes; then
-    rc=${PIPESTATUS[0]}
-    echo "post_provision_config_nodes failed with rc=$rc"
-    exit "$rc"
+rc=0
+post_provision_config_nodes || rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "post_provision_config_nodes failed with rc=$rc"
+  junit_result "post_provision_config $node_alias" \
+         "post_provision_config_nodes failed with rc=$rc"
+  exit "$rc"
 fi
 
 # Workaround to enable binding devices back to nvme or vfio-pci after they are unbound from vfio-pci
@@ -78,9 +99,10 @@ if lspci | grep -i nvme; then
   daos_server nvme reset && rmmod vfio_pci && modprobe vfio_pci
 fi
 
-
 systemctl enable nfs-server.service
 systemctl start nfs-server.service
+junit_pass_result "post_provision_config $node_alias" \
+                  "post_provision_config_nodes completed successfully"
 sync
 sync
 exit 0

--- a/ci/provisioning/post_provision_config_nodes_EL.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL.sh
@@ -6,17 +6,8 @@
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 
 bootstrap_dnf() {
-set +e
-    systemctl enable postfix.service
-    systemctl start postfix.service
-    postfix_start_exit=$?
-    if [ $postfix_start_exit -ne 0 ]; then
-        echo "WARNING: Postfix not started: $postfix_start_exit"
-        systemctl status postfix.service
-        journalctl -xe -u postfix.service
-    fi
-set -e
-    # Seems to be needed to fix some issues.
+    # This must be the first DNF operation after image restore to avoid
+    # repeated noisy DNF logging in subsequent package operations.
     dnf -y reinstall sssd-common
 }
 

--- a/ci/provisioning/query_node_interfaces.sh
+++ b/ci/provisioning/query_node_interfaces.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+#  Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# Query node interfaces and categorize them by type.
+# Detects primary interface from SSH_CONNECTION environment variable.
+# Output: IP|INTERFACE|TYPE|SUBNET|NUMA|MAC (one per line)
+#
+
+# Get primary interface from SSH connection
+primary_ip=$(echo "$SSH_CONNECTION" | awk '{print $3}')
+
+# Get all interfaces with IPv4 addresses
+ip addr show | awk '
+    /^[0-9]+:/ {
+        iface = $2
+        gsub(/:$/, "", iface)
+    }
+    /inet / && iface !~ /^lo/ {
+        split($2, parts, "/")
+        ip = parts[1]
+        print ip " " iface
+    }
+' | while read -r ip iface; do
+    # Categorize interface: primary (SSH connection IP),
+    # InfiniBand (ARPHRD type 32), or private.
+    if [ "$ip" = "$primary_ip" ]; then
+        iface_type="primary"
+    elif [ "$(cat "/sys/class/net/$iface/type" 2>/dev/null)" = "32" ]; then
+        iface_type="infiniband"
+    else
+        iface_type="private"
+    fi
+
+    subnet=$(ip -4 route show dev "$iface" proto kernel scope link | \
+        awk -v ip="$ip" '$0 ~ ("src " ip) {print $1; exit}')
+    numa=$(cat "/sys/class/net/$iface/device/numa_node" 2>/dev/null || echo -1)
+    mac=$(cat "/sys/class/net/$iface/address" 2>/dev/null || echo "")
+
+    echo "$ip|$iface|$iface_type|$subnet|$numa|$mac"
+done

--- a/ci/provisioning/update_daos_hosts_block.sh
+++ b/ci/provisioning/update_daos_hosts_block.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+#  Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+set -eux
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <generated-hosts-file>"
+    exit 2
+fi
+
+generated_hosts_file="$1"
+base_file="/var/tmp/hosts.base"
+
+if [ ! -s "$generated_hosts_file" ]; then
+    echo "ERROR: Missing or empty hosts file: $generated_hosts_file"
+    exit 1
+fi
+
+awk 'BEGIN{skip=0}
+/^# BEGIN DAOS CI HOSTS$/{skip=1; next}
+/^# END DAOS CI HOSTS$/{skip=0; next}
+!skip{print}' /etc/hosts > "$base_file"
+
+{
+    echo '# BEGIN DAOS CI HOSTS'
+    cat "$generated_hosts_file"
+    echo '# END DAOS CI HOSTS'
+} >> "$base_file"
+cp "$base_file" /etc/hosts

--- a/ci/stacktrace.sh
+++ b/ci/stacktrace.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+#
+#  Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
 stacktrace() {
     local msg=${1:-"Unchecked error condition at"}
     local i=${2:-0}

--- a/src/control/run_go_tests.sh
+++ b/src/control/run_go_tests.sh
@@ -192,6 +192,37 @@ GO_TEST_EXTRA_ARGS=${*:-""}
 
 controldir="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
 
+: "${DLV_MODE:=false}"
+: "${DLV_PACKAGE:=}"
+: "${DLV_TEST_NAME:=}"
+
+if $DLV_MODE; then
+	if [[ -z "$DLV_PACKAGE" ]]; then
+		echo "Usage: $0 --dlv [--run <TestName>] <package>" >&2
+		exit 1
+	fi
+	DLV_BUILD_FLAGS="-mod vendor -tags firmware,fault_injection,test_stubs,spdk"
+	DLV_ARGS=()
+	[[ -n "$DLV_TEST_NAME" ]] && DLV_ARGS=(-- -test.run "$DLV_TEST_NAME")
+	echo "Environment:"
+	echo "  GO VERSION: $(go version | awk '{print $3" "$4}')"
+	echo "  LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+	echo "  CGO_LDFLAGS: $CGO_LDFLAGS"
+	echo "  CGO_CFLAGS: $CGO_CFLAGS"
+	echo
+	echo "Starting dlv session for $DLV_PACKAGE..."
+	pushd "$controldir" >/dev/null
+	testrc=0
+	LD_LIBRARY_PATH="$LD_LIBRARY_PATH" \
+	CGO_LDFLAGS="$CGO_LDFLAGS" \
+	CGO_CFLAGS="$CGO_CFLAGS" \
+		dlv test --build-flags "$DLV_BUILD_FLAGS" "$DLV_PACKAGE" "${DLV_ARGS[@]}" || testrc=$?
+	popd >/dev/null
+	exit $testrc
+fi
+
+GO_TEST_RUNNER=$(get_test_runner)
+
 check_formatting "$controldir"
 
 echo "Environment:"
@@ -204,12 +235,11 @@ echo
 
 echo "Running all tests under $controldir..."
 pushd "$controldir" >/dev/null
-set +e
+testrc=0
 LD_LIBRARY_PATH="$LD_LIBRARY_PATH" \
 CGO_LDFLAGS="$CGO_LDFLAGS" \
 CGO_CFLAGS="$CGO_CFLAGS" \
-	$GO_TEST_RUNNER "$GO_TEST_EXTRA_ARGS"
-testrc=$?
+	$GO_TEST_RUNNER "$GO_TEST_EXTRA_ARGS" || testrc=$?
 popd >/dev/null
 
 if [ -f "$GO_TEST_XML" ]; then

--- a/utils/githooks/README.md
+++ b/utils/githooks/README.md
@@ -1,3 +1,9 @@
+<!--
+   Copyright 2026 Hewlett Packard Enterprise Development LP
+
+   SPDX-License-Identifier: BSD-2-Clause-Patent
+-->
+
 # About DAOS Git hooks
 
 Githooks are a [well documented](https://git-scm.com/docs/githooks) feature
@@ -14,7 +20,8 @@ Installing is a two-step process:
 
 ### 1. Install the hooks
 
-Configure your `core.hookspath`.  
+Configure your `core.hookspath`.
+
 Any new githooks added to the repository will automatically run,
 but possibly require additional software to produce the desired effect.
 Additionally, as the branch changes, the githooks change with it.
@@ -32,25 +39,36 @@ The Githooks framework in DAOS is such that the hooks will all run.
 However, some hooks will simply check for required software and are
 effectively a noop if such is not installed.
 
-Requirements come from a combination of `pip` and system packages and can usually be installed through standard means.  
+Requirements come from a combination of `pip` and system packages and can usually be installed
+through standard means.
 
 #### Install pip packages
-To install `pip` packages specified in [utils/cq/requirements.txt](../../utils/cq/requirements.txt) it is recommended to setup a virtual environment and install with pip.  
-It is recommended to use python 3.11, but you need at least 3.10 to get the latest version of each package.  
+
+To install `pip` packages specified in [utils/cq/requirements.txt](../../utils/cq/requirements.txt)
+it is recommended to setup a virtual environment and install with pip.
+It is recommended to use python 3.11, but you need at least 3.10 to get the latest version of each
+package.
+
 You can setup a virtual environment with:
+
 ```sh
 python3.11 -m venv /path/to/my_env
 ```
+
 Then, to use it:
+
 ```sh
 source /path/to/my_env/bin/activate
 ```
+
 Then, to install the requirements:
+
 ```sh
 python3 -m pip install -r utils/cq/requirements.txt
 ```
 
 #### Install System Packages
+
 Install system packages with your package manager - for example:
 
 ```sh
@@ -108,7 +126,8 @@ allowing the user to inspect the changes and retry the commit.
 7. isort - Linter for python imports on modified python files
 8. flake - Linter for python files
 9. pylint - Additional linter for modified python files
-   - See [daos_pylint.py](../../utils/cq/daos_pylint.py) for a custom wrapper around `pylint` which manages `PYTHONPATH` setup internally.
+   - See [daos_pylint.py](../../utils/cq/daos_pylint.py) for a custom wrapper around `pylint` which
+     manages `PYTHONPATH` setup internally.
 10. ftest - Custom linter for modified ftest files
 
 ### prepare-commit-msg


### PR DESCRIPTION
Backport of #18507 

Update post-provisioning error handling to provide better diagnostics.

The post-processing has is now starting to eliminate retries for errors that a retry is not going to fix.

When post-processing detects a fatal infrastructure issue, it will cause the CI cluster to be taken offline.

Add Jenkins workspace cleanup in post section to reduce agent disk usage

Fix intermittent e-mail delivery by allowing a mail relay setting.

Enhancements for future Use:

Add network alias names needed for Slingshot and newer networking hardware.

We are starting to get dual port network cards that only one port is in use and the only way we can guarantee that all hosts have the same interface name for the same network is to use these assigned network aliases.

We also need this to support VMs as test controllers.

Per-file changes:
- Jenkinsfile: Add post-build workspace cleanup to reduce disk usage on Jenkins agents. Change storage prep stage to use el-9.

- ci/functional/test_main_prep_node.sh: Add persistent and predictable aliases to network interfaces. Create a data file for later use to future proof CI tests.

- ci/gha_functions.sh:
- ci/stacktrace.sh: Fix executable permission bit in git repository.

- ci/junit.sh: Improve error trap to make it more readable. Fix handling of missing report files.

- ci/provisioning/post_provision_config.sh: Add missing source for stacktrace script, add DAOS_FAILURE_STEP markers for ci/junit.sh

- ci/provisioning/post_provision_config_common_functions.sh: set STAGE_NAME default to post_provision_config to improve readability of error messages. Install optional mail relay host

- ci/provisioning/query_node_interfaces.sh
- ci/provisioning/update_daos_hosts_block.sh Add aliases for future simplification of test code and needed for finding the correct interfaces for ethenet high speed transports.

- docs/dev/documentation.md: Add VS Code cSpell setup guidance and fix markdown linting issues. Change to Linux line endings.

- utils/githooks/README.md:  Fix markdown linting issues.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
