### PR TITLE
DAOS-19533 test: Update Pytorch yaml files to use old default

### DIFF
--- a/src/tests/ftest/pytorch/checkpoint.yaml
+++ b/src/tests/ftest/pytorch/checkpoint.yaml
@@ -1,6 +1,7 @@
 hosts:
   test_servers: 1
   test_clients: 1
+
 server_config:
   name: daos_server
   engines_per_host: 1
@@ -13,10 +14,14 @@ server_config:
           class: ram
           scm_mount: /mnt/daos
   system_ram_reserved: 1
+
 pool:
   size: 8G
+  properties: rd_fac:0,space_rb:0
+
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 timeout: 2000
 

--- a/src/tests/ftest/pytorch/dataset.yaml
+++ b/src/tests/ftest/pytorch/dataset.yaml
@@ -1,6 +1,7 @@
 hosts:
   test_servers: 2
   test_clients: 1
+
 server_config:
   name: daos_server
   engines_per_host: 1
@@ -13,11 +14,15 @@ server_config:
           class: ram
           scm_mount: /mnt/daos
   system_ram_reserved: 1
+
 pool:
   size: 8G
+  properties: rd_fac:0,space_rb:0
+
 container:
   type: POSIX
   dir_oclass: SX
+  properties: cksum:off,srv_cksum:off
 
 timeout: 270
 


### PR DESCRIPTION
Use old default property values for pool and container. Pool - properties: rd_fac:0,space_rb:0
Container - properties: cksum:off,srv_cksum:off

Skip-fault-injection-test: true
Test-tag: pytorch

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
