### PR TITLE
DAOS-17321 ddb: Add checksum check command to ddb C API

### DIFF
--- a/src/utils/ddb/ddb.h
+++ b/src/utils/ddb/ddb.h
@@ -188,6 +188,12 @@ struct csum_dump_options {
 	daos_epoch_t epoch;
 };
 
+struct csum_check_options {
+	char        *path;
+	daos_epoch_t epoch;
+	bool         verbose;
+};
+
 /* Run commands ... */
 int
 ddb_run_ls(struct ddb_ctx *ctx, struct ls_options *opt);
@@ -248,5 +254,7 @@ int
 ddb_run_dtx_aggr(struct ddb_ctx *ctx, struct dtx_aggr_options *opt);
 int
 ddb_run_csum_dump(struct ddb_ctx *ctx, struct csum_dump_options *opt);
+int
+ddb_run_csum_check(struct ddb_ctx *ctx, struct csum_check_options *opt);
 
 #endif /* __DDB_RUN_CMDS_H */

--- a/src/utils/ddb/ddb_commands.c
+++ b/src/utils/ddb/ddb_commands.c
@@ -393,7 +393,143 @@ print_csum_bufs(struct ddb_ctx *ctx, struct dcs_csum_info *ci)
 		for (j = 0; j < ci->cs_len; j++)
 			ddb_printf(ctx, "%02" PRIx8, csum_buf[j]);
 	}
