### PR TITLE
DAOS-19603 test: fix pydaos.raw pool connect handle

### DIFF
--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2018-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -84,7 +84,7 @@ class DaosPool():
                        ctypes.byref(self.handle), ctypes.byref(c_info), None)
 
             if ret != 0:
-                self.handle = 0
+                self.handle = ctypes.c_uint64(0)
                 raise DaosApiError("Pool connect returned non-zero. RC: {0}".format(ret))
             self.connected = 1
         else:

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -1,6 +1,6 @@
 '''
   (C) Copyright 2018-2023 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -56,7 +56,11 @@ class Permission(TestWithServers):
 
         container = add_container(self, pool, create=False)
         self.log.debug("Container initialization successful")
+        # Set pool.connected to True in case it failed above (expected),
+        # so that container.create() does not try to connect to the pool again.
+        was_connected = pool.connected
         try:
+            pool.connected = True
             container.create()
             self.log.debug("Container create successful")
             # now open it
@@ -66,6 +70,8 @@ class Permission(TestWithServers):
             self.log.error(str(error))
             if expected_result == RESULT_PASS:
                 self.fail("Test was expected to pass but it failed at container operations.")
+        finally:
+            pool.connected = was_connected
 
         thedata = b"a string that I want to stuff into an object"
         size = 45


### PR DESCRIPTION
Fix the pool connect handle reset on failure.
It should be a ctype, not a native int.

Adjust ftest/pool/permission.py handling of pool.connect() to not try to
connect to the pool again on container.create().


Test-tag: test_file_modification
Quick-functional: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
