### PR TITLE
DAOS-19479 test: Update ftest/performance yaml files to use old defau…

### DIFF
--- a/src/tests/ftest/performance/ior_easy.yaml
+++ b/src/tests/ftest/performance/ior_easy.yaml
@@ -28,6 +28,7 @@ pool:
 
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 ior: &ior_base
   client_processes:

--- a/src/tests/ftest/performance/ior_hard.yaml
+++ b/src/tests/ftest/performance/ior_hard.yaml
@@ -28,6 +28,7 @@ pool:
 
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 ior: &ior_base
   client_processes:

--- a/src/tests/ftest/performance/mdtest_easy.yaml
+++ b/src/tests/ftest/performance/mdtest_easy.yaml
@@ -28,6 +28,7 @@ pool:
 
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 mdtest: &mdtest_base
   client_processes:

--- a/src/tests/ftest/performance/mdtest_hard.yaml
+++ b/src/tests/ftest/performance/mdtest_hard.yaml
@@ -28,6 +28,7 @@ pool:
 
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 mdtest: &mdtest_base
   client_processes:


### PR DESCRIPTION
…lt (#18965)

Use old default property values for container as below. properties: cksum:off,srv_cksum:off

Skip-fault-injection-test: true
Skip-func-hw-test-medium: false
Test-tag: IorEasy IorHard MdtestEasy MdtestHard

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
