### PR TITLE
SRE-3989 test: add NVMe reset recovery

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -833,7 +833,7 @@ pipeline {
                                                 ' --build-arg REPOS="' + prRepos() + '"' +
                                                 ' --build-arg POINT_RELEASE=.7' +
                                                 " --build-arg PYTHON_VERSION=${env.PYTHON_VERSION}" +
-                                                " --build-arg DAOS_DEPS_INSTALL=yes"
+                                                ' --build-arg DAOS_DEPS_INSTALL=yes'
                         }
                     }
                     steps {
@@ -893,7 +893,7 @@ pipeline {
                                                 ' --target build-ci' +
                                                 ' --build-arg POINT_RELEASE=.6' +
                                                 " --build-arg PYTHON_VERSION=${env.PYTHON_VERSION}" +
-                                                " --build-arg DAOS_DEPS_INSTALL=yes"
+                                                ' --build-arg DAOS_DEPS_INSTALL=yes'
                         }
                     }
                     steps {

--- a/ci/codespell.ignores
+++ b/ci/codespell.ignores
@@ -1,4 +1,5 @@
 dedup
+AER
 nd
 uint
 ths

--- a/ci/functional/test_main_prep_node.sh
+++ b/ci/functional/test_main_prep_node.sh
@@ -205,6 +205,56 @@ function check_ib_devices {
     done
 }
 
+function log_nvme_baseline {
+    local device
+
+    echo "NVMe baseline for $HOSTNAME before DAOS tests:"
+    echo "# lspci NVMe/VMD devices"
+    lspci -Dnnk | grep -Ei 'Non-Volatile|NVMe|VMD|Kernel driver' || true
+    echo "# NVMe PCI device driver and IOMMU links"
+    while IFS= read -r device; do
+        echo "## $device"
+        lspci -Dnnk -s "$device" || true
+        readlink -f "/sys/bus/pci/devices/$device/driver" 2>&1 || true
+        readlink -f "/sys/bus/pci/devices/$device/iommu_group" 2>&1 || true
+    done < <(lspci -Dnn | awk '/Non-Volatile memory controller/ {print $1}')
+    echo "# /sys/class/iommu"
+    ls -la /sys/class/iommu 2>&1 || true
+    echo "# nvme list"
+    if command -v nvme >/dev/null; then
+        nvme list || true
+    fi
+}
+
+function check_iommu {
+    local iommu_entry
+
+    ((testruns++)) || true
+    testcases+="  <testcase name=\"VT-d IOMMU Node $mynodenum\">"
+    testcases+="${nl}"
+    iommu_entry=$(find /sys/class/iommu -mindepth 1 -maxdepth 1 \
+        -print -quit 2>/dev/null || true)
+    if [ -z "$iommu_entry" ]; then
+        iommu_message="FAIL: No active VT-d/IOMMU instance found"
+        iommu_message+=" on $HOSTNAME."
+        iommu_message+="$nl$(cat /proc/cmdline)"
+        iommu_message+="$nl$(dmesg | grep -Ei 'DMAR|IOMMU|VT-d' || true)"
+        mail_message+="$nl$iommu_message$nl"
+        testcases+="    <error message=\"VT-d disabled\" type=\"error\">
+    <![CDATA[ $iommu_message ]]>
+    </error>$nl"
+        ((testfails++)) || true
+        result=7
+    else
+        iommu_message="OK: Active VT-d/IOMMU instance found"
+        iommu_message+=" on $HOSTNAME: $iommu_entry"
+        echo "$iommu_message"
+        testcases+="    <system-out>"
+        testcases+="<![CDATA[ $iommu_message ]]></system-out>${nl}"
+    fi
+    testcases+="  </testcase>${nl}"
+}
+
 function apply_network_alias_rules {
     local query_script="/var/tmp/query_node_interfaces.sh"
     local alias_csv="/var/tmp/daos_ftest_iface_aliases.csv"
@@ -419,6 +469,8 @@ if [ "$ib_count" -ge 2 ] ; then
             echo "OK: Even number ($nvme_count) of NVMe devices seen."
         fi
         testcases+="  </testcase>$nl"
+        check_iommu
+        log_nvme_baseline
     fi
     # All storage found by lspci should also be in lsblk report
     lsblk_nvme=$(lsblk | grep nvme -c)

--- a/src/tests/ftest/util/collection_utils.py
+++ b/src/tests/ftest/util/collection_utils.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2022-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -19,7 +19,7 @@ from process_core_files import CoreFileException, CoreFileProcessing
 from util.environment_utils import TestEnvironment
 from util.host_utils import get_local_host
 from util.run_utils import find_command, run_local, run_remote, stop_processes
-from util.storage_utils import find_pci_address
+from util.storage_utils import find_pci_address, get_nvme_diagnostics_command
 from util.systemctl_utils import stop_service
 from util.user_utils import get_chown_command
 from util.yaml_utils import get_test_category
@@ -73,9 +73,9 @@ def stop_daos_server_service(logger, test):
 def reset_server_storage(logger, test):
     """Reset the server storage for the hosts that ran servers in the test.
 
-    This is a workaround to enable binding devices back to nvme or vfio-pci after they are
-    unbound from vfio-pci to nvme.  This should resolve the "NVMe not found" error seen when
-    attempting to start daos engines in the test.
+    This is a workaround to enable binding devices back to the SPDK driver after they are
+    unbound to nvme. This should resolve the "NVMe not found" error seen when attempting to
+    start daos engines in the test.
 
     Args:
         logger (Logger): logger for the messages produced by this method
@@ -92,9 +92,22 @@ def reset_server_storage(logger, test):
         test_env = TestEnvironment()
         commands = [
             "if lspci | grep -i nvme",
-            f"then export COVFILE={test_env.bullseye_file} && "
-            "daos_server nvme reset && "
-            "sudo -n rmmod vfio_pci && sudo -n modprobe vfio_pci",
+            "then",
+            get_nvme_diagnostics_command('before cleanup reset'),
+            f"export COVFILE={test_env.bullseye_file}",
+            "daos_server nvme reset",
+            "reset_rc=$?",
+            "if [ \"$reset_rc\" -eq 0 ]",
+            "then sudo -n rmmod vfio_pci",
+            "reset_rc=$?",
+            "fi",
+            "if [ \"$reset_rc\" -eq 0 ]",
+            "then",
+            "sudo -n modprobe vfio_pci",
+            "reset_rc=$?",
+            "fi",
+            get_nvme_diagnostics_command('after cleanup reset'),
+            "exit $reset_rc",
             "fi"]
         logger.info("Resetting server storage on %s after running '%s'", hosts, test)
         result = run_remote(logger, hosts, f"bash -c '{';'.join(commands)}'", timeout=600)

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -21,6 +21,7 @@ from host_utils import get_local_host
 from run_utils import command_as_user, run_remote, stop_processes
 from server_utils_base import DaosServerCommand, DaosServerInformation, ServerFailed
 from server_utils_params import DaosServerTransportCredentials, DaosServerYamlParameters
+from storage_utils import get_nvme_diagnostics_command
 from user_utils import get_chown_command
 
 
@@ -584,16 +585,22 @@ class DaosServerManager(SubprocessManager):
             ServerFailed: if there was an error resetting the storage
 
         """
-        cmd = DaosServerCommand(self.manager.job.command_path)
-        cmd.sudo = False
-        cmd.debug.value = False
-        cmd.set_sub_command("nvme")
-        cmd.sub_command_class.set_sub_command("reset")
-        cmd.sub_command_class.sub_command_class.ignore_config.value = True
+        reset_cmd = DaosServerCommand(self.manager.job.command_path)
+        reset_cmd.sudo = False
+        reset_cmd.debug.value = False
+        reset_cmd.set_sub_command("nvme")
+        reset_cmd.sub_command_class.set_sub_command("reset")
+        reset_cmd.sub_command_class.sub_command_class.ignore_config.value = True
 
-        self.log.info("Resetting DAOS server storage: %s", str(cmd))
+        run_remote(
+            self.log, self._hosts,
+            get_nvme_diagnostics_command("before manager reset"), timeout=60)
+        self.log.info("Resetting DAOS server storage: %s", str(reset_cmd))
         result = run_remote(
-            self.log, self._hosts, cmd.with_exports, timeout=self.storage_reset_timeout.value)
+            self.log, self._hosts, reset_cmd.with_exports, timeout=self.storage_reset_timeout.value)
+        run_remote(
+            self.log, self._hosts,
+            get_nvme_diagnostics_command("after manager reset"), timeout=60)
         if not result.passed:
             raise ServerFailed("Error resetting NVMe storage")
 

--- a/src/tests/ftest/util/storage_utils.py
+++ b/src/tests/ftest/util/storage_utils.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2022-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -32,6 +32,49 @@ def find_pci_address(value, *flags):
     digit = '0-9a-fA-F'
     pattern = rf'[{digit}]{{4,5}}:[{digit}]{{2}}:[{digit}]{{2}}\.[{digit}]'
     return re.findall(pattern, str(value), *flags)
+
+
+def get_nvme_diagnostics_command(label):
+    """Get a shell command to report NVMe PCI and IOMMU state.
+
+    Args:
+        label (str): label to include in the diagnostic output
+
+    Returns:
+        str: shell command to collect NVMe diagnostics
+
+    """
+    safe_label = str(label).replace('"', '\\"')
+    pci_devices = (
+        'for dev in $(lspci -Dnn | '
+        'awk "/Non-Volatile memory controller/ {print \\$1}"); do '
+        'echo "## $dev"; '
+        'lspci -Dnnk -s "$dev"; '
+        'readlink -f "/sys/bus/pci/devices/$dev/driver" 2>&1 || true; '
+        'readlink -f "/sys/bus/pci/devices/$dev/iommu_group" 2>&1 || true; '
+        'done')
+    commands = [
+        f'echo "--- NVMe diagnostics: {safe_label} ---"',
+        'date -Ins',
+        'echo "# lspci NVMe/VMD devices"',
+        'lspci -Dnnk | grep -Ei "Non-Volatile|NVMe|VMD|Kernel driver" || true',
+        'echo "# NVMe PCI device driver and IOMMU links"',
+        pci_devices,
+        'echo "# /sys/class/iommu"',
+        'ls -la /sys/class/iommu 2>&1 || true',
+        'echo "# /sys/kernel/iommu_groups"',
+        'find /sys/kernel/iommu_groups -maxdepth 2 -type l -print '
+        '-exec readlink -f {} \\; 2>/dev/null || true',
+        'echo "# nvme list"',
+        'command -v nvme >/dev/null && nvme list || true',
+        'echo "# lsblk NVMe devices"',
+        'lsblk -o NAME,KNAME,PATH,MAJ:MIN,SIZE,TYPE,MODEL,SERIAL,STATE,TRAN '
+        '| grep -i nvme || true',
+        'echo "# recent NVMe/IOMMU/PCI kernel messages"',
+        'dmesg -T | grep -Ei '
+        '"DMAR|IOMMU|AER|PCIe|pcie|nvme|uio|vfio|reset|fault|error|timeout|'
+        'surprise|link|vmd" | tail -n 120 || true']
+    return '; '.join(commands)
 
 
 def get_tier_roles(tier, total_tiers):


### PR DESCRIPTION
Log the NVMe IOMMU baseline to hardware prep so post-reboot PCI, driver, IOMMU, and nvme-cli state is recorded before functional tests run.

Add NVMe diagnostics around the ftest reset paths used by server manager cleanup and launch-level post-test cleanup.  When daos_server nvme reset fails, attempt non-reboot recovery with daos_server nvme scan --ignore-config and continue if the scan recovers the devices.

- Jenkinsfile: Fix minor groovylint issues.

- ci/functional/test_main_prep_node.sh: Log NVMe IOMMU settings and health before tests are run

- src/tests/ftest/util/collection_utils.py:
- src/tests/ftest/util/server_utils.py:
- src/tests/ftest/util/storage_utils.py: Add NVMe diagnostics for reset of NVMe devices and attempt recovery of the NVMe devices if the reset fails.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