+}
+
+/*
+ * Shared body for print_csum_sv() (dump) and print_csum_check_sv() (check). \a got_csums is
+ * NULL for a plain dump; when checking, got_csums[0] is non-NULL if the single value's
+ * checksum failed to match, holding the recomputed value in that case. \a verbose only
+ * matters when checking: when false, only corrupted entries are printed -- matching entries
+ * and "no checksum stored" are both fully suppressed (not even the path/header), so a clean
+ * check produces no output at all.
+ */
+static int
+print_csum_sv_body(struct ddb_ctx *ctx, struct dv_indexed_tree_path *vtp, daos_epoch_t sv_epoch,
+		   struct dcs_ci_list *cil, struct dcs_csum_info **got_csums, bool verbose)
+{
+	struct dcs_csum_info *ci;
+	struct hash_ft       *hf;
+
+	/* non-verbose check mode: only entries that are actually corrupted are printed */
+	if (got_csums != NULL && got_csums[0] == NULL && !verbose)
+		return 0;
+
+	if (cil->dcl_csum_infos_nr == 0) {
+		/* verbose is always true for a dump */
+		if (!verbose)
+			return 0;
+		ddb_print(ctx, "No checksum at ");
+		itp_print_full(ctx, vtp);
+		ddb_print(ctx, "\n");
+		return 0;
+	}
+	D_ASSERT(cil->dcl_csum_infos_nr == 1);
+
+	ci = dcs_csum_info_get(cil, 0);
+	D_ASSERT(ci_is_valid(ci));
+	D_ASSERT(ci->cs_nr == 1);
+
+	hf = daos_mhash_type2algo(ci->cs_type);
+
+	itp_print_full(ctx, vtp);
 	ddb_print(ctx, "\n");
+	ddb_printf(ctx, "Type: %s, Length: %" PRIu16 ", Epoch: %" PRIu64 ", Value: ", hf->cf_name,
+		   ci->cs_len, sv_epoch);
+	print_csum_bufs(ctx, ci);
+
+	if (got_csums == NULL)
+		goto out;
+
+	ddb_printf(ctx, ", State: %s", got_csums[0] ? "NOK" : "OK");
+	if (got_csums[0] != NULL) {
+		ddb_print(ctx, " (got=");
+		print_csum_bufs(ctx, got_csums[0]);
+		ddb_print(ctx, ")");
+	}
+
+out:
+	ddb_print(ctx, "\n");
+	return 0;
+}
+
+/*
+ * Shared body for print_csum_recx() (dump) and print_csum_check_recx() (check). See
+ * print_csum_sv_body() for the meaning of \a got_csums/\a verbose.
+ */
+static int
+print_csum_recx_body(struct ddb_ctx *ctx, struct dv_indexed_tree_path *vtp,
+		     struct daos_recx_ep_list *recx_rel, struct dcs_ci_list *cil,
+		     struct dcs_csum_info **got_csums, bool verbose)
+{
+	struct dcs_csum_info  *ci;
+	struct hash_ft        *hf;
+	uint32_t               chunk_sz;
+	bool                   header_printed = false;
+	int                    i;
+
+	if (cil->dcl_csum_infos_nr == 0) {
+		/* verbose is always true for a dump */
+		if (!verbose)
+			return 0;
+		ddb_print(ctx, "No checksum at ");
+		itp_print_full(ctx, vtp);
+		ddb_print(ctx, "\n");
+		return 0;
+	}
+
+	D_ASSERT(recx_rel != NULL);
+	D_ASSERT(cil->dcl_csum_infos_nr == recx_rel->re_nr);
+
+	ci = dcs_csum_info_get(cil, 0);
+	D_ASSERT(ci_is_valid(ci));
+	hf       = daos_mhash_type2algo(ci->cs_type);
+	chunk_sz = ci->cs_chunksize;
+
+	/* dcl_csum_infos_nr can be > 1 for a single path: e.g. overlapping recx writes at
+	 * different epochs each contribute their own checksummed segment. */
+	for (i = 0; i < cil->dcl_csum_infos_nr; i++) {
+		struct daos_recx_ep *rep;
+
+		/* non-verbose check mode: only entries that are actually corrupted are printed */
+		if (got_csums != NULL && got_csums[i] == NULL && !verbose)
+			continue;
+
+		ci = dcs_csum_info_get(cil, i);
+		D_ASSERT(ci_is_valid(ci));
+		rep = &recx_rel->re_items[i];
+
+		if (!header_printed) {
+			itp_print_full(ctx, vtp);
+			ddb_print(ctx, "\n");
+			ddb_printf(ctx,
+				   "Checksum Type: %s, Checksum Length: %" PRIu16
+				   ", Chunk Size: %" PRIu32 ", Record Extent(s):\n",
+				   hf->cf_name, ci->cs_len, chunk_sz);
+			header_printed = true;
+		}
+
+		ddb_printf(ctx,
+			   "- Record Indexes: {%" PRIu64 "-%" PRIu64 "}, Record Size: %" PRIu32
+			   ", Epoch: %" PRIu64 ", Checksum Value(s): ",
+			   rep->re_recx.rx_idx, rep->re_recx.rx_idx + rep->re_recx.rx_nr - 1,
+			   rep->re_rec_size, rep->re_ep);
+		print_csum_bufs(ctx, ci);
+
+		if (got_csums == NULL) {
+			ddb_print(ctx, "\n");
+			continue;
+		}
+
+		ddb_printf(ctx, ", State: %s", got_csums[i] ? "NOK" : "OK");
+		if (got_csums[i] != NULL) {
+			ddb_print(ctx, " (got=");
+			print_csum_bufs(ctx, got_csums[i]);
+			ddb_print(ctx, ")");
+		}
+		ddb_print(ctx, "\n");
+	}
+
+	return 0;
 }
 
 struct dump_csum_args {
@@ -406,61 +542,9 @@ static int
 print_csum_recx(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
 		struct dcs_ci_list *cil)
 {
-	struct dump_csum_args *args;
-	struct ddb_ctx        *ctx;
-	struct dcs_csum_info  *ci;
-	struct hash_ft        *hf;
-	struct daos_recx_ep   *rep;
-	uint32_t               chunk_sz;
-	int                    i;
+	struct dump_csum_args *args = cb_args;
 
-	args = cb_args;
-	ctx  = args->dca_ctx;
-
-	if (cil->dcl_csum_infos_nr == 0) {
-		ddb_print(ctx, "No checksum at ");
-		itp_print_full(ctx, args->dca_vtp);
-		ddb_print(ctx, "\n");
-		return 0;
-	}
-
-	D_ASSERT(recx_rel != NULL);
-	D_ASSERT(cil->dcl_csum_infos_nr == recx_rel->re_nr);
-
-	ci = dcs_csum_info_get(cil, 0);
-	D_ASSERT(ci_is_valid(ci));
-	rep      = &recx_rel->re_items[0];
-	hf       = daos_mhash_type2algo(ci->cs_type);
-	chunk_sz = ci->cs_chunksize;
-
-	itp_print_full(ctx, args->dca_vtp);
-	ddb_print(ctx, "\n");
-	ddb_printf(ctx,
-		   "Checksum Type: %s, Checksum Length: %" PRIu16 ", Chunk Size: %" PRIu32
-		   ", Record Extent(s):\n",
-		   hf->cf_name, ci->cs_len, chunk_sz);
-
-	ddb_printf(ctx,
-		   "- Record Indexes: {%" PRIu64 "-%" PRIu64 "}, Record Size: %" PRIu32
-		   ", Epoch: %" PRIu64 ", Checksum Value(s): ",
-		   rep->re_recx.rx_idx, rep->re_recx.rx_idx + rep->re_recx.rx_nr - 1,
-		   rep->re_rec_size, rep->re_ep);
-	print_csum_bufs(ctx, ci);
-
-	for (i = 1; i < cil->dcl_csum_infos_nr; i++) {
-		ci = dcs_csum_info_get(cil, i);
-		D_ASSERT(ci_is_valid(ci));
-		rep = &recx_rel->re_items[i];
-
-		ddb_printf(ctx,
-			   "- Record Indexes: {%" PRIu64 "-%" PRIu64 "}, Record Size: %" PRIu32
-			   ", Epoch: %" PRIu64 ", Checksum Value(s): ",
-			   rep->re_recx.rx_idx, rep->re_recx.rx_idx + rep->re_recx.rx_nr - 1,
-			   rep->re_rec_size, rep->re_ep);
-		print_csum_bufs(ctx, ci);
-	}
-
-	return 0;
+	return print_csum_recx_body(args->dca_ctx, args->dca_vtp, recx_rel, cil, NULL, true);
 }
 
 static int
@@ -564,34 +648,9 @@ static int
 print_csum_sv(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
 	      struct dcs_ci_list *cil)
 {
-	struct dump_csum_args *args;
-	struct ddb_ctx        *ctx;
-	struct dcs_csum_info  *ci;
-	struct hash_ft        *hf;
+	struct dump_csum_args *args = cb_args;
 
-	args = cb_args;
-	ctx  = args->dca_ctx;
-
-	if (cil->dcl_csum_infos_nr == 0) {
-		ddb_print(ctx, "No checksum at ");
-		itp_print_full(ctx, args->dca_vtp);
-		ddb_print(ctx, "\n");
-		return 0;
-	}
-	D_ASSERT(cil->dcl_csum_infos_nr == 1);
-
-	ci = dcs_csum_info_get(cil, 0);
-	D_ASSERT(ci_is_valid(ci));
-	D_ASSERT(ci->cs_nr == 1);
-	hf = daos_mhash_type2algo(ci->cs_type);
-
-	itp_print_full(ctx, args->dca_vtp);
-	ddb_print(ctx, "\n");
-	ddb_printf(ctx, "Type: %s, Length: %" PRIu16 ", Epoch: %" PRIu64 ", Value: ", hf->cf_name,
-		   ci->cs_len, sv_epoch);
-	print_csum_bufs(ctx, ci);
-
-	return 0;
+	return print_csum_sv_body(args->dca_ctx, args->dca_vtp, sv_epoch, cil, NULL, true);
 }
 
 static int
@@ -674,6 +733,79 @@ ddb_run_csum_dump(struct ddb_ctx *ctx, struct csum_dump_options *opt)
 	itp_to_vos_path(&itp, &vtp);
 
 	rc = dv_dump_csum(ctx->dc_poh, &vtp, opt->epoch, cb, &dca);
+
+out_itp:
+	itp_free(&itp);
+
+out:
+	return rc;
+}
+
+struct check_csum_args {
+	struct ddb_ctx              *cca_ctx;
+	struct dv_indexed_tree_path *cca_vtp;
+	bool                         cca_verbose;
+};
+
+static int
+print_csum_check_sv(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
+		    struct dcs_ci_list *cil, struct dcs_csum_info **got_csums)
+{
+	struct check_csum_args *args = cb_args;
+
+	return print_csum_sv_body(args->cca_ctx, args->cca_vtp, sv_epoch, cil, got_csums,
+				  args->cca_verbose);
+}
+
+static int
+print_csum_check_recx(void *cb_args, struct daos_recx_ep_list *recx_rel, daos_epoch_t sv_epoch,
+		      struct dcs_ci_list *cil, struct dcs_csum_info **got_csums)
+{
+	struct check_csum_args *args = cb_args;
+
+	return print_csum_recx_body(args->cca_ctx, args->cca_vtp, recx_rel, cil, got_csums,
+				    args->cca_verbose);
+}
+
+int
+ddb_run_csum_check(struct ddb_ctx *ctx, struct csum_check_options *opt)
+{
+	struct dv_indexed_tree_path itp = {0};
+	struct dv_tree_path         vtp;
+	struct check_csum_args      cca = {0};
+	dv_check_csum_cb            cb;
+	int                         rc;
+
+	if (!opt->path) {
+		ddb_error(ctx, "A VOS path to check is required.\n");
+		rc = -DER_INVAL;
+		goto out;
+	}
+
+	rc = init_path(ctx, opt->path, &itp);
+	if (!SUCCESS(rc))
+		goto out;
+
+	if (!itp_has_value(&itp)) {
+		ddb_errorf(ctx, "Path [%s] is incomplete.\n", opt->path);
+		rc = -DDBER_INCOMPLETE_PATH_VALUE;
+		goto out_itp;
+	}
+
+	cb = itp_has_recx(&itp) ? print_csum_check_recx : print_csum_check_sv;
+
+	cca.cca_ctx     = ctx;
+	cca.cca_vtp     = &itp;
+	cca.cca_verbose = opt->verbose;
+
+	itp_to_vos_path(&itp, &vtp);
+
+	rc = dv_check_csum(ctx->dc_poh, &vtp, opt->epoch, cb, &cca);
+	if (SUCCESS(rc) && opt->verbose)
+		ddb_print(ctx, "OK: no corruption detected.\n");
+	if (rc == -DER_CSUM)
+		ddb_error(ctx, "Data corruption detected: one or more checksums do not match the "
+			       "stored data.\n");
 
 out_itp:
 	itp_free(&itp);

--- a/src/utils/ddb/tests/ddb_cmocka.h
+++ b/src/utils/ddb/tests/ddb_cmocka.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2022 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -67,6 +67,12 @@
 	do { \
 		if (strstr(str, substr) == NULL) \
 			fail_msg("'%s' not found in '%s'", substr, str); \
+	} while (0)
+
+#define assert_string_not_contains(str, substr)                                                    \
+	do {                                                                                       \
+		if (strstr(str, substr) != NULL)                                                   \
+			fail_msg("'%s' unexpectedly found in '%s'", substr, str);                  \
 	} while (0)
 
 #define assert_invalid(x) assert_rc_equal(-DER_INVAL, (x))

--- a/src/utils/ddb/tests/ddb_commands_tests.c
+++ b/src/utils/ddb/tests/ddb_commands_tests.c
@@ -874,6 +874,221 @@ write_csum_recx_tests(void **state)
 	dvt_fake_print_reset();
 }
 
