### PR TITLE
DAOS-19557 test: replace add_pool with self.get_pool

### DIFF
--- a/src/tests/ftest/aggregation/dfuse_space_check.py
+++ b/src/tests/ftest/aggregation/dfuse_space_check.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -97,7 +97,7 @@ class DfuseSpaceCheck(IorTestBase):
         self.__block_size = self.params.get('block_size', '/run/dfuse_space_check/*')
 
         # Create a pool, container, and start dfuse
-        self.create_pool()
+        self.pool = self.get_pool(connect=False)
         self.create_cont()
         dfuse = get_dfuse(self, self.hostlist_clients)
         start_dfuse(self, dfuse, self.pool, self.container)

--- a/src/tests/ftest/checksum/csum_basic.py
+++ b/src/tests/ftest/checksum/csum_basic.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2019-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -11,7 +11,6 @@ from apricot import TestWithServers
 from general_utils import create_string_buffer
 from pydaos.raw import DaosObj, IORequest
 from test_utils_container import add_container
-from test_utils_pool import add_pool
 
 
 class CsumContainerValidation(TestWithServers):
@@ -38,7 +37,7 @@ class CsumContainerValidation(TestWithServers):
         no_of_akeys = self.params.get("no_of_akeys", '/run/akeys/*')
         record_length = self.params.get("length", '/run/record/*')
 
-        pool = add_pool(self, connect=False)
+        pool = self.get_pool(connect=False)
         pool.connect(2)
 
         container = add_container(self, pool)

--- a/src/tests/ftest/container/basic_snapshot.py
+++ b/src/tests/ftest/container/basic_snapshot.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -7,7 +8,6 @@ from apricot import TestWithServers
 from general_utils import get_random_bytes
 from pydaos.raw import DaosApiError, DaosSnapshot
 from test_utils_container import add_container
-from test_utils_pool import add_pool
 
 
 class BasicSnapshot(TestWithServers):
@@ -45,7 +45,7 @@ class BasicSnapshot(TestWithServers):
         :avocado: tags=BasicSnapshot,test_basic_snapshot
         """
         # Set up the pool and container.
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
         container.open()
 

--- a/src/tests/ftest/container/boundary.py
+++ b/src/tests/ftest/container/boundary.py
@@ -42,7 +42,7 @@ class BoundaryTest(TestWithServers):
         self.io_obj_classs = self.params.get("obj_classs", '/run/container/execute_io/*')
         self.dmg = self.get_dmg_command()
 
-    def create_pool(self):
+    def __create_pool(self):
         """Get a test pool object and append to list.
 
         Returns:
