### PR TITLE
SRE-4015 test: stacked PR CI validation (layer 2 of 3) - DO NOT LAND

### DIFF
--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -867,3 +867,5 @@ daos_count_free_bits(uint64_t *used, int bmap_sz)
 
 	return nr;
 }
+
+/* SRE-4015 stacked PR CI validation layer 2 - do not land */


### PR DESCRIPTION
Temporary validation stack for SRE-4015 tip-only CI. Layer 2 of 3, mid-stack. Expected: cheap checks plus a compile-only build only.