### PR TITLE
DAOS-19560 test: replace assertTrue with Greater or Less

### DIFF
--- a/src/tests/ftest/aggregation/basic.py
+++ b/src/tests/ftest/aggregation/basic.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2022 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -89,7 +90,7 @@ class DaosAggregationBasic(IorTestBase):
 
         # Verify the free space after second ior is less at least twice the
         # size of space_used_by_ior from initial_free_space
-        self.assertLessEqual(free_space_after_second_ior, 
+        self.assertLessEqual(free_space_after_second_ior,
                              (initial_free_space - space_used_by_ior * 2),
                              "Running IOR the 2nd time using same file option did not succeed.")
 

--- a/src/tests/ftest/aggregation/basic.py
+++ b/src/tests/ftest/aggregation/basic.py
@@ -77,7 +77,7 @@ class DaosAggregationBasic(IorTestBase):
 
         self.log.info("Space used by first ior = %s", space_used_by_ior)
         self.log.info("Free space after first ior = %s", free_space_after_first_ior)
-        self.assertTrue(free_space_after_first_ior < initial_free_space,
+        self.assertLess(free_space_after_first_ior, initial_free_space,
                         "IOR run was not successful.")
 
         # Run ior the second time on the same pool and container, so another
@@ -89,8 +89,9 @@ class DaosAggregationBasic(IorTestBase):
 
         # Verify the free space after second ior is less at least twice the
         # size of space_used_by_ior from initial_free_space
-        self.assertTrue(free_space_after_second_ior <= (initial_free_space - space_used_by_ior * 2),
-                        "Running IOR the 2nd time using same file option did not succeed.")
+        self.assertLessEqual(free_space_after_second_ior, 
+                             (initial_free_space - space_used_by_ior * 2),
+                             "Running IOR the 2nd time using same file option did not succeed.")
 
         # Enable the aggregation
         self.pool.set_property("reclaim", "time")
@@ -104,5 +105,5 @@ class DaosAggregationBasic(IorTestBase):
         # Verify the space taken by second ior is reclaimed after aggregation
         # (logical locations will be overwritten as part of aggregation)
         # The free space should be equal to the free space after initial run.
-        self.assertTrue(free_space_after_aggregate == free_space_after_first_ior,
-                        "Aggregation did not reclaim the space")
+        self.assertEqual(free_space_after_aggregate, free_space_after_first_ior,
+                         "Aggregation did not reclaim the space")

--- a/src/tests/ftest/aggregation/punching.py
+++ b/src/tests/ftest/aggregation/punching.py
@@ -98,5 +98,5 @@ class AggregationPunching(MdtestBase):
         self.log.info("Checking if space is reclaimed")
         self.log.info("Expect final_free_space >= free_space_after_mdtest + mdtest_data_size")
         self.log.info("%s >= %s", final_free_space, expected_free_space)
-        self.assertGreaterEqual(final_free_space, expected_free_space, 
+        self.assertGreaterEqual(final_free_space, expected_free_space,
                                 'Free space is less than expected')

--- a/src/tests/ftest/aggregation/punching.py
+++ b/src/tests/ftest/aggregation/punching.py
@@ -59,12 +59,13 @@ class AggregationPunching(MdtestBase):
         free_space_after_mdtest =\
             pool_info.pi_space.ps_space.s_free[storage_index]
 
-        self.log.info("free_space_after_mdtest <= initial_free_space - mdtest_data_size")
+        self.log.info("Expect free_space_after_mdtest <= initial_free_space - mdtest_data_size")
         self.log.info("mdtest_data_size = %s", mdtest_data_size)
         self.log.info("Storage Index = %s",
                       "NVMe" if storage_index else "SCM")
         self.log.info("%s <= %s", free_space_after_mdtest, initial_free_space - mdtest_data_size)
-        self.assertTrue(free_space_after_mdtest <= initial_free_space - mdtest_data_size)
+        self.assertLessEqual(free_space_after_mdtest, initial_free_space - mdtest_data_size,
+                             'Free space after mdtest is greater than expected')
 
         # Enable the aggregation
         self.log.info("Enabling aggregation")
@@ -95,6 +96,7 @@ class AggregationPunching(MdtestBase):
             pool_info.pi_space.ps_space.s_free[storage_index]
 
         self.log.info("Checking if space is reclaimed")
-        self.log.info("final_free_space >= free_space_after_mdtest + mdtest_data_size")
+        self.log.info("Expect final_free_space >= free_space_after_mdtest + mdtest_data_size")
         self.log.info("%s >= %s", final_free_space, expected_free_space)
-        self.assertTrue(final_free_space >= expected_free_space)
+        self.assertGreaterEqual(final_free_space, expected_free_space, 
+                                'Free space is less than expected')

--- a/src/tests/ftest/nvme/pool_exclude.py
+++ b/src/tests/ftest/nvme/pool_exclude.py
@@ -127,7 +127,7 @@ class NvmePoolExclude(OSAUtils):
                 pver_exclude = self.pool.get_version(True)
                 self.log.info("Pool Version after exclude %s", pver_exclude)
                 # Check pool version incremented after pool exclude
-                self.assertTrue(pver_exclude > pver_begin, "Pool Version Error:  After exclude")
+                self.assertGreater(pver_exclude, pver_begin, "Pool Version Error:  After exclude")
 
                 # Wait to finish the threads
                 for thrd in threads:

--- a/src/tests/ftest/osa/offline_extend.py
+++ b/src/tests/ftest/osa/offline_extend.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -122,7 +123,7 @@ class OSAOfflineExtend(OSAUtils):
             display_string = "Pool{} space at the End".format(val)
             pool[val].display_pool_daos_space(display_string)
             self.assertGreater(free_space_after_extend, initial_free_space,
-                            "Expected free space after extend is less than initial")
+                               "Expected free space after extend is less than initial")
 
             if data:
                 # Perform the IOR read using the same

--- a/src/tests/ftest/osa/offline_extend.py
+++ b/src/tests/ftest/osa/offline_extend.py
@@ -118,10 +118,10 @@ class OSAOfflineExtend(OSAUtils):
             pver_extend = self.pool.get_version(True)
             self.log.info("Pool Version after extend %d", pver_extend)
             # Check pool version incremented after pool extend
-            self.assertTrue(pver_extend > pver_begin, "Pool Version Error:  After extend")
+            self.assertGreater(pver_extend, pver_begin, "Pool Version Error:  After extend")
             display_string = "Pool{} space at the End".format(val)
             pool[val].display_pool_daos_space(display_string)
-            self.assertTrue(free_space_after_extend > initial_free_space,
+            self.assertGreater(free_space_after_extend, initial_free_space,
                             "Expected free space after extend is less than initial")
 
             if data:

--- a/src/tests/ftest/osa/offline_parallel_test.py
+++ b/src/tests/ftest/osa/offline_parallel_test.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/ftest/osa/offline_parallel_test.py
+++ b/src/tests/ftest/osa/offline_parallel_test.py
@@ -171,11 +171,11 @@ class OSAOfflineParallelTest(OSAUtils):
             pver_end = self.pool.get_version(True)
             self.log.info("Pool Version at the End %s", pver_end)
             if self.server_boot is True:
-                self.assertTrue(
-                    pver_end >= 17, "Pool Version Error: {} at the end < 17".format(pver_end))
+                self.assertGreaterEqual(
+                    pver_end, 17, "Pool Version Error: {} at the end < 17".format(pver_end))
             else:
-                self.assertTrue(
-                    pver_end >= 25, "Pool Version Error: {} at the end < 25".format(pver_end))
+                self.assertGreaterEqual(
+                    pver_end, 25, "Pool Version Error: {} at the end < 25".format(pver_end))
 
         # Finally run IOR to read the data and perform daos_container_check
         for val in range(0, num_pool):

--- a/src/tests/ftest/osa/online_extend.py
+++ b/src/tests/ftest/osa/online_extend.py
@@ -132,8 +132,8 @@ class OSAOnlineExtend(OSAUtils):
             pver_extend = self.pool.get_version(True)
             self.log.info("Pool Version after extend %s", pver_extend)
             # Check pool version incremented after pool exclude
-            self.assertTrue(pver_extend > pver_begin, "Pool Version Error:  After extend")
-            self.assertTrue(free_space_after_extend > initial_free_space,
+            self.assertGreater(pver_extend, pver_begin, "Pool Version Error:  After extend")
+            self.assertGreater(free_space_after_extend, initial_free_space,
                             "Expected free space after extend is less than initial")
             # Wait to finish the threads
             for thrd in threads:

--- a/src/tests/ftest/osa/online_extend.py
+++ b/src/tests/ftest/osa/online_extend.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -134,7 +135,7 @@ class OSAOnlineExtend(OSAUtils):
             # Check pool version incremented after pool exclude
             self.assertGreater(pver_extend, pver_begin, "Pool Version Error:  After extend")
             self.assertGreater(free_space_after_extend, initial_free_space,
-                            "Expected free space after extend is less than initial")
+                               "Expected free space after extend is less than initial")
             # Wait to finish the threads
             for thrd in threads:
                 thrd.join()

--- a/src/tests/ftest/osa/online_reintegration.py
+++ b/src/tests/ftest/osa/online_reintegration.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -114,9 +114,9 @@ class OSAOnlineReintegration(OSAUtils):
             # Check pool version incremented after pool exclude
             # pver_exclude should be greater than
             # pver_begin + 8 targets.
-            self.assertTrue(pver_exclude > (pver_begin + 8), "Pool Version Error:  After exclude")
-            self.assertTrue(initial_free_space > free_space_after_exclude,
-                            "Expected space after exclude is less than initial")
+            self.assertGreater(pver_exclude, (pver_begin + 8), "Pool Version Error:  After exclude")
+            self.assertGreater(initial_free_space, free_space_after_exclude,
+                               "Expected space after exclude is less than initial")
             output = self.pool.reintegrate(ranks)
             self.print_and_assert_on_rebuild_failure(output)
             free_space_after_reintegration = self.pool.get_total_free_space(refresh=True)
@@ -124,10 +124,10 @@ class OSAOnlineReintegration(OSAUtils):
             pver_reint = self.pool.get_version(True)
             self.log.info("Pool Version after reintegrate %d", pver_reint)
             # Check pool version incremented after pool reintegrate
-            self.assertTrue(pver_reint > (pver_exclude + 1),
-                            "Pool Version Error:  After reintegrate")
-            self.assertTrue(free_space_after_reintegration > free_space_after_exclude,
-                            "Expected free space after reintegration is less than exclude")
+            self.assertGreater(pver_reint, (pver_exclude + 1),
+                               "Pool Version Error:  After reintegrate")
+            self.assertGreater(free_space_after_reintegration, free_space_after_exclude,
+                               "Expected free space after reintegration is less than exclude")
             # Wait to finish the threads
             for thrd in threads:
                 thrd.join()

--- a/src/tests/ftest/pool/create.py
+++ b/src/tests/ftest/pool/create.py
@@ -94,8 +94,8 @@ class PoolCreateTests(TestWithServers):
         pools = [add_pool(self, namespace="/run/pool_2/*", create=False, **params[0])]
         self.log.info("Creating")
         pools[0].create()
-        self.assertTrue(
-            pools[0].dmg.result.exit_status == 0,
+        self.assertEqual(
+            pools[0].dmg.result.exit_status, 0,
             "Creating a large capacity pool on a single server should succeed."
         )
 

--- a/src/tests/ftest/pool/list_verbose.py
+++ b/src/tests/ftest/pool/list_verbose.py
@@ -258,7 +258,7 @@ class ListVerboseTest(IorTestBase):
 
         self.log.info("actual_pools: %s", actual_pools)
         self.log.info("expected_pools: %s", expected_pools)
-        self.assertListEqual(expected_pools, actual_pools, 
+        self.assertListEqual(expected_pools, actual_pools,
                              "List of expected pools and pools returned by 'dmg pool list'")
 
         # For convenience.

--- a/src/tests/ftest/pool/list_verbose.py
+++ b/src/tests/ftest/pool/list_verbose.py
@@ -186,7 +186,7 @@ class ListVerboseTest(IorTestBase):
 
         msg = "Round up amount is too big! Threshold = {}, Diff = {}".format(
             threshold, diff)
-        self.assertTrue(diff < threshold, msg)
+        self.assertLess(diff, threshold, msg)
 
     def verify_pool_lists(self, targets_disabled, scm_size, nvme_size, state, rebuild_state,
                           ranks_disabled, rebuild_degraded):
@@ -258,7 +258,8 @@ class ListVerboseTest(IorTestBase):
 
         self.log.info("actual_pools: %s", actual_pools)
         self.log.info("expected_pools: %s", expected_pools)
-        self.assertListEqual(expected_pools, actual_pools)
+        self.assertListEqual(expected_pools, actual_pools, 
+                             "List of expected pools and pools returned by 'dmg pool list'")
 
         # For convenience.
         return actual_pools


### PR DESCRIPTION
Replace the call to assertTrue with assertGreater, assertGreaterEqual, assertLess or asserLessEqual where what we are checking is greater than, greater than or equal, less than or less than or equal to, respectively.

Also, add a message to the assert if one is missing.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
