### PR TITLE
SRE-3999 ci: allow VM provisioning without Mellanox adapters.

### DIFF
--- a/ci/functional/test_main_prep_node.sh
+++ b/ci/functional/test_main_prep_node.sh
@@ -96,7 +96,7 @@ while IFS= read -r line; do
     if [ "$mlnx_type" -ge 6 ]; then
         ((hdr_count++)) || true
     fi
-done < <(lspci -mm | grep "ConnectX" | grep -i "infiniband" || true)
+done < <(lspci -mm | grep "ConnectX" | grep -i "infiniband" )
 echo "Found $hdr_count Mellanox HDR adapters."
 if [ "$hdr_count" -gt 0 ]; then
     ((ib_count=hdr_count)) || true

--- a/ci/functional/test_main_prep_node.sh
+++ b/ci/functional/test_main_prep_node.sh
@@ -96,7 +96,7 @@ while IFS= read -r line; do
     if [ "$mlnx_type" -ge 6 ]; then
         ((hdr_count++)) || true
     fi
-done < <(lspci -mm | grep "ConnectX" | grep -i "infiniband" )
+done < <(lspci -mm | grep "ConnectX" | grep -i "infiniband" || true)
 echo "Found $hdr_count Mellanox HDR adapters."
 if [ "$hdr_count" -gt 0 ]; then
     ((ib_count=hdr_count)) || true

--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -428,7 +428,7 @@ post_provision_config_nodes() {
             mellanox_drivers=true
             break
         fi
-    done < <(lspci -mm | grep "ConnectX")
+    done < <(lspci -mm | grep "ConnectX" || true)
 
     if "$mellanox_drivers"; then
         # Remove OPA and install MOFED

--- a/ci/stacktrace.sh
+++ b/ci/stacktrace.sh
@@ -10,11 +10,12 @@ stacktrace() {
     local msg=${1:-"Unchecked error condition at"}
     local i=${2:-0}
 
+    # prevent re-triggering the trap
+    trap '' ERR
+
     while true; do
-        read -r line func file < <(caller "$i")
+        read -r line func file < <(caller "$i") || true
         if [ -z "$line" ]; then
-            # prevent cascading ERRs
-            trap '' ERR
             break
         fi
         if [ "$i" -eq 0 ]; then

--- a/ci/stacktrace.sh
+++ b/ci/stacktrace.sh
@@ -10,12 +10,11 @@ stacktrace() {
     local msg=${1:-"Unchecked error condition at"}
     local i=${2:-0}
 
-    # caller returns 1 once the outermost frame is reached.
-    trap '' ERR
-
     while true; do
-        read -r line func file < <(caller "$i") || true
+        read -r line func file < <(caller "$i")
         if [ -z "$line" ]; then
+            # prevent cascading ERRs
+            trap '' ERR
             break
         fi
         if [ "$i" -eq 0 ]; then

--- a/ci/stacktrace.sh
+++ b/ci/stacktrace.sh
@@ -10,11 +10,12 @@ stacktrace() {
     local msg=${1:-"Unchecked error condition at"}
     local i=${2:-0}
 
+    # caller returns 1 once the outermost frame is reached.
+    trap '' ERR
+
     while true; do
-        read -r line func file < <(caller "$i")
+        read -r line func file < <(caller "$i") || true
         if [ -z "$line" ]; then
-            # prevent cascading ERRs
-            trap '' ERR
             break
         fi
         if [ "$i" -eq 0 ]; then


### PR DESCRIPTION
In the `post_provision_config_nodes()` function treat an absent ConnectX adapter as an expected condition during
provisioning. Prevent the  probe from triggering the ERR trap when no Mellanox hardware is present.

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
