### PR TITLE
DAOS-19281 control: Suppress storage tier ratio warning for MD-on-SSD…

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -193,19 +193,46 @@ type poolCreateCmd struct {
 
 func ratio2Percentage(log logging.Logger, tier1, tier2 float64) (p float64) {
 	p = 100.00
-	min := storage.MinScmToNVMeRatio * p
 
 	if tier2 > 0 {
 		p *= tier1 / (tier1 + tier2)
-		if p < min {
-			log.Noticef("storage tier ratio is less than %0.2f%%, DAOS performance "+
-				"will suffer!", min)
-		}
 		return
 	}
 
 	log.Notice("Creating DAOS pool with only a single tier of storage")
 	return
+}
+
+// checkPoolCreateTierRatioWarning examines the pool create response and returns a warning
+// message if the tier ratio is below the minimum threshold for PMem mode. Returns empty
+// string if no warning is needed (MD-on-SSD mode or acceptable ratio).
+func checkPoolCreateTierRatioWarning(resp *control.PoolCreateResp) string {
+	// Only check for two-tier configurations (SCM/NVMe or metadata/data)
+	if len(resp.TierBytes) != 2 {
+		return ""
+	}
+
+	// Skip if second tier is not configured
+	if resp.TierBytes[1] == 0 {
+		return ""
+	}
+
+	// Skip warning for MD-on-SSD mode - low metadata ratios are normal
+	if resp.MdOnSsdActive {
+		return ""
+	}
+
+	// Calculate actual tier ratio from allocated bytes
+	percentage := 100.00 * float64(resp.TierBytes[0]) / float64(resp.TierBytes[0]+resp.TierBytes[1])
+	minPercentage := storage.MinScmToNVMeRatio * 100.00
+
+	// Warn if ratio is below minimum for PMem mode (SCM:NVMe)
+	if percentage < minPercentage {
+		return fmt.Sprintf("storage tier ratio is less than %0.2f%%, DAOS performance may suffer!",
+			minPercentage)
+	}
+
+	return ""
 }
 
 // MemRatio can be supplied as two fractions that make up 1 or a single fraction less than 1.
@@ -394,6 +421,11 @@ func (cmd *poolCreateCmd) Execute(args []string) error {
 
 	if err != nil {
 		return err
+	}
+
+	// Check if low tier ratio warning should be shown
+	if warning := checkPoolCreateTierRatioWarning(resp); warning != "" {
+		cmd.Notice(warning)
 	}
 
 	var bld strings.Builder

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -1,6 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -1489,6 +1489,106 @@ func TestDmg_PoolListCmd_Errors(t *testing.T) {
 
 			gotErr := cmd.Execute(nil)
 			test.CmpErr(t, tc.expErr, gotErr)
+		})
+	}
+}
+
+func Test_checkPoolCreateTierRatioWarning(t *testing.T) {
+	for name, tc := range map[string]struct {
+		resp       *control.PoolCreateResp
+		expWarning string
+	}{
+		"PMem mode with low tier ratio - warning expected": {
+			resp: &control.PoolCreateResp{
+				TierBytes:     []uint64{100 * humanize.GiByte, 10 * humanize.TiByte}, // 0.98% ratio
+				MdOnSsdActive: false,
+			},
+			expWarning: "storage tier ratio is less than 1.00%, DAOS performance may suffer!",
+		},
+		"PMem mode with acceptable tier ratio - no warning": {
+			resp: &control.PoolCreateResp{
+				TierBytes:     []uint64{600 * humanize.GiByte, 9400 * humanize.GiByte}, // 6% ratio
+				MdOnSsdActive: false,
+			},
+			expWarning: "",
+		},
+		"PMem mode at minimum threshold - no warning": {
+			resp: &control.PoolCreateResp{
+				TierBytes:     []uint64{100 * humanize.GiByte, 9900 * humanize.GiByte}, // 1.0% ratio
+				MdOnSsdActive: false,
+			},
+			expWarning: "",
+		},
+		"PMem mode just below threshold - warning expected": {
+			resp: &control.PoolCreateResp{
+				TierBytes:     []uint64{99 * humanize.GiByte, 9901 * humanize.GiByte}, // 0.99% ratio
+				MdOnSsdActive: false,
+			},
+			expWarning: "storage tier ratio is less than 1.00%, DAOS performance may suffer!",
+		},
+		"MD-on-SSD mode with low tier ratio - no warning": {
+			resp: &control.PoolCreateResp{
+				TierBytes:     []uint64{142 * humanize.GiByte, 20 * humanize.TiByte}, // ~0.7% ratio
+				MdOnSsdActive: true,
+			},
+			expWarning: "",
+		},
+		"MD-on-SSD mode with very low tier ratio - no warning": {
+			resp: &control.PoolCreateResp{
+				TierBytes:     []uint64{10 * humanize.GiByte, 10 * humanize.TiByte}, // ~0.1% ratio
+				MdOnSsdActive: true,
+			},
+			expWarning: "",
+		},
+		"MD-on-SSD mode with normal tier ratio - no warning": {
+			resp: &control.PoolCreateResp{
+				TierBytes:     []uint64{1200 * humanize.GiByte, 18800 * humanize.GiByte}, // 6% ratio
+				MdOnSsdActive: true,
+			},
+			expWarning: "",
+		},
+		"single tier configuration - no warning": {
+			resp: &control.PoolCreateResp{
+				TierBytes:     []uint64{1000 * humanize.GiByte},
+				MdOnSsdActive: false,
+			},
+			expWarning: "",
+		},
+		"no second tier - no warning": {
+			resp: &control.PoolCreateResp{
+				TierBytes:     []uint64{1000 * humanize.GiByte, 0},
+				MdOnSsdActive: false,
+			},
+			expWarning: "",
+		},
+		"three tier configuration - no warning": {
+			resp: &control.PoolCreateResp{
+				TierBytes:     []uint64{100 * humanize.GiByte, 1000 * humanize.GiByte, 10000 * humanize.GiByte},
+				MdOnSsdActive: false,
+			},
+			expWarning: "",
+		},
+		"empty response - no warning": {
+			resp: &control.PoolCreateResp{
+				TierBytes:     []uint64{},
+				MdOnSsdActive: false,
+			},
+			expWarning: "",
+		},
+		"nil tier bytes - no warning": {
+			resp: &control.PoolCreateResp{
+				TierBytes:     nil,
+				MdOnSsdActive: false,
+			},
+			expWarning: "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotWarning := checkPoolCreateTierRatioWarning(tc.resp)
+
+			if diff := cmp.Diff(tc.expWarning, gotWarning); diff != "" {
+				t.Fatalf("unexpected warning (-want, +got):\n%s", diff)
+			}
 		})
 	}
 }


### PR DESCRIPTION
… pools (#18619)

Remove misleading low tier ratio warning when creating pools with MD-on-SSD enabled. Low metadata-to-data ratios (~0.7%) are normal and expected in MD-on-SSD mode, unlike PMem mode where <6% ratios may impact performance. Add comprehensive unit tests.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
