### PR TITLE
DAOS-17321 ddb: add csum_check command to verify data checksums

### DIFF
--- a/src/control/cmd/ddb/commands_wrapper.go
+++ b/src/control/cmd/ddb/commands_wrapper.go
@@ -399,3 +399,22 @@ func (ctx *DdbContext) CsumDump(path string, dst string, epoch uint64) error {
 	/* Run the c code command */
 	return daosError(ddb_run_csum_dump(&ctx.ctx, &options))
 }
+
+// CsumCheck recomputes the checksum(s) of the currently stored data at the VOS tree path and
+// compares them against the checksum(s) already stored on disk, reporting a match/corruption
+// verdict. It is read-only: no data or checksums are modified. epoch selects which version to
+// check: for a single value akey it is the epoch at or before which the value is fetched, and
+// for an array akey it is the maximal epoch of the visible record extent(s) to select. Pass
+// math.MaxUint64 (EPOCH_MAX) to check the latest. By default, only corrupted entries are
+// printed (plus a final summary); pass verbose to print every entry (matching, corrupted, and
+// "no checksum").
+func (ctx *DdbContext) CsumCheck(path string, epoch uint64, verbose bool) error {
+	/* Set up the options */
+	options := C.struct_csum_check_options{}
+	options.path = C.CString(path)
+	defer freeString(options.path)
+	options.epoch = C.uint64_t(epoch)
+	options.verbose = C.bool(verbose)
+	/* Run the c code command */
+	return daosError(ddb_run_csum_check(&ctx.ctx, &options))
+}

