### PR TITLE
DAOS-19020 test: parallelize container/list.py

### DIFF
--- a/src/tests/ftest/container/list.py
+++ b/src/tests/ftest/container/list.py
@@ -4,6 +4,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
+import queue
+import threading
+
 from apricot import TestWithServers
 
 
@@ -20,6 +23,22 @@ class ListContainerTest(TestWithServers):
 
     :avocado: recursive
     """
+    def __container_create(self, pool, result_queue):
+        """
+        Create a container in the given pool and put the result in the result queue.
+
+        Args:
+            pool (TestPool): The pool in which to create the container.
+            result_queue (queue.Queue): Queue to store the result of the container creation.
+        """
+        try:
+            container = self.get_container(pool, create=False)
+            container.silent.value = True
+            result = container.create()
+            result_queue.put(
+                (result["response"]["container_uuid"], result["response"]["container_label"]))
+        except Exception as error:  # pylint: disable=broad-except
+            result_queue.put(error)
 
     def create_list(self, count, pool, expected_uuids_labels):
         """Create container and call daos pool list-cont to list and verify.
@@ -30,12 +49,24 @@ class ListContainerTest(TestWithServers):
             expected_uuids_labels (list): list of tuples containing expected (uuid, label) for
                 all containers in the pool
         """
-        # Create containers and store the container UUIDs and labels
+        result_queue = queue.Queue()
+
+        # Create containers in parallel and store the container UUIDs and labels
+        threads = []
         for _ in range(count):
-            container = self.get_container(pool, create=False)
-            result = container.create()
-            expected_uuids_labels.append(
-                (result["response"]["container_uuid"], result["response"]["container_label"]))
+            thread = threading.Thread(target=self.__container_create, args=(pool, result_queue))
+            thread.start()
+            threads.append(thread)
+
+        for thread in threads:
+            thread.join()
+
+        while not result_queue.empty():
+            result = result_queue.get()
+            if isinstance(result, Exception):
+                self.fail(f"Container creation failed with error: {result}")
+            expected_uuids_labels.append(result)
+
         expected_uuids_labels.sort()
 
         # Call container list and collect the UUIDs.

--- a/src/tests/ftest/container/list.yaml
+++ b/src/tests/ftest/container/list.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 1
   test_clients: 1
 
-timeout: 480
+timeout: 420
 
 server_config:
   name: daos_server


### PR DESCRIPTION
Parallelize the container creates in container/list.py to speedup the test and further stress the system.

Test-tag: test_list_containers
Test-repeat: 10
Quick-functional: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
