### PR TITLE
DAOS-19611 test: move server/dynamic_start_stop.py from HW Large to VM

### DIFF
--- a/src/tests/ftest/pool/rf.py
+++ b/src/tests/ftest/pool/rf.py
@@ -93,7 +93,7 @@ class PoolRedunFacProperty(IorTestBase):
         Jira ID: DAOS-9217, DAOS-17768
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large
+        :avocado: tags=vm
         :avocado: tags=pool,redundancy,redundancy_factor,rf
         :avocado: tags=PoolRedunFacProperty,test_rf_pool_property
         """

--- a/src/tests/ftest/pool/rf.py
+++ b/src/tests/ftest/pool/rf.py
@@ -93,7 +93,7 @@ class PoolRedunFacProperty(IorTestBase):
         Jira ID: DAOS-9217, DAOS-17768
 
         :avocado: tags=all,full_regression
-        :avocado: tags=vm
+        :avocado: tags=hw,large
         :avocado: tags=pool,redundancy,redundancy_factor,rf
         :avocado: tags=PoolRedunFacProperty,test_rf_pool_property
         """

--- a/src/tests/ftest/server/dynamic_start_stop.py
+++ b/src/tests/ftest/server/dynamic_start_stop.py
@@ -77,7 +77,7 @@ class DynamicStartStop(TestWithServers):
         5. Stop one of the original servers - Stopping with pool.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large
+        :avocado: tags=vm
         :avocado: tags=server
         :avocado: tags=DynamicStartStop,test_dynamic_server_addition
         """

--- a/src/tests/ftest/server/dynamic_start_stop.yaml
+++ b/src/tests/ftest/server/dynamic_start_stop.yaml
@@ -6,13 +6,16 @@ server_config:
   engines_per_host: 1
   engines:
     0:
+      targets: 4
+      nr_xs_helpers: 0
       storage:
         0:
           class: ram
           scm_mount: /mnt/daos
+  system_ram_reserved: 1
 extra_servers:
   test_servers: server-[3-5]
 pool:
-  scm_size: 1G
+  scm_size: 134217728
 dmg:
   json: true


### PR DESCRIPTION
### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
