### PR TITLE
SRE-4013 tests: Move Pil4dfsFio.test_pil4dfs_vs_dfs to cb

### DIFF
--- a/src/tests/ftest/dfuse/pil4dfs_fio.py
+++ b/src/tests/ftest/dfuse/pil4dfs_fio.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2019-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -185,7 +186,7 @@ class Pil4dfsFio(TestWithServers):
             Check bandwidth consistency of FIO DFS ioengine and the PIL4DFS interception library
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=hw,medium
+        :avocado: tags=cb,hw,medium
         :avocado: tags=dfs,dfuse,pil4dfs,fio
         :avocado: tags=Pil4dfsFio,test_pil4dfs_vs_dfs
         """

--- a/src/tests/ftest/dfuse/pil4dfs_fio.yaml
+++ b/src/tests/ftest/dfuse/pil4dfs_fio.yaml
@@ -12,11 +12,13 @@ server_config:
       pinned_numa_node: 0
       log_file: daos_server0.log
       log_mask: INFO
+      nr_xs_helpers: 1
       storage: auto
     1:
       pinned_numa_node: 1
       log_file: daos_server1.log
       log_mask: INFO
+      nr_xs_helpers: 1
       storage: auto
 
 pool:


### PR DESCRIPTION
- Pil4dfsFio.test_pil4dfs_vs_dfs

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
