### PR TITLE
DAOS-19602 docs: Document SysXS device failure offline recovery proce…

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -575,6 +575,15 @@ boro-11
 
 #### Exclusion and Hotplug
 
+!!! note
+    **SysXS Device Failure**: A SysXS device is a special NVMe SSD region that
+    contains critical system metadata for a DAOS engine. If a SysXS device fails,
+    the engine will terminate immediately. Unlike regular NVMe device faults that
+    can be addressed using online hotplug, SysXS device failures require
+    **offline** device replacement using `dmg storage format --replace`. See
+    [SysXS Device Failure Recovery](#sysxs-device-failure-recovery) for detailed
+    procedures.
+
 - Automatic exclusion of an NVMe SSD:
 
 Automatic exclusion based on faulty criteria is the default behavior in DAOS
@@ -1277,6 +1286,113 @@ An example workflow for SSD failure in MD-on-SSD mode would be:
     the PMEM correctly.  Resolve the configuration issue and re-run `dmg storage format --replace`
     or run `dmg storage format` without `--replace` to create a new rank with a different fabric
     URI (for example).
+
+#### SysXS Device Failure Recovery
+
+SysXS is a special region on NVMe SSDs that stores critical system metadata for DAOS engines.
+In MD-on-SSD mode, each engine will contain a "special" SysXS target on one of it's SSDs.
+Unlike regular NVMe device failures that can often be handled online using hotplug procedures,
+a SysXS device failure causes the engine to terminate immediately.
+
+The command `dmg storage query list-devices` command can be used to identify which device is
+running the SysXS target on a given engine/rank.
+
+**Key Characteristics of SysXS Failure:**
+- The engine will **exit unexpectedly** when the SysXS device fails and `engine_died` RAS event
+will be emitted
+- Engine will transition to "Errored" or "Excluded" state and engine logs show SysXS related
+errors at failure point
+- Online hotplug procedures (see [Exclusion and Hotplug](#exclusion-and-hotplug)) do not apply
+- The engine cannot self-exclude and restart; manual intervention is required
+- The failed SSD must be replaced offline (server powered down)
+- Recovery requires `dmg storage format --replace` to reuse the engine's "old" rank once fixed
+
+**Example Scenario: Engine with SysXS on Data/WAL/Meta SSD**
+
+If a server is configured with engines where a single SSD carries the data, WAL, and meta roles
+(including the SysXS system metadata), and that SSD fails:
+
+1. The engine immediately terminates with an `engine_died` RAS event
+2. The engine becomes excluded from the system
+3. The failed SSD must be physically replaced
+4. `dmg storage format --replace` is used to recover the engine with it's original rank
+5. `dmg system reintegrate -r <rank>` is used to reintegrate rank into it's pools
+
+**Recovery Workflow for SysXS Device Failure:**
+
+1. Verify Failure
+```bash
+dmg system query -v  # Look for "Errored" state
+tail -f /var/log/daos/daos_engine.0.log  # Check for device errors
+```
+
+2. Stop Server
+```bash
+systemctl stop daos_server
+```
+
+3. Physical Replacement
+- Power down the storage server
+- Replace the faulty SSD
+- Power up but don't start daos_server
+
+4. Prepare To Trigger Format Request By Removing Superblock
+```bash
+# Example for engine 0
+rm /mnt/control_metadata/daos_control/engine0/superblock
+```
+
+5. Restart Server
+```bash
+systemctl start daos_server
+```
+
+6. Format with Replace
+```bash
+dmg storage format --replace -l <storage-server-hostname>
+```
+
+7. Verify Recovery
+After waiting for storage format command to complete and engine to start/join.
+```bash
+dmg system query -v  # Check engine is "Joined"
+dmg storage query list-devices --health  # Verify new device health
+```
+
+8. Reintegrate Rank Into Pools
+Reintegrate the replaced rank into it's pools (retrieve rank identifier from
+'dmg system query' output).
+```bash
+dmg system reintegrate -r <engine_rank>
+```
+
+**Differences from Online Hotplug:**
+
+| Aspect | Online Hotplug (Regular NVMe) | Offline Replacement (SysXS) |
+|--------|------|------|
+| Engine Behavior | Engine may report IO and media errors | Engine terminates immediately |
+| Data Availability | System continues running | Engine goes offline |
+| Procedure | `dmg storage set nvme-faulty` + `dmg storage replace nvme` | Power down + hardware replacement + `dmg storage format --replace` |
+| Timing | Can be performed while system is running | Requires system shutdown on affected host |
+| Recovery Time | Minutes (online) | Hours (includes downtime) |
+
+**Common Mistakes to AVOID:**
+
+1. **❌ Do NOT use online hotplug commands for SysXS failures**
+   - `dmg storage set nvme-faulty` - Won't work, engine already died
+   - `dmg storage replace nvme` - Requires online hotplug support
+
+2. **❌ Do NOT restart daos_server without removing superblock**
+   - Engine won't trigger format request
+   - May use wrong rank assignment
+
+3. **❌ Do NOT remove control_metadata for multi-engine hosts**
+   - Only remove the failed engine's superblock
+   - Preserve other engines' metadata
+
+4. **❌ Do NOT use dmg storage format without --replace flag**
+   - Will create a NEW rank instead of reusing the old one
+   - Orphaned ranks are generally considered undesirable
 
 ### System Erase
 

--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -1294,8 +1294,25 @@ In MD-on-SSD mode, each engine will contain a "special" SysXS target on one of i
 Unlike regular NVMe device failures that can often be handled online using hotplug procedures,
 a SysXS device failure causes the engine to terminate immediately.
 
-The command `dmg storage query list-devices` command can be used to identify which device is
-running the SysXS target on a given engine/rank.
+The command `dmg storage query list-devices` can be used to identify which device is
+running the SysXS target on a given engine/rank. The output will show "SysXS" in each device that
+contains either a meta or wal role AND hosts target-0 as illustrated in the following example:
+
+```bash
+$ dmg storage query list-devices
+--------
+daos-16
+--------
+  Devices
+    UUID:440a7ce9-849f-440c-befe-017d1cc2072b [TrAddr:0000:5e:00.0 NSID:1]
+      Roles:data,meta,wal SysXS Targets:[0 2 4 6 8 10 12 14] Rank:3 State:NORMAL LED:NA
+    UUID:9ee24bbf-6cd9-40c0-94f3-776056e9ea69 [TrAddr:0000:5f:00.0 NSID:1]
+      Roles:data,meta,wal Targets:[1 3 5 7 9 11 13 15] Rank:3 State:NORMAL LED:NA
+    UUID:67ad6337-c14b-497b-a37d-521e604d17be [TrAddr:0000:8e:00.0 NSID:1]
+      Roles:data,meta,wal SysXS Targets:[0 2 4 6 8 10 12 14] Rank:4 State:NORMAL LED:NA
+    UUID:5a81ca73-c33e-49f2-a31b-fd86ea48669a [TrAddr:0000:8f:00.0 NSID:1]
+      Roles:data,meta,wal Targets:[1 3 5 7 9 11 13 15] Rank:4 State:NORMAL LED:NA
+```
 
 **Key Characteristics of SysXS Failure:**
 - The engine will **exit unexpectedly** when the SysXS device fails and `engine_died` RAS event
@@ -1304,7 +1321,7 @@ will be emitted
 errors at failure point
 - Online hotplug procedures (see [Exclusion and Hotplug](#exclusion-and-hotplug)) do not apply
 - The engine cannot self-exclude and restart; manual intervention is required
-- The failed SSD must be replaced offline (server powered down)
+- The failed SSD must be replaced when `daos_server` process is stopped
 - Recovery requires `dmg storage format --replace` to reuse the engine's "old" rank once fixed
 
 **Example Scenario: Engine with SysXS on Data/WAL/Meta SSD**
@@ -1321,20 +1338,26 @@ If a server is configured with engines where a single SSD carries the data, WAL,
 **Recovery Workflow for SysXS Device Failure:**
 
 1. Verify Failure
+When an engine terminates because of SysXS device failure the following will be logged by the
+engine:
+```bash
+2026/06/25 16:55:18.107687 daos-75 DAOS[12274/0/243] pool ERR  src/pool/srv_util.c:1835 nvme_reaction() SYS target SSD is failed, kill the engine...
+```
+To verify:
 ```bash
 dmg system query -v  # Look for "Errored" state
-tail -f /var/log/daos/daos_engine.0.log  # Check for device errors
+dmg storage query list-devices  # Confirm failure is on SysXS device
+grep -i "SYS target SSD is failed" /var/log/daos/daos_engine.0.log  # Check for SysXS-related errors
 ```
 
 2. Stop Server
 ```bash
 systemctl stop daos_server
+systemctl disable daos_server
 ```
 
-3. Physical Replacement
-- Power down the storage server
+3. Physical Replacement (either online or offline)
 - Replace the faulty SSD
-- Power up but don't start daos_server
 
 4. Prepare To Trigger Format Request By Removing Superblock
 ```bash
@@ -1344,6 +1367,7 @@ rm /mnt/control_metadata/daos_control/engine0/superblock
 
 5. Restart Server
 ```bash
+systemctl enable daos_server
 systemctl start daos_server
 ```
 
@@ -1372,15 +1396,15 @@ dmg system reintegrate -r <engine_rank>
 |--------|------|------|
 | Engine Behavior | Engine may report IO and media errors | Engine terminates immediately |
 | Data Availability | System continues running | Engine goes offline |
-| Procedure | `dmg storage set nvme-faulty` + `dmg storage replace nvme` | Power down + hardware replacement + `dmg storage format --replace` |
-| Timing | Can be performed while system is running | Requires system shutdown on affected host |
+| Procedure | `dmg storage set nvme-faulty` + `dmg storage replace nvme` | Stop `daos_server` + hardware replacement + remove superblock + Start `daos_server` + `dmg storage format --replace` |
+| Timing | Can be performed while system is running | Requires DAOS service stop/start on affected host |
 | Recovery Time | Minutes (online) | Hours (includes downtime) |
 
 **Common Mistakes to AVOID:**
 
 1. **❌ Do NOT use online hotplug commands for SysXS failures**
    - `dmg storage set nvme-faulty` - Won't work, engine already died
-   - `dmg storage replace nvme` - Requires online hotplug support
+   - `dmg storage replace nvme` - Requires online hotplug support, command will fail
 
 2. **❌ Do NOT restart daos_server without removing superblock**
    - Engine won't trigger format request


### PR DESCRIPTION
…dures

Add comprehensive documentation for SysXS device failure recovery in MD-on-SSD
configurations. SysXS stores critical system metadata on NVMe SSDs, and unlike
regular NVMe faults that support online hotplug, SysXS failures cause the
engine to terminate immediately, requiring offline replacement with rank
preservation.

Key distinction documented: SysXS failures require dmg storage format --replace
(offline) NOT dmg storage set nvme-faulty (online).

Doc-only: true

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
