### PR TITLE
DAOS-19476 test: Update ftest/nvme yaml files to use old default (#18…

### DIFF
--- a/src/tests/ftest/nvme/enospace.yaml
+++ b/src/tests/ftest/nvme/enospace.yaml
@@ -39,10 +39,12 @@ pool:
   usage_min_scm: 92
   # NVMe will not be 100% because data distribution is not fully uniform.
   usage_min_nvme: 96
+  properties: rd_fac:0,space_rb:0
 
 container:
   register_cleanup: False  # Skip teardown destroy. Test manually destroys containers.
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 ior:
   api: "DFS"

--- a/src/tests/ftest/nvme/fault.yaml
+++ b/src/tests/ftest/nvme/fault.yaml
@@ -19,9 +19,14 @@ dmg:
     allow_insecure: True
 pool:
   size: 96%
+  pool_query_timeout: 330
+  pool_query_delay: 20
+  properties: rd_fac:0,space_rb:0
+
 container:
   type: POSIX
-  properties: rd_fac:1
+  properties: rd_fac:1,cksum:off,srv_cksum:off
+
 ior:
   api: DFS
   client_processes:

--- a/src/tests/ftest/nvme/fragmentation.yaml
+++ b/src/tests/ftest/nvme/fragmentation.yaml
@@ -21,9 +21,11 @@ server_config:
 
 pool:
   size: 95%
+  properties: rd_fac:0,space_rb:0
 
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 ior:
   num_repeat: 30

--- a/src/tests/ftest/nvme/health.yaml
+++ b/src/tests/ftest/nvme/health.yaml
@@ -35,3 +35,4 @@ pool:
   max_num_pools: 40
   total_pool_percentage: 95
   min_nvme_per_target: 1073741824 # 1 GiB
+  properties: rd_fac:0,space_rb:0

--- a/src/tests/ftest/nvme/io.yaml
+++ b/src/tests/ftest/nvme/io.yaml
@@ -18,6 +18,7 @@ pool:
 
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 ior:
   flags: -w -r -k -vv

--- a/src/tests/ftest/nvme/io_verification.yaml
+++ b/src/tests/ftest/nvme/io_verification.yaml
@@ -22,20 +22,28 @@ server_config:
 pool:
   num_pools: 4
 
+pool_base: &pool_base
+  properties: rd_fac:0,space_rb:0
+
 pool_0:
+  <<: *pool_base
   size: 20%
 
 pool_1:
+  <<: *pool_base
   size: 30%
 
 pool_2:
+  <<: *pool_base
   size: 50%
 
 pool_3:
+  <<: *pool_base
   size: 60%
 
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 ior:
   client_processes:

--- a/src/tests/ftest/nvme/object.yaml
+++ b/src/tests/ftest/nvme/object.yaml
@@ -21,15 +21,21 @@ server_config:
       log_file: daos_server1.log
       storage: auto
 
+pool_base: &pool_base
+  properties: rd_fac:0,space_rb:0
+
 pool_1:
+  <<: *pool_base
   scm_size: 4GB
   nvme_size: 20G
 
 pool_2:
+  <<: *pool_base
   scm_size: 4GB
   nvme_size: 100GB
 
 pool_3:
+  <<: *pool_base
   scm_size: 4GB
   nvme_size: 350GB
 
@@ -44,3 +50,4 @@ container:
   dkey_size: 10
   data_size: 4096
   array_size: 1
+  properties: cksum:off,srv_cksum:off

--- a/src/tests/ftest/nvme/pool_capacity.yaml
+++ b/src/tests/ftest/nvme/pool_capacity.yaml
@@ -34,6 +34,7 @@ pool_qty_10:
 
 container:
   type: POSIX
+  properties: cksum:off,srv_cksum:off
 
 ior:
   no_parallel_job: 10

--- a/src/tests/ftest/nvme/pool_exclude.yaml
+++ b/src/tests/ftest/nvme/pool_exclude.yaml
@@ -4,8 +4,7 @@ hosts:
 
 # If we define the server under test_servers, launch.py will convert it to the
 # actual server name passed into --test_servers. If above test_servers is hosts,
-# it'll be used as one of the servers at test startup time, so use something
-# other than hosts.
+# it'll be used as one of the servers at test startup time, so use something other than hosts.
 timeout: 1000
 
 setup:
@@ -29,11 +28,12 @@ server_config:
       storage: auto
 
 pool:
-  scm_size: 50000000000
-  nvme_size: 300000000000
+  scm_size: 50G
+  nvme_size: 300G
   svcn: 4
   rebuild_timeout: 180
   pool_query_timeout: 30
+  properties: rd_fac:0,space_rb:0
 
 container:
   type: POSIX


### PR DESCRIPTION
…968)

Use old default property values for container as below. Pool - properties: cksum:off,srv_cksum:off
Container - properties: cksum:off,srv_cksum:off

Skip-fault-injection-test: true
Skip-func-hw-test-medium: false
Skip-func-hw-test-large: false
Test-tag: NvmeEnospace NvmeFault NvmeFragmentation NvmeHealth NvmeIoVerification NvmeIo NvmeObject NvmePoolCapacity NvmePoolExclude

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
