### PR TITLE
DAOS-19563 control: Translate ENETUNREACH to Fault

### DIFF
--- a/src/control/lib/control/interceptors.go
+++ b/src/control/lib/control/interceptors.go
@@ -33,7 +33,8 @@ func connErrToFault(st *status.Status, target string) error {
 		strings.Contains(st.Message(), "closed the connection"),
 		strings.Contains(st.Message(), net.ErrClosed.Error()):
 		return FaultConnectionClosed(target)
-	case strings.Contains(st.Message(), "no route to host"):
+	case strings.Contains(st.Message(), "no route to host"),
+		strings.Contains(st.Message(), "network is unreachable"):
 		return FaultConnectionNoRoute(target)
 	case strings.Contains(st.Message(), "no such host"):
 		return FaultConnectionBadHost(target)

--- a/src/control/lib/control/interceptors_test.go
+++ b/src/control/lib/control/interceptors_test.go
@@ -32,6 +32,10 @@ func TestControl_connErrToFault(t *testing.T) {
 			st:     status.New(codes.Unavailable, "no route to host"),
 			expErr: FaultConnectionNoRoute(testTarget),
 		},
+		"network is unreachable": {
+			st:     status.New(codes.Unavailable, "network is unreachable"),
+			expErr: FaultConnectionNoRoute(testTarget),
+		},
 		"nonexistent host": {
 			st:     status.New(codes.Unavailable, "no such host"),
 			expErr: FaultConnectionBadHost(testTarget),


### PR DESCRIPTION
- Translate ENETUNREACH error in a gRPC status.Status to a useful DAOS Fault.

Features: control

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
