### PR TITLE
DAOS-17681 object: fix bug in obj_ec_iom_merge/iom_recx_merge()

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5292,7 +5292,17 @@ obj_comp_cb(tse_task_t *task, void *data)
 
 	if (obj_auxi->io_retry) {
 		if (obj_auxi->opc == DAOS_OBJ_RPC_FETCH) {
+			daos_obj_fetch_t *f_args = dc_task_get_args(task);
+
+			/* The IOM merge restarts from scratch on retry. */
 			obj_auxi->reasb_req.orr_iom_tgt_nr = 0;
+			obj_auxi->reasb_req.orr_iom_nr     = 0;
+			if (f_args->ioms != NULL) {
+				uint32_t j;
+
+				for (j = 0; j < obj_auxi->iod_nr; j++)
+					f_args->ioms[j].iom_nr_out = 0;
+			}
 			obj_io_set_new_shard_task(obj_auxi);
 		}
 

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -908,7 +908,7 @@ obj_reasb_req_init(struct obj_reasb_req *reasb_req, struct dc_object *obj, daos_
 {
 	daos_size_t			 size_iod, size_sgl, size_oiod;
 	daos_size_t			 size_recx, size_tgt_nr, size_singv;
-	daos_size_t			 size_sorter, size_array, size_fetch_stat, buf_size;
+	daos_size_t                      size_sorter, size_array, size_fetch_stat, buf_size;
 	daos_iod_t			*uiod, *riod;
 	struct obj_ec_recx_array	*ec_recx;
 	void				*buf;
@@ -923,12 +923,11 @@ obj_reasb_req_init(struct obj_reasb_req *reasb_req, struct dc_object *obj, daos_
 	size_sorter = roundup(sizeof(struct obj_ec_seg_sorter) * iod_nr, 8);
 	size_singv = roundup(sizeof(struct dcs_layout) * iod_nr, 8);
 	size_array = sizeof(daos_size_t) * obj_get_grp_size(obj) * iod_nr;
-	size_fetch_stat = sizeof(struct shard_fetch_stat) * iod_nr;
+	size_fetch_stat    = sizeof(struct shard_fetch_stat) * iod_nr;
 	/* for oer_tgt_recx_nrs/_idxs */
 	size_tgt_nr = roundup(sizeof(uint32_t) * obj_get_grp_size(obj), 8);
-	buf_size = size_iod + size_sgl + size_oiod + size_recx + size_sorter +
-		   size_singv + size_array + size_tgt_nr * iod_nr * 2 + OBJ_TGT_BITMAP_LEN +
-		   size_fetch_stat;
+	buf_size    = size_iod + size_sgl + size_oiod + size_recx + size_sorter + size_singv +
+		   size_array + size_tgt_nr * iod_nr * 2 + OBJ_TGT_BITMAP_LEN + size_fetch_stat;
 	D_ALLOC(buf, buf_size);
 	if (buf == NULL)
 		return -DER_NOMEM;
@@ -5017,6 +5016,55 @@ obj_dup_sgls_free(struct obj_auxi_args *obj_auxi)
 	api_args->sgls              = obj_auxi->reasb_req.orr_usgls;
 }
 
+/* Allocate the per-IOM merge state used by the EC fetch IOM merge. It is kept
+ * across retries of the same task, so that the ownership of the iom_recxs
+ * buffers (oims_realloc) is never lost.
+ */
+static int
+obj_iom_state_init(struct obj_auxi_args *obj_auxi, daos_obj_fetch_t *args)
+{
+	if (!obj_auxi->is_ec_obj || args->ioms == NULL || obj_auxi->iom_state != NULL)
+		return 0;
+
+	D_ALLOC_ARRAY(obj_auxi->iom_state, obj_auxi->iod_nr);
+	if (obj_auxi->iom_state == NULL)
+		return -DER_NOMEM;
+
+	return 0;
+}
+
+static void
+obj_iom_state_fini(struct obj_auxi_args *obj_auxi)
+{
+	D_FREE(obj_auxi->iom_state);
+}
+
+/* The IOM merge restarts from scratch on retry, only the merge progress is
+ * reset - the iom_recxs buffers (and their ownership) are kept, so that a
+ * buffer grown by a previous attempt can be reused by the retry.
+ */
+static void
+obj_iom_retry_reset(struct obj_auxi_args *obj_auxi)
+{
+	daos_obj_fetch_t *args;
+	uint32_t          i;
+
+	if (obj_auxi->opc != DAOS_OBJ_RPC_FETCH || obj_auxi->obj_task == NULL)
+		return;
+
+	args = dc_task_get_args(obj_auxi->obj_task);
+	if (args->ioms == NULL)
+		return;
+
+	for (i = 0; i < obj_auxi->iod_nr; i++) {
+		args->ioms[i].iom_nr_out = 0;
+		if (obj_auxi->iom_state != NULL) {
+			obj_auxi->iom_state[i].oims_tgt_nr   = 0;
+			obj_auxi->iom_state[i].oims_extra_nr = 0;
+		}
+	}
+}
+
 static void
 obj_reasb_io_fini(struct obj_auxi_args *obj_auxi, bool retry)
 {
@@ -5038,8 +5086,10 @@ obj_reasb_io_fini(struct obj_auxi_args *obj_auxi, bool retry)
 	/* zero it as user might reuse/resched the task, for
 	 * example the usage in dac_array_set_size().
 	 */
-	if (!retry)
+	if (!retry) {
+		obj_iom_state_fini(obj_auxi);
 		memset(obj_auxi, 0, sizeof(*obj_auxi));
+	}
 }
 
 /**
@@ -5292,17 +5342,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 
 	if (obj_auxi->io_retry) {
 		if (obj_auxi->opc == DAOS_OBJ_RPC_FETCH) {
-			daos_obj_fetch_t *f_args = dc_task_get_args(task);
-
-			/* The IOM merge restarts from scratch on retry. */
-			obj_auxi->reasb_req.orr_iom_tgt_nr = 0;
-			obj_auxi->reasb_req.orr_iom_nr     = 0;
-			if (f_args->ioms != NULL) {
-				uint32_t j;
-
-				for (j = 0; j < obj_auxi->iod_nr; j++)
-					f_args->ioms[j].iom_nr_out = 0;
-			}
+			obj_iom_retry_reset(obj_auxi);
 			obj_io_set_new_shard_task(obj_auxi);
 		}
 
@@ -6097,6 +6137,10 @@ dc_obj_fetch_task(tse_task_t *task)
 
 	obj_auxi->dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, args->dkey);
 	obj_auxi->iod_nr = args->nr;
+
+	rc = obj_iom_state_init(obj_auxi, args);
+	if (rc != 0)
+		D_GOTO(out_task, rc);
 
 	if (obj_auxi->ec_wait_recov)
 		goto out_task;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -232,9 +232,10 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 	daos_recx_t		 hi, lo, recx, tmpr;
 	daos_recx_t		 recov_hi = { 0 };
 	daos_recx_t		 recov_lo = { 0 };
+	uint64_t                 iom_nr;
 	uint32_t		 tgt_off;
-	uint32_t		 iom_nr, i;
-	bool			 done;
+	uint32_t                 i;
+	bool                     first, done;
 	int			 rc = 0;
 
 	tgt_off = obj_ec_shard_off(obj, dkey_hash, tgt_idx);
@@ -245,6 +246,17 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 		daos_recx_ep_list_hilo(recov_list, &recov_hi, &recov_lo);
 
 	D_MUTEX_LOCK(&reasb_req->orr_mutex);
+
+	reasb_req->orr_iom_tgt_nr++;
+	D_ASSERTF(reasb_req->orr_iom_tgt_nr <= reasb_req->orr_tgt_nr,
+		  "orr_iom_tgt_nr %d, orr_tgt_nr %d.\n", reasb_req->orr_iom_tgt_nr,
+		  reasb_req->orr_tgt_nr);
+	first = (reasb_req->orr_iom_tgt_nr == 1);
+	done  = (reasb_req->orr_iom_tgt_nr == reasb_req->orr_tgt_nr);
+	if (first) {
+		dst->iom_type = src->iom_type;
+		dst->iom_size = src->iom_size;
+	}
 
 	/* merge iom_recx_hi */
 	hi = src->iom_recx_hi;
@@ -258,13 +270,21 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 	if (recov_list != NULL &&
 	    DAOS_RECX_END(recov_hi) > DAOS_RECX_END(hi))
 		hi = recov_hi;
-	if (reasb_req->orr_iom_tgt_nr == 0)
+	/* An empty contribution must not be merged, it would otherwise pull
+	 * dst->iom_recx_hi down to index 0 (a zero-length recx is "adjacent"
+	 * to any recx starting at 0).
+	 */
+	if (hi.rx_nr == 0) {
+		if (first)
+			dst->iom_recx_hi = hi;
+	} else if (first || dst->iom_recx_hi.rx_nr == 0) {
 		dst->iom_recx_hi = hi;
-	else if (DAOS_RECX_OVERLAP(dst->iom_recx_hi, hi) ||
-		 DAOS_RECX_ADJACENT(dst->iom_recx_hi, hi))
+	} else if (DAOS_RECX_OVERLAP(dst->iom_recx_hi, hi) ||
+		   DAOS_RECX_ADJACENT(dst->iom_recx_hi, hi)) {
 		daos_recx_merge(&hi, &dst->iom_recx_hi);
-	else if (hi.rx_idx > dst->iom_recx_hi.rx_idx)
+	} else if (hi.rx_idx > dst->iom_recx_hi.rx_idx) {
 		dst->iom_recx_hi = hi;
+	}
 
 	/* merge iom_recx_lo */
 	lo = src->iom_recx_lo;
@@ -278,13 +298,17 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 	if (recov_list != NULL && (end == 0 ||
 	    DAOS_RECX_END(recov_lo) < DAOS_RECX_END(lo)))
 		lo = recov_lo;
-	if (reasb_req->orr_iom_tgt_nr == 0)
+	if (lo.rx_nr == 0) {
+		if (first)
+			dst->iom_recx_lo = lo;
+	} else if (first || dst->iom_recx_lo.rx_nr == 0) {
 		dst->iom_recx_lo = lo;
-	else if (DAOS_RECX_OVERLAP(dst->iom_recx_lo, lo) ||
-		 DAOS_RECX_ADJACENT(dst->iom_recx_lo, lo))
+	} else if (DAOS_RECX_OVERLAP(dst->iom_recx_lo, lo) ||
+		   DAOS_RECX_ADJACENT(dst->iom_recx_lo, lo)) {
 		daos_recx_merge(&lo, &dst->iom_recx_lo);
-	else if (lo.rx_idx < dst->iom_recx_lo.rx_idx)
+	} else if (lo.rx_idx < dst->iom_recx_lo.rx_idx) {
 		dst->iom_recx_lo = lo;
+	}
 
 	if ((dst->iom_flags & DAOS_IOMF_DETAIL) == 0) {
 		dst->iom_nr_out = 0;
@@ -292,11 +316,12 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 		return 0;
 	}
 
-	/* If user provides NULL iom_recxs an requires DAOS_IOMF_DETAIL,
+	/* If user provides NULL iom_recxs and requires DAOS_IOMF_DETAIL,
 	 * DAOS internally allocates the buffer and user should free it.
 	 */
 	if (dst->iom_recxs == NULL) {
-		iom_nr = src->iom_nr * reasb_req->orr_tgt_nr;
+		iom_nr = (uint64_t)src->iom_nr * reasb_req->orr_tgt_nr;
+		iom_nr = min(max(iom_nr, 8), (uint64_t)(UINT32_MAX - 7));
 		iom_nr = roundup(iom_nr, 8);
 		D_ALLOC_ARRAY(dst->iom_recxs, iom_nr);
 		if (dst->iom_recxs == NULL) {
@@ -308,12 +333,6 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 	}
 
 	/* merge iom_recxs */
-	reasb_req->orr_iom_tgt_nr++;
-	D_ASSERTF(reasb_req->orr_iom_tgt_nr <= reasb_req->orr_tgt_nr,
-		  "orr_iom_tgt_nr %d, orr_tgt_nr %d.\n",
-		  reasb_req->orr_iom_tgt_nr, reasb_req->orr_tgt_nr);
-	done = (reasb_req->orr_iom_tgt_nr == reasb_req->orr_tgt_nr);
-	reasb_req->orr_iom_nr += src->iom_nr;
 	for (i = 0; i < src->iom_nr; i++) {
 		recx = src->iom_recxs[i];
 		D_ASSERT(recx.rx_nr > 0);
@@ -333,9 +352,12 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 			if (rc == -DER_NOMEM)
 				break;
 			if (rc == -DER_REC2BIG) {
-				if (done)
-					dst->iom_nr_out = reasb_req->orr_iom_nr
-						+ reasb_req->orr_tgt_nr;
+				/* The extent cannot be stored in the
+				 * caller's buffer, just account it so that
+				 * the needed number of extents can be
+				 * reported through iom_nr_out.
+				 */
+				reasb_req->orr_iom_nr++;
 				rc = 0;
 			}
 		}
@@ -352,8 +374,7 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 			if (rc == -DER_NOMEM)
 				break;
 			if (rc == -DER_REC2BIG) {
-				if (done)
-					dst->iom_nr_out += recov_list->re_nr;
+				reasb_req->orr_iom_nr++;
 				rc = 0;
 			}
 		}
@@ -363,9 +384,9 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 		daos_recx_t	*r1, *r2;
 		daos_size_t	 move_len;
 
+		D_ASSERTF(dst->iom_nr_out <= dst->iom_nr, "iom_nr_out %d, iom_nr %d\n",
+			  dst->iom_nr_out, dst->iom_nr);
 		daos_iom_sort(dst);
-		if (dst->iom_nr_out > dst->iom_nr)
-			goto out;
 		for (i = 1; i < dst->iom_nr_out; i++) {
 			r1 = &dst->iom_recxs[i - 1];
 			r2 = &dst->iom_recxs[i];
@@ -381,9 +402,13 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 				i--;
 			}
 		}
