### PR TITLE
DAOS-19477 test: add pool properties in object

### DIFF
--- a/src/tests/ftest/object/fetch_bad_param.yaml
+++ b/src/tests/ftest/object/fetch_bad_param.yaml
@@ -17,3 +17,4 @@ server_config:
   system_ram_reserved: 1
 pool:
   scm_size: 1073741824
+  properties: "rd_fac:0,space_rb:0"

--- a/src/tests/ftest/object/integrity.yaml
+++ b/src/tests/ftest/object/integrity.yaml
@@ -17,6 +17,7 @@ server_config:
   system_ram_reserved: 1
 pool:
   scm_size: 3G
+  properties: "rd_fac:0,space_rb:0"
 array_size:
   size: 10
 dkeys: !mux

--- a/src/tests/ftest/object/punch_test.yaml
+++ b/src/tests/ftest/object/punch_test.yaml
@@ -16,3 +16,4 @@ server_config:
   system_ram_reserved: 1
 pool:
   scm_size: 1073741824
+  properties: "rd_fac:0,space_rb:0"

--- a/src/tests/ftest/object/update_bad_param.yaml
+++ b/src/tests/ftest/object/update_bad_param.yaml
@@ -15,3 +15,4 @@ server_config:
   system_ram_reserved: 1
 pool:
   scm_size: 1073741824
+  properties: "rd_fac:0,space_rb:0"


### PR DESCRIPTION
We will run tests with the default pool and container properties but some tests will fail with these default properties. Add pool properties to object tests that fail with the default pool properties.

Test-tag: object

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
