### PR TITLE
DAOS-19622 test: fix FaultInjection.stop()

### DIFF
--- a/src/tests/ftest/util/fault_config_utils.py
+++ b/src/tests/ftest/util/fault_config_utils.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2019-2024 Intel Corporation.
+  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -331,4 +332,9 @@ class FaultInjection():
             result = run_local(log, command)
         if not result.passed:
             error_list.append(f"Error removing fault injection file {self.fault_file}")
+
+        # Unset the local and environment reference since the file is gone
+        self.fault_file = None
+        del os.environ["D_FI_CONFIG"]
+
         return error_list


### PR DESCRIPTION
Fix FaultInjection.stop() to unset the env and local reference after the file is removed.

Test-tag: Snapshot BasicTxTest EcodFaultInjection PoolServicesFaultInjection TestScrubberEvictWithAggregation TestWithScrubberFault TestScrubberEvictWithRebuild TestScrubberEvictWithSnapshot TestWithScrubberTargetEviction
Quick-functional: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
