### PR TITLE
DAOS-19620 object: unlock cob_lock on single-replica EIO

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -744,7 +744,7 @@ obj_replica_leader_select(struct dc_object *obj, unsigned int grp_idx, uint64_t 
 		if (shard->po_target == -1) {
 			D_ERROR(DF_OID" grp_size 1, obj_get_shard failed\n",
 				DP_OID(obj->cob_md.omd_id));
-			return -DER_IO;
+			D_GOTO(unlock, rc = -DER_IO);
 		}
 
 		/*


### PR DESCRIPTION
obj_replica_leader_select() doesn't release cob_lock in the grp_size == 1 branch, skipping the unlock label that every other exit uses. The next write lock on that object then blocks forever.

Return through the unlock label instead, with D_GOTO(unlock, rc = -DER_IO).

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
