### PR TITLE
Dinghwah/daos-19227 test: restore default rd_fac for functional tests

### DIFF
--- a/src/tests/ftest/aggregation/basic.yaml
+++ b/src/tests/ftest/aggregation/basic.yaml
@@ -12,7 +12,6 @@ server_config:
 pool:
   scm_size: 50000000000
   nvme_size: 500000000000
-  properties: rd_fac:0
 container:
   type: POSIX
 ior:

--- a/src/tests/ftest/aggregation/dfuse_space_check.yaml
+++ b/src/tests/ftest/aggregation/dfuse_space_check.yaml
@@ -15,7 +15,7 @@ server_config:
 pool:
   scm_size: 200MB
   nvme_size: 1GiB  # Minimum for 1 target
-  properties: "rd_fac:0,space_rb:0"
+  properties: "space_rb:0"
 
 container:
   type: POSIX

--- a/src/tests/ftest/aggregation/io_small.yaml
+++ b/src/tests/ftest/aggregation/io_small.yaml
@@ -15,7 +15,7 @@ pool:
   scm_size: 10000000000
   nvme_size: 10000000000
   svcn: 1
-  properties: "rd_fac:0,space_rb:0"
+  properties: "space_rb:0"
 
 container:
   type: POSIX

--- a/src/tests/ftest/aggregation/multiple_pool_cont.yaml
+++ b/src/tests/ftest/aggregation/multiple_pool_cont.yaml
@@ -33,7 +33,7 @@ server_config:
 pool:
   size: 40%
   svcn: 1
-  properties: "rd_fac:0,space_rb:0"
+  properties: "space_rb:0"
 
 container:
   type: POSIX

--- a/src/tests/ftest/aggregation/punching.yaml
+++ b/src/tests/ftest/aggregation/punching.yaml
@@ -15,10 +15,8 @@ server_config:
 pool: !mux
   default:
     size: 100%
-    properties: rd_fac:0
   md_on_ssd_p2:
     size: 100%
-    properties: rd_fac:0
     mem_ratio: 25
 container:
   type: POSIX

--- a/src/tests/ftest/aggregation/shutdown_restart.yaml
+++ b/src/tests/ftest/aggregation/shutdown_restart.yaml
@@ -14,7 +14,7 @@ server_config:
 pool:
   size: 50%
   svcn: 1
-  properties: "rd_fac:0,space_rb:0"
+  properties: "space_rb:0"
 
 container:
   type: POSIX

--- a/src/tests/ftest/aggregation/throttling.yaml
+++ b/src/tests/ftest/aggregation/throttling.yaml
@@ -16,7 +16,7 @@ pool:
   scm_size: 20000000000
   nvme_size: 50000000000
   svcn: 1
-  properties: "rd_fac:0,space_rb:0"
+  properties: "space_rb:0"
 
 container:
   type: POSIX


### PR DESCRIPTION
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