+static void
+csum_check_error_tests(void **state)
+{
+	char                     *path_invalid = "foo";
+	struct dt_vos_pool_ctx   *tctx         = *state;
+	struct ddb_ctx            ctx          = {0};
+	struct csum_check_options opt          = {0};
+	char                      path[128];
+	int                       rc;
+
+	ctx.dc_poh                     = tctx->dvt_poh;
+	ctx.dc_io_ft.ddb_print_error   = dvt_fake_print;
+	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
+	ctx.dc_write_mode              = false;
+
+	rc = ddb_run_csum_check(&ctx, &opt);
+	assert_rc_equal(-DER_INVAL, rc);
+	assert_string_contains(dvt_fake_print_buffer, "A VOS path to check is required.");
+	dvt_fake_print_reset();
+
+	opt.path = &path_invalid[0];
+	rc       = ddb_run_csum_check(&ctx, &opt);
+	assert_rc_equal(-DER_INVAL, rc);
+	assert_string_contains(dvt_fake_print_buffer, "Container is invalid");
+	dvt_fake_print_reset();
+
+	/* path must be complete (point to a value): an array akey path with no extent
+	 * resolves to neither a RECX nor an SV value, so it is rejected as incomplete. */
+	opt.path = path;
+	csum_test_sv_path_init(path, sizeof(path), &g_oids[1], g_akeys_str[1]);
+	rc = ddb_run_csum_check(&ctx, &opt);
+	assert_rc_equal(-DDBER_INCOMPLETE_PATH_VALUE, rc);
+	assert_string_contains(dvt_fake_print_buffer, "is incomplete");
+	dvt_fake_print_reset();
+}
+
+static void
+check_csum_sv_tests(void **state)
+{
+	const char               *regex_prf = "0x";
+	struct dt_vos_pool_ctx   *tctx      = *state;
+	struct dt_csum_ctx       *csum_ctx  = tctx->dvt_extra;
+	struct ddb_ctx            ctx       = {0};
+	struct csum_check_options opt       = {0};
+	char                      path[128];
+	char                      buf[256];
+	uint8_t                   good_bytes[64];
+	struct dcs_csum_info     *ci;
+	int                       rc;
+
+	ctx.dc_poh                     = tctx->dvt_poh;
+	ctx.dc_io_ft.ddb_print_error   = dvt_fake_print;
+	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
+	ctx.dc_write_mode              = false;
+
+	opt.path  = path;
+	opt.epoch = DAOS_EPOCH_MAX;
+
+	/* no csum info (g_oids[0]: SV at epoch 1, no checksum stored, non-verbose) */
+	csum_test_sv_path_init(path, sizeof(path), &g_oids[0], g_akeys_str[0]);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	assert_string_equal(dvt_fake_print_buffer, "");
+	dvt_fake_print_reset();
+
+	/* valid, matching checksum, default (non-verbose) */
+	csum_test_sv_path_init(path, sizeof(path), &g_oids[1], g_akeys_str[0]);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	assert_string_equal(dvt_fake_print_buffer, "");
+	dvt_fake_print_reset();
+
+	/* same, but --verbose: every entry is printed (matching, in this case). */
+	opt.verbose = true;
+	csum_test_sv_path_init(path, sizeof(path), &g_oids[1], g_akeys_str[0]);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	assert_string_contains(dvt_fake_print_buffer, "Epoch: 2");
+	memcpy(buf, regex_prf, strlen(regex_prf));
+	ci = csum_ctx->dct_sv_ics[1]->ic_data;
+	csumbuf_dump(buf + strlen(regex_prf), ci_idx2csum(ci, 0), ci->cs_len);
+	assert_string_contains(dvt_fake_print_buffer, buf);
+	assert_string_contains(dvt_fake_print_buffer, "State: OK");
+	assert_string_contains(dvt_fake_print_buffer, "OK: no corruption detected.");
+	dvt_fake_print_reset();
+	opt.verbose = false;
+
+	/* deliberately corrupted checksum: reports CORRUPTED and -DER_CSUM, along with the
+	 * want (stored)/got (recomputed) checksum values -- always printed regardless of
+	 * verbose, since corrupted entries are never suppressed. */
+	csum_test_sv_path_init(path, sizeof(path), &g_oids[2], g_akeys_str[0]);
+	rc = ddb_run_csum_check(&ctx, &opt);
+	assert_rc_equal(-DER_CSUM, rc);
+	assert_string_contains(dvt_fake_print_buffer, "State: NOK");
+	assert_string_contains(dvt_fake_print_buffer, "Data corruption detected");
+
+	/* "want" is the stored (corrupted) checksum, shown on the main Value: line; "got" is
+	 * the checksum recomputed from the still-valid data, shown in "(got=...)". The fixture
+	 * only flips the stored checksum's first byte before writing it (see
+	 * csum_test_corrupt_sv_setup()), so "got" is "want" with that flip undone. */
+	ci = csum_ctx->dct_sv_ic_bad->ic_data;
+	strcpy(buf, "Value: 0x");
+	csumbuf_dump(buf + strlen(buf), ci_idx2csum(ci, 0), ci->cs_len);
+	assert_string_contains(dvt_fake_print_buffer, buf);
+
+	memcpy(good_bytes, ci_idx2csum(ci, 0), ci->cs_len);
+	good_bytes[0] ^= 0xff;
+	strcpy(buf, "(got=0x");
+	csumbuf_dump(buf + strlen(buf), good_bytes, ci->cs_len);
+	assert_string_contains(dvt_fake_print_buffer, buf);
+	dvt_fake_print_reset();
+}
+
+static void
+check_csum_recx_tests(void **state)
+{
+	const char               *regex_prf = "0x";
+	struct dt_vos_pool_ctx   *tctx      = *state;
+	struct dt_csum_ctx       *csum_ctx  = tctx->dvt_extra;
+	struct ddb_ctx            ctx       = {0};
+	struct csum_check_options opt       = {0};
+	daos_recx_t               recx      = {.rx_idx = 0, .rx_nr = csum_ctx->dct_recx_size};
+	char                      path[128];
+	char                      buf[256];
+	char                     *buf_csum;
+	uint8_t                   good_bytes[64];
+	char                      got_buf[64];
+	struct dcs_csum_info     *ci;
+	int                       i;
+	int                       rc;
+
+	ctx.dc_poh                     = tctx->dvt_poh;
+	ctx.dc_io_ft.ddb_print_error   = dvt_fake_print;
+	ctx.dc_io_ft.ddb_print_message = dvt_fake_print;
+	ctx.dc_write_mode              = false;
+
+	opt.path  = path;
+	opt.epoch = DAOS_EPOCH_MAX;
+
+	/* no csum info, non-verbose: fully silent (no path/header, no summary). */
+	csum_test_recx_path_init(path, sizeof(path), &g_oids[0], g_akeys_str[1], &recx);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	assert_string_equal(dvt_fake_print_buffer, "");
+	dvt_fake_print_reset();
+
+	/* same, but --verbose: "No checksum at ..." is reported, plus the final "OK" summary
+	 * (still success -- there's simply nothing to check). */
+	opt.verbose = true;
+	csum_test_recx_path_init(path, sizeof(path), &g_oids[0], g_akeys_str[1], &recx);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	assert_string_contains(dvt_fake_print_buffer, "No checksum at ");
+	assert_string_contains(dvt_fake_print_buffer, "OK: no corruption detected.");
+	dvt_fake_print_reset();
+	opt.verbose = false;
+
+	/* valid, matching checksums, default (non-verbose): fully silent, no per-entry
+	 * detail and no final summary line either. */
+	csum_test_recx_path_init(path, sizeof(path), &g_oids[1], g_akeys_str[1], &recx);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	assert_string_equal(dvt_fake_print_buffer, "");
+	dvt_fake_print_reset();
+
+	/* same, but --verbose: every entry is printed (matching, for each segment here). */
+	opt.verbose = true;
+	csum_test_recx_path_init(path, sizeof(path), &g_oids[1], g_akeys_str[1], &recx);
+	assert_success(ddb_run_csum_check(&ctx, &opt));
+	memcpy(buf, regex_prf, strlen(regex_prf));
+	buf_csum = buf + strlen(regex_prf);
+	for (i = 0; i < DVT_FAKE_RECX_COUNT; i++) {
+		int csum_idx;
+
+		ci = csum_ctx->dct_recx_ics[i]->ic_data;
+		for (csum_idx = 0; csum_idx < ci->cs_nr; ++csum_idx) {
+			csumbuf_dump(buf_csum, ci_idx2csum(ci, csum_idx), ci->cs_len);
+			assert_string_contains(dvt_fake_print_buffer, buf);
+		}
+	}
+	assert_string_contains(dvt_fake_print_buffer, "State: OK");
+	assert_string_contains(dvt_fake_print_buffer, "OK: no corruption detected.");
+	dvt_fake_print_reset();
+	opt.verbose = false;
+
+	/* shared by both the non-verbose and --verbose corrupted-checksum checks below: the
+	 * bad entry's stored (corrupted) checksum ("want") and its recomputed value ("got") */
+	ci = csum_ctx->dct_recx_ics_bad[DVT_FAKE_RECX_BAD_IDX]->ic_data;
+	strcpy(buf, "Checksum Value(s): 0x");
+	csumbuf_dump(buf + strlen(buf), ci_idx2csum(ci, 0), ci->cs_len);
+	memcpy(good_bytes, ci_idx2csum(ci, 0), ci->cs_len);
+	good_bytes[0] ^= 0xff;
+	strcpy(got_buf, " (got=0x");
+	csumbuf_dump(got_buf + strlen(got_buf), good_bytes, ci->cs_len);
+
+	/* g_oids[2]: one of DVT_FAKE_RECX_COUNT segments has a corrupted checksum. Non-verbose
+	 * still reports it (corrupted entries are never suppressed); the good entry is
+	 * suppressed here (see --verbose below). */
+	csum_test_recx_path_init(path, sizeof(path), &g_oids[2], g_akeys_str[1], &recx);
+	rc = ddb_run_csum_check(&ctx, &opt);
+	assert_rc_equal(-DER_CSUM, rc);
+	assert_string_contains(dvt_fake_print_buffer, "State: NOK");
+	assert_string_contains(dvt_fake_print_buffer, "Data corruption detected");
+	assert_string_contains(dvt_fake_print_buffer, buf);
+	assert_string_contains(dvt_fake_print_buffer, got_buf);
+	assert_string_not_contains(dvt_fake_print_buffer, "State: OK");
+	dvt_fake_print_reset();
+
+	/* same, but --verbose: the good entry must report "State: OK\n" (no "(got=...)"),
+	 * proving the bad entry's corruption didn't bleed into it (the bug fixed in
+	 * 65dacd2e4a). */
+	opt.verbose = true;
+	rc          = ddb_run_csum_check(&ctx, &opt);
+	assert_rc_equal(-DER_CSUM, rc);
+	assert_string_contains(dvt_fake_print_buffer, "State: OK\n");
+	assert_string_contains(dvt_fake_print_buffer, "State: NOK");
+	assert_string_contains(dvt_fake_print_buffer, buf);
+	assert_string_contains(dvt_fake_print_buffer, got_buf);
+	dvt_fake_print_reset();
+}
+
 /*
  * --------------------------------------------------------------
  * End test functions
@@ -979,6 +1194,9 @@ ddb_commands_tests_run()
 	    TEST_CSUM(write_csum_sv_tests),
 	    TEST_CSUM(print_csum_recx_tests),
 	    TEST_CSUM(write_csum_recx_tests),
+	    TEST_CSUM(csum_check_error_tests),
+	    TEST_CSUM(check_csum_sv_tests),
+	    TEST_CSUM(check_csum_recx_tests),
 	};
 
 	return cmocka_run_group_tests_name("DDB commands tests", tests,


### PR DESCRIPTION
Second patch in the 3-way split of #18940 ("DAOS-17321 ddb: add csum_check command to verify data checksums"):

1. **patch-006** — added `dv_check_csum()` to the ddb VOS API (`ddb_vos.c`/`ddb_vos.h`), with unit tests.
2. **This patch** — adds the `ddb_run_csum_check()` ddb C command on top of `dv_check_csum()`, with unit tests.
3. **patch-008** (stacked on this one) — wires `csum_check` through to the ddb Go CLI, plus documentation.

Supersedes #18940. Mirrors the layering used for the sibling `csum_dump` command (#18543 in that earlier series).

## Changes

### `ddb_run_csum_check()` — new ddb C API command (`ddb.h`, `ddb_commands.c`)

`ddb_run_csum_check(struct ddb_ctx *ctx, struct csum_check_options *opt)` is the new top-level command function. The option struct has three fields:

- `path` — VOS tree path to check (required; must be complete, i.e. resolve to an actual value — including the akey, and the extent for an array value).
- `epoch` — for a single value, the epoch at or before which the value is fetched; for an array value, the maximal epoch of the visible record extent(s) to select. Defaults to `DAOS_EPOCH_MAX`.
- `verbose` — by default the command is silent on a clean result (matching, or no checksum stored) and only prints corrupted entries plus a final error summary; `verbose` prints every entry regardless of outcome, plus a final summary line even on success.

The command resolves the path, then calls `dv_check_csum()` with a callback that shares its print formatting with the existing `csum_dump` command: `print_csum_sv_body()`/`print_csum_recx_body()` were factored out of `print_csum_sv()`/`print_csum_recx()` so both `csum_dump` and `csum_check` render through the same code, with `csum_check` passing a non-NULL `got_csums` array and a `verbose` flag that `csum_dump` doesn't need (dump always behaves as if `verbose`).

**Sample output** — a corrupted single value:
```
Type: crc64, Length: 8, Epoch: 42, Value: 0xdeadbeef01020304, State: NOK (got=0xdeadbeef010203ab)
```
A clean array (only shown with `--verbose`, otherwise fully silent):
```
Checksum Type: crc16, Checksum Length: 2, Chunk Size: 64, Record Extent(s):
- Record Indexes: {0-127}, Record Size: 1, Epoch: 1, Checksum Value(s): 0x1234, State: OK
```

The command returns `-DER_CSUM` if any checksum entry fails to match (propagated from `dv_check_csum()`), after which `ddb_run_csum_check()` prints a "Data corruption detected" summary.

### Tests (`tests/ddb_commands_tests.c`, `tests/ddb_cmocka.h`)

Three new test cases under the existing csum command test suite:

| Test | What it covers |
|---|---|
| `csum_check_error_tests` | Missing path, invalid container, incomplete path (array akey with no extent) |
| `check_csum_sv_tests` | No-csum (silent), matching csum (silent by default, full detail + "State: OK" with `--verbose`), corrupted csum (always printed: "State: NOK", stored value, and `(got=...)` recomputed value) |
| `check_csum_recx_tests` | Same matrix for array akeys, plus per-entry isolation: with one of several overlapping segments corrupted, the corrupted entry is always printed while the good entry is suppressed by default and only shown (as "State: OK", no `(got=...)`) with `--verbose` |

Also adds an `assert_string_not_contains()` cmocka helper (`ddb_cmocka.h`) used by `check_csum_recx_tests` to confirm a known-good entry's output is absent when it should be suppressed.


## Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

## After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