+		/* Report the number of extents needed to hold the whole iom,
+		 * so that the caller can re-allocate iom_recxs and fetch
+		 * again. iom_nr_out > iom_nr means the iom is truncated.
+		 */
+		dst->iom_nr_out += reasb_req->orr_iom_nr;
 	}
 
-out:
 	D_MUTEX_UNLOCK(&reasb_req->orr_mutex);
 	return rc;
 }

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -223,7 +223,7 @@ iom_recx_merge(daos_iom_t *dst, daos_recx_t *recx, bool iom_realloc)
 static int
 obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_t dkey_hash,
 		 uint32_t shard, uint32_t tgt_idx, const daos_iom_t *src, daos_iom_t *dst,
-		 struct daos_recx_ep_list *recov_list)
+		 struct obj_iom_merge_state *state, struct daos_recx_ep_list *recov_list)
 {
 	struct daos_oclass_attr	*oca = reasb_req->orr_oca;
 	uint64_t		 stripe_rec_nr = obj_ec_stripe_rec_nr(oca);
@@ -231,7 +231,7 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 	uint64_t		 end, rec_nr;
 	daos_recx_t		 hi, lo, recx, tmpr;
 	daos_recx_t		 recov_hi = { 0 };
-	daos_recx_t		 recov_lo = { 0 };
+	daos_recx_t              recov_lo = {0};
 	uint64_t                 iom_nr;
 	uint32_t		 tgt_off;
 	uint32_t                 i;
@@ -247,16 +247,17 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 
 	D_MUTEX_LOCK(&reasb_req->orr_mutex);
 
-	reasb_req->orr_iom_tgt_nr++;
-	D_ASSERTF(reasb_req->orr_iom_tgt_nr <= reasb_req->orr_tgt_nr,
-		  "orr_iom_tgt_nr %d, orr_tgt_nr %d.\n", reasb_req->orr_iom_tgt_nr,
-		  reasb_req->orr_tgt_nr);
-	first = (reasb_req->orr_iom_tgt_nr == 1);
-	done  = (reasb_req->orr_iom_tgt_nr == reasb_req->orr_tgt_nr);
+	state->oims_tgt_nr++;
+	D_ASSERTF(state->oims_tgt_nr <= reasb_req->orr_tgt_nr, "oims_tgt_nr %d, orr_tgt_nr %d.\n",
+		  state->oims_tgt_nr, reasb_req->orr_tgt_nr);
+	first = (state->oims_tgt_nr == 1);
+	done  = (state->oims_tgt_nr == reasb_req->orr_tgt_nr);
 	if (first) {
-		dst->iom_type = src->iom_type;
-		dst->iom_size = src->iom_size;
+		dst->iom_type   = src->iom_type;
+		dst->iom_nr_out = 0;
 	}
+	if (dst->iom_size == 0)
+		dst->iom_size = src->iom_size;
 
 	/* merge iom_recx_hi */
 	hi = src->iom_recx_hi;
@@ -329,7 +330,7 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 			return -DER_NOMEM;
 		}
 		dst->iom_nr = iom_nr;
