### PR TITLE
DAOS-19540 build: FIX - disable RPMs verification by default

### DIFF
--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -124,6 +124,7 @@ RUN --mount=type=bind,source=requirements-build.txt,target=/tmp/daos/requirement
 
 # Install DAOS dependencies if available
 ARG DAOS_DEPS_INSTALL=yes
+ARG POINT_RELEASE
 RUN --mount=type=bind,source=ci/rpm/install_deps.sh,target=/tmp/daos/ci/rpm/install_deps.sh \
     --mount=type=bind,source=ci/parse_ci_envs.sh,target=/tmp/daos/ci/parse_ci_envs.sh \
     --mount=type=bind,source=utils/rpms/package_version.sh,target=/tmp/daos/utils/rpms/package_version.sh \

--- a/utils/rpms/build_packages.sh
+++ b/utils/rpms/build_packages.sh
@@ -9,14 +9,14 @@
 #
 # Args:
 #   build_type  What to build: deps|daos|all. Default: all
-#   verify      Run verify_rpms.sh after package build: yes|no. Default: yes
+#   verify      Run verify_rpms.sh after package build: yes|no. Default: no
 set -eEuo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 repo_root="$(cd "${script_dir}/../.." >/dev/null 2>&1 && pwd)"
 
 build_type="${1:-all}"
-verify_rpms="${2:-yes}"
+verify_rpms="${2:-no}"
 
 case "${verify_rpms}" in
   yes|no)


### PR DESCRIPTION
This PR eliminate regressions introduced by https://github.com/daos-stack/daos/pull/18915

## Problem

Build stages in Docker:

1. **`build_packages.sh` failed hard when dependency RPMs were already satisfied by
   pre-installed packages.**
   With `DAOS_DEPS_INSTALL=yes`, dependencies are installed from pre-built system
   packages rather than compiled from source, so the subsequent `deps` packaging step
   legitimately produces zero RPMs. `build_packages.sh` defaulted its `verify` parameter
   to `yes` and called `verify_rpms.sh` unconditionally, which hard-fails with
   `ERROR: no RPM files found under ...` in that scenario, aborting the Docker build.

   **RPM verification will be enabled in a separate PR**

2. **Wrong dependency package distro tag on Leap 15.**
   `install_deps.sh` was invoked with `suse.lp15${POINT_RELEASE#\.}`, but `POINT_RELEASE`
   was empty at that point in the build, so it resolved to the generic `suse.lp15`
   instead of the intended `suse.lp156`. This caused `package_version.sh` to resolve
   package name/version strings for the wrong distro tag (e.g.
   `libfabric-devel-1.22.0-5.suse.lp15` instead of the `...suse.lp156` package),
   even though `--build-arg POINT_RELEASE=.6` was correctly passed to `docker build`.

## Root cause

1. **`build_packages.sh` verify default**: the script's `verify_rpms` parameter
   defaulted to `"yes"`, causing an internal, non-optional call to `verify_rpms.sh`
   regardless of whether any RPMs were actually produced.

2. **Docker `ARG` scoping**: `POINT_RELEASE` was declared globally (before the first
   `FROM`) and re-declared later in the `build-ci` stage (in the "Build DAOS
   dependencies RPMs" section) — but *not* before the earlier "Install DAOS
   dependencies" `RUN` step. Docker resets `ARG` scope at every `FROM`, and a build
   arg must be re-declared in a stage before it can be referenced there, even if a
   global default already exists. Without it, the shell saw `POINT_RELEASE` as unset,
   so `${POINT_RELEASE#\.}` expanded to empty.

## Fix

- **`utils/rpms/build_packages.sh`**: change the default `verify` parameter from `yes`
  to `no`, matching the historical default and avoiding the hard failure when the
  `deps` build step produces no RPMs. Verification remains available by explicitly
  passing `verify_rpms.sh`'s `yes` argument where desired.

- **`utils/docker/Dockerfile.leap.15`**: add `ARG POINT_RELEASE` immediately before the
  "Install DAOS dependencies" `RUN` block, so the already-declared global/build-arg
  value is in scope where it's actually used.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
