### PR TITLE
DAOS-19452 test: Update soak yaml files to use old default (#18939)

### DIFF
--- a/src/tests/ftest/soak/faults.yaml
+++ b/src/tests/ftest/soak/faults.yaml
@@ -5,14 +5,18 @@ hosts:
   # server_partition: daos_server
   client_partition: daos_client
   # client_reservation: daos-test
+
 orterun:
   allow_run_as_root: true
+
 # This timeout must be longer than the test_timeout param (+15minutes)
 # 1 hour test
 timeout: 24H15M
+
 setup:
   start_servers: true
   start_agents: true
+
 server_config:
   name: daos_server
   control_log_mask: INFO
@@ -35,19 +39,26 @@ server_config:
       env_vars:
         - FI_UNIVERSE_SIZE=16383
       storage: auto
+
 # pool_params - attributes of the pools to create; Currently only create one
 pool_jobs:
   size: 75%
+  properties: rd_fac:0,space_rb:0
+
 pool_reserved:
   size: 10%
+  properties: rd_fac:0,space_rb:0
+
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
+
 container_reserved:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
   file_oclass: EC_2P1GX
   dir_oclass: RP_2GX
+
 faults:
   fault_list:
     # - DAOS_DTX_LOST_RPC_REQUEST
@@ -82,6 +93,7 @@ soak_faults:
     test_soak_faults: 24
   joblist:
     - ior_faults
+
 # Commandline parameters
 # Benchmark and application params
 # IOR params -a DFS and -a MPIIO
@@ -118,11 +130,14 @@ ior_faults:
   dfuse:
     mount_dir: "/tmp/soak_dfuse_ior/"
     disable_caching: true
+
 hdf5_vol:
   plugin_path: "/usr/lib64/mpich/lib"
+
 events:
   - "mce: [Hardware Error]: Machine check events logged"
   - "Package temperature above threshold"
+
 monitor:
   - "/usr/bin/free -h"
   - "/usr/bin/vmstat -w"

--- a/src/tests/ftest/soak/harassers.yaml
+++ b/src/tests/ftest/soak/harassers.yaml
@@ -5,13 +5,17 @@ hosts:
   # server_partition: daos_server
   client_partition: daos_client
   # client_reservation: daos-test
+
 orterun:
   allow_run_as_root: true
+
 # This timeout must be longer than the test_timeout param (+15minutes)
 timeout: 24H30M
+
 setup:
   start_servers: true
   start_agents: true
+
 server_config:
   name: daos_server
   control_log_mask: INFO
@@ -37,25 +41,32 @@ server_config:
         - FI_UNIVERSE_SIZE=16383
         - DD_MASK=rebuild
       storage: auto
+
 # pool_params - attributes of the pools to create; Currently only create one
 pool_jobs:
   size: 90%
   rebuild_timeout: 600
   pool_query_timeout: 120
+  properties: rd_fac:0,space_rb:0
+
 pool_reserved:
   size: 5%
   rebuild_timeout: 600
   pool_query_timeout: 120
+  properties: rd_fac:0,space_rb:0
+
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
   daos_timeout: 30
+
 container_reserved:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:2
   file_oclass: EC_2P2GX
   dir_oclass: RP_3GX
   daos_timeout: 30
+
 # test_params - Defines the type of test to run and how long it runs
 #               It also defines how many pools and jobs to create
 #               name:                The name of the Avocado testcase
@@ -105,6 +116,7 @@ soak_harassers:
   enable_remote_logging: false
   enable_scrubber: false
   enable_rebuild_logmasks: false
+
 # Commandline parameters
 # Benchmark and application params
 # IOR params -a DFS and -a MPIIO
@@ -141,6 +153,7 @@ ior_harasser:
   dfuse:
     mount_dir: "/tmp/soak_dfuse_ior"
     disable_caching: true
+
 fio_harasser:
   api:
     - POSIX
@@ -173,6 +186,7 @@ fio_harasser:
   dfuse:
     mount_dir: "/tmp/soak_dfuse_fio/"
     disable_caching: true
+
 mdtest_harasser:
   # maximum timeout for a single job in test in minutes
   job_timeout: 30
@@ -205,13 +219,17 @@ mdtest_harasser:
   dfuse:
     mount_dir: "/tmp/soak_dfuse_mdtest/"
     disable_caching: true
+
 hdf5_vol:
   plugin_path: "/usr/lib64/mpich/lib"
+
 events:
   - "mce: [Hardware Error]: Machine check events logged"
   - "Package temperature above threshold"
+
 monitor:
   - "/usr/bin/free -h"
   - "/usr/bin/vmstat -w"
   - "ps -C daos_engine -o %mem,%cpu,cmd"
+
 enable_telemetry: true

--- a/src/tests/ftest/soak/smoke.yaml
+++ b/src/tests/ftest/soak/smoke.yaml
@@ -5,16 +5,21 @@ hosts:
   # server_partition: daos_server
   client_partition: daos_client
   # client_reservation: daos-test
+
 orterun:
   allow_run_as_root: true
+
 mpi_module: mpi/mpich-x86_64
+
 enable_sudo: true
+
 # This timeout must be longer than the test_timeout param (+15minutes)
 # 24 Min test
 timeout: 30M
 setup:
   start_servers: true
   start_agents: true
+
 server_config:
   name: daos_server
   control_log_mask: INFO
@@ -37,21 +42,30 @@ server_config:
       env_vars:
         - FI_UNIVERSE_SIZE=2048
       storage: auto
+
 # pool_params - attributes of the pools to create; Currently only create one
 pool_jobs:
   size: 90%
+  properties: rd_fac:0,space_rb:0
+
 pool_reserved:
   size: 5%
+  properties: rd_fac:0,space_rb:0
+
 pool_racer:
   size: 5%
+  properties: rd_fac:0,space_rb:0
+
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
+
 container_reserved:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
   file_oclass: EC_2P1GX
   dir_oclass: RP_2GX
+
 # test_params - Defines the type of test to run and how long it runs
 #               It also defines how many pools and jobs to create
 #               name:                The name of the Avocado testcase
@@ -84,6 +98,7 @@ smoke:
   enable_intercept_lib: true
   enable_remote_logging: false
   enable_scrubber: true
+
 # Commandline parameters
 # Benchmark and application params
 # IOR params -a DFS and -a MPIIO
@@ -121,6 +136,7 @@ ior_smoke:
     disable_caching: true
     thread_count: 8
     cores: '0-7'
+
 fio_smoke:
   api:
     - POSIX
@@ -156,8 +172,10 @@ fio_smoke:
     disable_caching: true
     thread_count: 8
     cores: '0-7'
+
 daos_racer:
   runtime: 120
+
 vpic_smoke:
   job_timeout: 10
   nodesperjob:
@@ -177,6 +195,7 @@ vpic_smoke:
     cores: '0-7'
   oclass:
     - ["EC_2P1GX", "RP_2GX"]
+
 lammps_smoke:
   job_timeout: 10
   nodesperjob:
@@ -196,6 +215,7 @@ lammps_smoke:
     cores: '0-7'
   oclass:
     - ["EC_2P1GX", "RP_2GX"]
+
 mdtest_smoke:
   # maximum timeout for a single job in test in minutes
   job_timeout: 10
@@ -227,6 +247,7 @@ mdtest_smoke:
     disable_caching: true
     thread_count: 8
     cores: '0-7'
+
 macsio_smoke:
   job_timeout: 10
   nodesperjob:
@@ -251,6 +272,7 @@ macsio_smoke:
     disable_caching: true
     thread_count: 8
     cores: '0-7'
+
 datamover_smoke:
   job_timeout: 10
   nodesperjob:
@@ -284,13 +306,17 @@ datamover_smoke:
       - 4G
     test_file: "daos:/testFile"
     dfs_destroy: false
+
 hdf5_vol:
   plugin_path: "/usr/lib64/mpich/lib"
+
 events:
   - "mce: [Hardware Error]: Machine check events logged"
   - "Package temperature above threshold"
+
 monitor:
   - "/usr/bin/free -h"
   - "/usr/bin/vmstat -w"
   - "ps -C daos_engine -o %mem,%cpu,cmd"
+
 enable_telemetry: true

--- a/src/tests/ftest/soak/stress.yaml
+++ b/src/tests/ftest/soak/stress.yaml
@@ -5,8 +5,10 @@ hosts:
   # server_partition: daos_server
   client_partition: daos_client
   # client_reservation: daos-test
+
 orterun:
   allow_run_as_root: true
+
 # This timeout must be longer than the test_timeout param (+15minutes)
 # 48 hour test
 timeouts:
@@ -14,9 +16,11 @@ timeouts:
   test_soak_stress_48h: 48H30M
   test_soak_stress_24h: 24H30M
   test_soak_stress_12h: 12H30M
+
 setup:
   start_servers: true
   start_agents: true
+
 server_config:
   name: daos_server
   control_log_mask: INFO
@@ -42,21 +46,30 @@ server_config:
         - FI_UNIVERSE_SIZE=16383
         - DAOS_MD_CAP=1024
       storage: auto
+
 # pool_params - attributes of the pools to create; Currently only create one
 pool_jobs:
   size: 90%
+  properties: rd_fac:0,space_rb:0
+
 pool_reserved:
   size: 5%
+  properties: rd_fac:0,space_rb:0
+
 pool_racer:
   size: 5%
+  properties: rd_fac:0,space_rb:0
+
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
+
 container_reserved:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
   file_oclass: EC_2P1GX
   dir_oclass: RP_2GX
+
 # test_params - Defines the type of test to run and how long it runs
 #               It also defines how many pools and jobs to create
 #               name:                The name of the Avocado testcase
@@ -90,6 +103,7 @@ soak_stress:
   enable_intercept_lib: true
   enable_remote_logging: false
   enable_scrubber: true
+
 # Commandline parameters
 # Benchmark and application params
 # IOR params -a DFS and -a MPIIO
@@ -177,8 +191,10 @@ fio_stress:
     disable_caching: true
     thread_count: 8
     cores: '0-7'
+
 daos_racer:
   runtime: 120
+
 vpic_stress:
   # Requires opeapi
   job_timeout: 20
@@ -197,6 +213,7 @@ vpic_stress:
     disable_caching: true
   oclass:
     - ["EC_2P1GX", "RP_2GX"]
+
 lammps_stress:
   job_timeout: 55
   nodesperjob:
@@ -216,6 +233,7 @@ lammps_stress:
     cores: '0-7'
   oclass:
     - ["EC_2P1GX", "RP_2GX"]
+
 mdtest_stress:
   # maximum timeout for a single job in test in minutes
   job_timeout: 40
@@ -255,6 +273,7 @@ mdtest_stress:
     disable_caching: true
     thread_count: 8
     cores: '0-7'
+
 macsio_stress:
   job_timeout: 30
   nodesperjob:
@@ -286,6 +305,7 @@ macsio_stress:
     disable_caching: true
     thread_count: 8
     cores: '0-7'
+
 datamover_stress:
   job_timeout: 10
   nodesperjob:
@@ -324,13 +344,17 @@ datamover_stress:
       - 4G
     test_file: "daos:/testFile"
     dfs_destroy: false
+
 hdf5_vol:
   plugin_path: "/usr/lib64/mpich/lib"
+
 events:
   - "mce: [Hardware Error]: Machine check events logged"
   - "Package temperature above threshold"
+
 monitor:
   - "/usr/bin/free -h"
   - "/usr/bin/vmstat -w"
   - "ps -C daos_engine -o %mem,%cpu,cmd"
+
 enable_telemetry: true

--- a/src/tests/ftest/soak/stress_2h.yaml
+++ b/src/tests/ftest/soak/stress_2h.yaml
@@ -5,13 +5,17 @@ hosts:
   # server_partition: daos_server
   client_partition: normal
   client_reservation: daos-test
+
 mpi_module: mpich/gnu-tcp
+
 # This timeout must be longer than the test_timeout param (+15minutes)
 # 2 hour test
 timeout: 2H15M
+
 setup:
   start_servers: false
   start_agents: false
+
 server_config:
   name: daos_server
   control_log_mask: INFO
@@ -24,26 +28,35 @@ server_config:
       storage: auto
   transport_config:
     allow_insecure: true
+
 agent_config:
   transport_config:
     allow_insecure: true
+
 dmg:
   transport_config:
     allow_insecure: true
+
 # pool_params - attributes of the pools to create; Currently only create one
 pool_jobs:
   size: 75%
+  properties: rd_fac:0,space_rb:0
+
 pool_reserved:
   size: 10%
+  properties: rd_fac:0,space_rb:0
+
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
+
 container_reserved:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on,rd_fac:1
   file_oclass: SX
   dir_oclass: SX
   daos_timeout: 30
+
 # test_params - Defines the type of test to run and how long it runs
 #               It also defines how many pools and jobs to create
 #               name:                The name of the Avocado testcase
@@ -66,6 +79,7 @@ soak_stress:
     - mdtest_stress
     - vpic_stress
     - lammps_stress
+
 # Commandline parameters
 # Benchmark and application params
 # IOR params -a DFS and -a MPIIO
@@ -97,6 +111,7 @@ ior_stress:
   dfuse:
     mount_dir: "/tmp/soak_dfuse_ior/"
     disable_caching: true
+
 mdtest_stress:
   # maximum timeout for a single job in test in minutes
   job_timeout: 10
@@ -124,6 +139,7 @@ mdtest_stress:
   dfuse:
     mount_dir: "/tmp/soak_dfuse_mdtest/"
     disable_caching: true
+
 vpic_stress:
   job_timeout: 20
   nodesperjob:
@@ -138,6 +154,7 @@ vpic_stress:
     disable_caching: true
   oclass:
     - ["SX","SX"]
+
 lammps_stress:
   job_timeout: 30
   nodesperjob:


### PR DESCRIPTION
Use old default property values for pool.
properties: rd_fac:0,space_rb:0

Skip-fault-injection-test: true
Skip-func-hw-test-large: false
Test-tag: test_soak_smoke

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