-		reasb_req->orr_iom_realloc = 1;
+		state->oims_realloc = 1;
 	}
 
 	/* merge iom_recxs */
@@ -347,8 +348,7 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 							  stripe_rec_nr,
 							  cell_rec_nr,
 							  tgt_off);
-			rc = iom_recx_merge(dst, &tmpr,
-					    reasb_req->orr_iom_realloc);
+			rc          = iom_recx_merge(dst, &tmpr, state->oims_realloc);
 			if (rc == -DER_NOMEM)
 				break;
 			if (rc == -DER_REC2BIG) {
@@ -357,7 +357,7 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 				 * the needed number of extents can be
 				 * reported through iom_nr_out.
 				 */
-				reasb_req->orr_iom_nr++;
+				state->oims_extra_nr++;
 				rc = 0;
 			}
 		}
@@ -368,13 +368,12 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 	/* merge recov list */
 	if (recov_list != NULL && rc == 0) {
 		for (i = 0; i < recov_list->re_nr; i++) {
-			rc = iom_recx_merge(dst,
-					    &recov_list->re_items[i].re_recx,
-					    reasb_req->orr_iom_realloc);
+			rc = iom_recx_merge(dst, &recov_list->re_items[i].re_recx,
+					    state->oims_realloc);
 			if (rc == -DER_NOMEM)
 				break;
 			if (rc == -DER_REC2BIG) {
-				reasb_req->orr_iom_nr++;
+				state->oims_extra_nr++;
 				rc = 0;
 			}
 		}
@@ -406,7 +405,7 @@ obj_ec_iom_merge(struct dc_object *obj, struct obj_reasb_req *reasb_req, uint64_
 		 * so that the caller can re-allocate iom_recxs and fetch
 		 * again. iom_nr_out > iom_nr means the iom is truncated.
 		 */
-		dst->iom_nr_out += reasb_req->orr_iom_nr;
+		dst->iom_nr_out += state->oims_extra_nr;
 	}
 
 	D_MUTEX_UNLOCK(&reasb_req->orr_mutex);
@@ -1066,11 +1065,13 @@ dc_rw_cb(tse_task_t *task, void *arg)
 					struct obj_auxi_args	*obj_auxi;
 
 					obj_auxi = rw_args->shard_args->auxi.obj_auxi;
-					rc = obj_ec_iom_merge(obj_auxi->obj, reasb_req,
-							      obj_auxi->dkey_hash,
-							      orw->orw_oid.id_shard,
-							      orw->orw_tgt_idx, reply_maps,
-							      &rw_args->maps[i], recov_list);
+					D_ASSERT(obj_auxi->iom_state != NULL);
+					D_ASSERTF(i < obj_auxi->iod_nr, "iod_idx %d, iod_nr %d.\n",
+						  i, obj_auxi->iod_nr);
+					rc = obj_ec_iom_merge(
+					    obj_auxi->obj, reasb_req, obj_auxi->dkey_hash,
+					    orw->orw_oid.id_shard, orw->orw_tgt_idx, reply_maps,
+					    &rw_args->maps[i], &obj_auxi->iom_state[i], recov_list);
 				} else {
 					rc = daos_iom_copy(reply_maps, &rw_args->maps[i]);
 				}
