### PR TITLE
DAOS-19591 container: avoid false sluggish EC boundary warning

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1814,14 +1814,15 @@ cont_track_eph_leader_alloc(struct cont_svc *cont_svc, uuid_t cont_uuid,
 	eph_ldr->cte_servers_num = rank_nr;
 	eph_ldr->cte_current_ec_agg_eph = 0;
 	eph_ldr->cte_rdb_ec_agg_eph     = 0;
+	eph_ldr->cte_start_ts           = daos_gettime_coarse();
 	for (i = 0; i < rank_nr; i++) {
 		eph_ldr->cte_server_ephs[i].re_rank = doms[i].do_comp.co_rank;
 		eph_ldr->cte_server_ephs[i].re_ec_agg_eph = 0;
 		eph_ldr->cte_server_ephs[i].re_stable_eph = 0;
-		eph_ldr->cte_server_ephs[i].re_ec_agg_eph_update_ts = daos_gettime_coarse();
+		eph_ldr->cte_server_ephs[i].re_ec_agg_eph_update_ts = eph_ldr->cte_start_ts;
 	}
 	d_list_add(&eph_ldr->cte_list, &cont_svc->cs_cont_ephs_leader_list);
-	eph_ldr->cte_ec_agg_warn_slug_ts = daos_gettime_coarse();
+	eph_ldr->cte_ec_agg_warn_slug_ts = eph_ldr->cte_start_ts;
 	*leader_p = eph_ldr;
 out:
 	if (rc) {
@@ -2260,7 +2261,8 @@ cont_agg_eph_sync(struct ds_pool *pool, struct cont_svc *svc)
 		cur_eph = d_hlc2sec(eph_ldr->cte_current_ec_agg_eph);
 		new_eph = d_hlc2sec(min_ec_agg_eph);
 		if ((cur_ts > eph_ldr->cte_ec_agg_warn_slug_ts + 600) && cur_eph &&
-		    (new_eph > cur_eph) && (new_eph - cur_eph) >= 600)
+		    (new_eph > cur_eph) && (new_eph - cur_eph) >= 600 &&
+		    (cur_ts - eph_ldr->cte_start_ts) >= (new_eph - cur_eph))
 			D_WARN(DF_CONT ": Sluggish EC boundary reporting. "
 				       "cur:" DF_U64 " new:" DF_U64 " gap:" DF_U64 "\n",
 			       DP_CONT(svc->cs_pool_uuid, eph_ldr->cte_cont_uuid), cur_eph, new_eph,

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -75,6 +75,11 @@ struct cont_track_eph_leader {
 	d_list_t                 cte_list;
 	int                      cte_servers_num;
 	uint32_t                 cte_deleted : 1;
+	/* Time when this leader started tracking the container. A boundary jump larger
+	 * than the tracking age cannot have been observed by this leader, it comes from
+	 * the stale epoch loaded from rdb at leader step-up, so it is not a real stall.
+	 */
+	uint64_t                 cte_start_ts;
 	/* TS to check for ec_agg_eph sluggish warning */
 	uint64_t                 cte_ec_agg_warn_slug_ts;
 };


### PR DESCRIPTION
A new container service leader loads the EC aggregation boundary from rdb, which can be far behind the current time. The first comparison of the tracked epoch against the newly reported minimum then shows a large gap and triggers a bogus "Sluggish EC boundary reporting" warning.

Record the time when the leader starts tracking a container and only warn when the leader has been tracking it at least as long as the observed epoch gap, so a gap that predates this leader is not reported as a stall.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
