### PR TITLE
DAOS-19487 test: add pool properties in telemetry

### DIFF
--- a/src/tests/ftest/telemetry/dkey_akey_enum_punch.yaml
+++ b/src/tests/ftest/telemetry/dkey_akey_enum_punch.yaml
@@ -18,3 +18,4 @@ server_config:
 
 pool:
   scm_size: 1G
+  properties: "rd_fac:0,space_rb:0"


### PR DESCRIPTION
We will run tests in CI with the default pool and container properties but some tests will fail with these default properties. Add pool properties to telemetry tests that fail with the default pool properties.

Test-tag: test_dkey_akey_enum_punch

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
