### PR TITLE
DAOS-19292 doc: warn against using PMEM_NO_FLUSH (#18703)

### DIFF
--- a/docs/admin/performance_tuning.md
+++ b/docs/admin/performance_tuning.md
@@ -398,10 +398,22 @@ Duration across processes:
 Completed test=FETCH
 ```
 
-!!! note
-    With 3rd Gen Intel® Xeon® Scalable processors (ICX), the PMEM_NO_FLUSH
-    environment variable can be set to 1 to take advantage of the extended
-    asynchronous DRAM refresh (eADR) feature
+!!! warning
+    Do not set the `PMEM_NO_FLUSH` environment variable in production. This
+    document previously recommended setting `PMEM_NO_FLUSH=1` on 3rd Gen
+    Intel® Xeon® Scalable processors (ICX) to take advantage of the extended
+    asynchronous DRAM refresh (eADR) feature; **that guidance is deprecated
+    and must no longer be followed**.
+
+    Per PMDK's [libpmem(7)](https://github.com/daos-stack/pmdk/blob/stable-2.1/doc/libpmem/libpmem.7.md)
+    documentation, environment variables such as `PMEM_NO_FLUSH` are "largely
+    intended for testing and are not normally required". Setting
+    `PMEM_NO_FLUSH=1` unconditionally disables the
+    `CLFLUSH`/`CLFLUSHOPT`/`CLWB` cache-flush instructions, regardless of
+    whether the platform's persistence domain actually covers CPU caches.
+    PMDK already checks this safely and automatically at runtime via
+    [`pmem_has_auto_flush()`](https://github.com/daos-stack/pmdk/blob/stable-2.1/doc/libpmem/pmem_flush.3.md),
+    so no manual override should be used in production.
 
 A tool called daos\_perf with the same syntax as vos\_perf is also available
 to run tests from a compute node with the full DAOS stack. Please refer


### PR DESCRIPTION
### Description

Replace the note recommending PMEM_NO_FLUSH=1 on ICX systems with an explicit warning against setting it in production. Per PMDK's libpmem(7) documentation, this variable is testing-only; PMDK already detects eADR support automatically via
pmem_has_auto_flush().

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