@@ -1293,9 +1294,18 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 			orw->orw_flags |= (ORF_CREATE_MAP |
 					   ORF_CREATE_MAP_DETAIL);
 		} else if (rw_args.maps != NULL) {
+			uint32_t j;
+
 			orw->orw_flags |= ORF_CREATE_MAP;
-			if (rw_args.maps->iom_flags & DAOS_IOMF_DETAIL)
-				orw->orw_flags |= ORF_CREATE_MAP_DETAIL;
+			/* one IOM per IOD, detailed map is needed if any of
+			 * them asks for it.
+			 */
+			for (j = 0; j < nr; j++) {
+				if (rw_args.maps[j].iom_flags & DAOS_IOMF_DETAIL) {
+					orw->orw_flags |= ORF_CREATE_MAP_DETAIL;
+					break;
+				}
+			}
 		}
 	}
 

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -142,6 +142,27 @@ struct shard_fetch_stat {
 	int32_t			sfs_rc_other;
 };
 
+/* Per-IOM state for the client side EC IOM merge (obj_ec_iom_merge()).
+ * A fetch request can carry multiple IODs and one IOM per IOD, so this
+ * state must be tracked per IOM rather than per request. It is anchored in
+ * struct obj_auxi_args (rather than in struct obj_reasb_req) so that it
+ * survives the request re-assembly teardown/re-init that some retry paths
+ * perform, keeping the oims_realloc flag consistent with the iom_recxs
+ * buffer ownership across retries.
+ */
+struct obj_iom_merge_state {
+	/* number of targets that with this IOM handled */
+	uint32_t oims_tgt_nr;
+	/* number of iom extents that could not be stored in the caller
+	 * provided iom_recxs buffer (used to report the needed iom_nr).
+	 */
+	uint32_t oims_extra_nr;
+	/* the flag of this IOM's iom_recxs internally allocated by DAOS
+	 * (and so re-allocable).
+	 */
+	uint32_t oims_realloc : 1;
+};
+
 /**
  * Reassembled obj request.
  * User input iod/sgl possibly need to be reassembled at client before sending
@@ -171,15 +192,9 @@ struct obj_reasb_req {
 	/* to record returned data size from each targets */
 	daos_size_t			*orr_data_sizes;
 	/* number of targets this IO req involves */
-	uint32_t			 orr_tgt_nr;
-	/* number of targets that with IOM handled */
-	uint32_t			 orr_iom_tgt_nr;
-	/* number of iom extents that could not be stored in the caller
-	 * provided iom_recxs buffer (used to report the needed iom_nr).
-	 */
-	uint32_t			 orr_iom_nr;
+	uint32_t                         orr_tgt_nr;
 	/* #iods of IO req */
-	uint32_t			 orr_iod_nr;
+	uint32_t                         orr_iod_nr;
 	struct daos_oclass_attr		*orr_oca;
 	struct obj_ec_codec		*orr_codec;
 	pthread_mutex_t			 orr_mutex;
@@ -194,23 +209,21 @@ struct obj_reasb_req {
 	struct daos_recx_ep_list	*orr_parity_lists;
 	uint32_t			 orr_parity_list_nr;
 	/* for data recovery flag */
-	uint32_t			 orr_recov:1,
-	/* for snapshot data recovery flag */
-					 orr_recov_snap:1,
-	/* for iod_size fetching flag */
-					 orr_size_fetch:1,
-	/* for iod_size fetched flag */
-					 orr_size_fetched:1,
-	/* only with single data target flag */
-					 orr_single_tgt:1,
-	/* only for single-value IO flag */
-					 orr_singv_only:1,
-	/* the flag of IOM re-allocable (used for EC IOM merge) */
-					 orr_iom_realloc:1,
-	/* orr_fail allocated flag, recovery task's orr_fail is inherited */
-					 orr_fail_alloc:1,
-	/* The fetch data/sgl is rebuilt by EC parity rebuild */
-					 orr_recov_data:1;
+	uint32_t                         orr_recov : 1,
+	    /* for snapshot data recovery flag */
+	    orr_recov_snap                         : 1,
+	    /* for iod_size fetching flag */
+	    orr_size_fetch                         : 1,
+	    /* for iod_size fetched flag */
+	    orr_size_fetched                       : 1,
+	    /* only with single data target flag */
+	    orr_single_tgt                         : 1,
+	    /* only for single-value IO flag */
+	    orr_singv_only                         : 1,
+	    /* orr_fail allocated flag, recovery task's orr_fail is inherited */
+	    orr_fail_alloc                         : 1,
+	    /* The fetch data/sgl is rebuilt by EC parity rebuild */
+	    orr_recov_data                         : 1;
 };
 
 static inline void
