### PR TITLE
DAOS-18609 test: Resolving slurm issue for el9 (#18294)

### DIFF
--- a/src/tests/ftest/slurm_setup.py
+++ b/src/tests/ftest/slurm_setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -34,7 +35,7 @@ class SlurmSetup():
         '/etc/slurm/slurmdbd.conf.example']
     MUNGE_DIR = '/etc/munge'
     MUNGE_KEY = '/etc/munge/munge.key'
-    PACKAGE_LIST = ['slurm', 'slurm-example-configs', 'slurm-slurmctld', 'slurm-slurmd']
+    PACKAGE_LIST = ['slurm', 'slurm-slurmdbd', 'slurm-slurmctld', 'slurm-slurmd']
     SLURM_CONF = '/etc/slurm/slurm.conf'
     SLURM_LOG_DIR = '/var/log/slurm'
 
@@ -182,18 +183,19 @@ class SlurmSetup():
 
         # Restart slurmctld on the control node
         self._restart_systemctl(
-            self.control, 'slurmctld', '/var/log/slurmctld.log', self.SLURM_CONF)
+            self.control, 'slurmctld', '/var/log/slurm/slurmctld.log', self.SLURM_CONF)
 
         # Restart slurmd on all nodes
-        self._restart_systemctl(self.all_nodes, 'slurmd', '/var/log/slurmd.log', self.SLURM_CONF)
+        self._restart_systemctl(
+            self.all_nodes, 'slurmd', '/var/log/slurm/slurmd.log', self.SLURM_CONF)
 
         # Update nodes to the idle state
         command = command_as_user(
             f'scontrol update nodename={str(self.nodes)} state=idle', self.root)
         result = run_remote(self.log, self.nodes, command)
         if not result.passed or debug:
-            self._display_debug(self.control, '/var/log/slurmctld.log', self.SLURM_CONF)
-            self._display_debug(self.all_nodes, '/var/log/slurmd.log', self.SLURM_CONF)
+            self._display_debug(self.control, '/var/log/slurm/slurmctld.log', self.SLURM_CONF)
+            self._display_debug(self.all_nodes, '/var/log/slurm/slurmd.log', self.SLURM_CONF)
         if not result.passed:
             raise SlurmSetupException(f'Error setting nodes to idle on {self.nodes}')
 
@@ -268,8 +270,8 @@ class SlurmSetup():
 
         # Update the config file with the slurm epilog file
         self._modify_slurm_config_file(
-            'epilog file', self.all_nodes, 's#EpilogSlurmctld=#EpilogSlurmctld={EPILOG_FILE}#g',
-            self.root)
+            'epilog file', self.all_nodes,
+            f's#EpilogSlurmctld=#EpilogSlurmctld={self.EPILOG_FILE}#g', self.root)
 
         # Update the config file with the slurm control node
         not_updated = self.all_nodes.copy()
@@ -280,7 +282,7 @@ class SlurmSetup():
                 not_updated.remove(
                     self._modify_slurm_config_file(
                         'slurm control node', results.passed_hosts,
-                        f's/{control_keyword}=linux0/{control_keyword}={str(self.control)}/g',
+                        f's/{control_keyword}=localhost/{control_keyword}={str(self.control)}/g',
                         self.root))
         if not_updated:
             raise SlurmSetupException(f'Slurm control node not updated on {not_updated}')

--- a/src/tests/ftest/soak/smoke.yaml
+++ b/src/tests/ftest/soak/smoke.yaml
@@ -77,7 +77,7 @@ smoke:
     - fio_smoke
     #- daos_racer
     - mdtest_smoke
-    - vpic_smoke
+    #- vpic_smoke
     - lammps_smoke
     - macsio_smoke
     - datamover_smoke

--- a/src/tests/ftest/util/slurm_utils.py
+++ b/src/tests/ftest/util/slurm_utils.py
@@ -1,6 +1,6 @@
 """
 (C) Copyright 2019-2024 Intel Corporation.
-(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+(C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -52,7 +52,7 @@ def create_partition(log, control, name, hosts, default='yes', max_time='UNLIMIT
     Returns:
         CommandResult: results from the scontrol command
     """
-    command = ['scontrol', 'create']
+    command = ['sudo', 'scontrol', 'create']
     command.append('='.join(['PartitionName', str(name)]))
     command.append('='.join(['Nodes', str(hosts)]))
     command.append('='.join(['Default', str(default)]))
@@ -73,7 +73,7 @@ def delete_partition(log, control, name):
         int: return status from scontrol command
 
     """
-    command = ['scontrol', 'delete']
+    command = ['sudo', 'scontrol', 'delete']
     command.append('='.join(['PartitionName', str(name)]))
     return run_remote(log, control, ' '.join(command))
 

--- a/src/tests/ftest/util/soak_utils.py
+++ b/src/tests/ftest/util/soak_utils.py
@@ -5,6 +5,7 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 # pylint: disable=too-many-lines
+# pylint: disable=too-many-locals
 
 import getpass
 import os
@@ -1482,8 +1483,30 @@ def create_app_cmdline(self, job_spec, pool, ppn, nodesperjob):
     # ${DAOS_TEST_APP_SRC}/suse             =>  apps built with suse and gnu-mpich
     # pylint: disable-next=wrong-spelling-in-comment,fixme
     # ${DAOS_TEST_APP_SRC}/suse/intelmpi    =>  apps built with suse and intelmpi
-    if "suse" in detect().name.lower() and os.environ.get("DAOS_TEST_MODE") is None:
-        os.environ["DAOS_TEST_APP_DIR"] += os.path.join(os.sep, "suse")
+    os_info = detect()
+    os_name = (os_info.name or "").lower()
+    os_version = str(os_info.version or "").strip()
+
+    # Fallback for cases where avocado detect() returns unknown/0.
+    if (not os_name or os_name == "unknown" or not os_version or os_version == "0") \
+            and os.path.exists("/etc/os-release"):
+        os_release = {}
+        with open("/etc/os-release", "r", encoding="utf-8") as fd:
+            for line in fd:
+                if "=" not in line:
+                    continue
+                key, value = line.rstrip().split("=", 1)
+                os_release[key] = value.strip().strip('"')
+        os_name = (os_release.get("NAME") or os_release.get("ID") or os_name).lower()
+        os_version = (os_release.get("VERSION_ID") or os_version).strip()
+
+    if os.environ.get("DAOS_TEST_MODE") is None:
+        if "suse" in os_name:
+            os.environ["DAOS_TEST_APP_DIR"] += os.path.join(os.sep, "suse")
+        elif os_version == "9":
+            os.environ["DAOS_TEST_APP_DIR"] += os.path.join(os.sep, "el9")
+        elif os_version == "8":
+            os.environ["DAOS_TEST_APP_DIR"] += os.path.join(os.sep, "el8")
     if "mpi/latest" in mpi_module and os.environ.get("DAOS_TEST_MODE") is None:
         os.environ["DAOS_TEST_APP_DIR"] += os.path.join(os.sep, "intelmpi")
         os.environ["I_MPI_OFI_LIBRARY_INTERNAL"] = "0"


### PR DESCRIPTION
After CI moved over to el9 slurm package
installation needed readjusting.
slurm-example-configs removed
slurm-slurmdbd added

Test-tag: test_soak_smoke

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