--- a/src/control/cmd/ddb/ddb_commands.go
+++ b/src/control/cmd/ddb/ddb_commands.go
@@ -507,4 +507,34 @@ select`,
 		},
 		Completer: nil,
 	})
+	// Command csum_check
+	app.AddCommand(&grumble.Command{
+		Name:    "csum_check",
+		Aliases: nil,
+		Help:    "Check visible checksum(s) against the stored data",
+		LongHelp: `Recompute the visible checksum(s) at the vos path from the currently
+stored data and compare them against the checksum(s) already stored on disk. The vos
+path should be a complete path, including the akey and if the value is an array
+value it should include the extent. This command is read-only: no data or
+checksums are modified. The --epoch flag selects which version of the checksum
+to check: for a single value akey it selects the value visible at or before
+that epoch, and for an array value it defines the maximal epoch of the visible
+record extent to select. By default, nothing is printed unless corruption is
+detected: only corrupted entries are printed, followed by a final error
+summary; a clean result (matching or no checksum stored) produces no output
+at all. Pass --verbose to print every entry regardless of outcome (matching,
+no checksum stored, or corrupted), plus a final summary line even on success`,
+		HelpGroup: "vos",
+		Args: func(a *grumble.Args) {
+			a.String("path", "VOS tree path to check.")
+		},
+		Flags: func(f *grumble.Flags) {
+			f.Uint64("e", "epoch", math.MaxUint64, "Maximal epoch of the checksum value to select (default EPOCH_MAX).")
+			f.Bool("v", "verbose", false, "Print every checksum entry, not just corrupted ones.")
+		},
+		Run: func(c *grumble.Context) error {
+			return ctx.CsumCheck(c.Args.String("path"), c.Flags.Uint64("epoch"), c.Flags.Bool("verbose"))
+		},
+		Completer: nil,
+	})
 }

--- a/src/control/cmd/ddb/ddb_commands_test.go
+++ b/src/control/cmd/ddb/ddb_commands_test.go
@@ -133,6 +133,11 @@ func TestDdb_HelpCmds(t *testing.T) {
 			cmdStr:     "csum_dump",
 			helpSubStr: "Usage:\n  csum_dump [flags] path [dst]\n",
 		},
+		"help for 'csum_check' command": {
+			cmdStr:     "csum_check",
+			helpSubStr: "Usage:\n  csum_check [flags] path\n",
+		},
+		// TODO(follow-up PR): Add help tests for the remaining commands.
 	} {
 		t.Run(name, func(t *testing.T) {
 			ctx := newTestContext(t)
@@ -273,6 +278,16 @@ func TestDdb_Cmds(t *testing.T) {
 			test.CmpAny(t, "path", wantPath, path)
 			test.CmpAny(t, "dst", wantDst, dst)
 			test.CmpAny(t, "epoch", wantEpoch, epoch)
+			return nil
+		}
+	}
+
+	csumCheckFnChecking := func(t *testing.T, wantPath string, wantEpoch uint64, wantVerbose bool) func(string, uint64, bool) error {
+		return func(path string, epoch uint64, verbose bool) error {
+			fmt.Println("csum_check called")
+			test.CmpAny(t, "path", wantPath, path)
+			test.CmpAny(t, "epoch", wantEpoch, epoch)
+			test.CmpAny(t, "verbose", wantVerbose, verbose)
 			return nil
 		}
 	}
@@ -853,6 +868,58 @@ func TestDdb_Cmds(t *testing.T) {
 				ddb_run_csum_dump_Fn = csumDumpFnChecking(t, "/[0]", "/tmp/csum_dump.out", 500)
 			},
 			expStdout: []string{"csum_dump called"},
+		},
+
+		// --- csum_check command ---
+		"csum_check missing path": {
+			args:   []string{"csum_check"},
+			expErr: ddbTestErr("missing argument 'path'"),
+		},
+		"csum_check invalid options": {
+			args:   []string{"csum_check", "--bar"},
+			expErr: ddbTestErr("invalid flag: --bar"),
+		},
+		"csum_check default": {
+			args: []string{"csum_check", "/[0]"},
+			setup: func(t *testing.T) {
+				ddb_run_csum_check_Fn = csumCheckFnChecking(t, "/[0]", math.MaxUint64, false)
+			},
+			expStdout: []string{"csum_check called"},
+		},
+		"csum_check epoch short": {
+			args: []string{"csum_check", "-e", "999", "/[0]"},
+			setup: func(t *testing.T) {
+				ddb_run_csum_check_Fn = csumCheckFnChecking(t, "/[0]", 999, false)
+			},
+			expStdout: []string{"csum_check called"},
+		},
+		"csum_check epoch long": {
+			args: []string{"csum_check", "--epoch=666", "/[0]"},
+			setup: func(t *testing.T) {
+				ddb_run_csum_check_Fn = csumCheckFnChecking(t, "/[0]", 666, false)
+			},
+			expStdout: []string{"csum_check called"},
+		},
+		"csum_check verbose short": {
+			args: []string{"csum_check", "-v", "/[0]"},
+			setup: func(t *testing.T) {
+				ddb_run_csum_check_Fn = csumCheckFnChecking(t, "/[0]", math.MaxUint64, true)
+			},
+			expStdout: []string{"csum_check called"},
+		},
+		"csum_check verbose long": {
+			args: []string{"csum_check", "--verbose", "/[0]"},
+			setup: func(t *testing.T) {
+				ddb_run_csum_check_Fn = csumCheckFnChecking(t, "/[0]", math.MaxUint64, true)
+			},
+			expStdout: []string{"csum_check called"},
+		},
+		"csum_check verbose and epoch": {
+			args: []string{"csum_check", "-e", "999", "-v", "/[0]"},
+			setup: func(t *testing.T) {
+				ddb_run_csum_check_Fn = csumCheckFnChecking(t, "/[0]", 999, true)
+			},
+			expStdout: []string{"csum_check called"},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/cmd/ddb/libddb.go
+++ b/src/control/cmd/ddb/libddb.go
@@ -135,3 +135,7 @@ func ddb_run_dtx_aggr(ctx *C.struct_ddb_ctx, opts *C.struct_dtx_aggr_options) C.
 func ddb_run_csum_dump(ctx *C.struct_ddb_ctx, opts *C.struct_csum_dump_options) C.int {
 	return C.ddb_run_csum_dump(ctx, opts)
 }
+
+func ddb_run_csum_check(ctx *C.struct_ddb_ctx, opts *C.struct_csum_check_options) C.int {
+	return C.ddb_run_csum_check(ctx, opts)
+}

--- a/src/control/cmd/ddb/libddb_stubs.go
+++ b/src/control/cmd/ddb/libddb_stubs.go
@@ -60,6 +60,7 @@ func resetDdbStubs() {
 	ddb_run_prov_mem_RC, ddb_run_prov_mem_Fn = 0, nil
 	ddb_run_dtx_aggr_RC, ddb_run_dtx_aggr_Fn = 0, nil
 	ddb_run_csum_dump_RC, ddb_run_csum_dump_Fn = 0, nil
+	ddb_run_csum_check_RC, ddb_run_csum_check_Fn = 0, nil
 }
 
 var ddb_init_RC C.int = 0
@@ -474,4 +475,20 @@ func ddb_run_csum_dump(_ *C.struct_ddb_ctx, opts *C.struct_csum_dump_options) C.
 		))
 	}
 	return ddb_run_csum_dump_RC
+}
+
+var (
+	ddb_run_csum_check_RC C.int = 0
+	ddb_run_csum_check_Fn func(path string, epoch uint64, verbose bool) error
+)
+
+func ddb_run_csum_check(_ *C.struct_ddb_ctx, opts *C.struct_csum_check_options) C.int {
+	if ddb_run_csum_check_Fn != nil {
+		return fromGoErr(ddb_run_csum_check_Fn(
+			C.GoString(opts.path),
+			uint64(opts.epoch),
+			bool(opts.verbose),
+		))
+	}
+	return ddb_run_csum_check_RC
 }

--- a/src/utils/ddb/README.md
+++ b/src/utils/ddb/README.md
@@ -113,6 +113,8 @@ smd
 
 vos
   close                    Close the currently opened vos pool shard
+  csum_check               Check visible checksum(s) against the stored data
+  csum_dump                Dump visible checksum(s)
   dev_list                 List all devices
   dev_replace              Replace an old device with a new unused device
   dtx_act_abort            Mark the active dtx entry as aborted

--- a/src/utils/ddb/ddb.h
+++ b/src/utils/ddb/ddb.h
@@ -188,6 +188,12 @@ struct csum_dump_options {
 	daos_epoch_t epoch;
 };
 
+struct csum_check_options {
+	char        *path;
+	daos_epoch_t epoch;
+	bool         verbose;
+};
+
 /* Run commands ... */
 int
 ddb_run_ls(struct ddb_ctx *ctx, struct ls_options *opt);
@@ -248,5 +254,7 @@ int
 ddb_run_dtx_aggr(struct ddb_ctx *ctx, struct dtx_aggr_options *opt);
 int
 ddb_run_csum_dump(struct ddb_ctx *ctx, struct csum_dump_options *opt);
+int
+ddb_run_csum_check(struct ddb_ctx *ctx, struct csum_check_options *opt);
 
 #endif /* __DDB_RUN_CMDS_H */

--- a/src/utils/ddb/ddb_commands.c
+++ b/src/utils/ddb/ddb_commands.c
@@ -393,7 +393,143 @@ print_csum_bufs(struct ddb_ctx *ctx, struct dcs_csum_info *ci)
 		for (j = 0; j < ci->cs_len; j++)
 			ddb_printf(ctx, "%02" PRIx8, csum_buf[j]);
 	}
+}
+
+/*
+ * Shared body for print_csum_sv() (dump) and print_csum_check_sv() (check). \a got_csums is
+ * NULL for a plain dump; when checking, got_csums[0] is non-NULL if the single value's
+ * checksum failed to match, holding the recomputed value in that case. \a verbose only
+ * matters when checking: when false, only corrupted entries are printed -- matching entries
+ * and "no checksum stored" are both fully suppressed (not even the path/header), so a clean
+ * check produces no output at all.
+ */
+static int
+print_csum_sv_body(struct ddb_ctx *ctx, struct dv_indexed_tree_path *vtp, daos_epoch_t sv_epoch,
+		   struct dcs_ci_list *cil, struct dcs_csum_info **got_csums, bool verbose)
+{
+	struct dcs_csum_info *ci;
+	struct hash_ft       *hf;
+
+	/* non-verbose check mode: only entries that are actually corrupted are printed */
+	if (got_csums != NULL && got_csums[0] == NULL && !verbose)
+		return 0;
+
+	if (cil->dcl_csum_infos_nr == 0) {
+		/* verbose is always true for a dump */
+		if (!verbose)
+			return 0;
+		ddb_print(ctx, "No checksum at ");
+		itp_print_full(ctx, vtp);
+		ddb_print(ctx, "\n");
+		return 0;
+	}
+	D_ASSERT(cil->dcl_csum_infos_nr == 1);
+
+	ci = dcs_csum_info_get(cil, 0);
+	D_ASSERT(ci_is_valid(ci));
+	D_ASSERT(ci->cs_nr == 1);
+
+	hf = daos_mhash_type2algo(ci->cs_type);
+
+	itp_print_full(ctx, vtp);
 	ddb_print(ctx, "\n");
+	ddb_printf(ctx, "Type: %s, Length: %" PRIu16 ", Epoch: %" PRIu64 ", Value: ", hf->cf_name,
+		   ci->cs_len, sv_epoch);
+	print_csum_bufs(ctx, ci);
+
+	if (got_csums == NULL)
+		goto out;
+
+	ddb_printf(ctx, ", State: %s", got_csums[0] ? "NOK" : "OK");
+	if (got_csums[0] != NULL) {
+		ddb_print(ctx, " (got=");
+		print_csum_bufs(ctx, got_csums[0]);
+		ddb_print(ctx, ")");
+	}
+
+out:
+	ddb_print(ctx, "\n");
+	return 0;
+}
+
+/*
+ * Shared body for print_csum_recx() (dump) and print_csum_check_recx() (check). See
+ * print_csum_sv_body() for the meaning of \a got_csums/\a verbose.
+ */
+static int
+print_csum_recx_body(struct ddb_ctx *ctx, struct dv_indexed_tree_path *vtp,
+		     struct daos_recx_ep_list *recx_rel, struct dcs_ci_list *cil,
+		     struct dcs_csum_info **got_csums, bool verbose)
+{
+	struct dcs_csum_info  *ci;
+	struct hash_ft        *hf;
+	uint32_t               chunk_sz;
+	bool                   header_printed = false;
+	int                    i;
+
+	if (cil->dcl_csum_infos_nr == 0) {
+		/* verbose is always true for a dump */
+		if (!verbose)
+			return 0;
+		ddb_print(ctx, "No checksum at ");
+		itp_print_full(ctx, vtp);
+		ddb_print(ctx, "\n");
+		return 0;
+	}
+
+	D_ASSERT(recx_rel != NULL);
+	D_ASSERT(cil->dcl_csum_infos_nr == recx_rel->re_nr);
+
+	ci = dcs_csum_info_get(cil, 0);
+	D_ASSERT(ci_is_valid(ci));
+	hf       = daos_mhash_type2algo(ci->cs_type);
+	chunk_sz = ci->cs_chunksize;
+
+	/* dcl_csum_infos_nr can be > 1 for a single path: e.g. overlapping recx writes at
+	 * different epochs each contribute their own checksummed segment. */
+	for (i = 0; i < cil->dcl_csum_infos_nr; i++) {
+		struct daos_recx_ep *rep;
+
+		/* non-verbose check mode: only entries that are actually corrupted are printed */
+		if (got_csums != NULL && got_csums[i] == NULL && !verbose)
+			continue;
+
+		ci = dcs_csum_info_get(cil, i);
+		D_ASSERT(ci_is_valid(ci));
+		rep = &recx_rel->re_items[i];
+
+		if (!header_printed) {
+			itp_print_full(ctx, vtp);
+			ddb_print(ctx, "\n");
+			ddb_printf(ctx,
+				   "Checksum Type: %s, Checksum Length: %" PRIu16
+				   ", Chunk Size: %" PRIu32 ", Record Extent(s):\n",
+				   hf->cf_name, ci->cs_len, chunk_sz);
+			header_printed = true;
+		}
+
+		ddb_printf(ctx,
+			   "- Record Indexes: {%" PRIu64 "-%" PRIu64 "}, Record Size: %" PRIu32
+			   ", Epoch: %" PRIu64 ", Checksum Value(s): ",
+			   rep->re_recx.rx_idx, rep->re_recx.rx_idx + rep->re_recx.rx_nr - 1,
+			   rep->re_rec_size, rep->re_ep);
+		print_csum_bufs(ctx, ci);
+
+		if (got_csums == NULL) {
+			ddb_print(ctx, "\n");
+			continue;
+		}
+
+		ddb_printf(ctx, ", State: %s", got_csums[i] ? "NOK" : "OK");
+		if (got_csums[i] != NULL) {
+			ddb_print(ctx, " (got=");
+			print_csum_bufs(ctx, got_csums[i]);
+			ddb_print(ctx, ")");
+		}
+		ddb_print(ctx, "\n");
+	}
+
+	return 0;
 }
 
 struct dump_csum_args {
@@ -406,61 +542,9 @@ static int
 print_csum_recx(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
 		struct dcs_ci_list *cil)
 {
-	struct dump_csum_args *args;
-	struct ddb_ctx        *ctx;
-	struct dcs_csum_info  *ci;
-	struct hash_ft        *hf;
-	struct daos_recx_ep   *rep;
-	uint32_t               chunk_sz;
-	int                    i;
+	struct dump_csum_args *args = cb_args;
 
-	args = cb_args;
-	ctx  = args->dca_ctx;
-
-	if (cil->dcl_csum_infos_nr == 0) {
-		ddb_print(ctx, "No checksum at ");
-		itp_print_full(ctx, args->dca_vtp);
-		ddb_print(ctx, "\n");
-		return 0;
-	}
-
-	D_ASSERT(recx_rel != NULL);
-	D_ASSERT(cil->dcl_csum_infos_nr == recx_rel->re_nr);
-
-	ci = dcs_csum_info_get(cil, 0);
-	D_ASSERT(ci_is_valid(ci));
-	rep      = &recx_rel->re_items[0];
-	hf       = daos_mhash_type2algo(ci->cs_type);
-	chunk_sz = ci->cs_chunksize;
-
-	itp_print_full(ctx, args->dca_vtp);
-	ddb_print(ctx, "\n");
-	ddb_printf(ctx,
-		   "Checksum Type: %s, Checksum Length: %" PRIu16 ", Chunk Size: %" PRIu32
-		   ", Record Extent(s):\n",
-		   hf->cf_name, ci->cs_len, chunk_sz);
-
-	ddb_printf(ctx,
-		   "- Record Indexes: {%" PRIu64 "-%" PRIu64 "}, Record Size: %" PRIu32
-		   ", Epoch: %" PRIu64 ", Checksum Value(s): ",
-		   rep->re_recx.rx_idx, rep->re_recx.rx_idx + rep->re_recx.rx_nr - 1,
-		   rep->re_rec_size, rep->re_ep);
-	print_csum_bufs(ctx, ci);
-
-	for (i = 1; i < cil->dcl_csum_infos_nr; i++) {
-		ci = dcs_csum_info_get(cil, i);
-		D_ASSERT(ci_is_valid(ci));
-		rep = &recx_rel->re_items[i];
-
-		ddb_printf(ctx,
-			   "- Record Indexes: {%" PRIu64 "-%" PRIu64 "}, Record Size: %" PRIu32
-			   ", Epoch: %" PRIu64 ", Checksum Value(s): ",
-			   rep->re_recx.rx_idx, rep->re_recx.rx_idx + rep->re_recx.rx_nr - 1,
-			   rep->re_rec_size, rep->re_ep);
-		print_csum_bufs(ctx, ci);
-	}
-
-	return 0;
+	return print_csum_recx_body(args->dca_ctx, args->dca_vtp, recx_rel, cil, NULL, true);
 }
 
 static int
@@ -564,34 +648,9 @@ static int
 print_csum_sv(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
 	      struct dcs_ci_list *cil)
 {
-	struct dump_csum_args *args;
-	struct ddb_ctx        *ctx;
-	struct dcs_csum_info  *ci;
-	struct hash_ft        *hf;
+	struct dump_csum_args *args = cb_args;
 
-	args = cb_args;
-	ctx  = args->dca_ctx;
-
-	if (cil->dcl_csum_infos_nr == 0) {
-		ddb_print(ctx, "No checksum at ");
-		itp_print_full(ctx, args->dca_vtp);
-		ddb_print(ctx, "\n");
-		return 0;
-	}
-	D_ASSERT(cil->dcl_csum_infos_nr == 1);
-
-	ci = dcs_csum_info_get(cil, 0);
-	D_ASSERT(ci_is_valid(ci));
-	D_ASSERT(ci->cs_nr == 1);
-	hf = daos_mhash_type2algo(ci->cs_type);
-
-	itp_print_full(ctx, args->dca_vtp);
-	ddb_print(ctx, "\n");
-	ddb_printf(ctx, "Type: %s, Length: %" PRIu16 ", Epoch: %" PRIu64 ", Value: ", hf->cf_name,
-		   ci->cs_len, sv_epoch);
-	print_csum_bufs(ctx, ci);
-
-	return 0;
+	return print_csum_sv_body(args->dca_ctx, args->dca_vtp, sv_epoch, cil, NULL, true);
 }
 
 static int
@@ -674,6 +733,79 @@ ddb_run_csum_dump(struct ddb_ctx *ctx, struct csum_dump_options *opt)
 	itp_to_vos_path(&itp, &vtp);
 
 	rc = dv_dump_csum(ctx->dc_poh, &vtp, opt->epoch, cb, &dca);
+
+out_itp:
+	itp_free(&itp);
+
+out:
+	return rc;
+}
+
+struct check_csum_args {
+	struct ddb_ctx              *cca_ctx;
+	struct dv_indexed_tree_path *cca_vtp;
+	bool                         cca_verbose;
+};
+
+static int
+print_csum_check_sv(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
+		    struct dcs_ci_list *cil, struct dcs_csum_info **got_csums)
+{
+	struct check_csum_args *args = cb_args;
+
+	return print_csum_sv_body(args->cca_ctx, args->cca_vtp, sv_epoch, cil, got_csums,
+				  args->cca_verbose);
+}
+
+static int
+print_csum_check_recx(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
+		      struct dcs_ci_list *cil, struct dcs_csum_info **got_csums)
+{
+	struct check_csum_args *args = cb_args;
+
+	return print_csum_recx_body(args->cca_ctx, args->cca_vtp, recx_rel, cil, got_csums,
+				    args->cca_verbose);
+}
+
+int
+ddb_run_csum_check(struct ddb_ctx *ctx, struct csum_check_options *opt)
+{
+	struct dv_indexed_tree_path itp = {0};
+	struct dv_tree_path         vtp;
+	struct check_csum_args      cca = {0};
+	dv_check_csum_cb            cb;
+	int                         rc;
+
+	if (!opt->path) {
+		ddb_error(ctx, "A VOS path to check is required.\n");
+		rc = -DER_INVAL;
+		goto out;
+	}
+
+	rc = init_path(ctx, opt->path, &itp);
+	if (!SUCCESS(rc))
+		goto out;
+
+	if (!itp_has_value(&itp)) {
+		ddb_errorf(ctx, "Path [%s] is incomplete.\n", opt->path);
+		rc = -DDBER_INCOMPLETE_PATH_VALUE;
+		goto out_itp;
+	}
+
+	cb = itp_has_recx(&itp) ? print_csum_check_recx : print_csum_check_sv;
+
+	cca.cca_ctx     = ctx;
+	cca.cca_vtp     = &itp;
+	cca.cca_verbose = opt->verbose;
+
+	itp_to_vos_path(&itp, &vtp);
+
+	rc = dv_check_csum(ctx->dc_poh, &vtp, opt->epoch, cb, &cca);
+	if (SUCCESS(rc) && opt->verbose)
+		ddb_print(ctx, "OK: no corruption detected.\n");
+	if (rc == -DER_CSUM)
+		ddb_error(ctx, "Data corruption detected: one or more checksums do not match the "
+			       "stored data.\n");
 
 out_itp:
 	itp_free(&itp);

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -1099,7 +1099,6 @@ dump_csum_sv(daos_handle_t coh, daos_key_t *dkey, daos_unit_oid_t *oid, daos_iod
 {
 	daos_handle_t       ioh;
 	struct dcs_ci_list *cil;
-	int                 cb_rc = 0;
 	int                 rc;
 
 	rc = vos_fetch_begin(coh, *oid, epoch, dkey, 1, iod, VOS_OF_FETCH_CSUM, NULL, &ioh, NULL);
@@ -1110,19 +1109,13 @@ dump_csum_sv(daos_handle_t coh, daos_key_t *dkey, daos_unit_oid_t *oid, daos_iod
 	}
 
 	cil = vos_ioh2ci(ioh);
-	cb_rc = dump_cb(cb_arg, NULL, vos_ioh2sv_epoch(ioh), cil);
-	if (!SUCCESS(cb_rc))
+	rc  = dump_cb(cb_arg, NULL, vos_ioh2sv_epoch(ioh), cil);
+	if (!SUCCESS(rc))
 		D_DEBUG(DB_IO, "Csum dump callback for " DF_UOID " returned: " DF_RC "\n",
-			DP_UOID(*oid), DP_RC(cb_rc));
-
-	rc = vos_fetch_end(ioh, NULL, cb_rc);
-	if (!SUCCESS(rc) && rc != cb_rc)
-		D_ERROR("vos_fetch_end for csum dump of " DF_UOID " failed: " DF_RC "\n",
 			DP_UOID(*oid), DP_RC(rc));
 
+	rc = vos_fetch_end(ioh, NULL, rc);
 out:
-	if (!SUCCESS(cb_rc))
-		rc = cb_rc;
 	return rc;
 }
 
@@ -1133,7 +1126,6 @@ dump_csum_recx(daos_handle_t coh, daos_key_t *dkey, daos_unit_oid_t *oid, daos_i
 	daos_handle_t             ioh;
 	struct dcs_ci_list       *cil;
 	struct daos_recx_ep_list *rel;
-	int                       cb_rc = 0;
 	int                       rc;
 
 	rc = vos_fetch_begin(coh, *oid, epoch, dkey, 1, iod, VOS_OF_FETCH_CSUM, NULL, &ioh, NULL);
@@ -1145,21 +1137,15 @@ dump_csum_recx(daos_handle_t coh, daos_key_t *dkey, daos_unit_oid_t *oid, daos_i
 
 	cil = vos_ioh2ci(ioh);
 	rel = vos_ioh2recx_list(ioh);
-	cb_rc = dump_cb(cb_arg, rel, 0, cil);
-	if (!SUCCESS(cb_rc))
+	rc  = dump_cb(cb_arg, rel, 0, cil);
+	if (!SUCCESS(rc))
 		D_DEBUG(DB_IO, "Csum dump callback for " DF_UOID " returned: " DF_RC "\n",
-			DP_UOID(*oid), DP_RC(cb_rc));
+			DP_UOID(*oid), DP_RC(rc));
 
 	/* rel ownership is transferred by vos_ioh2recx_list(); free before vos_fetch_end. */
 	daos_recx_ep_list_free(rel, iod->iod_nr);
-	rc = vos_fetch_end(ioh, NULL, cb_rc);
-	if (!SUCCESS(rc) && rc != cb_rc)
-		D_ERROR("vos_fetch_end for csum dump of " DF_UOID " failed: " DF_RC "\n",
-			DP_UOID(*oid), DP_RC(rc));
-
+	rc = vos_fetch_end(ioh, NULL, rc);
 out:
-	if (!SUCCESS(cb_rc))
-		rc = cb_rc;
 	return rc;
 }
 
@@ -1198,6 +1184,314 @@ dv_dump_csum(daos_handle_t poh, struct dv_tree_path *path, daos_epoch_t epoch,
 
 	vos_cont_close(coh);
 
+out:
+	return rc;
+}
+
+/*
+ * Fetch the record data for a single checksum-verification segment (either the whole single
+ * value, or one physical recx/epoch segment of an array value) into a freshly allocated
+ * buffer in \a sgl. Uses the same 2-pass vos_obj_fetch() pattern as dv_dump_value(): the first
+ * pass discovers the record size, the second pass fetches the data.
+ *
+ * A zero-length result (hole/punch at \a epoch) is not an error; the caller's sgl is left
+ * empty in that case.
+ */
+static int
+fetch_check_value(daos_handle_t coh, daos_unit_oid_t *oid, daos_key_t *dkey, daos_iod_t *iod,
+		  daos_epoch_t epoch, d_sg_list_t *sgl)
+{
+	size_t data_size;
+	int    rc;
+
+	iod->iod_size = 0;
+	rc            = vos_obj_fetch(coh, *oid, epoch, 0, dkey, 1, iod, NULL);
+	if (!SUCCESS(rc)) {
+		D_ERROR("vos_obj_fetch (size) for csum check of " DF_UOID " failed: " DF_RC "\n",
+			DP_UOID(*oid), DP_RC(rc));
+		return rc;
+	}
+
+	data_size = iod->iod_size;
+	if (iod->iod_type == DAOS_IOD_ARRAY)
+		data_size *= iod->iod_recxs[0].rx_nr;
+
+	if (data_size == 0) /* hole/punch: nothing to verify */
+		return 0;
+
+	D_ALLOC(sgl->sg_iovs[0].iov_buf, data_size);
+	if (sgl->sg_iovs[0].iov_buf == NULL)
+		return -DER_NOMEM;
+	sgl->sg_iovs[0].iov_buf_len = data_size;
+
+	rc = vos_obj_fetch(coh, *oid, epoch, 0, dkey, 1, iod, sgl);
+	if (!SUCCESS(rc)) {
+		D_ERROR("vos_obj_fetch (data) for csum check of " DF_UOID " failed: " DF_RC "\n",
+			DP_UOID(*oid), DP_RC(rc));
+		D_FREE(sgl->sg_iovs[0].iov_buf);
+		return rc;
+	}
+
+	return 0;
+}
+
+/*
+ * Create an independent copy of \a src (metadata + checksum bytes) in a single D_ALLOC'd
+ * struct+buffer, matching daos_csummer_calc_key()'s allocation pattern. The result is freed by
+ * the caller with a plain D_FREE() -- it is not a daos_csummer-owned allocation, so
+ * daos_csummer_free_ci()/_ic() must not be used on it.
+ */
+static int
+snapshot_csum_info(struct dcs_csum_info *src, struct dcs_csum_info **snapshot)
+{
+	struct dcs_csum_info *dst;
+	uint8_t              *buf;
+
+	D_ALLOC(dst, sizeof(*dst) + src->cs_buf_len);
+	if (dst == NULL)
+		return -DER_NOMEM;
+
+	/* &dst[1] is "one past the struct", i.e. the start of the trailing buffer allocated
+	 * above (struct dcs_csum_info has no flexible array member of its own). */
+	buf = (uint8_t *)&dst[1];
+	memcpy(buf, ci_idx2csum(src, 0), src->cs_buf_len);
+	ci_set(dst, buf, src->cs_buf_len, src->cs_len, src->cs_nr, src->cs_chunksize, src->cs_type);
+
+	*snapshot = dst;
+	return 0;
+}
+
+/*
+ * Recompute the checksum of one segment's currently stored data and compare it against the
+ * checksum info already fetched from disk (\a ci). Returns 0 if the checksums match,
+ * -DER_CSUM if they differ, or another negative rc on a hard I/O/system error.
+ *
+ * On a -DER_CSUM mismatch, *got_csum is set to an independent snapshot of the recomputed
+ * checksum (to be freed by the caller with D_FREE()); left NULL on a match or a hard error.
+ */
+static int
+verify_segment_csum(daos_handle_t coh, daos_key_t *dkey, daos_unit_oid_t *oid, daos_iod_t *iod,
+		    daos_epoch_t epoch, struct dcs_csum_info *ci, struct dcs_csum_info **got_csum)
+{
+	struct daos_csummer  *csummer       = NULL;
+	struct dcs_iod_csums *got_iod_csums = NULL;
+	d_sg_list_t           sgl           = {0};
+	int                   rc;
+
+	*got_csum = NULL;
+
+	rc = d_sgl_init(&sgl, 1);
+	if (!SUCCESS(rc))
+		goto out;
+
+	rc = fetch_check_value(coh, oid, dkey, iod, epoch, &sgl);
+	if (!SUCCESS(rc))
+		goto out_sgl;
+
+	rc = daos_csummer_init_with_type(&csummer, ci->cs_type, ci->cs_chunksize, 0);
+	if (!SUCCESS(rc)) {
+		D_ERROR("daos_csummer_init_with_type failed: " DF_RC "\n", DP_RC(rc));
+		goto out_sgl;
+	}
+	/* csummer is local to this call and destroyed below, so no save/restore is needed.
+	 * Only dcs_skip_key_calc is set: it's the only flag daos_csummer_calc_iods() (below)
+	 * consults -- dcs_skip_key_verify/dcs_skip_data_verify belong to other, unused-here
+	 * helpers. */
+	csummer->dcs_skip_key_calc = true;
+
+	rc = daos_csummer_calc_iods(csummer, &sgl, iod, NULL, 1, false, NULL, 0, &got_iod_csums);
+	if (!SUCCESS(rc)) {
+		D_ERROR("daos_csummer_calc_iods failed: " DF_RC "\n", DP_RC(rc));
+		goto out_csummer;
+	}
+
+	if (!daos_csummer_compare_csum_info(csummer, &got_iod_csums->ic_data[0], ci)) {
+		rc = snapshot_csum_info(&got_iod_csums->ic_data[0], got_csum);
+		if (SUCCESS(rc))
+			rc = -DER_CSUM;
+	}
+
+	daos_csummer_free_ic(csummer, &got_iod_csums);
+out_csummer:
+	daos_csummer_destroy(&csummer);
+out_sgl:
+	d_sgl_fini(&sgl, true);
+out:
+	return rc;
+}
+
+static int
+check_csum_sv(daos_handle_t coh, daos_key_t *dkey, daos_unit_oid_t *oid, daos_iod_t *iod,
+	      daos_epoch_t epoch, dv_check_csum_cb check_cb, void *cb_arg)
+{
+	daos_handle_t         ioh;
+	struct dcs_ci_list   *cil;
+	struct dcs_csum_info *ci;
+	struct dcs_csum_info *got_csum = NULL;
+	daos_epoch_t          sv_epoch;
+	int                   rc;
+
+	rc = vos_fetch_begin(coh, *oid, epoch, dkey, 1, iod, VOS_OF_FETCH_CSUM, NULL, &ioh, NULL);
+	if (!SUCCESS(rc)) {
+		D_ERROR("vos_fetch_begin for csum check of " DF_UOID " failed: " DF_RC "\n",
+			DP_UOID(*oid), DP_RC(rc));
+		goto out;
+	}
+
+	cil      = vos_ioh2ci(ioh);
+	sv_epoch = vos_ioh2sv_epoch(ioh);
+
+	if (cil->dcl_csum_infos_nr == 0) {
+		rc = check_cb(cb_arg, NULL, sv_epoch, cil, NULL);
+		goto out_fetch_end;
+	}
+
+	D_ASSERT(cil->dcl_csum_infos_nr == 1);
+	ci = dcs_csum_info_get(cil, 0);
+	D_ASSERT(ci_is_valid(ci));
+
+	rc = verify_segment_csum(coh, dkey, oid, iod, sv_epoch, ci, &got_csum);
+	if (rc == -DER_CSUM) {
+		D_DEBUG(DB_IO, "Checksum mismatch of " DF_UOID "\n", DP_UOID(*oid));
+		rc = 0;
+	}
+	if (!SUCCESS(rc)) {
+		D_ERROR("Checksum verification of " DF_UOID " failed: " DF_RC "\n", DP_UOID(*oid),
+			DP_RC(rc));
+		goto out_fetch_end;
+	}
+
+	rc = check_cb(cb_arg, NULL, sv_epoch, cil, &got_csum);
+	if (!SUCCESS(rc))
+		D_DEBUG(DB_IO, "Csum check callback for " DF_UOID " returned: " DF_RC "\n",
+			DP_UOID(*oid), DP_RC(rc));
+
+out_fetch_end:
+	rc = vos_fetch_end(ioh, NULL, rc);
+out:
+	/* got_csum != NULL is the mismatch signal; check before D_FREE() clears the pointer. */
+	if (SUCCESS(rc) && got_csum != NULL)
+		rc = -DER_CSUM;
+	D_FREE(got_csum);
+	return rc;
+}
+
+static int
+check_csum_recx(daos_handle_t coh, daos_key_t *dkey, daos_unit_oid_t *oid, daos_iod_t *iod,
+		daos_epoch_t epoch, dv_check_csum_cb check_cb, void *cb_arg)
+{
+	daos_handle_t             ioh;
+	struct dcs_ci_list       *cil;
+	struct daos_recx_ep_list *rel;
+	struct dcs_csum_info    **got_csums  = NULL;
+	bool                      csum_error = false;
+	int                       i;
+	int                       rc;
+
+	rc = vos_fetch_begin(coh, *oid, epoch, dkey, 1, iod, VOS_OF_FETCH_CSUM, NULL, &ioh, NULL);
+	if (!SUCCESS(rc)) {
+		D_ERROR("vos_fetch_begin for csum check of " DF_UOID " failed: " DF_RC "\n",
+			DP_UOID(*oid), DP_RC(rc));
+		goto out;
+	}
+
+	cil = vos_ioh2ci(ioh);
+	rel = vos_ioh2recx_list(ioh);
+	D_ASSERT(rel != NULL);
+	if (cil->dcl_csum_infos_nr == 0) {
+		/* no checksum stored: got_csums is left NULL, never allocated below */
+		rc = check_cb(cb_arg, rel, 0, cil, got_csums);
+		goto out_rel;
+	}
+	D_ASSERT(cil->dcl_csum_infos_nr == rel->re_nr);
+
+	D_ALLOC_ARRAY(got_csums, cil->dcl_csum_infos_nr);
+	if (got_csums == NULL) {
+		rc = -DER_NOMEM;
+		goto out_rel;
+	}
+
+	for (i = 0; i < cil->dcl_csum_infos_nr; i++) {
+		struct dcs_csum_info *ci;
+		struct daos_recx_ep  *rep;
+		daos_iod_t            seg_iod;
+
+		ci = dcs_csum_info_get(cil, i);
+		D_ASSERT(ci_is_valid(ci));
+		rep = &rel->re_items[i];
+
+		seg_iod           = *iod;
+		seg_iod.iod_recxs = &rep->re_recx;
+
+		rc = verify_segment_csum(coh, dkey, oid, &seg_iod, rep->re_ep, ci, &got_csums[i]);
+		if (rc == -DER_CSUM) {
+			D_DEBUG(DB_IO, "Checksum mismatch of " DF_UOID " " DF_RECX "\n",
+				DP_UOID(*oid), DP_RECX(rep->re_recx));
+			csum_error = true;
+			rc         = 0; /* continue checking other segments */
+			continue;
+		}
+		if (!SUCCESS(rc)) {
+			D_ERROR("Checksum verification of " DF_UOID " " DF_RECX " failed: " DF_RC
+				"\n",
+				DP_UOID(*oid), DP_RECX(rep->re_recx), DP_RC(rc));
+			goto out_got_csums;
+		}
+	}
+
+	rc = check_cb(cb_arg, rel, 0, cil, got_csums);
+	if (!SUCCESS(rc))
+		D_DEBUG(DB_IO, "Csum check callback for " DF_UOID " returned: " DF_RC "\n",
+			DP_UOID(*oid), DP_RC(rc));
+
+out_got_csums:
+	for (i = 0; i < cil->dcl_csum_infos_nr; i++)
+		D_FREE(got_csums[i]);
+	D_FREE(got_csums);
+out_rel:
+	/* rel ownership is transferred by vos_ioh2recx_list(); free before vos_fetch_end. */
+	daos_recx_ep_list_free(rel, iod->iod_nr);
+	rc = vos_fetch_end(ioh, NULL, rc);
+out:
+	if (rc == 0 && csum_error)
+		rc = -DER_CSUM;
+	return rc;
+}
+
+int
+dv_check_csum(daos_handle_t poh, struct dv_tree_path *path, daos_epoch_t epoch,
+	      dv_check_csum_cb check_cb, void *cb_arg)
+{
+	daos_handle_t coh;
+	daos_iod_t    iod = {0};
+	int           rc  = 0;
+
+	/* No-op when no callback is provided; the caller controls whether to consume results. */
+	if (check_cb == NULL)
+		goto out;
+
+	rc = vos_cont_open(poh, path->vtp_cont, &coh);
+	if (!SUCCESS(rc)) {
+		D_ERROR("Opening container for csum check of " DF_UOID " failed: " DF_RC "\n",
+			DP_UOID(path->vtp_oid), DP_RC(rc));
+		goto out;
+	}
+
+	iod.iod_name  = path->vtp_akey;
+	iod.iod_recxs = &path->vtp_recx;
+	iod.iod_nr    = 1;
+	iod.iod_size  = 0;
+	if (path->vtp_is_recx) {
+		iod.iod_type = DAOS_IOD_ARRAY;
+		rc = check_csum_recx(coh, &path->vtp_dkey, &path->vtp_oid, &iod, epoch, check_cb,
+				     cb_arg);
+	} else {
+		iod.iod_type = DAOS_IOD_SINGLE;
+		rc = check_csum_sv(coh, &path->vtp_dkey, &path->vtp_oid, &iod, epoch, check_cb,
+				   cb_arg);
+	}
+
+	vos_cont_close(coh);
 out:
 	return rc;
 }

--- a/src/utils/ddb/ddb_vos.h
+++ b/src/utils/ddb/ddb_vos.h
@@ -189,6 +189,52 @@ int
 dv_dump_csum(daos_handle_t poh, struct dv_tree_path *path, daos_epoch_t epoch,
 	     dv_dump_csum_cb dump_cb, void *cb_arg);
 
+/**
+ * Callback invoked by dv_check_csum() with the fetched checksum information and, for each
+ * checksum entry, whether the checksum recomputed from the currently stored data matches.
+ *
+ * @param cb_arg      User-provided argument passed through from dv_check_csum().
+ * @param recx_rel    Recx/epoch list describing the stored extents. Non-NULL for array akeys;
+ *                    NULL for single-value akeys. The caller must not free this pointer.
+ * @param sv_epoch    Actual stored epoch of the single value. Non-zero for single-value akeys
+ *                    when an SV was found within the requested epoch range; 0 for array akeys
+ *                    or when no SV was found (hole or -DER_NONEXIST).
+ * @param cil         Checksum info list. Valid only for the duration of the callback.
+ * @param got_csums   Array of cil->dcl_csum_infos_nr struct dcs_csum_info pointers. got_csums[i]
+ *                    holds the checksum recomputed from the currently stored data when entry i
+ *                    failed verification against the stored data, and is NULL when entry i
+ *                    matched -- got_csums[i] != NULL therefore also serves as the mismatch flag
+ *                    for entry i. NULL (the whole array) when cil has 0 entries (nothing to
+ *                    verify). Valid only for the duration of the callback; the caller must not
+ *                    free it.
+ * @return            0 on success; a negative error code is propagated back to the caller of
+ *                    dv_check_csum().
+ */
+typedef int (*dv_check_csum_cb)(void *cb_arg, struct daos_recx_ep_list *recx_rel,
+				daos_epoch_t sv_epoch, struct dcs_ci_list *cil,
+				struct dcs_csum_info **got_csums);
+
+/**
+ * Fetch the checksum information for the akey identified by \a path, recompute the checksum(s)
+ * from the currently stored data, and compare them against what is stored on disk.
+ *
+ * @param poh       Open pool handle.
+ * @param path      VOS tree path identifying the container, object, dkey, and akey.
+ *                  For array akeys, path->vtp_recx selects the extent to inspect.
+ * @param epoch     Epoch for the fetch. For single-value akeys, controls which version is
+ *                  checked — pass DAOS_EPOCH_MAX to check the latest, or a snapshot epoch to
+ *                  check an earlier version. For array akeys, selects the visible extent set.
+ * @param check_cb  Callback invoked with the result. If NULL, the function returns 0 without
+ *                  opening the container or calling VOS.
+ * @param cb_arg    Opaque argument forwarded to \a check_cb.
+ * @return          0 on success (no checksum found, or all checksum(s) matched); -DER_CSUM if
+ *                  at least one checksum entry did not match the stored data; another negative
+ *                  error code on I/O or system errors.
+ */
+int
+dv_check_csum(daos_handle_t poh, struct dv_tree_path *path, daos_epoch_t epoch,
+	      dv_check_csum_cb check_cb, void *cb_arg);
+
 struct ddb_ilog_entry {
 	uint32_t	die_idx;
 	int32_t		die_status;

--- a/src/utils/ddb/tests/ddb_cmocka.h
+++ b/src/utils/ddb/tests/ddb_cmocka.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2022 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -67,6 +67,12 @@
 	do { \
 		if (strstr(str, substr) == NULL) \
 			fail_msg("'%s' not found in '%s'", substr, str); \
+	} while (0)
+
+#define assert_string_not_contains(str, substr)                                                    \
+	do {                                                                                       \
+		if (strstr(str, substr) != NULL)                                                   \
+			fail_msg("'%s' unexpectedly found in '%s'", substr, str);                  \
 	} while (0)
 
 #define assert_invalid(x) assert_rc_equal(-DER_INVAL, (x))

--- a/src/utils/ddb/tests/ddb_commands_tests.c
+++ b/src/utils/ddb/tests/ddb_commands_tests.c
@@ -874,6 +874,221 @@ write_csum_recx_tests(void **state)
 	dvt_fake_print_reset();
 }
 
+static void
+csum_check_error_tests(void **state)
+{
+	char                     *path_invalid = "foo";
+	struct dt_vos_pool_ctx   *tctx         = *state;
+	struct ddb_ctx            ctx          = {0};
+	struct csum_check_options opt          = {0};
+	char                      path[128];
+	int                       rc;
+
+	ctx.dc_poh                     = tctx->dvt_poh;
+	ctx.dc_io_ft.ddb_print_error   = dvt_fake_print;
+	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
+	ctx.dc_write_mode              = false;
+
+	rc = ddb_run_csum_check(&ctx, &opt);
+	assert_rc_equal(-DER_INVAL, rc);
+	assert_string_contains(dvt_fake_print_buffer, "A VOS path to check is required.");
+	dvt_fake_print_reset();
+
+	opt.path = &path_invalid[0];
+	rc       = ddb_run_csum_check(&ctx, &opt);
+	assert_rc_equal(-DER_INVAL, rc);
+	assert_string_contains(dvt_fake_print_buffer, "Container is invalid");
+	dvt_fake_print_reset();
+
+	/* path must be complete (point to a value): an array akey path with no extent
+	 * resolves to neither a RECX nor an SV value, so it is rejected as incomplete. */
+	opt.path = path;
+	csum_test_sv_path_init(path, sizeof(path), &g_oids[1], g_akeys_str[1]);
+	rc = ddb_run_csum_check(&ctx, &opt);
+	assert_rc_equal(-DDBER_INCOMPLETE_PATH_VALUE, rc);
+	assert_string_contains(dvt_fake_print_buffer, "is incomplete");
+	dvt_fake_print_reset();
+}
+
+static void
+check_csum_sv_tests(void **state)
+{
+	const char               *regex_prf = "0x";
+	struct dt_vos_pool_ctx   *tctx      = *state;
+	struct dt_csum_ctx       *csum_ctx  = tctx->dvt_extra;
+	struct ddb_ctx            ctx       = {0};
+	struct csum_check_options opt       = {0};
+	char                      path[128];
+	char                      buf[256];
+	uint8_t                   good_bytes[64];
+	struct dcs_csum_info     *ci;
+	int                       rc;
+
+	ctx.dc_poh                     = tctx->dvt_poh;
+	ctx.dc_io_ft.ddb_print_error   = dvt_fake_print;
+	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
+	ctx.dc_write_mode              = false;
+
+	opt.path  = path;
+	opt.epoch = DAOS_EPOCH_MAX;
+
+	/* no csum info (g_oids[0]: SV at epoch 1, no checksum stored, non-verbose) */
+	csum_test_sv_path_init(path, sizeof(path), &g_oids[0], g_akeys_str[0]);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	assert_string_equal(dvt_fake_print_buffer, "");
+	dvt_fake_print_reset();
+
+	/* valid, matching checksum, default (non-verbose) */
+	csum_test_sv_path_init(path, sizeof(path), &g_oids[1], g_akeys_str[0]);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	assert_string_equal(dvt_fake_print_buffer, "");
+	dvt_fake_print_reset();
+
+	/* same, but --verbose: every entry is printed (matching, in this case). */
+	opt.verbose = true;
+	csum_test_sv_path_init(path, sizeof(path), &g_oids[1], g_akeys_str[0]);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	assert_string_contains(dvt_fake_print_buffer, "Epoch: 2");
+	memcpy(buf, regex_prf, strlen(regex_prf));
+	ci = csum_ctx->dct_sv_ics[1]->ic_data;
+	csumbuf_dump(buf + strlen(regex_prf), ci_idx2csum(ci, 0), ci->cs_len);
+	assert_string_contains(dvt_fake_print_buffer, buf);
+	assert_string_contains(dvt_fake_print_buffer, "State: OK");
+	assert_string_contains(dvt_fake_print_buffer, "OK: no corruption detected.");
+	dvt_fake_print_reset();
+	opt.verbose = false;
+
+	/* deliberately corrupted checksum: reports CORRUPTED and -DER_CSUM, along with the
+	 * want (stored)/got (recomputed) checksum values -- always printed regardless of
+	 * verbose, since corrupted entries are never suppressed. */
+	csum_test_sv_path_init(path, sizeof(path), &g_oids[2], g_akeys_str[0]);
+	rc = ddb_run_csum_check(&ctx, &opt);
+	assert_rc_equal(-DER_CSUM, rc);
+	assert_string_contains(dvt_fake_print_buffer, "State: NOK");
+	assert_string_contains(dvt_fake_print_buffer, "Data corruption detected");
+
+	/* "want" is the stored (corrupted) checksum, shown on the main Value: line; "got" is
+	 * the checksum recomputed from the still-valid data, shown in "(got=...)". The fixture
+	 * only flips the stored checksum's first byte before writing it (see
+	 * csum_test_corrupt_sv_setup()), so "got" is "want" with that flip undone. */
+	ci = csum_ctx->dct_sv_ic_bad->ic_data;
+	strcpy(buf, "Value: 0x");
+	csumbuf_dump(buf + strlen(buf), ci_idx2csum(ci, 0), ci->cs_len);
+	assert_string_contains(dvt_fake_print_buffer, buf);
+
+	memcpy(good_bytes, ci_idx2csum(ci, 0), ci->cs_len);
+	good_bytes[0] ^= 0xff;
+	strcpy(buf, "(got=0x");
+	csumbuf_dump(buf + strlen(buf), good_bytes, ci->cs_len);
+	assert_string_contains(dvt_fake_print_buffer, buf);
+	dvt_fake_print_reset();
+}
+
+static void
+check_csum_recx_tests(void **state)
+{
+	const char               *regex_prf = "0x";
+	struct dt_vos_pool_ctx   *tctx      = *state;
+	struct dt_csum_ctx       *csum_ctx  = tctx->dvt_extra;
+	struct ddb_ctx            ctx       = {0};
+	struct csum_check_options opt       = {0};
+	daos_recx_t               recx      = {.rx_idx = 0, .rx_nr = csum_ctx->dct_recx_size};
+	char                      path[128];
+	char                      buf[256];
+	char                     *buf_csum;
+	uint8_t                   good_bytes[64];
+	char                      got_buf[64];
+	struct dcs_csum_info     *ci;
+	int                       i;
+	int                       rc;
+
+	ctx.dc_poh                     = tctx->dvt_poh;
+	ctx.dc_io_ft.ddb_print_error   = dvt_fake_print;
+	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
+	ctx.dc_write_mode              = false;
+
+	opt.path  = path;
+	opt.epoch = DAOS_EPOCH_MAX;
+
+	/* no csum info, non-verbose: fully silent (no path/header, no summary). */
+	csum_test_recx_path_init(path, sizeof(path), &g_oids[0], g_akeys_str[1], &recx);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	assert_string_equal(dvt_fake_print_buffer, "");
+	dvt_fake_print_reset();
+
+	/* same, but --verbose: "No checksum at ..." is reported, plus the final "OK" summary
+	 * (still success -- there's simply nothing to check). */
+	opt.verbose = true;
+	csum_test_recx_path_init(path, sizeof(path), &g_oids[0], g_akeys_str[1], &recx);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	assert_string_contains(dvt_fake_print_buffer, "No checksum at ");
+	assert_string_contains(dvt_fake_print_buffer, "OK: no corruption detected.");
+	dvt_fake_print_reset();
+	opt.verbose = false;
+
+	/* valid, matching checksums, default (non-verbose): fully silent, no per-entry
+	 * detail and no final summary line either. */
+	csum_test_recx_path_init(path, sizeof(path), &g_oids[1], g_akeys_str[1], &recx);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	assert_string_equal(dvt_fake_print_buffer, "");
+	dvt_fake_print_reset();
+
+	/* same, but --verbose: every entry is printed (matching, for each segment here). */
+	opt.verbose = true;
+	csum_test_recx_path_init(path, sizeof(path), &g_oids[1], g_akeys_str[1], &recx);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	memcpy(buf, regex_prf, strlen(regex_prf));
+	buf_csum = buf + strlen(regex_prf);
+	for (i = 0; i < DVT_FAKE_RECX_COUNT; i++) {
+		int csum_idx;
+
+		ci = csum_ctx->dct_recx_ics[i]->ic_data;
+		for (csum_idx = 0; csum_idx < ci->cs_nr; ++csum_idx) {
+			csumbuf_dump(buf_csum, ci_idx2csum(ci, csum_idx), ci->cs_len);
+			assert_string_contains(dvt_fake_print_buffer, buf);
+		}
+	}
+	assert_string_contains(dvt_fake_print_buffer, "State: OK");
+	assert_string_contains(dvt_fake_print_buffer, "OK: no corruption detected.");
+	dvt_fake_print_reset();
+	opt.verbose = false;
+
+	/* shared by both the non-verbose and --verbose corrupted-checksum checks below: the
+	 * bad entry's stored (corrupted) checksum ("want") and its recomputed value ("got") */
+	ci = csum_ctx->dct_recx_ics_bad[DVT_FAKE_RECX_BAD_IDX]->ic_data;
+	strcpy(buf, "Checksum Value(s): 0x");
+	csumbuf_dump(buf + strlen(buf), ci_idx2csum(ci, 0), ci->cs_len);
+	memcpy(good_bytes, ci_idx2csum(ci, 0), ci->cs_len);
+	good_bytes[0] ^= 0xff;
+	strcpy(got_buf, " (got=0x");
+	csumbuf_dump(got_buf + strlen(got_buf), good_bytes, ci->cs_len);
+
+	/* g_oids[2]: one of DVT_FAKE_RECX_COUNT segments has a corrupted checksum. Non-verbose
+	 * still reports it (corrupted entries are never suppressed); the good entry is
+	 * suppressed here (see --verbose below). */
+	csum_test_recx_path_init(path, sizeof(path), &g_oids[2], g_akeys_str[1], &recx);
+	rc = ddb_run_csum_check(&ctx, &opt);
+	assert_rc_equal(-DER_CSUM, rc);
+	assert_string_contains(dvt_fake_print_buffer, "State: NOK");
+	assert_string_contains(dvt_fake_print_buffer, "Data corruption detected");
+	assert_string_contains(dvt_fake_print_buffer, buf);
+	assert_string_contains(dvt_fake_print_buffer, got_buf);
+	assert_string_not_contains(dvt_fake_print_buffer, "State: OK");
+	dvt_fake_print_reset();
+
+	/* same, but --verbose: the good entry must report "State: OK\n" (no "(got=...)"),
+	 * proving the bad entry's corruption didn't bleed into it (the bug fixed in
+	 * 65dacd2e4a). */
+	opt.verbose = true;
+	rc          = ddb_run_csum_check(&ctx, &opt);
+	assert_rc_equal(-DER_CSUM, rc);
+	assert_string_contains(dvt_fake_print_buffer, "State: OK\n");
+	assert_string_contains(dvt_fake_print_buffer, "State: NOK");
+	assert_string_contains(dvt_fake_print_buffer, buf);
+	assert_string_contains(dvt_fake_print_buffer, got_buf);
+	dvt_fake_print_reset();
+}
+
 /*
  * --------------------------------------------------------------
  * End test functions
@@ -979,6 +1194,9 @@ ddb_commands_tests_run()
 	    TEST_CSUM(write_csum_sv_tests),
 	    TEST_CSUM(print_csum_recx_tests),
 	    TEST_CSUM(write_csum_recx_tests),
+	    TEST_CSUM(csum_check_error_tests),
+	    TEST_CSUM(check_csum_sv_tests),
+	    TEST_CSUM(check_csum_recx_tests),
 	};
 
 	return cmocka_run_group_tests_name("DDB commands tests", tests,

--- a/src/utils/ddb/tests/ddb_test_driver.c
+++ b/src/utils/ddb/tests/ddb_test_driver.c
@@ -734,7 +734,7 @@ csum_test_recx_setup(struct dt_vos_pool_ctx *tctx, daos_handle_t coh, d_sg_list_
 	epoch  = 1;
 	filler = 'c';
 	for (recx_idx = 0; recx_idx < DVT_FAKE_RECX_COUNT; recx_idx++) {
-		recx.rx_idx   = recx_idx * csum_ctx->dct_recx_size / 2;
+		recx.rx_idx   = recx_idx * csum_ctx->dct_recx_size / DVT_FAKE_RECX_COUNT;
 		iod.iod_recxs = &recx;
 
 		memset(buf, filler, csum_ctx->dct_recx_size);
@@ -751,7 +751,7 @@ csum_test_recx_setup(struct dt_vos_pool_ctx *tctx, daos_handle_t coh, d_sg_list_
 	/* g_oids[1]: recxs written with checksum */
 	epoch = 1;
 	for (recx_idx = 0; recx_idx < DVT_FAKE_RECX_COUNT; recx_idx++) {
-		recx.rx_idx   = recx_idx * csum_ctx->dct_recx_size / 2;
+		recx.rx_idx   = recx_idx * csum_ctx->dct_recx_size / DVT_FAKE_RECX_COUNT;
 		iod.iod_recxs = &recx;
 
 		memset(buf, filler, csum_ctx->dct_recx_size);
@@ -778,6 +778,132 @@ out_ics:
 			daos_csummer_free_ic(csum_ctx->dct_csummer,
 					     &csum_ctx->dct_recx_ics[recx_idx]);
 		}
+	}
+out_buf:
+	D_FREE(buf);
+out:
+	return rc;
+}
+
+/*
+ * Write one checksummed value/segment, optionally corrupting its stored checksum (flips
+ * the first byte) before writing it to VOS. Shared by csum_test_corrupt_sv_setup() (called
+ * once) and csum_test_corrupt_recx_setup() (called once per overlapping segment).
+ */
+static int
+write_maybe_corrupt(struct daos_csummer *csummer, daos_handle_t coh, daos_unit_oid_t oid,
+		    daos_epoch_t epoch, daos_iod_t *iod, d_sg_list_t *sgl, bool corrupt,
+		    struct dcs_iod_csums **ic_out)
+{
+	uint8_t *csum_buf;
+	int      rc;
+
+	rc = daos_csummer_calc_iods(csummer, sgl, iod, NULL, 1, false, NULL, 0, ic_out);
+	if (rc != 0)
+		return rc;
+
+	if (corrupt) {
+		csum_buf = ci_idx2csum((*ic_out)->ic_data, 0);
+		csum_buf[0] ^= 0xff;
+	}
+
+	return vos_obj_update(coh, oid, epoch, 0, 0, &g_dkeys[0], 1, iod, *ic_out, sgl);
+}
+
+/*
+ * g_oids[2]: single value written with valid data but a deliberately corrupted (flipped)
+ * stored checksum, to exercise csum_check's corruption-detection path.
+ */
+static int
+csum_test_corrupt_sv_setup(struct dt_vos_pool_ctx *tctx, daos_handle_t coh, d_sg_list_t *sgl)
+{
+	struct dt_csum_ctx *csum_ctx;
+	daos_iod_t          iod;
+	char               *buf;
+	int                 rc;
+
+	csum_ctx = tctx->dvt_extra;
+
+	D_ALLOC(buf, csum_ctx->dct_sv_size);
+	if (buf == NULL)
+		return -DER_NOMEM;
+
+	d_iov_set(&iod.iod_name, g_akeys_str[0], strlen(g_akeys_str[0]));
+	iod.iod_nr    = 1;
+	iod.iod_type  = DAOS_IOD_SINGLE;
+	iod.iod_size  = csum_ctx->dct_sv_size;
+	iod.iod_recxs = NULL;
+
+	memset(buf, 'd', csum_ctx->dct_sv_size);
+	d_iov_set(sgl->sg_iovs, &buf[0], csum_ctx->dct_sv_size);
+
+	rc = write_maybe_corrupt(csum_ctx->dct_csummer, coh, g_oids[2], 1, &iod, sgl, true,
+				 &csum_ctx->dct_sv_ic_bad);
+	if (rc != 0)
+		daos_csummer_free_ic(csum_ctx->dct_csummer, &csum_ctx->dct_sv_ic_bad);
+
+	D_FREE(buf);
+	return rc;
+}
+
+/*
+ * g_oids[2]: recx written with valid data, DVT_FAKE_RECX_COUNT overlapping segments (same
+ * layout as csum_test_recx_setup()'s g_oids[1] fixture), but only DVT_FAKE_RECX_BAD_IDX's
+ * stored checksum is deliberately corrupted -- the other segment(s) keep a genuinely
+ * matching checksum, so csum_check's per-entry mismatch isolation can be exercised (only
+ * the bad entry should ever be flagged, never the good one(s)).
+ */
+static int
+csum_test_corrupt_recx_setup(struct dt_vos_pool_ctx *tctx, daos_handle_t coh, d_sg_list_t *sgl)
+{
+	struct dt_csum_ctx *csum_ctx;
+	daos_iod_t          iod;
+	char               *buf;
+	char                filler;
+	daos_recx_t         recx;
+	int                 recx_idx;
+	daos_epoch_t        epoch;
+	int                 rc;
+
+	csum_ctx = tctx->dvt_extra;
+
+	D_ALLOC(buf, csum_ctx->dct_recx_size);
+	if (buf == NULL) {
+		rc = -DER_NOMEM;
+		goto out;
+	}
+
+	d_iov_set(&iod.iod_name, g_akeys_str[1], strlen(g_akeys_str[1]));
+	iod.iod_nr   = 1;
+	iod.iod_type = DAOS_IOD_ARRAY;
+	iod.iod_size = 1;
+	recx.rx_nr   = csum_ctx->dct_recx_size;
+
+	epoch  = 1;
+	filler = 'f';
+	for (recx_idx = 0; recx_idx < DVT_FAKE_RECX_COUNT; recx_idx++) {
+		recx.rx_idx   = recx_idx * csum_ctx->dct_recx_size / DVT_FAKE_RECX_COUNT;
+		iod.iod_recxs = &recx;
+
+		memset(buf, filler, csum_ctx->dct_recx_size);
+		d_iov_set(sgl->sg_iovs, &buf[0], csum_ctx->dct_recx_size);
+
+		rc = write_maybe_corrupt(csum_ctx->dct_csummer, coh, g_oids[2], epoch, &iod, sgl,
+					 recx_idx == DVT_FAKE_RECX_BAD_IDX,
+					 &csum_ctx->dct_recx_ics_bad[recx_idx]);
+		if (rc != 0)
+			goto out_ics;
+
+		epoch++;
+		filler++;
+	}
+	goto out_buf;
+
+out_ics:
+	for (recx_idx = 0; recx_idx < DVT_FAKE_RECX_COUNT; recx_idx++) {
+		if (csum_ctx->dct_recx_ics_bad[recx_idx] == NULL)
+			continue;
+		daos_csummer_free_ic(csum_ctx->dct_csummer, &csum_ctx->dct_recx_ics_bad[recx_idx]);
 	}
 out_buf:
 	D_FREE(buf);
@@ -814,6 +940,8 @@ ddb_test_csum_setup(void **state)
 	csum_ctx->dct_csum_type  = DVT_FAKE_CSUM_TYPE;
 	memset(&csum_ctx->dct_sv_ics[0], 0, sizeof(csum_ctx->dct_sv_ics));
 	memset(&csum_ctx->dct_recx_ics[0], 0, sizeof(csum_ctx->dct_recx_ics));
+	csum_ctx->dct_sv_ic_bad = NULL;
+	memset(&csum_ctx->dct_recx_ics_bad[0], 0, sizeof(csum_ctx->dct_recx_ics_bad));
 	rc = daos_csummer_init_with_type(&csum_ctx->dct_csummer, csum_ctx->dct_csum_type,
 					 csum_ctx->dct_chunk_size, 0);
 	if (rc != 0)
@@ -838,6 +966,12 @@ ddb_test_csum_setup(void **state)
 	if (rc != 0)
 		goto out_sgl;
 	rc = csum_test_recx_setup(tctx, coh, &sgl);
+	if (rc != 0)
+		goto out_sgl;
+	rc = csum_test_corrupt_sv_setup(tctx, coh, &sgl);
+	if (rc != 0)
+		goto out_sgl;
+	rc = csum_test_corrupt_recx_setup(tctx, coh, &sgl);
 
 out_sgl:
 	d_sgl_fini(&sgl, false);
@@ -880,6 +1014,9 @@ ddb_test_csum_teardown(void **state)
 		daos_csummer_free_ic(csum_ctx->dct_csummer, &csum_ctx->dct_sv_ics[ci_idx]);
 	for (ci_idx = 0; ci_idx < DVT_FAKE_RECX_COUNT; ci_idx++)
 		daos_csummer_free_ic(csum_ctx->dct_csummer, &csum_ctx->dct_recx_ics[ci_idx]);
+	daos_csummer_free_ic(csum_ctx->dct_csummer, &csum_ctx->dct_sv_ic_bad);
+	for (ci_idx = 0; ci_idx < DVT_FAKE_RECX_COUNT; ci_idx++)
+		daos_csummer_free_ic(csum_ctx->dct_csummer, &csum_ctx->dct_recx_ics_bad[ci_idx]);
 	daos_csummer_destroy(&csum_ctx->dct_csummer);
 
 	vos_cont_destroy(tctx->dvt_poh, csum_ctx->dct_cont_uuid);

--- a/src/utils/ddb/tests/ddb_test_driver.h
+++ b/src/utils/ddb/tests/ddb_test_driver.h
@@ -51,7 +51,8 @@ struct dt_vos_pool_ctx {
 #define DVT_FAKE_SV_SIZE    (1u << 10)
 #define DVT_FAKE_RECX_SIZE  (1u << 13)
 #define DVT_FAKE_CHUNK_SIZE (1u << 12)
-#define DVT_FAKE_CSUM_TYPE  (HASH_TYPE_CRC64)
+#define DVT_FAKE_CSUM_TYPE    (HASH_TYPE_CRC64)
+#define DVT_FAKE_RECX_BAD_IDX (1)
 
 struct dt_csum_ctx {
 	uuid_t                dct_cont_uuid;
@@ -62,6 +63,8 @@ struct dt_csum_ctx {
 	struct daos_csummer  *dct_csummer;
 	struct dcs_iod_csums *dct_sv_ics[DVT_FAKE_SV_COUNT];
 	struct dcs_iod_csums *dct_recx_ics[DVT_FAKE_RECX_COUNT];
+	struct dcs_iod_csums *dct_sv_ic_bad;
+	struct dcs_iod_csums *dct_recx_ics_bad[DVT_FAKE_RECX_COUNT];
 };
 
 daos_unit_oid_t dvt_gen_uoid(uint32_t i);

--- a/src/utils/ddb/tests/ddb_vos_tests.c
+++ b/src/utils/ddb/tests/ddb_vos_tests.c
@@ -1478,6 +1478,283 @@ dump_csum_recx_tests(void **state)
 	assert_rc_equal(-DER_INVAL, rc);
 }
 
+/* Callback that returns *(int *)cb_args, or 0 if cb_args is NULL. */
+static int
+check_cb_return_rc(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
+		   struct dcs_ci_list *cil, struct dcs_csum_info **got_csums)
+{
+	return (cb_args != NULL) ? (*(int *)cb_args) : (0);
+}
+
+static void
+check_csum_error_tests(void **state)
+{
+	struct dt_vos_pool_ctx *tctx     = *state;
+	struct dt_csum_ctx     *csum_ctx = tctx->dvt_extra;
+	struct dv_tree_path     path     = {0};
+	int                     rc;
+
+	uuid_copy(path.vtp_cont, csum_ctx->dct_cont_uuid);
+	path.vtp_dkey    = g_dkeys[0];
+	path.vtp_akey    = g_akeys[0]; /* single value type */
+	path.vtp_is_recx = false;
+
+	/* invalid poh: error comes from vos_cont_open */
+	rc = dv_check_csum(DAOS_HDL_INVAL, &path, DAOS_EPOCH_MAX, check_cb_return_rc, NULL);
+	assert_rc_equal(-DER_INVAL, rc);
+}
+
+/*
+ * g_oids[0]: SV stored at epoch 1 without checksum.
+ * Fetching at EPOCH_MAX finds the SV (sv_epoch=1) but cil is empty (no checksum stored), so
+ * there is nothing to verify and got_csums is NULL.
+ */
+static int
+verify_csum_sv_cb_001(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
+		      struct dcs_ci_list *cil, struct dcs_csum_info **got_csums)
+{
+	assert_null(cb_args);
+	assert_null(recx_rel);
+	assert_int_equal(sv_epoch, 1);
+	assert_non_null(cil);
+	assert_int_equal(cil->dcl_csum_infos_nr, 0);
+	assert_null(got_csums);
+
+	return 0;
+}
+
+/* g_oids[1]: SV stored at epoch 1 with a valid, matching checksum. */
+static int
+verify_csum_sv_cb_002(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
+		      struct dcs_ci_list *cil, struct dcs_csum_info **got_csums)
+{
+	assert_non_null(cb_args);
+	assert_null(recx_rel);
+	assert_int_equal(sv_epoch, 1);
+	assert_non_null(cil);
+	assert_int_equal(cil->dcl_csum_infos_nr, 1);
+	assert_non_null(got_csums);
+	assert_null(got_csums[0]);
+
+	return 0;
+}
+
+/* g_oids[1]: SV stored at epoch 2 (latest) with a valid, matching checksum. */
+static int
+verify_csum_sv_cb_002_latest(void *cb_args, struct daos_recx_ep_list *recx_rel,
+			     daos_epoch_t sv_epoch, struct dcs_ci_list *cil,
+			     struct dcs_csum_info **got_csums)
+{
+	assert_non_null(cb_args);
+	assert_null(recx_rel);
+	assert_int_equal(sv_epoch, 2);
+	assert_non_null(cil);
+	assert_int_equal(cil->dcl_csum_infos_nr, 1);
+	assert_non_null(got_csums);
+	assert_null(got_csums[0]);
+
+	return 0;
+}
+
+/*
+ * g_oids[2]: SV stored with valid data but a deliberately corrupted stored checksum (fixture
+ * flips the first byte of an otherwise-correct checksum before writing it -- see
+ * csum_test_corrupt_sv_setup()). got_csums[0] should hold the checksum *recomputed* from the
+ * still-valid data, i.e. the stored value with that one byte's flip undone.
+ */
+static int
+verify_csum_sv_cb_003(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
+		      struct dcs_ci_list *cil, struct dcs_csum_info **got_csums)
+{
+	struct dcs_csum_info *stored_ci;
+	struct dcs_csum_info *got_ci;
+	uint8_t               expect_byte0;
+
+	assert_non_null(cb_args);
+	assert_null(recx_rel);
+	assert_int_equal(sv_epoch, 1);
+	assert_non_null(cil);
+	assert_int_equal(cil->dcl_csum_infos_nr, 1);
+
+	assert_non_null(got_csums);
+	assert_non_null(got_csums[0]);
+	stored_ci    = dcs_csum_info_get(cil, 0);
+	got_ci       = got_csums[0];
+	expect_byte0 = ci_idx2csum(stored_ci, 0)[0] ^ 0xff;
+	assert_int_equal(got_ci->cs_len, stored_ci->cs_len);
+	assert_int_equal(got_ci->cs_nr, stored_ci->cs_nr);
+	assert_int_equal(ci_idx2csum(got_ci, 0)[0], expect_byte0);
+	assert_memory_equal(ci_idx2csum(got_ci, 0) + 1, ci_idx2csum(stored_ci, 0) + 1,
+			    stored_ci->cs_len - 1);
+
+	return 0;
+}
+
+static void
+check_csum_sv_tests(void **state)
+{
+	struct dt_vos_pool_ctx *tctx     = *state;
+	struct dt_csum_ctx     *csum_ctx = tctx->dvt_extra;
+	struct dv_tree_path     path     = {0};
+	int                     rc;
+
+	uuid_copy(path.vtp_cont, csum_ctx->dct_cont_uuid);
+	path.vtp_dkey    = g_dkeys[0];
+	path.vtp_akey    = g_akeys[0]; /* single value type */
+	path.vtp_is_recx = false;
+
+	/* no csum info: nothing to verify, success */
+	path.vtp_oid = g_oids[0];
+	rc = dv_check_csum(tctx->dvt_poh, &path, DAOS_EPOCH_MAX, verify_csum_sv_cb_001, NULL);
+	assert_success(rc);
+
+	/* valid, matching csum info: epoch 1 returns the epoch-1 checksum */
+	path.vtp_oid = g_oids[1];
+	rc           = dv_check_csum(tctx->dvt_poh, &path, 1, verify_csum_sv_cb_002, csum_ctx);
+	assert_success(rc);
+
+	/* valid, matching csum info: EPOCH_MAX returns the latest (epoch-2) checksum */
+	path.vtp_oid = g_oids[1];
+	rc = dv_check_csum(tctx->dvt_poh, &path, DAOS_EPOCH_MAX, verify_csum_sv_cb_002_latest,
+			   csum_ctx);
+	assert_success(rc);
+
+	/* deliberately corrupted csum info: -DER_CSUM */
+	path.vtp_oid = g_oids[2];
+	rc = dv_check_csum(tctx->dvt_poh, &path, DAOS_EPOCH_MAX, verify_csum_sv_cb_003, csum_ctx);
+	assert_rc_equal(-DER_CSUM, rc);
+
+	/* with csum info, without callback */
+	path.vtp_oid = g_oids[1];
+	rc           = dv_check_csum(tctx->dvt_poh, &path, DAOS_EPOCH_MAX, NULL, csum_ctx);
+	assert_success(rc);
+
+	/* callback failure is propagated */
+	path.vtp_oid = g_oids[1];
+	rc           = dv_check_csum(tctx->dvt_poh, &path, DAOS_EPOCH_MAX, check_cb_return_rc,
+				     &(int){-DER_INVAL});
+	assert_rc_equal(-DER_INVAL, rc);
+}
+
+/* g_oids[0]: recxs stored without checksum. */
+static int
+verify_csum_recx_cb_001(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
+			struct dcs_ci_list *cil, struct dcs_csum_info **got_csums)
+{
+	assert_null(cb_args);
+	assert_non_null(recx_rel);
+	assert_int_equal(sv_epoch, 0);
+	assert_non_null(cil);
+	assert_int_equal(cil->dcl_csum_infos_nr, 0);
+	assert_null(got_csums);
+
+	return 0;
+}
+
+/* g_oids[1]: recxs stored with valid, matching checksums (2 overlapping segments). */
+static int
+verify_csum_recx_cb_002(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
+			struct dcs_ci_list *cil, struct dcs_csum_info **got_csums)
+{
+	assert_non_null(cb_args);
+	assert_non_null(recx_rel);
+	assert_int_equal(sv_epoch, 0);
+	assert_non_null(cil);
+	assert_int_equal(cil->dcl_csum_infos_nr, DVT_FAKE_RECX_COUNT);
+	assert_non_null(got_csums);
+	assert_null(got_csums[0]);
+	assert_null(got_csums[1]);
+
+	return 0;
+}
+
+/*
+ * g_oids[2]: recx stored with valid data, DVT_FAKE_RECX_COUNT overlapping segments (same
+ * layout as verify_csum_recx_cb_002()/g_oids[1]), but only DVT_FAKE_RECX_BAD_IDX's stored
+ * checksum is deliberately corrupted (single-byte flip, same fixture style as
+ * verify_csum_sv_cb_003() above) -- the other segment(s) keep a genuinely matching
+ * checksum. Exercises that got_csums[] correctly isolates the corrupted entry without
+ * affecting the others (the exact scenario behind the flat-buffer indexing bug fixed in
+ * 65dacd2e4a).
+ */
+static int
+verify_csum_recx_cb_003(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
+			struct dcs_ci_list *cil, struct dcs_csum_info **got_csums)
+{
+	struct dcs_csum_info *stored_ci;
+	struct dcs_csum_info *got_ci;
+	uint8_t               expect_byte0;
+	int                   i;
+
+	assert_non_null(cb_args);
+	assert_non_null(recx_rel);
+	assert_int_equal(sv_epoch, 0);
+	assert_non_null(cil);
+	assert_int_equal(cil->dcl_csum_infos_nr, DVT_FAKE_RECX_COUNT);
+	assert_non_null(got_csums);
+
+	for (i = 0; i < DVT_FAKE_RECX_COUNT; i++) {
+		if (i != DVT_FAKE_RECX_BAD_IDX) {
+			assert_null(got_csums[i]);
+			continue;
+		}
+
+		assert_non_null(got_csums[i]);
+		stored_ci    = dcs_csum_info_get(cil, i);
+		got_ci       = got_csums[i];
+		expect_byte0 = ci_idx2csum(stored_ci, 0)[0] ^ 0xff;
+		assert_int_equal(got_ci->cs_len, stored_ci->cs_len);
+		assert_int_equal(got_ci->cs_nr, stored_ci->cs_nr);
+		assert_int_equal(ci_idx2csum(got_ci, 0)[0], expect_byte0);
+		assert_memory_equal(ci_idx2csum(got_ci, 0) + 1, ci_idx2csum(stored_ci, 0) + 1,
+				    stored_ci->cs_len - 1);
+	}
+
+	return 0;
+}
+
+static void
+check_csum_recx_tests(void **state)
+{
+	struct dt_vos_pool_ctx *tctx     = *state;
+	struct dt_csum_ctx     *csum_ctx = tctx->dvt_extra;
+	struct dv_tree_path     path     = {0};
+	int                     rc;
+
+	uuid_copy(path.vtp_cont, csum_ctx->dct_cont_uuid);
+	path.vtp_dkey        = g_dkeys[0];
+	path.vtp_akey        = g_akeys[1]; /* array value type */
+	path.vtp_is_recx     = true;
+	path.vtp_recx.rx_idx = 0;
+	path.vtp_recx.rx_nr  = csum_ctx->dct_recx_size;
+
+	/* no csum info */
+	path.vtp_oid = g_oids[0];
+	rc = dv_check_csum(tctx->dvt_poh, &path, DAOS_EPOCH_MAX, verify_csum_recx_cb_001, NULL);
+	assert_success(rc);
+
+	/* valid, matching csum info */
+	path.vtp_oid = g_oids[1];
+	rc = dv_check_csum(tctx->dvt_poh, &path, DAOS_EPOCH_MAX, verify_csum_recx_cb_002, csum_ctx);
+	assert_success(rc);
+
+	/* deliberately corrupted csum info: -DER_CSUM */
+	path.vtp_oid = g_oids[2];
+	rc = dv_check_csum(tctx->dvt_poh, &path, DAOS_EPOCH_MAX, verify_csum_recx_cb_003, csum_ctx);
+	assert_rc_equal(-DER_CSUM, rc);
+
+	/* with csum info, without callback */
+	path.vtp_oid = g_oids[1];
+	rc           = dv_check_csum(tctx->dvt_poh, &path, DAOS_EPOCH_MAX, NULL, csum_ctx);
+	assert_success(rc);
+
+	/* callback failure is propagated */
+	path.vtp_oid = g_oids[1];
+	rc           = dv_check_csum(tctx->dvt_poh, &path, DAOS_EPOCH_MAX, check_cb_return_rc,
+				     &(int){-DER_INVAL});
+	assert_rc_equal(-DER_INVAL, rc);
+}
+
 /*
  * All these tests use the same VOS tree that is created at suit_setup. Therefore, tests
  * that modify the state of the tree (delete, add, etc) should be run after all others.
@@ -1516,6 +1793,9 @@ const struct CMUnitTest dv_test_cases[] = {
     TEST_CSUM(dump_csum_error_tests),
     TEST_CSUM(dump_csum_sv_tests),
     TEST_CSUM(dump_csum_recx_tests),
+    TEST_CSUM(check_csum_error_tests),
+    TEST_CSUM(check_csum_sv_tests),
+    TEST_CSUM(check_csum_recx_tests),
 };
 
 int


### PR DESCRIPTION
### Description

Adds a new `ddb csum_check <path>` command that recomputes the checksum(s) stored at a VOS tree path from the currently stored data and compares them against what is stored on disk, without modifying anything. The path must be complete (including the akey, and the extent for an array value). The --epoch flag selects which version to check: for a single value it selects the value visible at or before that epoch; for an array value it bounds the visible record extent. By default the command is silent on a clean result (matching, or no checksum stored) and only prints corrupted entries plus a final error summary; --verbose prints every entry regardless of outcome and a final summary line even on success. The command exits non-zero (-DER_CSUM) if any checksum entry fails to match.

Implementation:
- ddb_vos.c/.h: adds dv_check_csum(), mirroring the structure of the existing dv_dump_csum() (open container, build the iod from path, dispatch by value type, close container) as an independent implementation that additionally fetches the live data, recomputes its checksum(s), and compares against what was fetched. Reports results through a callback with a got_csums array: got_csums[i] holds the recomputed checksum when entry i's stored checksum did not match, and is NULL when it matched or there was nothing to check.
- ddb_commands.c: wires csum_check into the interactive/scripted command set, sharing print formatting with the existing csum_dump command (adding "State: OK"/"NOK", with the recomputed value shown as "(got=...)" on a mismatch).
- src/control/cmd/ddb: adds the Go-side command/flag definitions and cgo wrapper so csum_check is available from the ddb binary.
- README.md: documents the new command (and the previously undocumented csum_dump) in the command reference.

Test coverage: unit tests for dv_check_csum() (single value and array, matching/mismatching/no-checksum cases, and per-entry mismatch isolation when one of several overlapping array segments is corrupted) and for the csum_check command's print output and verbosity behavior, using extended VOS test fixtures for corrupted single-value and array checksums.

Validated locally (scons build under -Werror, full ddb_tests suite) and on hardware (brd-216: rebuilt, ran ddb_ut/ddb_tests/go unit tests, and a live functional pass with a real pool/container -- csum_check agreed with csum_dump on a clean value, and correctly detected corruption after directly modifying stored data).

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