@@ -486,6 +499,10 @@ struct obj_auxi_args {
 	uint32_t			 initial_shard;
 	d_list_t			 shard_task_head;
 	struct obj_reasb_req		 reasb_req;
+	/* per-IOM merge state for EC fetch, one per iod, allocated on demand
+	 * and kept across retries.
+	 */
+	struct obj_iom_merge_state      *iom_state;
 	struct obj_auxi_tgt_list	*failed_tgt_list;
 	uint64_t			 dkey_hash;
 	/* one shard_args embedded to save one memory allocation if the obj

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -174,7 +174,9 @@ struct obj_reasb_req {
 	uint32_t			 orr_tgt_nr;
 	/* number of targets that with IOM handled */
 	uint32_t			 orr_iom_tgt_nr;
-	/* number of iom extends */
+	/* number of iom extents that could not be stored in the caller
+	 * provided iom_recxs buffer (used to report the needed iom_nr).
+	 */
 	uint32_t			 orr_iom_nr;
 	/* #iods of IO req */
 	uint32_t			 orr_iod_nr;

--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -2872,6 +2872,129 @@ ec_fetch_iom(void **state)
 	D_FREE(buf);
 }
 
+/*
+ * Verify the client side IOM merge of EC array fetch with multiple IODs, one
+ * IOM per IOD. Each IOM must be merged independently: the per-IOM merge state
+ * (number of shards merged, number of extents that did not fit, and whether
+ * the iom_recxs buffer was internally allocated by DAOS) must not be shared
+ * between the IOMs.
+ */
+static void
+ec_fetch_multi_iom(void **state)
+{
+	test_arg_t   *arg = *state;
+	daos_obj_id_t oid;
+	daos_handle_t oh;
+	d_iov_t       dkey;
+	d_sg_list_t   sgls[2];
+	d_iov_t       sg_iovs[2];
+	daos_iod_t    iods[2];
+	daos_iom_t    ioms[2];
+	daos_recx_t   iom_recxs[EC_IOM_BUF_NR];
+	daos_recx_t   recxs[EC_IOM_EXT_NR];
+	daos_size_t   cell_size = ec_cell_size;
+	daos_size_t   buf_len;
+	char         *buf;
+	int           i, rc;
+
+	if (!test_runable(arg, 6))
+		return;
+
+	buf_len = EC_IOM_EXT_NR * EC_IOM_EXT_SIZE;
+	D_ALLOC(buf, buf_len);
+	assert_non_null(buf);
+	dts_buf_render(buf, buf_len);
+
+	oid = daos_test_oid_gen(arg->coh, ec_obj_class, 0, 0, arg->myrank);
+	rc  = daos_obj_open(arg->coh, oid, DAOS_OO_RW, &oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	d_iov_set(&dkey, "miom_dkey", strlen("miom_dkey"));
+	for (i = 0; i < EC_IOM_EXT_NR; i++) {
+		recxs[i].rx_idx = i * cell_size;
+		recxs[i].rx_nr  = EC_IOM_EXT_SIZE;
+	}
+
+	for (i = 0; i < 2; i++) {
+		d_iov_set(&sg_iovs[i], buf, buf_len);
+		sgls[i].sg_nr     = 1;
+		sgls[i].sg_nr_out = 0;
+		sgls[i].sg_iovs   = &sg_iovs[i];
+
+		memset(&iods[i], 0, sizeof(iods[i]));
+		d_iov_set(&iods[i].iod_name, i == 0 ? "miom_akey0" : "miom_akey1",
+			  strlen("miom_akey0"));
+		iods[i].iod_size  = 1;
+		iods[i].iod_recxs = recxs;
+		iods[i].iod_type  = DAOS_IOD_ARRAY;
+		iods[i].iod_nr    = EC_IOM_EXT_NR;
+	}
+
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 2, iods, sgls, NULL);
+	assert_rc_equal(rc, 0);
+
+	print_message("fetch 2 IODs, caller provided iom_recxs for both IOMs\n");
+	memset(iom_recxs, 0, sizeof(iom_recxs));
+	memset(ioms, 0, sizeof(ioms));
+	ioms[0].iom_recxs = iom_recxs;
+	ioms[0].iom_nr    = EC_IOM_BUF_NR;
+	ioms[0].iom_flags = DAOS_IOMF_DETAIL;
+	/* the 2nd IOM asks DAOS to allocate the iom_recxs buffer */
+	ioms[1].iom_recxs = NULL;
+	ioms[1].iom_flags = DAOS_IOMF_DETAIL;
+	rc                = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 2, iods, sgls, ioms, NULL);
+	assert_rc_equal(rc, 0);
+
+	for (i = 0; i < 2; i++) {
+		assert_int_equal(ioms[i].iom_type, DAOS_IOD_ARRAY);
+		assert_int_equal(ioms[i].iom_size, 1);
+		assert_int_equal(ioms[i].iom_nr_out, EC_IOM_EXT_NR);
+		assert_true(ioms[i].iom_nr_out <= ioms[i].iom_nr);
+		assert_int_equal(ioms[i].iom_recx_lo.rx_idx, 0);
+		assert_int_equal(ioms[i].iom_recx_lo.rx_nr, EC_IOM_EXT_SIZE);
+		assert_int_equal(ioms[i].iom_recx_hi.rx_idx, (EC_IOM_EXT_NR - 1) * cell_size);
+		assert_int_equal(ioms[i].iom_recx_hi.rx_nr, EC_IOM_EXT_SIZE);
+	}
+	/* the caller provided buffer must not have been re-allocated */
+	assert_ptr_equal(ioms[0].iom_recxs, iom_recxs);
+	assert_int_equal(ioms[0].iom_nr, EC_IOM_BUF_NR);
+	assert_non_null(ioms[1].iom_recxs);
+	assert_ptr_not_equal(ioms[1].iom_recxs, iom_recxs);
+	for (i = 0; i < EC_IOM_EXT_NR; i++) {
+		assert_int_equal(ioms[0].iom_recxs[i].rx_idx, i * cell_size);
+		assert_int_equal(ioms[0].iom_recxs[i].rx_nr, EC_IOM_EXT_SIZE);
+		assert_int_equal(ioms[1].iom_recxs[i].rx_idx, i * cell_size);
+		assert_int_equal(ioms[1].iom_recxs[i].rx_nr, EC_IOM_EXT_SIZE);
+	}
+	D_FREE(ioms[1].iom_recxs);
+
+	print_message("fetch 2 IODs, the 1st IOM buffer is too small\n");
+	memset(iom_recxs, 0, sizeof(iom_recxs));
+	memset(ioms, 0, sizeof(ioms));
+	ioms[0].iom_recxs = iom_recxs;
+	ioms[0].iom_nr    = EC_IOM_SMALL_NR;
+	ioms[0].iom_flags = DAOS_IOMF_DETAIL;
+	ioms[1].iom_recxs = NULL;
+	ioms[1].iom_flags = DAOS_IOMF_DETAIL;
+	rc                = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 2, iods, sgls, ioms, NULL);
+	assert_rc_equal(rc, 0);
+	/* the truncation of the 1st IOM must not be accounted in the 2nd one */
+	assert_int_equal(ioms[0].iom_nr, EC_IOM_SMALL_NR);
+	assert_int_equal(ioms[0].iom_nr_out, EC_IOM_EXT_NR);
+	assert_int_equal(ioms[1].iom_nr_out, EC_IOM_EXT_NR);
+	assert_true(ioms[1].iom_nr_out <= ioms[1].iom_nr);
+	/* nothing beyond iom_nr should have been read or written */
+	for (i = EC_IOM_SMALL_NR; i < EC_IOM_BUF_NR; i++) {
+		assert_int_equal(iom_recxs[i].rx_idx, 0);
+		assert_int_equal(iom_recxs[i].rx_nr, 0);
+	}
+	D_FREE(ioms[1].iom_recxs);
+
+	rc = daos_obj_close(oh, NULL);
+	assert_rc_equal(rc, 0);
+	D_FREE(buf);
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest ec_tests[] = {
     {"EC0: ec dkey list and punch test", ec_dkey_list_punch, async_disable, test_case_teardown},
@@ -2919,6 +3042,7 @@ static const struct CMUnitTest ec_tests[] = {
     {"EC29: ec full and partial punch then aggregation", ec_full_partial_punch_agg, async_disable,
      test_case_teardown},
     {"EC30: ec fetch iom merge", ec_fetch_iom, async_disable, test_case_teardown},
+    {"EC31: ec fetch multiple iom merge", ec_fetch_multi_iom, async_disable, test_case_teardown},
 };
 
 int

--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2698,66 +2698,227 @@ ec_full_partial_punch_agg(void **state)
 	free(verify_data);
 }
 
