### PR TITLE
DAOS-19542 dfs: make rename/exchange of an entry with itself a no-op …

### DIFF
--- a/src/client/dfs/rename.c
+++ b/src/client/dfs/rename.c
@@ -181,6 +181,11 @@ restart:
 	if (moid)
 		oid_cp(moid, entry.oid);
 
+	/** source and target are the same entry: POSIX requires success with no other action */
+	if (flags == 0 && parent->oid.hi == new_parent->oid.hi &&
+	    parent->oid.lo == new_parent->oid.lo && strcmp(name, new_name) == 0)
+		D_GOTO(out, rc = 0);
+
 	rc = fetch_entry(dfs->layout_v, new_parent->oh, th, new_name, new_len, true, &exists,
 			 &new_entry, 0, NULL, NULL, NULL);
 	if (rc) {
@@ -381,6 +386,11 @@ restart:
 
 	if (exists == false)
 		D_GOTO(out, rc = EINVAL);
+
+	/** exchanging an entry with itself is a no-op */
+	if (parent1->oid.hi == parent2->oid.hi && parent1->oid.lo == parent2->oid.lo &&
+	    strcmp(name1, name2) == 0)
+		D_GOTO(out, rc = 0);
 
 	/** remove the first entry from parent1 (just the dkey) */
 	d_iov_set(&dkey, (void *)name1, len1);

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -1062,12 +1062,14 @@ static void
 dfs_test_rename(void **state)
 {
 	test_arg_t		*arg = *state;
-	dfs_obj_t		*obj1, *obj2;
+	dfs_obj_t               *obj1, *obj2, *root;
 	char			*f1 = "f1";
 	char			*f2 = "f2";
 	d_sg_list_t		sgl;
 	d_iov_t			iov;
 	char			buf[64];
+	char                     rbuf[64];
+	daos_size_t              read_size;
 	struct stat		stbuf;
 	struct timespec		prev_ts;
 	int			rc;
@@ -1141,6 +1143,36 @@ dfs_test_rename(void **state)
 	memset(&stbuf, 0, sizeof(stbuf));
 	rc = dfs_stat(dfs_mt, NULL, f2, &stbuf);
 	assert_int_equal(rc, 0);
+
+	/** renaming / exchanging an entry with itself must succeed and not destroy the file */
+	rc = dfs_move(dfs_mt, NULL, f2, NULL, f2, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_exchange(dfs_mt, NULL, f2, NULL, f2);
+	assert_int_equal(rc, 0);
+	/** same parent dir, but through a different open handle */
+	rc = dfs_lookup(dfs_mt, "/", O_RDWR, &root, NULL, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_move(dfs_mt, root, f2, NULL, f2, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_exchange(dfs_mt, root, f2, NULL, f2);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(root);
+	assert_int_equal(rc, 0);
+
+	/** the entry, its metadata and its data should all be intact */
+	memset(&stbuf, 0, sizeof(stbuf));
+	rc = dfs_stat(dfs_mt, NULL, f2, &stbuf);
+	assert_int_equal(rc, 0);
+	assert_int_equal(stbuf.st_size, 128);
+	memset(rbuf, 0, 64);
+	d_iov_set(&iov, rbuf, 64);
+	sgl.sg_nr     = 1;
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs   = &iov;
+	rc            = dfs_read(dfs_mt, obj2, &sgl, 64, &read_size, NULL);
+	assert_int_equal(rc, 0);
+	assert_int_equal(read_size, 64);
+	assert_int_equal(memcmp(buf, rbuf, 64), 0);
 
 	rc = dfs_move(dfs_mt, NULL, f2, NULL, f1, NULL);
 	assert_int_equal(rc, 0);


### PR DESCRIPTION
…(#18919)

dfs_move() with the same parent and name punched the object and removed the dirent, destroying the file. Return success without any action instead, and do the same for dfs_exchange().

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