@@ -90,7 +90,7 @@ class BoundaryTest(TestWithServers):
 
         """
         # Create pools in parallel
-        pool_manager = ThreadManager(self.create_pool, self.get_remaining_time() - 30)
+        pool_manager = ThreadManager(self.__create_pool, self.get_remaining_time() - 30)
         for _ in range(num_pools):
             pool_manager.add()
         self.log.info('Creating %d pools', num_pools)

--- a/src/tests/ftest/container/query_properties.py
+++ b/src/tests/ftest/container/query_properties.py
@@ -1,12 +1,11 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from apricot import TestWithServers
 from test_utils_container import add_container
-from test_utils_pool import add_pool
 
 
 class QueryPropertiesTest(TestWithServers):
@@ -32,7 +31,7 @@ class QueryPropertiesTest(TestWithServers):
         :avocado: tags=QueryPropertiesTest,test_query_properties
         """
         self.log_step("Create pool and container with properties")
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
 
         expected_props = {

--- a/src/tests/ftest/container/snapshot.py
+++ b/src/tests/ftest/container/snapshot.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -7,7 +8,6 @@ from apricot import TestWithServers
 from general_utils import get_random_bytes
 from pydaos.raw import DaosApiError, DaosSnapshot, c_uuid_to_str
 from test_utils_container import add_container
-from test_utils_pool import add_pool
 
 
 # pylint: disable=broad-except
@@ -37,7 +37,7 @@ class Snapshot(TestWithServers):
         """
         self.log_step('Creating pool and container')
         self.log.info("self.context= %s", self.context)
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
 
         self.log_step('Querying container and verifying UUID matches')

--- a/src/tests/ftest/control/dmg_system_reformat.py
+++ b/src/tests/ftest/control/dmg_system_reformat.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -9,7 +10,7 @@ from apricot import TestWithServers
 from avocado.core.exceptions import TestFail
 from exception_utils import CommandFailure
 from general_utils import journalctl_time
-from test_utils_pool import add_pool, get_size_params
+from test_utils_pool import get_size_params
 
 
 class DmgSystemReformatTest(TestWithServers):
@@ -41,11 +42,11 @@ class DmgSystemReformatTest(TestWithServers):
         dmg = self.get_dmg_command().copy()
 
         # Create pool using 90% of the available NVMe capacity
-        pools = [add_pool(self, dmg=dmg)]
+        pools = [self.get_pool(dmg=dmg)]
 
         self.log.info("Check that new pool will fail with DER_NOSPACE")
         dmg.exit_status_exception = False
-        pools.append(add_pool(self, create=False, **get_size_params(pools[0])))
+        pools.append(self.get_pool(create=False, **get_size_params(pools[0])))
         try:
             pools[-1].create()
         except TestFail as error:
@@ -101,7 +102,7 @@ class DmgSystemReformatTest(TestWithServers):
                 dmg.result.stdout_text))
 
         # Create last pool now that memory has been wiped.
-        pools.append(add_pool(self, connect=False, dmg=dmg))
+        pools.append(self.get_pool(connect=False, dmg=dmg))
 
         # Lastly, verify that last created pool is in the list
         pool_uuids = dmg.get_pool_list_uuids()

--- a/src/tests/ftest/control/ms_resilience.py
+++ b/src/tests/ftest/control/ms_resilience.py
@@ -67,7 +67,7 @@ class ManagementServiceResilience(TestWithServers):
                 return pool_uuid
         return None
 
-    def create_pool(self):
+    def __create_pool(self):
         """Create a pool on the server group."""
         self.pool = self.get_pool(create=False)
         self.pool.name.value = self.server_group
@@ -249,7 +249,7 @@ class ManagementServiceResilience(TestWithServers):
 
         # Finally, verify that quorum has been retained by performing
         # write operations.
-        self.create_pool()
+        self.__create_pool()
         self.pool = None
 
     def verify_regained_quorum(self, num_hosts):
@@ -266,7 +266,7 @@ class ManagementServiceResilience(TestWithServers):
         leader = self.verify_leader(replicas)
 
         # First, create a pool.
-        self.create_pool()
+        self.__create_pool()
 
         # Next, kill the leader plus enough other replicas to
         # lose quorum.
@@ -290,7 +290,7 @@ class ManagementServiceResilience(TestWithServers):
         # Dump the current system state.
         self.get_dmg_command().system_query()
 
-        self.create_pool()
+        self.__create_pool()
         self.pool = None
 
     def test_ms_resilience_1(self):

--- a/src/tests/ftest/deployment/disk_failure.py
+++ b/src/tests/ftest/deployment/disk_failure.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2022-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -12,7 +12,6 @@ from dmg_utils import get_dmg_response, get_storage_query_device_info
 from exception_utils import CommandFailure
 from general_utils import list_to_str
 from osa_utils import OSAUtils
-from test_utils_pool import add_pool
 
 
 class DiskFailureTest(OSAUtils):
@@ -48,7 +47,7 @@ class DiskFailureTest(OSAUtils):
                 self.log.info("  %s: %s", key, entry[key])
 
         for val in range(0, num_pool):
-            pool[val] = add_pool(self, connect=False)
+            pool[val] = self.get_pool(connect=False)
             threads = []
             self.pool = pool[val]
             # The following thread runs while raising disk faults

--- a/src/tests/ftest/dfuse/sparse_file.py
+++ b/src/tests/ftest/dfuse/sparse_file.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -51,7 +51,7 @@ class SparseFile(IorTestBase):
         :avocado: tags=SparseFile,test_sparsefile
         """
         # Create a pool, container and start dfuse.
-        self.create_pool()
+        self.pool = self.get_pool(connect=False)
         self.create_cont()
         dfuse = get_dfuse(self, self.hostlist_clients)
         start_dfuse(self, dfuse, self.pool, self.container)

--- a/src/tests/ftest/dtx/basic.py
+++ b/src/tests/ftest/dtx/basic.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -8,7 +9,6 @@ import traceback
 from apricot import TestWithServers
 from pydaos.raw import DaosApiError, c_uuid_to_str
 from test_utils_container import add_container
-from test_utils_pool import add_pool
 
 
 class BasicTxTest(TestWithServers):
@@ -35,7 +35,7 @@ class BasicTxTest(TestWithServers):
         """
         # initialize a python pool object then create the underlying
         # daos storage and connect to the pool
-        pool = add_pool(self)
+        pool = self.get_pool()
 
         # create a container
         container = add_container(self, pool)

--- a/src/tests/ftest/io/parallel_io.py
+++ b/src/tests/ftest/io/parallel_io.py
@@ -35,7 +35,7 @@ class ParallelIo(FioBase, IorTestBase):
         self.pool = []
         self.container = []
 
-    def create_pool(self):
+    def __create_pool(self):
         """Create a thread safe TestPool object."""
         # Use a dedicated DmgCommand copy per thread; sharing self.get_dmg_command()'s
         # single instance across threads races on its parameters and causes partial commands.
@@ -135,7 +135,7 @@ class ParallelIo(FioBase, IorTestBase):
         threads = []
 
         # Create a pool and start dfuse.
-        self.create_pool()
+        self.__create_pool()
         dfuse = get_dfuse(self, self.hostlist_clients)
         start_dfuse(self, dfuse, self.pool[0])
 
@@ -215,7 +215,7 @@ class ParallelIo(FioBase, IorTestBase):
 
         self.log_step("Create pools in parallel.")
         for _ in range(self.pool_count):
-            pool_thread = threading.Thread(target=self.create_pool)
+            pool_thread = threading.Thread(target=self.__create_pool)
             pool_threads.append(pool_thread)
             pool_thread.start()
         # Wait for pool create to finish

--- a/src/tests/ftest/nvme/pool_exclude.py
+++ b/src/tests/ftest/nvme/pool_exclude.py
@@ -13,7 +13,6 @@ from exception_utils import CommandFailure
 from ior_utils import run_ior, thread_run_ior
 from job_manager_utils import get_job_manager
 from osa_utils import OSAUtils
-from test_utils_pool import add_pool
 from write_host_file import write_host_file
 
 
@@ -63,7 +62,7 @@ class NvmePoolExclude(OSAUtils):
         rank_list = list(range(1, exclude_servers))
 
         for val in range(0, num_pool):
-            pool[val] = add_pool(self, connect=False)
+            pool[val] = self.get_pool(connect=False)
             pool[val].set_property("reclaim", "disabled")
 
         job_manager = get_job_manager(self, subprocess=None, timeout=120)

--- a/src/tests/ftest/object/fetch_bad_param.py
+++ b/src/tests/ftest/object/fetch_bad_param.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -8,7 +9,6 @@ import traceback
 from apricot import TestWithServers
 from pydaos.raw import DaosApiError
 from test_utils_container import add_container
-from test_utils_pool import add_pool
 
 
 class ObjFetchBadParam(TestWithServers):
@@ -25,7 +25,7 @@ class ObjFetchBadParam(TestWithServers):
             TestContainer: the created container
         """
         self.log_step('Creating a pool')
-        pool = add_pool(self)
+        pool = self.get_pool()
 
         self.log_step('Creating a container')
         return add_container(self, pool)

--- a/src/tests/ftest/object/integrity.py
+++ b/src/tests/ftest/object/integrity.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -12,7 +12,6 @@ from apricot import TestWithServers
 from general_utils import create_string_buffer
 from pydaos.raw import DaosApiError, DaosObj, IORequest
 from test_utils_container import add_container
-from test_utils_pool import add_pool
 
 
 class ObjectDataValidation(TestWithServers):
@@ -93,7 +92,7 @@ class ObjectDataValidation(TestWithServers):
         """
         record_length = self.params.get("length", '/run/record/*')
 
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
         obj = self.get_object(container)
         ioreq = self.get_io_request(obj)
@@ -192,7 +191,7 @@ class ObjectDataValidation(TestWithServers):
         no_of_akeys = self.params.get("no_of_akeys", '/run/akeys/*')[0]
         record_length = self.params.get("length", '/run/record/*')
 
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
         obj = self.get_object(container)
         ioreq = self.get_io_request(obj)
@@ -251,7 +250,7 @@ class ObjectDataValidation(TestWithServers):
         array_size = self.params.get("size", '/array_size/')
         record_length = self.params.get("length", '/run/record/*')
 
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
         obj = self.get_object(container)
         ioreq = self.get_io_request(obj)

--- a/src/tests/ftest/object/open_bad_param.py
+++ b/src/tests/ftest/object/open_bad_param.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -9,7 +9,6 @@ import traceback
 from apricot import TestWithServers
 from pydaos.raw import DaosApiError, DaosObjId
 from test_utils_container import add_container
-from test_utils_pool import add_pool
 
 
 class ObjOpenBadParam(TestWithServers):
@@ -27,7 +26,7 @@ class ObjOpenBadParam(TestWithServers):
             TestContainer: the created container
         """
         self.log_step('Creating a pool')
-        pool = add_pool(self)
+        pool = self.get_pool()
 
         self.log_step('Creating a container')
         return add_container(self, pool)

--- a/src/tests/ftest/object/punch_test.py
+++ b/src/tests/ftest/object/punch_test.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -7,7 +8,6 @@
 from apricot import TestWithServers
 from pydaos.raw import DaosApiError
 from test_utils_container import add_container
-from test_utils_pool import add_pool
 
 
 class PunchTest(TestWithServers):
@@ -25,7 +25,7 @@ class PunchTest(TestWithServers):
         :avocado: tags=object
         :avocado: tags=PunchTest,test_dkey_punch
         """
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
         container.open()
         try:
@@ -86,7 +86,7 @@ class PunchTest(TestWithServers):
         :avocado: tags=object
         :avocado: tags=PunchTest,test_akey_punch
         """
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
         container.open()
         try:
@@ -147,7 +147,7 @@ class PunchTest(TestWithServers):
         :avocado: tags=object
         :avocado: tags=PunchTest,test_obj_punch
         """
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
         container.open()
         try:

--- a/src/tests/ftest/object/update_bad_param.py
+++ b/src/tests/ftest/object/update_bad_param.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -8,7 +9,6 @@ import traceback
 from apricot import TestWithServers
 from pydaos.raw import DaosApiError
 from test_utils_container import add_container
-from test_utils_pool import add_pool
 
 
 class ObjUpdateBadParam(TestWithServers):
@@ -29,7 +29,7 @@ class ObjUpdateBadParam(TestWithServers):
         :avocado: tags=object
         :avocado: tags=ObjUpdateBadParam,test_obj_update_bad_handle
         """
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
         container.open()
         try:
@@ -70,7 +70,7 @@ class ObjUpdateBadParam(TestWithServers):
         :avocado: tags=object
         :avocado: tags=ObjUpdateBadParam,test_null_values
         """
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
         container.open()
 

--- a/src/tests/ftest/osa/dmg_negative_test.py
+++ b/src/tests/ftest/osa/dmg_negative_test.py
@@ -1,10 +1,10 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from osa_utils import OSAUtils
-from test_utils_pool import add_pool
 
 
 class OSADmgNegativeTest(OSAUtils):
@@ -68,7 +68,7 @@ class OSADmgNegativeTest(OSAUtils):
 
         for index in range(0, num_pool):
             self.log.info("=> Creating pool %s", index + 1)
-            pool_list.append(add_pool(self, create=False, connect=False))
+            pool_list.append(self.get_pool(create=False, connect=False))
             # Split total SCM and NVME size for creating multiple pools.
             pool_list[-1].scm_size.value = int(pool_list[-1].scm_size.value / num_pool)
             pool_list[-1].nvme_size.value = int(pool_list[-1].nvme_size.value / num_pool)

--- a/src/tests/ftest/osa/offline_drain.py
+++ b/src/tests/ftest/osa/offline_drain.py
@@ -6,7 +6,6 @@
 """
 from nvme_utils import ServerFillUp
 from osa_utils import OSAUtils
-from test_utils_pool import add_pool
 from write_host_file import write_host_file
 
 
@@ -53,7 +52,7 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
         t_string = "{},{}".format(target_list[0], target_list[1])
 
         for val in range(0, num_pool):
-            pool[val] = add_pool(self, connect=False)
+            pool[val] = self.get_pool(connect=False)
             self.pool = pool[val]
             self.pool.set_property("reclaim", "disabled")
             test_seq = self.ior_test_sequence[0]

--- a/src/tests/ftest/osa/offline_extend.py
+++ b/src/tests/ftest/osa/offline_extend.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -7,7 +8,6 @@ from time import sleep
 
 from dmg_utils import check_system_query_status
 from osa_utils import OSAUtils
-from test_utils_pool import add_pool
 
 
 class OSAOfflineExtend(OSAUtils):
@@ -56,7 +56,7 @@ class OSAOfflineExtend(OSAUtils):
                 index = val
             else:
                 index = 0
-            pool[val] = add_pool(self, connect=False)
+            pool[val] = self.get_pool(connect=False)
             self.pool = pool[val]
             test_seq = self.ior_test_sequence[0]
             self.pool.set_property("reclaim", "disabled")

--- a/src/tests/ftest/osa/offline_parallel_test.py
+++ b/src/tests/ftest/osa/offline_parallel_test.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -11,7 +11,6 @@ import time
 
 from dmg_utils import check_system_query_status
 from osa_utils import OSAUtils
-from test_utils_pool import add_pool
 
 
 class OSAOfflineParallelTest(OSAUtils):
@@ -93,7 +92,7 @@ class OSAOfflineParallelTest(OSAUtils):
 
         test_seq = self.ior_test_sequence[0]
         for val in range(0, num_pool):
-            pool[val] = add_pool(self, connect=False)
+            pool[val] = self.get_pool(connect=False)
             self.pool = pool[val]
             # Use only pool UUID while running the test.
             self.pool.use_label = False

--- a/src/tests/ftest/osa/offline_reintegration.py
+++ b/src/tests/ftest/osa/offline_reintegration.py
@@ -6,7 +6,6 @@
 """
 from nvme_utils import ServerFillUp
 from osa_utils import OSAUtils
-from test_utils_pool import add_pool
 from write_host_file import write_host_file
 
 
@@ -60,7 +59,7 @@ class OSAOfflineReintegration(OSAUtils, ServerFillUp):
             oclass = self.ior_cmd.dfs_oclass.value
         self.log.info("==> Creating %s pools with oclass: %s", num_pool, oclass)
         for index in range(0, num_pool):
-            pools.append(add_pool(self, connect=False))
+            pools.append(self.get_pool(connect=False))
             self.pool = pools[-1]
             self.pool.set_property("reclaim", "disabled")
             test_seq = self.ior_test_sequence[0]

--- a/src/tests/ftest/osa/online_drain.py
+++ b/src/tests/ftest/osa/online_drain.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -8,7 +8,6 @@ import threading
 import time
 
 from osa_utils import OSAUtils
-from test_utils_pool import add_pool
 from write_host_file import write_host_file
 
 
@@ -52,7 +51,7 @@ class OSAOnlineDrain(OSAUtils):
         t_string = ','.join(map(str, self.random.sample(range(targets), 2)))
 
         for val in range(0, num_pool):
-            pool[val] = add_pool(self, connect=False)
+            pool[val] = self.get_pool(connect=False)
             pool[val].set_property("reclaim", "disabled")
 
         # Drain the rank and targets

--- a/src/tests/ftest/osa/online_extend.py
+++ b/src/tests/ftest/osa/online_extend.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -9,7 +10,6 @@ import time
 from daos_racer_utils import DaosRacerCommand
 from dmg_utils import check_system_query_status
 from osa_utils import OSAUtils
-from test_utils_pool import add_pool
 from write_host_file import write_host_file
 
 
@@ -69,7 +69,7 @@ class OSAOnlineExtend(OSAUtils):
             time.sleep(30)
 
         for val in range(0, num_pool):
-            pool[val] = add_pool(self, connect=False)
+            pool[val] = self.get_pool(connect=False)
             pool[val].set_property("reclaim", "disabled")
 
         # Extend the pool, rank and targets

--- a/src/tests/ftest/osa/online_reintegration.py
+++ b/src/tests/ftest/osa/online_reintegration.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -10,7 +10,6 @@ import time
 
 from daos_racer_utils import DaosRacerCommand
 from osa_utils import OSAUtils
-from test_utils_pool import add_pool
 from write_host_file import write_host_file
 
 
@@ -68,7 +67,7 @@ class OSAOnlineReintegration(OSAUtils):
             time.sleep(30)
 
         for val in range(0, num_pool):
-            pool[val] = add_pool(self, connect=False)
+            pool[val] = self.get_pool(connect=False)
             pool[val].set_property("reclaim", "disabled")
 
         # Exclude and reintegrate the pool, rank and targets

--- a/src/tests/ftest/pool/create.py
+++ b/src/tests/ftest/pool/create.py
@@ -5,7 +5,7 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from apricot import TestWithServers
-from test_utils_pool import add_pool, check_pool_creation, get_size_params
+from test_utils_pool import check_pool_creation, get_size_params
 
 
 class PoolCreateTests(TestWithServers):
@@ -39,7 +39,7 @@ class PoolCreateTests(TestWithServers):
         # Create 1 pool using 90% of the available SCM capacity (no NVMe)
         data = self.server_managers[0].get_available_storage()
         params = {"scm_size": int(float(data["scm"]) * 0.9)}
-        pool = add_pool(self, namespace="/run/pool_1/*", create=False, **params)
+        pool = self.get_pool(namespace="/run/pool_1/*", create=False, **params)
         check_pool_creation(self, [pool], 60)
 
     def test_create_max_pool(self):
@@ -56,7 +56,7 @@ class PoolCreateTests(TestWithServers):
         :avocado: tags=PoolCreateTests,test_create_max_pool
         """
         # Create 1 pool using almost all of the available capacity
-        pool = add_pool(self, namespace="/run/pool_2/*", create=False)
+        pool = self.get_pool(namespace="/run/pool_2/*", create=False)
         check_pool_creation(self, [pool], 120)
 
     def test_create_no_space_loop(self):
@@ -91,7 +91,7 @@ class PoolCreateTests(TestWithServers):
         self.get_dmg_command().exit_status_exception = False
 
         # Create the first of three pools which should succeed.
-        pools = [add_pool(self, namespace="/run/pool_2/*", create=False, **params[0])]
+        pools = [self.get_pool(namespace="/run/pool_2/*", create=False, **params[0])]
         self.log.info("Creating")
         pools[0].create()
         self.assertTrue(
@@ -104,7 +104,7 @@ class PoolCreateTests(TestWithServers):
         for index in range(1, 3):
             params[index].update(size_params)
             pools.append(
-                add_pool(self, namespace="/run/pool_2/*", create=False, **params[index]))
+                self.get_pool(namespace="/run/pool_2/*", create=False, **params[index]))
 
         for index in range(20):
             # Create the second of three pools which should fail due to not enough space.

--- a/src/tests/ftest/pool/create_capacity.py
+++ b/src/tests/ftest/pool/create_capacity.py
@@ -1,12 +1,13 @@
 """
 (C) Copyright 2021-2024 Intel Corporation.
+(C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import time
 
 from apricot import TestWithServers
-from test_utils_pool import add_pool, check_pool_creation
+from test_utils_pool import check_pool_creation
 
 
 class PoolCreateCapacityTests(TestWithServers):
@@ -48,7 +49,7 @@ class PoolCreateCapacityTests(TestWithServers):
         self.log_step(f"Defining {pool_quantity[1]} pools to create")
         pools = []
         for _ in range(pool_quantity[1]):
-            pools.append(add_pool(self, create=False))
+            pools.append(self.get_pool(create=False))
 
         # Create all the pools
         self.log_step(f"Attempt to create {pool_quantity[1]} pools (dmg pool create)")

--- a/src/tests/ftest/pool/create_query.py
+++ b/src/tests/ftest/pool/create_query.py
@@ -5,7 +5,6 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from apricot import TestWithServers
-from test_utils_pool import add_pool
 
 
 class PoolCreateQueryTests(TestWithServers):
@@ -37,7 +36,7 @@ class PoolCreateQueryTests(TestWithServers):
         :avocado: tags=PoolCreateQueryTests,test_create_and_query
         """
         # Create pool
-        pool = add_pool(self)
+        pool = self.get_pool()
         epsilon_bytes = 1 << 20  # 1 MiB
         epsilon_scm_bytes = (
             ((1 << 24) * 8)  # 16 MiB * 8 tgts

--- a/src/tests/ftest/pool/mem_ratio.py
+++ b/src/tests/ftest/pool/mem_ratio.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -7,7 +7,7 @@ import json
 
 from apricot import TestWithServers
 from general_utils import bytes_to_human, list_to_str, report_errors
-from test_utils_pool import POOL_NAMESPACE, add_pools, get_pool_create_percentages
+from test_utils_pool import POOL_NAMESPACE, get_pool_create_percentages
 
 
 class MemRatioTest(TestWithServers):
@@ -69,7 +69,7 @@ class MemRatioTest(TestWithServers):
         :avocado: tags=MemRatioTest,test_mem_ratio
         """
         dmg = self.get_dmg_command()
-        kwargs_list = [{"test": self, "dmg": dmg.copy()}]
+        kwargs_list = [{"dmg": dmg.copy()}]
         if self.server_managers[0].manager.job.using_control_metadata:
             # Additional pools for MD on SSD
             _sizes = get_pool_create_percentages(5, self.params.get("size", POOL_NAMESPACE))
@@ -83,7 +83,6 @@ class MemRatioTest(TestWithServers):
             kwargs_list[0]["mem_ratio"] = _ratios[0]
             for index in range(1, 5):
                 kwargs_list.append({
-                    "test": self,
                     "dmg": dmg.copy(),
                     "size": _sizes[index],
                     "mem_ratio": _ratios[index],
@@ -91,7 +90,7 @@ class MemRatioTest(TestWithServers):
 
         # Create pools with different --mem_ratio arguments
         self.log_step(f"Creating {len(kwargs_list)} pool(s)")
-        pools = add_pools(dmg, kwargs_list, error_handler=self.check_insufficient_size)
+        pools = self.get_pools(kwargs_list, dmg=dmg, error_handler=self.check_insufficient_size)
         if len(kwargs_list) > 1 and len(pools) < 4:
             self.fail("Test failed to create a minimum of 4 pools with various mem-ratios")
 

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -1,6 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -8,7 +8,6 @@ from apricot import TestWithServers
 from avocado.core.exceptions import TestFail
 from pydaos.raw import DaosApiError
 from test_utils_container import add_container
-from test_utils_pool import add_pool
 
 RESULT_PASS = "PASS"  # nosec
 RESULT_FAIL = "FAIL"
@@ -42,7 +41,7 @@ class Permission(TestWithServers):
 
         # initialize a python pool object then create the underlying
         # daos storage
-        pool = add_pool(self, create=False)
+        pool = self.get_pool(create=False)
         self.log.debug("Pool initialization successful")
         pool.create()
         self.log.debug("Pool Creation successful")

--- a/src/tests/ftest/rebuild/container_create_race.py
+++ b/src/tests/ftest/rebuild/container_create_race.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -103,7 +103,7 @@ class RbldContainerCreate(IorTestBase):
         cont_qty = self.params.get("cont_qty", "/run/io/*")
 
         # create pool
-        self.create_pool()
+        self.pool = self.get_pool(connect=False)
 
         # make sure pool looks good before we start
         info_checks = {

--- a/src/tests/ftest/rebuild/pool_destroy_race.py
+++ b/src/tests/ftest/rebuild/pool_destroy_race.py
@@ -7,7 +7,6 @@
 from apricot import TestWithServers
 from ior_utils import write_data
 from test_utils_container import add_container
-from test_utils_pool import add_pool
 
 
 # pylint: disable=too-few-public-methods
@@ -48,7 +47,7 @@ class RbldPoolDestroyWithIO(TestWithServers):
 
         # create pool
         self.log_step('Creating the first pool')
-        pool = add_pool(self)
+        pool = self.get_pool()
 
         # make sure pool looks good before we start
         checks = {
@@ -92,7 +91,7 @@ class RbldPoolDestroyWithIO(TestWithServers):
         # re-create the pool of full size to verify the space was reclaimed,
         # after re-starting the server on excluded rank
         self.log_step('Creating a second pool of the same size as the first')
-        pool = add_pool(self)
+        pool = self.get_pool()
         self.log_step('Verify the space was reclaimed')
         pool.query()
 

--- a/src/tests/ftest/rebuild/with_ior.py
+++ b/src/tests/ftest/rebuild/with_ior.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2018-2022 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -41,7 +41,7 @@ class RbldWithIOR(IorTestBase):
         rank_to_kill = self.params.get("rank_to_kill", "/run/ior/*")
 
         # create pool
-        self.create_pool()
+        self.pool = self.get_pool(connect=False)
 
         # make sure pool looks good before we start
         checks = {

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -70,7 +70,7 @@ class ObjectMetadata(TestWithServers):
         # Number of created containers that should not be possible
         self.created_containers_limit = self.params.get("created_cont_max", "/run/metadata/*")
 
-    def create_pool(self, svc_ops_enabled=True):
+    def __create_pool(self, svc_ops_enabled=True):
         """Create a pool and display the svc ranks.
 
         Args:
@@ -238,7 +238,7 @@ class ObjectMetadata(TestWithServers):
 
         """
         self.log_step("Create pool with properties svc_ops_enabled: {}".format(svc_ops_enabled))
-        self.create_pool(svc_ops_enabled=svc_ops_enabled)
+        self.__create_pool(svc_ops_enabled=svc_ops_enabled)
         # Run dummy_metadata_workload when feature is enabled
         if svc_ops_enabled:
             self.log.info("svc_ops_enabled enabled, run dummy_metadata_workload")
@@ -369,7 +369,7 @@ class ObjectMetadata(TestWithServers):
         :avocado: tags=server,metadata,nvme
         :avocado: tags=ObjectMetadata,test_metadata_addremove
         """
-        self.create_pool()
+        self.__create_pool()
         svc_ops_enabled = self.pool.get_property("svc_ops_enabled")
         if svc_ops_enabled:
             svc_ops_entry_age = self.pool.get_property("svc_ops_entry_age")
@@ -447,7 +447,7 @@ class ObjectMetadata(TestWithServers):
         :avocado: tags=server,metadata,nvme,ior
         :avocado: tags=ObjectMetadata,test_metadata_server_restart
         """
-        self.create_pool()
+        self.__create_pool()
         files_per_thread = 400
         total_ior_threads = 5
         ior_managers = []

--- a/src/tests/ftest/server/replay.py
+++ b/src/tests/ftest/server/replay.py
@@ -10,7 +10,6 @@ from apricot import TestWithServers
 from dfuse_utils import get_dfuse, start_dfuse
 from general_utils import join
 from ior_utils import read_data, write_data
-from test_utils_pool import add_pool
 
 
 class ReplayTests(TestWithServers):
@@ -27,13 +26,13 @@ class ReplayTests(TestWithServers):
 
         Args:
             details (str, optional): additional log_step messaging
-            pool_params (dict, optional): named arguments to add_pool()
+            pool_params (dict, optional): named arguments to self.get_pool()
 
         Returns:
             TestContainer: the created container with a reference to the created pool
         """
         self.log_step(join(' ', 'Creating a pool (dmg pool create)', '-', details))
-        pool = add_pool(self, **pool_params)
+        pool = self.get_pool(**pool_params)
         self.log_step(join(' ', 'Creating a container (daos container create)', '-', details))
         return self.get_container(pool)
 

--- a/src/tests/ftest/telemetry/dkey_akey_enum_punch.py
+++ b/src/tests/ftest/telemetry/dkey_akey_enum_punch.py
@@ -1,5 +1,6 @@
 '''
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -9,7 +10,6 @@ from general_utils import create_string_buffer
 from pydaos.raw import DaosObjClass, IORequest
 from telemetry_test_base import TestWithTelemetry
 from test_utils_container import add_container
-from test_utils_pool import add_pool
 
 
 class DkeyAkeyEnumPunch(TestWithTelemetry):
@@ -232,7 +232,7 @@ class DkeyAkeyEnumPunch(TestWithTelemetry):
         :avocado: tags=DkeyAkeyEnumPunch,test_dkey_akey_enum_punch
         """
         errors = []
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
         container.open()
         total_targets, targets_per_rank = self.set_num_targets(pool)
@@ -364,7 +364,7 @@ class DkeyAkeyEnumPunch(TestWithTelemetry):
         :avocado: tags=DkeyAkeyEnumPunch,test_pool_tgt_dkey_akey_punch
         """
         errors = []
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
         container.open()
         obj_count = 100
@@ -442,7 +442,7 @@ class DkeyAkeyEnumPunch(TestWithTelemetry):
         :avocado: tags=DkeyAkeyEnumPunch,test_tgt_dkey_akey_punch
         """
         errors = []
-        pool = add_pool(self)
+        pool = self.get_pool()
         container = add_container(self, pool)
         container.open()
         total_targets, targets_per_rank = self.set_num_targets(pool)

--- a/src/tests/ftest/telemetry/wal_metrics.py
+++ b/src/tests/ftest/telemetry/wal_metrics.py
@@ -8,7 +8,6 @@ import time
 
 from ior_utils import write_data
 from telemetry_test_base import TestWithTelemetry
-from test_utils_pool import add_pool
 
 
 class WalMetrics(TestWithTelemetry):
@@ -36,7 +35,7 @@ class WalMetrics(TestWithTelemetry):
         wal_metrics = list(self.telemetry.ENGINE_POOL_VOS_WAL_METRICS)
 
         self.log_step('Creating a pool (dmg pool create)')
-        add_pool(self)
+        self.get_pool()
 
         self.log_step(
             'Collect WAL commit metrics after creating a pool (dmg telemetry metrics query)')
@@ -83,7 +82,7 @@ class WalMetrics(TestWithTelemetry):
         wal_metrics = list(self.telemetry.ENGINE_POOL_VOS_WAL_REPLAY_METRICS)
 
         self.log_step('Creating a pool (dmg pool create)')
-        add_pool(self)
+        self.get_pool()
 
         self.log_step(
             'Collect WAL replay metrics after creating a pool (dmg telemetry metrics query)')
@@ -143,7 +142,7 @@ class WalMetrics(TestWithTelemetry):
         wal_metrics = list(self.telemetry.ENGINE_POOL_CHECKPOINT_METRICS)
 
         self.log_step('Creating a pool with check pointing disabled (dmg pool create)')
-        add_pool(self, properties='rd_fac:0,space_rb:0,checkpoint:disabled')
+        self.get_pool(properties='rd_fac:0,space_rb:0,checkpoint:disabled')
 
         self.log_step(
             'Collect WAL checkpoint metrics after creating a pool w/o check pointing '
@@ -160,8 +159,8 @@ class WalMetrics(TestWithTelemetry):
             self.fail('WAL check point metrics not zero after creating a pool w/o check pointing')
 
         self.log_step('Creating a pool with timed check pointing (dmg pool create)')
-        pool = add_pool(
-            self, properties=f'rd_fac:0,space_rb:0,checkpoint:timed,checkpoint_freq:{frequency}')
+        pool = self.get_pool(
+            properties=f'rd_fac:0,space_rb:0,checkpoint:timed,checkpoint_freq:{frequency}')
 
         self.log_step(
             'Collect WAL checkpoint metrics after creating a pool w/ check pointing '

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -35,7 +35,7 @@ from run_utils import run_local, run_remote, stop_processes
 from server_utils import DaosServerManager
 from slurm_utils import SlurmFailed, get_partition_hosts, get_reservation_hosts
 from test_utils_container import CONT_NAMESPACE, add_container
-from test_utils_pool import POOL_NAMESPACE, LabelGenerator, add_pool
+from test_utils_pool import POOL_NAMESPACE, POOL_TIMEOUT_INCREMENT, LabelGenerator, TestPool
 from write_host_file import write_host_file
 
 
@@ -1723,7 +1723,93 @@ class TestWithServers(TestWithoutServers):
             TestPool: the created test pool object.
 
         """
-        return add_pool(self, namespace, create, connect, dmg, **params)
+        if dmg is None:
+            dmg = self.get_dmg_command()
+        pool = TestPool(
+            namespace=namespace, context=self.context, dmg_command=dmg,
+            label_generator=self.label_generator)
+        pool.get_params(self)
+        if params:
+            pool.update_params(**params)
+        if create:
+            pool.create()
+        if create and connect:
+            pool.connect()
+
+        # Add a step to remove this pool when the test completes and ensure there is enough time
+        # for the pool destroy to be attempted - accounting for a possible dmg command timeout
+        if pool.register_cleanup.value is True:
+            self.increment_timeout(POOL_TIMEOUT_INCREMENT)
+            self.register_cleanup(self.remove_pool, pool=pool)
+
+        return pool
+
+    def remove_pool(self, pool):
+        """Destroy and remove the requested pool from the test.
+
+        Args:
+            pool (TestPool): the pool to remove
+
+        Returns:
+            list: a list of any errors detected when removing the pool
+
+        """
+        self.log.info("Destroying pool %s", pool.identifier)
+
+        # Ensure exceptions are raised for any failed command
+        with pool.temp_exit_status_exception(True):
+            try:
+                pool.destroy(force=1, disconnect=1, recursive=1)
+            except (DaosApiError, TestFail) as error:
+                self.log.info("  %s", error)
+                return [f"Error destroying pool {pool.identifier}: {error}"]
+
+        return []
+
+    def get_pools(self, get_pool_kwargs, dmg=None, error_handler=None):
+        """Add multiple TestPool objects to the test.
+
+        Args:
+            get_pool_kwargs (list): list of kwargs (dict) for get_pool() method to use when
+                creating each pool. Must at least include the 'test' kwargs.
+                See self.get_pool() for other options.
+            dmg (DmgCommand, optional): dmg command used to update the server log mask before
+                creating the first pool and reset it after creating the last pool.
+                Not used if no pools are created. Defaults to self.get_dmg_command().
+            error_handler (method, optional): optional method to call when a pool create fails.
+                Defaults to None.
+
+        Returns:
+            list: a list of new pool objects
+        """
+        if dmg is None:
+            dmg = self.get_dmg_command()
+        _any_create = any(kwargs.get("create", True) is True for kwargs in get_pool_kwargs)
+
+        if _any_create:
+            # Set the DEBUG log mask before the first pool create
+            dmg.server_set_logmasks("DEBUG", raise_exception=False)
+
+        # Add the requested pools
+        pools = []
+        try:
+            for kwargs in get_pool_kwargs:
+                # Disable setting/resetting log masks for each individual pool create
+                _restore = kwargs.get("set_logmasks", True)
+                kwargs["set_logmasks"] = False
+                try:
+                    pools.append(self.get_pool(**kwargs))
+                    pools[-1].set_logmasks.value = _restore
+                except TestFail as error:
+                    if not error_handler:
+                        raise
+                    error_handler(error)
+        finally:
+            if _any_create:
+                # Reset the log mask after the last pool create
+                dmg.server_set_logmasks(raise_exception=False)
+
+        return pools
 
     def get_container(self, pool, namespace=CONT_NAMESPACE, create=True, daos=None, **params):
         """Create a TestContainer object.

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -175,12 +175,21 @@ class ExecutableCommand(CommandWithParameters):
         return command_as_user(self.with_bind, self.run_user, self.env)
 
     @contextlib.contextmanager
-    def no_exception(self):
-        """Temporarily disable raising exceptions for failed commands."""
+    def temp_exit_status_exception(self, value):
+        """Temporarily set the exit_status_exception attribute.
+
+        Args:
+            value (bool): the temporary value for exit_status_exception
+
+        """
         original_value = self.exit_status_exception
-        self.exit_status_exception = False
+        self.exit_status_exception = value
         yield
         self.exit_status_exception = original_value
+
+    def no_exception(self):
+        """Temporarily disable raising exceptions for failed commands."""
+        return self.temp_exit_status_exception(False)
 
     @contextlib.contextmanager
     def as_user(self, user):

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -54,11 +54,6 @@ class IorTestBase(TestWithServers):
         if not self.hostlist_clients:
             self.hostlist_clients = get_local_host()
 
-    def create_pool(self):
-        """Create a TestPool object to use with ior."""
-        # Get the pool params and create a pool
-        self.pool = self.get_pool(connect=False)
-
     def create_cont(self):
         """Create a TestContainer object to be used to create container.
 
@@ -166,7 +161,7 @@ class IorTestBase(TestWithServers):
         """
         # Create a pool if one does not already exist
         if self.pool is None:
-            self.create_pool()
+            self.pool = self.get_pool(connect=False)
         # Create a container, if needed.
         # Don't pass uuid and pool handle to IOR.
         # It will not enable checksum feature

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -23,120 +23,6 @@ POOL_NAMESPACE = "/run/pool/*"
 POOL_TIMEOUT_INCREMENT = 200
 
 
-def add_pools(dmg, add_pool_kwargs, error_handler=None):
-    """Add multiple TestPool objects to the test.
-
-    Args:
-        dmg (DmgCommand): dmg command used to update the server log mask before creating the first
-            pool and reset it after creating the last pool. Not used if no pools are created.
-        add_pool_args (list): list of kwargs (dict) for add_pool() method to use when creating each
-            pool. Must at least include the 'test' kwargs. See add_pool() for other options.
-        error_handler (method, optional): optional method to call when a pool create fails. Defaults
-            to None.
-
-    Returns:
-        list: a list of new pool objects
-    """
-    _any_create = any(kwargs.get("create", True) is True for kwargs in add_pool_kwargs)
-
-    if _any_create:
-        # Set the DEBUG log mask before the first pool create
-        dmg.server_set_logmasks("DEBUG", raise_exception=False)
-
-    # Add the requested pools
-    pools = []
-    try:
-        for kwargs in add_pool_kwargs:
-            # Disable setting/resetting log masks for each individual pool create
-            _restore = kwargs.get("set_logmasks", True)
-            kwargs["set_logmasks"] = False
-            try:
-                pools.append(add_pool(**kwargs))
-                pools[-1].set_logmasks.value = _restore
-            except TestFail as error:
-                if not error_handler:
-                    raise
-                error_handler(error)
-    finally:
-        if _any_create:
-            # Reset the log mask after the last pool create
-            dmg.server_set_logmasks(raise_exception=False)
-
-    return pools
-
-
-def add_pool(test, namespace=POOL_NAMESPACE, create=True, connect=True, dmg=None, **params):
-    """Add a new TestPool object to the test.
-
-    Args:
-        test (Test): the test to which the pool will be added
-        namespace (str, optional): TestPool parameters path in the test yaml file. Defaults to
-            POOL_NAMESPACE.
-        create (bool, optional): should the pool be created. Defaults to True.
-        connect (bool, optional): should the pool be connected. Defaults to True.
-        dmg (DmgCommand, optional): dmg command used to create the pool. Defaults to None, which
-            calls test.get_dmg_command().
-
-    Returns:
-        TestPool: the new pool object
-
-    """
-    if not dmg:
-        dmg = test.get_dmg_command()
-    pool = TestPool(
-        namespace=namespace, context=test.context, dmg_command=dmg,
-        label_generator=test.label_generator)
-    pool.get_params(test)
-    if params:
-        pool.update_params(**params)
-    if create:
-        pool.create()
-    if create and connect:
-        pool.connect()
-
-    # Add a step to remove this pool when the test completes and ensure their is enough time for the
-    # pool destroy to be attempted - accounting for a possible dmg command timeout
-    if pool.register_cleanup.value is True:
-        test.increment_timeout(POOL_TIMEOUT_INCREMENT)
-        test.register_cleanup(remove_pool, test=test, pool=pool)
-
-    return pool
-
-
-def remove_pool(test, pool):
-    """Remove the requested pool from the test.
-
-    Args:
-        test (Test): the test from which to destroy the pool
-        pool (TestPool): the pool to destroy
-
-    Returns:
-        list: a list of any errors detected when removing the pool
-
-    """
-    error_list = []
-    test.log.info("Destroying pool %s", pool.identifier)
-
-    # Ensure exceptions are raised for any failed command
-    exit_status_exception = None
-    if pool.dmg is not None:
-        exit_status_exception = pool.dmg.exit_status_exception
-        pool.dmg.exit_status_exception = True
-
-    # Attempt to destroy the pool
-    try:
-        pool.destroy(force=1, disconnect=1, recursive=1)
-    except (DaosApiError, TestFail) as error:
-        test.log.info("  {}".format(error))
-        error_list.append("Error destroying pool {}: {}".format(pool.identifier, error))
-
-    # Restore raising exceptions for any failed command
-    if exit_status_exception is False:
-        pool.dmg.exit_status_exception = exit_status_exception
-
-    return error_list
-
-
 def get_size_params(pool):
     """Get the TestPool params that can be used to create a pool of the same size.
 
@@ -148,7 +34,7 @@ def get_size_params(pool):
         pool (TestPool): pool whose size is being replicated.
 
     Returns:
-        dict: size params argument for an add_pool() method
+        dict: size params argument for an self.get_pool() method
 
     """
     return {"size": None,
@@ -422,6 +308,15 @@ class TestPool(TestDaosApiBase):
         if not isinstance(value, DmgCommand):
             raise TypeError("Invalid 'dmg' object type: {}".format(type(value)))
         self._dmg = value
+
+    def temp_exit_status_exception(self, value):
+        """Temporarily set the exit_status_exception attribute.
+
+        Args:
+            value (bool): the temporary value for exit_status_exception
+
+        """
+        return self.dmg.temp_exit_status_exception(value)
 
     def no_exception(self):
         """Temporarily disable raising exceptions for failed commands."""


### PR DESCRIPTION
- Replace test_utils_pool.py:add_pool with self.get_pool so there is only one pool method
- Do the same with add_pools
- Remove ior_test_base.py:create_pool
- Update tests to use self.get_pool
- Define ExecutableCommand.temp_exit_status_exception
  - Use it in self.remove_pool

Features: ior
Quick-functional: true
Allow-unstable-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
