### PR TITLE
DAOS-19560 test: replace assertTrue with specific assert calls

### DIFF
--- a/src/tests/ftest/server/cpu_usage.py
+++ b/src/tests/ftest/server/cpu_usage.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2020-2022 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -61,9 +61,9 @@ class CPUUsage(IorTestBase):
             usage (str): daos_engine CPU usage.
             usage_limit (int): Limit that we want daos_engine to use.
         """
-        self.assertTrue(usage != -1, "daos_engine CPU usage couldn't be obtained!")
-        self.assertTrue(
-            float(usage) < usage_limit, "CPU usage is above {}%: {}%".format(usage, usage_limit))
+        self.assertNotEqual(usage, -1, "daos_engine CPU usage couldn't be obtained!")
+        self.assertLess(
+            float(usage), usage_limit, "CPU usage is above {}%: {}%".format(usage, usage_limit))
 
     def test_cpu_usage(self):
         """JIRA ID: DAOS-4826.

--- a/src/tests/ftest/telemetry/pool_svc_metrics.py
+++ b/src/tests/ftest/telemetry/pool_svc_metrics.py
@@ -1,6 +1,6 @@
 '''
   (C) Copyright 2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -76,12 +76,12 @@ class PoolServiceMetrics(TestWithTelemetry):
 
         self.log_step("Collect pool service metrics prior to making changes.")
         initial_metrics = self.collect_svc_telemetry(pool.uuid)
-        self.assertTrue(MAP_VERSION_METRIC in initial_metrics,
-                        f"initial metrics don't contain {MAP_VERSION_METRIC} (no leader?)")
-        self.assertTrue(initial_metrics[MAP_VERSION_METRIC] == 1,
-                        "initial pool service map version is not 1")
-        self.assertTrue(initial_metrics[DEGRADED_RANKS_METRIC] == 0,
-                        "initial pool service degraded rank count is not 0")
+        self.assertIn(MAP_VERSION_METRIC, initial_metrics,
+                      f"initial metrics don't contain {MAP_VERSION_METRIC} (no leader?)")
+        self.assertEqual(initial_metrics[MAP_VERSION_METRIC], 1,
+                         "initial pool service map version is not 1")
+        self.assertEqual(initial_metrics[DEGRADED_RANKS_METRIC], 0,
+                         "initial pool service degraded rank count is not 0")
 
         restart_rank = initial_metrics[SVC_LEADER_METRIC]
         self.log_step(f"Stop pool service leader rank: {restart_rank}")
@@ -110,8 +110,8 @@ class PoolServiceMetrics(TestWithTelemetry):
         metrics = _wait_for_telemetry(lambda m: m[MAP_VERSION_METRIC] > 1)
 
         self.log_step("Verify that the pool service telemetry has updated.")
-        self.assertTrue(metrics[DEGRADED_RANKS_METRIC] == 1,
-                        "pool service degraded rank count should be 1")
+        self.assertEqual(metrics[DEGRADED_RANKS_METRIC], 1,
+                         "pool service degraded rank count should be 1")
 
         self.log_step("Restart the stopped rank.")
         self.server_managers[0].start_ranks(ranks=[restart_rank])

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -186,10 +186,14 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
         for name in expected_values:
             val = metrics[name]
             min_val, max_val = expected_values[name]
-            self.assertTrue(
-                min_val <= val <= max_val,
+            self.assertLessEqual(
+                min_val, val,
                 "Aggregated value of the metric {} for oclass {} is invalid: "
-                "got={}, wait_in=[{}, {}]".format(name, self.dfs_oclass, val, min_val, max_val))
+                "got={} > wait_in min{}".format(name, self.dfs_oclass, val, min_val))
+            self.assertLessEqual(
+                val, max_val,
+                "Aggregated value of the metric {} for oclass {} is invalid: "
+                "got={} > wait_in max{}".format(name, self.dfs_oclass, val, max_val))
             self.log.debug(
                 "Successfully check the metric %s for oclass %s: "
                 "got=%d, wait_in=[%d, %d]", name, self.dfs_oclass, val, min_val, max_val)


### PR DESCRIPTION
Replace the call to assertTrue with assertGreater, assertGreaterEqual, assertLess, asserLessEqual or other assert  where what we are checking is greater than, greater than or equal, less than or less than or equal to, respectively.

Also, add a message to the assert if one is missing.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
