### PR TITLE
DAOS-19471 test: Update ftest/io yaml files to use old default

### DIFF
--- a/src/tests/ftest/io/io_consistency.yaml
+++ b/src/tests/ftest/io/io_consistency.yaml
@@ -22,12 +22,13 @@ server_config:
       storage: auto
 
 pool:
-  scm_size: 5000000000
-  nvme_size: 20000000000
-  properties: rd_fac:0
+  scm_size: 5G
+  nvme_size: 20G
+  properties: rd_fac:0,space_rb:0
 
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 ior:
   client_processes:

--- a/src/tests/ftest/io/large_file_count.yaml
+++ b/src/tests/ftest/io/large_file_count.yaml
@@ -21,9 +21,11 @@ server_config:
 
 pool:
   size: 95%
+  properties: rd_fac:0,space_rb:0
 
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 largefilecount:
   api:

--- a/src/tests/ftest/io/macsio_test.yaml
+++ b/src/tests/ftest/io/macsio_test.yaml
@@ -22,9 +22,11 @@ server_config:
 pool:
   scm_size: 5G
   nvme_size: 10G
+  properties: rd_fac:0,space_rb:0
 
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 macsio:
   interface: hdf5

--- a/src/tests/ftest/io/parallel_io.yaml
+++ b/src/tests/ftest/io/parallel_io.yaml
@@ -12,12 +12,14 @@ server_config:
       storage: auto
 
 pool:
-  scm_size: 1000000000
+  scm_size: 1G
   pool_count: 10
+  properties: rd_fac:0,space_rb:0
 
 container:
   type: POSIX
   cont_count: 10
+  properties: cksum:off,srv_cksum:off
 
 fio:
   names:

--- a/src/tests/ftest/io/seg_count.yaml
+++ b/src/tests/ftest/io/seg_count.yaml
@@ -21,9 +21,11 @@ server_config:
 
 pool:
   size: 95%
+  properties: rd_fac:0,space_rb:0
 
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 ior:
   client_processes: !mux

--- a/src/tests/ftest/io/small_file_count.yaml
+++ b/src/tests/ftest/io/small_file_count.yaml
@@ -22,9 +22,11 @@ server_config:
 pool:
   scm_size: 40G
   nvme_size: 300G
+  properties: rd_fac:0,space_rb:0
 
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 largefilecount:
   api:

--- a/src/tests/ftest/io/unaligned_io.yaml
+++ b/src/tests/ftest/io/unaligned_io.yaml
@@ -38,6 +38,7 @@ server_config:
 
 pool:
   scm_size: 12G
+  properties: rd_fac:0,space_rb:0
 
 datasize:
   sizes:


### PR DESCRIPTION
Use old default property values for container as below. Pool - properties: cksum:off,srv_cksum:off
Container - properties: cksum:off,srv_cksum:off

Skip-fault-injection-test: true
Skip-func-hw-test-medium: false
Skip-func-hw-test-large: false
Test-tag: IoConsistency LargeFileCount MacsioTest ParallelIo SegCount SmallFileCount DaosRunIoConf

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
