### PR TITLE
Revert "DAOS-19087 pool: Recov conts in all reints/extends (#18651)"

### DIFF
--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -435,7 +435,8 @@ ds_mgmt_pool_target_update_state(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 				 pool_comp_state_t state, size_t scm_size, size_t nvme_size,
 				 size_t meta_size, bool skip_rf_check)
 {
-	int rc;
+	uint64_t deadline;
+	int      rc;
 
 	if (state == PO_COMP_ST_UP) {
 		/* When doing reintegration, need to make sure the pool is created and started on
@@ -459,8 +460,16 @@ ds_mgmt_pool_target_update_state(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 		}
 	}
 
-	rc = dsc_pool_svc_update_target_state(pool_uuid, svc_ranks, mgmt_ps_call_deadline(),
-					      target_addrs, state, skip_rf_check);
+	deadline = mgmt_ps_call_deadline();
+
+again:
+	rc = dsc_pool_svc_update_target_state(pool_uuid, svc_ranks, deadline, target_addrs, state,
+					      skip_rf_check);
+	if (rc == -DER_AGAIN && state == PO_COMP_ST_UP && daos_getmtime_coarse() < deadline) {
+		D_WARN("Retry incremental reintegration for pool " DF_UUID " because of race\n",
+		       DP_UUID(pool_uuid));
+		goto again;
+	}
 
 	return rc;
 }

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1865,7 +1865,7 @@ again:
 
 static int
 migrate_get_cont_child(struct migrate_pool_tls *tls, uuid_t cont_uuid,
-		       struct ds_cont_child **cont_p)
+		       struct ds_cont_child **cont_p, bool create)
 {
 	struct ds_cont_child	*cont_child = NULL;
 	int			rc;
@@ -1876,14 +1876,32 @@ migrate_get_cont_child(struct migrate_pool_tls *tls, uuid_t cont_uuid,
 		return 0;
 	}
 
-	rc = ds_cont_child_lookup(tls->mpt_pool_uuid, cont_uuid, &cont_child);
-	if (rc != 0) {
-		if (rc == -DER_CONT_NONEXIST || rc == -DER_CONT_DESTROYING)
-			D_DEBUG(DB_REBUILD,
-				DF_RB ": container " DF_UUID "already destroyed or destroying\n",
-				DP_RB_MPT(tls), DP_UUID(cont_uuid));
-		D_ASSERT(cont_child == NULL);
-		return rc;
+	/* For incremental reintegration, the container has already been (re)-created. */
+	if (create && !tls->mpt_reintegrating) {
+		/* Since the shard might be moved different location for any pool operation,
+		 * so it may need create the container in all cases.
+		 */
+		rc = ds_cont_child_open_create(tls->mpt_pool_uuid, cont_uuid, false, &cont_child);
+		if (rc != 0) {
+			if (rc == -DER_CONT_DESTROYING)
+				D_DEBUG(DB_REBUILD,
+					DF_RB ": container " DF_UUID
+					      "already destroyed or destroying\n",
+					DP_RB_MPT(tls), DP_UUID(cont_uuid));
+			D_ASSERT(cont_child == NULL);
+			return rc;
+		}
+	} else {
+		rc = ds_cont_child_lookup(tls->mpt_pool_uuid, cont_uuid, &cont_child);
+		if (rc != 0) {
+			if (rc == -DER_CONT_NONEXIST || rc == -DER_CONT_DESTROYING)
+				D_DEBUG(DB_REBUILD,
+					DF_RB ": container " DF_UUID
+					      "already destroyed or destroying\n",
+					DP_RB_MPT(tls), DP_UUID(cont_uuid));
+			D_ASSERT(cont_child == NULL);
+			return rc;
+		}
 	}
 
 	*cont_p = cont_child;
@@ -1899,7 +1917,7 @@ migrate_dkey(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 	int			 rc;
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
-	rc = migrate_get_cont_child(tls, mrone->mo_cont_uuid, &cont);
+	rc = migrate_get_cont_child(tls, mrone->mo_cont_uuid, &cont, true);
 	if (rc || cont == NULL)
 		D_GOTO(out, rc);
 
@@ -2953,6 +2971,8 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	}
 
 	if (!create_migrate_one) {
+		struct ds_cont_child *cont = NULL;
+
 		if (daos_is_dkey_uint64(io->ui_oid.id_pub) && io->ui_dkey.iov_len == 8)
 			D_DEBUG(DB_REBUILD,
 				DF_RB ": " DF_UOID "/int dkey: " DF_U64 " does not need rebuild.",
@@ -2961,6 +2981,13 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 		else
 			D_DEBUG(DB_REBUILD, DF_RB ": " DF_UOID "/" DF_KEY " does not need rebuild.",
 				DP_RB_MPT(tls), DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey));
+
+		/* Create the vos container when no record need to be rebuilt for this shard,
+		 * for the case of reintegrate the container was discarded ahead.
+		 */
+		rc = migrate_get_cont_child(tls, arg->arg->cont_uuid, &cont, true);
+		if (cont != NULL)
+			ds_cont_child_put(cont);
 
 		D_GOTO(put, rc = 0);
 	}
@@ -3012,7 +3039,7 @@ migrate_obj_punch_one(void *data)
 	D_DEBUG(DB_REBUILD, DF_RB ": tls %p version %d punch " DF_U64 " " DF_UOID "\n",
 		DP_RB_MPT(tls), tls, arg->version, arg->punched_epoch, DP_UOID(arg->oid));
 
-	rc = migrate_get_cont_child(tls, arg->cont_uuid, &cont);
+	rc = migrate_get_cont_child(tls, arg->cont_uuid, &cont, true);
 	if (rc != 0 || cont == NULL)
 		D_GOTO(out, rc);
 
@@ -3470,7 +3497,7 @@ migrate_obj_ult(void *data)
 		struct ds_cont_child *cont_child = NULL;
 
 		/* check again to see if the container is being destroyed. */
-		migrate_get_cont_child(tls, arg->cont_uuid, &cont_child);
+		migrate_get_cont_child(tls, arg->cont_uuid, &cont_child, false);
 		if (cont_child != NULL && !cont_child->sc_stopping) {
 			if (vos_oi_exist(cont_child->sc_hdl, arg->oid)) {
 				stable_epoch = vos_cont_get_global_stable_epoch(cont_child->sc_hdl);

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -162,6 +162,10 @@ enum pool_map_update_flags {
 	POOL_RESET_RECOV_CONT         = (1 << 1),
 };
 
+enum pool_recov_cont_flags {
+	PRCF_BIND_BULK = (1 << 0),
+};
+
 static inline uint32_t
 pool_opc_2map_opc(uint32_t pool_opc)
 {
@@ -944,6 +948,7 @@ CRT_RPC_DECLARE(pool_eval_self_heal, DAOS_ISEQ_POOL_EVAL_SELF_HEAL, DAOS_OSEQ_PO
 	((uint32_t)			(prci_flags)		CRT_VAR) \
 	((uint32_t)			(prci_padding)		CRT_VAR) \
 	((uint64_t)			(prci_cont_nr)		CRT_VAR) \
+	((crt_bulk_t)			(prci_cont_bulk)	CRT_VAR) \
 	((struct pool_target_addr)	(prci_addrs)		CRT_ARRAY)
 
 #define DAOS_OSEQ_POOL_RECOV_CONT	/* output fields */		 \

--- a/src/pool/srv_cli.c
+++ b/src/pool/srv_cli.c
@@ -1,6 +1,6 @@
 /*
  * (C) Copyright 2017-2024 Intel Corporation.
- * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -960,18 +960,12 @@ pool_extend_init(uuid_t pool_uuid, crt_rpc_t *rpc, void *varg)
 static int
 pool_extend_consume(uuid_t pool_uuid, crt_rpc_t *rpc, void *varg)
 {
-	struct pool_extend_arg *arg = varg;
 	struct pool_extend_out *out = crt_reply_get(rpc);
 	int                     rc  = out->peo_op.po_rc;
 
-	if (rc == -DER_AGAIN) {
-		D_DEBUG(DB_MGMT, DF_UUID ": extend to %d ranks: " DF_RC "\n", DP_UUID(pool_uuid),
-			arg->pea_ntargets, DP_RC(rc));
-		rc = DSC_POOL_SVC_CALL_AGAIN;
-	} else if (rc != 0) {
-		DL_ERROR(rc, DF_UUID ": failed to extend to %d ranks", DP_UUID(pool_uuid),
-			 arg->pea_ntargets);
-	}
+	if (rc != 0)
+		DL_ERROR(rc, DF_UUID ": Failed to set targets to UP state for reintegration",
+			 DP_UUID(pool_uuid));
 	return rc;
 }
 
@@ -1022,14 +1016,11 @@ pool_update_target_state_consume(uuid_t pool_uuid, crt_rpc_t *rpc, void *varg)
 	struct pool_tgt_update_out          *out = crt_reply_get(rpc);
 	int                                  rc  = out->pto_op.po_rc;
 
-	if (rc == -DER_AGAIN) {
-		D_DEBUG(DB_MGMT, DF_UUID ": set targets to state %s: " DF_RC "\n",
-			DP_UUID(pool_uuid), pool_map_status2name(arg->puta_state), DP_RC(rc));
-		rc = DSC_POOL_SVC_CALL_AGAIN;
-	} else if (rc != 0) {
+	if (rc != 0)
 		DL_ERROR(rc, DF_UUID ": Failed to set targets to %s state", DP_UUID(pool_uuid),
-			 pool_map_status2name(arg->puta_state));
-	}
+			 arg->puta_state == PO_COMP_ST_DOWN ? "DOWN"
+			 : arg->puta_state == PO_COMP_ST_UP ? "UP"
+							    : "UNKNOWN");
 	return rc;
 }
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -8109,13 +8109,11 @@ pool_discard(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr_li
 	struct pool_tgt_discard_in	*ptdi_in;
 	struct pool_tgt_discard_out	*ptdi_out;
 	crt_rpc_t			*rpc;
-	d_rank_list_t                   *rank_list = NULL;
+	d_rank_list_t			*rank_list = NULL;
+	struct pool_target_addr_list     valid_list = {0};
 	crt_opcode_t                     opc       = POOL_TGT_DISCARD;
 	int				i;
 	int				rc;
-
-	D_ASSERTF(list->pta_number > 0, DF_UUID ": discard %d target\n",
-		  DP_UUID(svc->ps_pool->sp_uuid), list->pta_number);
 
 	rc = ds_pool_encode_opc(&opc);
 	if (rc)
@@ -8125,19 +8123,33 @@ pool_discard(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr_li
 		D_ASSERTF(svc->ps_pool->sp_incr_reint == 0,
 			  "incremental reint should not get here\n");
 
-	rank_list = d_rank_list_alloc(list->pta_number);
+	rc = pool_discard_filter_tgts(svc, list, reint, &valid_list);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	if (valid_list.pta_number == 0) {
+		D_INFO(DF_UUID " discard 0 valid target.", DP_UUID(svc->ps_pool->sp_uuid));
+		D_GOTO(out, rc = 0);
+	}
+
+	rank_list = d_rank_list_alloc(valid_list.pta_number);
 	if (rank_list == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	rank_list->rl_nr = 0;
 	/* remove the duplicate ranks from list, see reintegrate target case */
-	for (i = 0; i < list->pta_number; i++) {
-		if (daos_rank_in_rank_list(rank_list, list->pta_addrs[i].pta_rank))
+	for (i = 0; i < valid_list.pta_number; i++) {
+		if (daos_rank_in_rank_list(rank_list, valid_list.pta_addrs[i].pta_rank))
 			continue;
 
-		rank_list->rl_ranks[rank_list->rl_nr++] = list->pta_addrs[i].pta_rank;
+		rank_list->rl_ranks[rank_list->rl_nr++] = valid_list.pta_addrs[i].pta_rank;
 		D_DEBUG(DB_MD, DF_UUID ": discard rank %u\n", DP_UUID(svc->ps_pool->sp_uuid),
-			list->pta_addrs[i].pta_rank);
+			valid_list.pta_addrs[i].pta_rank);
+	}
+
+	if (rank_list->rl_nr == 0) {
+		D_INFO(DF_UUID " discard 0 rank.", DP_UUID(svc->ps_pool->sp_uuid));
+		D_GOTO(out, rc = 0);
 	}
 
 	rc = crt_corpc_req_create(ctx, NULL, rank_list, opc, NULL,
@@ -8147,8 +8159,8 @@ pool_discard(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr_li
 		D_GOTO(out, rc);
 
 	ptdi_in = crt_req_get(rpc);
-	ptdi_in->ptdi_addrs.ca_arrays = list->pta_addrs;
-	ptdi_in->ptdi_addrs.ca_count  = list->pta_number;
+	ptdi_in->ptdi_addrs.ca_arrays = valid_list.pta_addrs;
+	ptdi_in->ptdi_addrs.ca_count  = valid_list.pta_number;
 	uuid_copy(ptdi_in->ptdi_uuid, svc->ps_pool->sp_uuid);
 	rc = dss_rpc_send(rpc);
 
@@ -8164,55 +8176,7 @@ pool_discard(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr_li
 out:
 	if (rank_list)
 		d_rank_list_free(rank_list);
-	return rc;
-}
-
-static int
-pool_recov_cont(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr_list *list);
-
-/*
- * Prepare targets to for reintegration or extension. Return
- *   - 0 if successful,
- *   - 1 if no target needs to join, or
- *   - a negative error code.
- */
-static int
-pool_join_pre(crt_context_t ctx, struct pool_svc *svc, crt_opcode_t opc,
-	      struct pool_target_addr_list *list)
-{
-	struct pool_target_addr_list valid_list = {0};
-	bool                         reint;
-	int                          rc;
-
-	D_ASSERT(opc == POOL_REINT || opc == POOL_EXTEND);
-	reint = (opc == POOL_REINT);
-
-	rc = pool_discard_filter_tgts(svc, list, reint, &valid_list);
-	if (rc != 0)
-		goto out;
-
-	if (valid_list.pta_number == 0) {
-		D_INFO(DF_UUID ": no valid target to join\n", DP_UUID(svc->ps_uuid));
-		rc = 1;
-		goto out_valid_list;
-	}
-
-	rc = pool_recov_cont(ctx, svc, &valid_list);
-	if (rc != 0) {
-		DL_CDEBUG(rc == -DER_NOTLEADER, DLOG_INFO, DLOG_ERR, rc,
-			  DF_UUID ": recover containers", DP_UUID(svc->ps_uuid));
-		goto out_valid_list;
-	}
-
-	if (!reint || svc->ps_pool->sp_reint_mode == DAOS_REINT_MODE_DATA_SYNC) {
-		rc = pool_discard(ctx, svc, &valid_list, reint);
-		if (rc != 0)
-			DL_ERROR(rc, DF_UUID ": pool_discard failed", DP_UUID(svc->ps_uuid));
-	}
-
-out_valid_list:
 	pool_target_addr_list_free(&valid_list);
-out:
 	return rc;
 }
 
@@ -8250,19 +8214,18 @@ ds_pool_extend_handler(crt_rpc_t *rpc)
 	if (rc != 0)
 		goto out;
 
-	rc = pool_join_pre(rpc->cr_ctx, svc, opc_get(rpc->cr_opc), &tgt_addr_list);
-	if (rc != 0) {
-		if (rc == 1) /* already joined */
-			rc = 0;
-		goto out_svc;
+	rc = pool_discard(rpc->cr_ctx, svc, &tgt_addr_list, false);
+	if (rc) {
+		DL_ERROR(rc, DF_UUID ": pool_discard failed.", DP_UUID(in->pei_op.pi_uuid));
+		goto failed;
 	}
 
 	rc = pool_svc_update_map(svc, pool_opc_2map_opc(opc_get(rpc->cr_opc)),
 				 false /* exclude_rank */, &rank_list, domains, ndomains, NULL,
 				 NULL, &out->peo_op.po_map_version, &out->peo_op.po_hint, MUS_DMG,
-				 POOL_TGT_UPDATE_SKIP_RF_CHECK | POOL_RESET_RECOV_CONT);
+				 POOL_TGT_UPDATE_SKIP_RF_CHECK);
 
-out_svc:
+failed:
 	pool_svc_put_leader(svc);
 out:
 	if (tgt_addr_list.pta_addrs != NULL)
@@ -8290,9 +8253,6 @@ pool_recov_cont(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr
 	int                         rc;
 	int                         i;
 
-	D_ASSERTF(list->pta_number > 0, DF_UUID ": recover cont on %d targets\n",
-		  DP_UUID(svc->ps_uuid), list->pta_number);
-
 	rc = ds_pool_encode_opc(&opc);
 	if (rc != 0)
 		goto out;
@@ -8311,6 +8271,9 @@ pool_recov_cont(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr
 				list->pta_addrs[i].pta_rank);
 		}
 	}
+
+	if (unlikely(ranks->rl_nr == 0))
+		D_GOTO(out, rc = 0);
 
 	rc = rdb_tx_begin(svc->ps_rsvc.s_db, svc->ps_rsvc.s_term, &tx);
 	if (rc != 0)
@@ -8341,20 +8304,29 @@ pool_recov_cont(crt_context_t ctx, struct pool_svc *svc, struct pool_target_addr
 		rc = crt_bulk_create(ctx, &cont_sgl, CRT_BULK_RO, &bulk);
 		if (rc != 0)
 			goto out;
+
+		if (ranks->rl_nr > 1) {
+			rc = crt_bulk_bind(bulk, ctx);
+			if (rc != 0)
+				goto out;
+		}
 	}
 
-	rc = crt_corpc_req_create(ctx, NULL, ranks, opc, bulk /* co_bulk_hdl */, NULL,
-				  CRT_RPC_FLAG_FILTER_INVERT, crt_tree_topo(CRT_TREE_KNOMIAL, 4),
-				  &rpc);
+	rc = crt_corpc_req_create(ctx, NULL, ranks, opc, NULL, NULL, CRT_RPC_FLAG_FILTER_INVERT,
+				  crt_tree_topo(CRT_TREE_KNOMIAL, 32), &rpc);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
 	prci                       = crt_req_get(rpc);
 	prci->prci_cont_nr         = cont_nr;
+	prci->prci_cont_bulk       = bulk;
 	prci->prci_addrs.ca_count  = list->pta_number;
 	prci->prci_addrs.ca_arrays = list->pta_addrs;
 	uuid_copy(prci->prci_uuid, svc->ps_uuid);
-	prci->prci_flags = 0;
+	if (ranks->rl_nr > 1)
+		prci->prci_flags = PRCF_BIND_BULK;
+	else
+		prci->prci_flags = 0;
 
 	rc = dss_rpc_send(rpc);
 	if (rc != 0)
@@ -8404,13 +8376,14 @@ pool_update_handler(crt_rpc_t *rpc, int handler_version)
 		goto out;
 
 	if (opc_get(rpc->cr_opc) == POOL_REINT) {
-		rc = pool_join_pre(rpc->cr_ctx, svc, opc_get(rpc->cr_opc), &list);
-		if (rc != 0) {
-			if (rc == 1) /* already joined */
-				rc = 0;
-			goto out_svc;
+		if (svc->ps_pool->sp_reint_mode == DAOS_REINT_MODE_DATA_SYNC) {
+			rc = pool_discard(rpc->cr_ctx, svc, &list, true);
+		} else if (svc->ps_pool->sp_reint_mode == DAOS_REINT_MODE_INCREMENTAL) {
+			flags |= POOL_RESET_RECOV_CONT;
+			rc = pool_recov_cont(rpc->cr_ctx, svc, &list);
 		}
-		flags |= POOL_RESET_RECOV_CONT;
+		if (rc)
+			goto out_svc;
 	}
 
 	rc = pool_svc_update_map(svc, pool_opc_2map_opc(opc_get(rpc->cr_opc)),

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -2817,8 +2817,6 @@ ds_pool_tgt_discard_ult(void *data)
 		D_GOTO(free, rc = 0);
 	}
 
-	/* Serialize against container recovery (see ds_pool_recov_cont_handler). */
-	ABT_rwlock_rdlock(pool->sp_recov_lock);
 	/*
 	 * arg->tgt_list has already been validated and filtered by the pool service
 	 * leader against the authoritative pool map (see pool_discard() in srv_pool.c),
@@ -2828,7 +2826,6 @@ ds_pool_tgt_discard_ult(void *data)
 	 */
 	rc = ds_pool_thread_collective(arg->pool_uuid, 0 /* exclude_status */, pool_child_discard,
 				       arg, DSS_ULT_DEEP_STACK);
-	ABT_rwlock_unlock(pool->sp_recov_lock);
 
 	ABT_mutex_lock(pool->sp_mutex);
 	pool->sp_discard_status = rc;
@@ -3126,19 +3123,44 @@ out:
 	return rc;
 }
 
+struct recov_cont_bulk_args {
+	ABT_eventual rcba_eventual;
+	int          rcba_result;
+};
+
+static int
+recov_cont_bulk_cp(const struct crt_bulk_cb_info *cb_info)
+{
+	struct recov_cont_bulk_args *rcba = cb_info->bci_arg;
+	int                          rc;
+
+	rcba->rcba_result = cb_info->bci_rc;
+	rc                = ABT_eventual_set(rcba->rcba_eventual, NULL, 0);
+	D_ASSERTF(rc == ABT_SUCCESS, "Failed to ABT_eventual_set: %d\n", rc);
+
+	return 0;
+}
+
 void
 ds_pool_recov_cont_handler(crt_rpc_t *rpc)
 {
 	struct pool_recov_cont_in  *prci      = crt_req_get(rpc);
 	struct pool_recov_cont_out *prco      = crt_reply_get(rpc);
 	struct ds_pool             *pool      = NULL;
+	struct recov_cont_bulk_args rcba      = {0};
 	struct pool_recov_cont_args prca      = {0};
+	struct crt_bulk_desc        bulk_desc = {0};
+	crt_bulk_opid_t             bulk_opid = {0};
+	crt_bulk_t                  bulk      = CRT_BULK_NULL;
 	d_sg_list_t                 sgl;
-	d_iov_t                     cont_iov = {0};
+	d_iov_t                     cont_iov;
+	uint32_t                    ex_status = PO_COMP_ST_UP | PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN;
 	int                         rc;
 
 	D_DEBUG(DB_REBUILD, "Try to recover ( " DF_U64 ") containers for the pool " DF_UUID "\n",
 		prci->prci_cont_nr, DP_UUID(prci->prci_uuid));
+
+	rcba.rcba_eventual = ABT_EVENTUAL_NULL;
 
 	if (DAOS_FAIL_CHECK(DAOS_POOL_REINT_SLOW))
 		dss_sleep(6000);
@@ -3155,15 +3177,46 @@ ds_pool_recov_cont_handler(crt_rpc_t *rpc)
 	if (prci->prci_cont_nr == 0)
 		goto lock;
 
+	D_ALLOC_ARRAY(prca.prca_conts, prci->prci_cont_nr);
+	if (prca.prca_conts == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	cont_iov.iov_buf     = prca.prca_conts;
+	cont_iov.iov_buf_len = sizeof(*prca.prca_conts) * prci->prci_cont_nr;
+	cont_iov.iov_len     = cont_iov.iov_buf_len;
+
 	sgl.sg_nr     = 1;
 	sgl.sg_nr_out = 0;
 	sgl.sg_iovs   = &cont_iov;
 
-	rc = crt_bulk_access(rpc->cr_co_bulk_hdl, &sgl);
+	rc = crt_bulk_create(rpc->cr_ctx, &sgl, CRT_BULK_RW, &bulk);
 	if (rc != 0)
 		goto out;
 
-	prca.prca_conts = cont_iov.iov_buf;
+	rc = ABT_eventual_create(0, &rcba.rcba_eventual);
+	if (rc != 0)
+		D_GOTO(out, rc = dss_abterr2der(rc));
+
+	bulk_desc.bd_rpc        = rpc;
+	bulk_desc.bd_bulk_op    = CRT_BULK_GET;
+	bulk_desc.bd_remote_hdl = prci->prci_cont_bulk;
+	bulk_desc.bd_local_hdl  = bulk;
+	bulk_desc.bd_len        = cont_iov.iov_buf_len;
+
+	rcba.rcba_result = 0;
+	if (prci->prci_flags & PRCF_BIND_BULK)
+		rc = crt_bulk_bind_transfer(&bulk_desc, recov_cont_bulk_cp, &rcba, &bulk_opid);
+	else
+		rc = crt_bulk_transfer(&bulk_desc, recov_cont_bulk_cp, &rcba, &bulk_opid);
+	if (rc != 0)
+		goto out;
+
+	rc = ABT_eventual_wait(rcba.rcba_eventual, NULL);
+	if (rc != 0)
+		goto out;
+
+	if (rcba.rcba_result != 0)
+		D_GOTO(out, rc = rcba.rcba_result);
 
 lock:
 	/*
@@ -3175,8 +3228,7 @@ lock:
 	 * aware that easily. So here, holding sp_recov_lock to prevent such race.
 	 */
 	ABT_rwlock_wrlock(pool->sp_recov_lock);
-	rc = ds_pool_thread_collective(prci->prci_uuid, 0 /* ex_status */, pool_tgt_recov_cont,
-				       &prca, 0);
+	rc = ds_pool_thread_collective(prci->prci_uuid, ex_status, pool_tgt_recov_cont, &prca, 0);
 	ABT_rwlock_unlock(pool->sp_recov_lock);
 
 	if (rc == 0)
@@ -3192,4 +3244,9 @@ out:
 
 	if (pool != NULL)
 		ds_pool_put(pool);
+	if (rcba.rcba_eventual != ABT_EVENTUAL_NULL)
+		ABT_eventual_free(&rcba.rcba_eventual);
+	if (bulk != CRT_BULK_NULL)
+		crt_bulk_free(bulk);
+	D_FREE(prca.prca_conts);
 }

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
- * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
  * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -978,7 +978,7 @@ ilog_modify(daos_handle_t loh, const struct ilog_id *id_in, const daos_epoch_ran
 	}
 done:
 	rc = ilog_tx_end(lctx, rc);
-	DL_CDEBUG(rc == 0 || rc == -DER_NONEXIST, DB_TRACE, DLOG_ERR, rc,
+	DL_CDEBUG(rc == 0 || rc == -DER_NONEXIST, DLOG_DBG, DLOG_ERR, rc,
 		  "%s in incarnation log " DF_X64 " flags %x, tree_version: %d", opc_str[opc],
 		  id_in->id_epoch, flags, ilog_mag2ver(lctx->ic_root->lr_magic));
 


### PR DESCRIPTION
This reverts commit 50713084633967ebcfeb960f7d7263bd9695a7e6.

Test-tag: OSADmgNegativeTest
Quick-functional: true
Test-repeat: 3

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