+/* number of extents written, one per EC cell so that they land on different
+ * data shards and cannot be merged with each other.
+ */
+#define EC_IOM_EXT_NR   8
+/* size of each extent, much smaller than a cell */
+#define EC_IOM_EXT_SIZE 1024
+/* size of the caller provided iom_recxs buffer */
+#define EC_IOM_BUF_NR   16
+/* size of the intentionally too small iom_recxs buffer */
+#define EC_IOM_SMALL_NR 3
+
+/*
+ * Verify the client side IOM merge of EC array fetch (obj_ec_iom_merge()):
+ *  - the extents returned by the different EC data shards are merged into the
+ *    caller's IOM, sorted and with correct iom_type/iom_size,
+ *  - iom_recx_lo/iom_recx_hi are merged across all the shards, also when
+ *    DAOS_IOMF_DETAIL is not set and when some shards return an empty IOM,
+ *  - when the caller's iom_recxs buffer is too small the number of extents
+ *    needed is reported through iom_nr_out and no memory beyond iom_nr is
+ *    touched.
+ */
+static void
+ec_fetch_iom(void **state)
+{
+	test_arg_t   *arg = *state;
+	daos_obj_id_t oid;
+	daos_handle_t oh;
+	d_iov_t       dkey;
+	d_sg_list_t   sgl;
+	d_iov_t       sg_iov;
+	daos_iod_t    iod;
+	daos_iom_t    iom = {0};
+	daos_recx_t   iom_recxs[EC_IOM_BUF_NR];
+	daos_recx_t   recxs[EC_IOM_EXT_NR];
+	daos_size_t   cell_size = ec_cell_size;
+	daos_size_t   buf_len;
+	char         *buf;
+	int           i, rc;
+
+	if (!test_runable(arg, 6))
+		return;
+
+	buf_len = EC_IOM_EXT_NR * EC_IOM_EXT_SIZE;
+	D_ALLOC(buf, buf_len);
+	assert_non_null(buf);
+	dts_buf_render(buf, buf_len);
+
+	oid = daos_test_oid_gen(arg->coh, ec_obj_class, 0, 0, arg->myrank);
+	rc  = daos_obj_open(arg->coh, oid, DAOS_OO_RW, &oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	d_iov_set(&dkey, "iom_dkey", strlen("iom_dkey"));
+	d_iov_set(&sg_iov, buf, buf_len);
+	sgl.sg_nr     = 1;
+	sgl.sg_nr_out = 0;
+	sgl.sg_iovs   = &sg_iov;
+
+	d_iov_set(&iod.iod_name, "iom_akey", strlen("iom_akey"));
+	iod.iod_size  = 1;
+	iod.iod_recxs = recxs;
+	iod.iod_type  = DAOS_IOD_ARRAY;
+	iod.iod_nr    = EC_IOM_EXT_NR;
+
+	for (i = 0; i < EC_IOM_EXT_NR; i++) {
+		recxs[i].rx_idx = i * cell_size;
+		recxs[i].rx_nr  = EC_IOM_EXT_SIZE;
+	}
+
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_rc_equal(rc, 0);
+
+	print_message("fetch IOM with a large enough iom_recxs buffer\n");
+	memset(iom_recxs, 0, sizeof(iom_recxs));
+	memset(&iom, 0, sizeof(iom));
+	iom.iom_recxs = iom_recxs;
+	iom.iom_nr    = EC_IOM_BUF_NR;
+	iom.iom_flags = DAOS_IOMF_DETAIL;
+	rc            = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, &iom, NULL);
+	assert_rc_equal(rc, 0);
+	assert_int_equal(iom.iom_nr_out, EC_IOM_EXT_NR);
+	assert_int_equal(iom.iom_type, DAOS_IOD_ARRAY);
+	assert_int_equal(iom.iom_size, 1);
+	for (i = 0; i < EC_IOM_EXT_NR; i++) {
+		assert_int_equal(iom.iom_recxs[i].rx_idx, i * cell_size);
+		assert_int_equal(iom.iom_recxs[i].rx_nr, EC_IOM_EXT_SIZE);
+	}
+	assert_int_equal(iom.iom_recx_lo.rx_idx, 0);
+	assert_int_equal(iom.iom_recx_lo.rx_nr, EC_IOM_EXT_SIZE);
+	assert_int_equal(iom.iom_recx_hi.rx_idx, (EC_IOM_EXT_NR - 1) * cell_size);
+	assert_int_equal(iom.iom_recx_hi.rx_nr, EC_IOM_EXT_SIZE);
+
+	print_message("fetch IOM with a too small iom_recxs buffer\n");
+	memset(iom_recxs, 0, sizeof(iom_recxs));
+	memset(&iom, 0, sizeof(iom));
+	iom.iom_recxs = iom_recxs;
+	iom.iom_nr    = EC_IOM_SMALL_NR;
+	iom.iom_flags = DAOS_IOMF_DETAIL;
+	rc            = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, &iom, NULL);
+	assert_rc_equal(rc, 0);
+	/* the number of extents needed to hold the whole IOM */
+	assert_int_equal(iom.iom_nr_out, EC_IOM_EXT_NR);
+	assert_int_equal(iom.iom_nr, EC_IOM_SMALL_NR);
+	/* nothing beyond iom_nr should have been read or written */
+	for (i = EC_IOM_SMALL_NR; i < EC_IOM_BUF_NR; i++) {
+		assert_int_equal(iom_recxs[i].rx_idx, 0);
+		assert_int_equal(iom_recxs[i].rx_nr, 0);
+	}
+	assert_int_equal(iom.iom_recx_lo.rx_idx, 0);
+	assert_int_equal(iom.iom_recx_lo.rx_nr, EC_IOM_EXT_SIZE);
+	assert_int_equal(iom.iom_recx_hi.rx_idx, (EC_IOM_EXT_NR - 1) * cell_size);
+	assert_int_equal(iom.iom_recx_hi.rx_nr, EC_IOM_EXT_SIZE);
+
+	print_message("fetch IOM without DAOS_IOMF_DETAIL\n");
+	memset(iom_recxs, 0, sizeof(iom_recxs));
+	memset(&iom, 0, sizeof(iom));
+	iom.iom_recxs = iom_recxs;
+	iom.iom_nr    = EC_IOM_BUF_NR;
+	rc            = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, &iom, NULL);
+	assert_rc_equal(rc, 0);
+	assert_int_equal(iom.iom_nr_out, 0);
+	/* iom_recx_lo/hi must be merged from all the shards, not overwritten
+	 * by the last shard that replied.
+	 */
+	assert_int_equal(iom.iom_recx_lo.rx_idx, 0);
+	assert_int_equal(iom.iom_recx_lo.rx_nr, EC_IOM_EXT_SIZE);
+	assert_int_equal(iom.iom_recx_hi.rx_idx, (EC_IOM_EXT_NR - 1) * cell_size);
+	assert_int_equal(iom.iom_recx_hi.rx_nr, EC_IOM_EXT_SIZE);
+
+	print_message("fetch IOM with shards returning an empty IOM\n");
+	/* Only write the extents of the 1st and the 3rd cell, the fetch below
+	 * still spans the first 4 cells so the shards of the 2nd and the 4th
+	 * cell return an empty IOM - which must not drag iom_recx_hi down to
+	 * index 0 nor pin iom_recx_lo to a zero length extent.
+	 */
+	d_iov_set(&dkey, "iom_dkey2", strlen("iom_dkey2"));
+	recxs[0].rx_idx = 0;
+	recxs[0].rx_nr  = EC_IOM_EXT_SIZE;
+	recxs[1].rx_idx = 2 * cell_size;
+	recxs[1].rx_nr  = EC_IOM_EXT_SIZE;
+	iod.iod_nr      = 2;
+	d_iov_set(&sg_iov, buf, 2 * EC_IOM_EXT_SIZE);
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_rc_equal(rc, 0);
+
+	recxs[0].rx_idx = 0;
+	recxs[1].rx_idx = cell_size;
+	recxs[2].rx_idx = 2 * cell_size;
+	recxs[3].rx_idx = 3 * cell_size;
+	for (i = 0; i < 4; i++)
+		recxs[i].rx_nr = EC_IOM_EXT_SIZE;
+	iod.iod_nr = 4;
+	d_iov_set(&sg_iov, buf, 4 * EC_IOM_EXT_SIZE);
+	memset(iom_recxs, 0, sizeof(iom_recxs));
+	memset(&iom, 0, sizeof(iom));
+	iom.iom_recxs = iom_recxs;
+	iom.iom_nr    = EC_IOM_BUF_NR;
+	iom.iom_flags = DAOS_IOMF_DETAIL;
+	rc            = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, &iom, NULL);
+	assert_rc_equal(rc, 0);
+	assert_int_equal(iom.iom_nr_out, 2);
+	assert_int_equal(iom.iom_recxs[0].rx_idx, 0);
+	assert_int_equal(iom.iom_recxs[0].rx_nr, EC_IOM_EXT_SIZE);
+	assert_int_equal(iom.iom_recxs[1].rx_idx, 2 * cell_size);
+	assert_int_equal(iom.iom_recxs[1].rx_nr, EC_IOM_EXT_SIZE);
+	assert_int_equal(iom.iom_recx_lo.rx_idx, 0);
+	assert_int_equal(iom.iom_recx_lo.rx_nr, EC_IOM_EXT_SIZE);
+	assert_int_equal(iom.iom_recx_hi.rx_idx, 2 * cell_size);
+	assert_int_equal(iom.iom_recx_hi.rx_nr, EC_IOM_EXT_SIZE);
+
+	rc = daos_obj_close(oh, NULL);
+	assert_rc_equal(rc, 0);
+	D_FREE(buf);
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest ec_tests[] = {
-	{"EC0: ec dkey list and punch test",
-	 ec_dkey_list_punch, async_disable, test_case_teardown},
-	{"EC1: ec akey list and punch test",
-	 ec_akey_list_punch, async_disable, test_case_teardown},
-	{"EC2: ec rec list and punch test",
-	 ec_rec_list_punch, async_disable, test_case_teardown},
-	{"EC3: ec partial update then aggregation",
-	 ec_partial_update_agg, async_disable, test_case_teardown},
-	{"EC4: ec cross cell partial update then aggregation",
-	 ec_cross_cell_partial_update_agg, async_disable, test_case_teardown},
-	{"EC5: ec full and partial update then aggregation",
-	 ec_full_partial_update_agg, async_disable, test_case_teardown},
-	{"EC6: ec partial and full update then aggregation",
-	 ec_partial_full_update_agg, async_disable, test_case_teardown},
-	{"EC7: ec file size check on parity",
-	 dfs_ec_check_size, async_disable, test_case_teardown},
-	{"EC8: ec file size check on non-parity",
-	 dfs_ec_check_size_nonparity, async_disable, test_case_teardown},
-	{"EC9: ec aggregation failed",
-	 ec_agg_fail, async_disable, test_case_teardown},
-	{"EC10: ec aggregation peer update failed",
-	 ec_agg_peer_fail, async_disable, test_case_teardown},
-	{"EC11: ec single-value array mixed IO",
-	 ec_singv_array_mixed_io, async_disable, test_case_teardown},
-	{"EC12: ec full stripe snapshot",
-	 ec_full_stripe_snapshot, async_disable, test_case_teardown},
-	{"EC13: ec partial stripe snapshot",
-	 ec_partial_stripe_snapshot, async_disable, test_case_teardown},
-	{"EC14: ec partial stripe cross boundary snapshot",
-	 ec_partial_stripe_cross_boundry_snapshot, async_disable,
-	 test_case_teardown},
-	{"EC15: ec punch and check_size", ec_punch_check_size, async_disable,
-	 test_case_teardown},
-	{"EC16: ec single-value overwrite", ec_singv_overwrite, async_disable,
-	 test_case_teardown},
-	{"EC17: ec single-value different size fetch", ec_singv_diff_size_fetch, async_disable,
-	 test_case_teardown},
-	{"EC18: ec conditional fetch", ec_cond_fetch, async_disable, test_case_teardown},
-	{"EC19: ec few partial stripe update", ec_few_partial_stripe_aggregation, async_disable,
-	 test_case_teardown},
-	{"EC20: ec recx list from parity", ec_rec_parity_list, async_disable, test_case_teardown},
-	{"EC21: ec update two akeys and parity shards failed", ec_update_2akeys, async_disable,
-	 test_case_teardown},
-	{"EC22: ec data recovery", ec_data_recov, async_disable, test_case_teardown},
-	{"EC23: ec multi-singv overwrite", ec_multi_singv_overwrite, async_disable,
-	test_case_teardown},
-	{"EC24: ec multi-array update", ec_multi_array, async_disable,
-	test_case_teardown},
-	{"EC25: ec dkey enumerate with failure shard", ec_dkey_enum_fail, async_disable,
-	test_case_teardown},
-	{"EC26: ec single nvme io failed", ec_single_stripe_nvme_io, async_disable,
-	test_case_teardown},
-	{"EC27: ec double nvme io failed", ec_two_stripes_nvme_io, async_disable,
-	test_case_teardown},
-	{"EC28: ec three nvme io failed", ec_three_stripes_nvme_io, async_disable,
-	test_case_teardown},
-	{"EC29: ec full and partial punch then aggregation",
-	 ec_full_partial_punch_agg, async_disable, test_case_teardown},
+    {"EC0: ec dkey list and punch test", ec_dkey_list_punch, async_disable, test_case_teardown},
+    {"EC1: ec akey list and punch test", ec_akey_list_punch, async_disable, test_case_teardown},
+    {"EC2: ec rec list and punch test", ec_rec_list_punch, async_disable, test_case_teardown},
+    {"EC3: ec partial update then aggregation", ec_partial_update_agg, async_disable,
+     test_case_teardown},
+    {"EC4: ec cross cell partial update then aggregation", ec_cross_cell_partial_update_agg,
+     async_disable, test_case_teardown},
+    {"EC5: ec full and partial update then aggregation", ec_full_partial_update_agg, async_disable,
+     test_case_teardown},
+    {"EC6: ec partial and full update then aggregation", ec_partial_full_update_agg, async_disable,
+     test_case_teardown},
+    {"EC7: ec file size check on parity", dfs_ec_check_size, async_disable, test_case_teardown},
+    {"EC8: ec file size check on non-parity", dfs_ec_check_size_nonparity, async_disable,
+     test_case_teardown},
+    {"EC9: ec aggregation failed", ec_agg_fail, async_disable, test_case_teardown},
+    {"EC10: ec aggregation peer update failed", ec_agg_peer_fail, async_disable,
+     test_case_teardown},
+    {"EC11: ec single-value array mixed IO", ec_singv_array_mixed_io, async_disable,
+     test_case_teardown},
+    {"EC12: ec full stripe snapshot", ec_full_stripe_snapshot, async_disable, test_case_teardown},
+    {"EC13: ec partial stripe snapshot", ec_partial_stripe_snapshot, async_disable,
+     test_case_teardown},
+    {"EC14: ec partial stripe cross boundary snapshot", ec_partial_stripe_cross_boundry_snapshot,
+     async_disable, test_case_teardown},
+    {"EC15: ec punch and check_size", ec_punch_check_size, async_disable, test_case_teardown},
+    {"EC16: ec single-value overwrite", ec_singv_overwrite, async_disable, test_case_teardown},
+    {"EC17: ec single-value different size fetch", ec_singv_diff_size_fetch, async_disable,
+     test_case_teardown},
+    {"EC18: ec conditional fetch", ec_cond_fetch, async_disable, test_case_teardown},
+    {"EC19: ec few partial stripe update", ec_few_partial_stripe_aggregation, async_disable,
+     test_case_teardown},
+    {"EC20: ec recx list from parity", ec_rec_parity_list, async_disable, test_case_teardown},
+    {"EC21: ec update two akeys and parity shards failed", ec_update_2akeys, async_disable,
+     test_case_teardown},
+    {"EC22: ec data recovery", ec_data_recov, async_disable, test_case_teardown},
+    {"EC23: ec multi-singv overwrite", ec_multi_singv_overwrite, async_disable, test_case_teardown},
+    {"EC24: ec multi-array update", ec_multi_array, async_disable, test_case_teardown},
+    {"EC25: ec dkey enumerate with failure shard", ec_dkey_enum_fail, async_disable,
+     test_case_teardown},
+    {"EC26: ec single nvme io failed", ec_single_stripe_nvme_io, async_disable, test_case_teardown},
+    {"EC27: ec double nvme io failed", ec_two_stripes_nvme_io, async_disable, test_case_teardown},
+    {"EC28: ec three nvme io failed", ec_three_stripes_nvme_io, async_disable, test_case_teardown},
+    {"EC29: ec full and partial punch then aggregation", ec_full_partial_punch_agg, async_disable,
+     test_case_teardown},
+    {"EC30: ec fetch iom merge", ec_fetch_iom, async_disable, test_case_teardown},
 };
 
 int


### PR DESCRIPTION
The original code possibly cause assertion or invalid memory access. Add a test case to reproduce the bug and verify the fix.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
