### PR TITLE
DAOS-19362 control: Skip tmpfs check early return in MD-on-SSD mode

### DIFF
--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -615,9 +615,17 @@ func checkEngineTmpfsMem(srv *server, ei *EngineInstance, smi *common.SysMemInfo
 		if usage.TotalBytes > memRamdisk {
 			return storage.FaultRamdiskBadSize(usage.TotalBytes, memRamdisk)
 		}
-		// Looks OK, so we can return early and bypass additional checks.
-		srv.log.Debugf("using existing tmpfs of size %s", humanize.IBytes(usage.TotalBytes))
-		return nil
+		// For MD-on-SSD, the ramdisk is always recreated during startup so we should
+		// validate memory rather than assuming the mount is valid and bypass checks.
+		if ei.storage.ControlMetadataPathConfigured() {
+			srv.log.Debugf("MD-on-SSD detected, validating ramdisk (%s) memory "+
+				"requirements", humanize.IBytes(usage.TotalBytes))
+		} else {
+			// Looks OK, so we can return early and bypass additional checks.
+			srv.log.Debugf("using existing tmpfs of size %s",
+				humanize.IBytes(usage.TotalBytes))
+			return nil
+		}
 	} else if err != nil {
 		return errors.Wrap(err, "unable to check for mounted tmpfs")
 	}

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -1623,6 +1623,20 @@ func TestServer_checkEngineTmpfsMem(t *testing.T) {
 			tmpfsMounted: true,
 			tmpfsSize:    9,
 		},
+		"tmpfs mounted; MD-on-SSD; validate memory": {
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				mdOnSsdTier := nvmeTier(0).WithBdevDeviceRoles(storage.BdevRoleMeta)
+				mdOnSsdEngine := ramEngine(0, 10)
+				mdOnSsdEngine.Storage.Tiers = append(mdOnSsdEngine.Storage.Tiers, mdOnSsdTier)
+				mdOnSsdEngine.Storage.ControlMetadata = storage.ControlMetadata{
+					Path: "/var/daos/md0",
+				}
+				return sc.WithEngines(mdOnSsdEngine)
+			},
+			tmpfsMounted: true,
+			tmpfsSize:    9,
+			memAvailGiB:  9,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(name)


### PR DESCRIPTION
     In MD-on-SSD mode, awaitStorageReady() automatically formats and mounts
     the ramdisk before NotifyStorageReady() callbacks fire. This causes
     checkEngineTmpfsMem() to find an already-mounted tmpfs and return early
     with "using existing tmpfs of size X" message, which is misleading since
     the tmpfs was just formatted moments earlier.

     Skip the early return when MD-on-SSD with meta role is configured to:
     1. Avoid the misleading "using existing tmpfs" log message
     2. Ensure full memory validation runs even for freshly mounted ramdisk
     3. Provide clearer logging about ramdisk validation in MD-on-SSD mode

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
