### PR TITLE
DAOS-19562 test: do not connect to pool for all ior (#18961)

### DIFF
--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -171,7 +171,6 @@ class IorTestBase(TestWithServers):
         # Don't pass uuid and pool handle to IOR.
         # It will not enable checksum feature
         if create_cont:
-            self.pool.connect()
             self.create_cont()
         # Update IOR params with the pool and container params
         self.ior_cmd.set_daos_params(self.pool, self.container.uuid)

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -486,6 +486,9 @@ class TestContainer(TestDaosApiBase):  # pylint: disable=too-many-public-methods
             result = self.daos.container_query(**kwargs)
 
         elif self.control_method.value == self.USE_API:
+            # Need a pool handle to create a container with the API method
+            self.pool.connect()
+
             # pydaos.raw doesn't support create with a label
             if not self.silent.value:
                 self.log.info("Ignoring label for container created with API")


### PR DESCRIPTION
Instead of connecting to the pool when creating an ior container, only connect to the pool on create when we are creating the container through the API.

Quick-functional: true
Features: ior container

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
