### PR TITLE
DAOS-19470 test: Update ftest/interoperability yaml files to use old …

### DIFF
--- a/src/tests/ftest/interoperability/updown_grade.yaml
+++ b/src/tests/ftest/interoperability/updown_grade.yaml
@@ -30,10 +30,11 @@ server_config:
 pool:
   size: 1G
   name: daos_server
+  properties: rd_fac:0,space_rb:0
 
 container:
   type: POSIX
-  properties: rf:0,rd_lvl:1
+  properties: rf:0,rd_lvl:1,cksum:off,srv_cksum:off
 
 attrtests:
   num_attributes: 20

--- a/src/tests/ftest/interoperability/updown_grade.yaml
+++ b/src/tests/ftest/interoperability/updown_grade.yaml
@@ -34,7 +34,7 @@ pool:
 
 container:
   type: POSIX
-  properties: rf:0,rd_lvl:1,cksum:off,srv_cksum:off
+  properties: cksum:off,srv_cksum:off
 
 attrtests:
   num_attributes: 20


### PR DESCRIPTION
…default

Use old default property values for container as below. Pool - properties: cksum:off,srv_cksum:off
Container - properties: cksum:off,srv_cksum:off

skip-unit-tests: true
skip-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
