### PR TITLE
DAOS-19340 test: set FI log level to warn for rebuild tests

### DIFF
--- a/src/tests/ftest/daos_test/rebuild.yaml
+++ b/src/tests/ftest/daos_test/rebuild.yaml
@@ -31,6 +31,8 @@ server_config:
         - DD_MASK=group_metadata_only,io,epc,rebuild
         - D_LOG_FILE_APPEND_PID=1
         - D_LOG_FILE_APPEND_RANK=1
+        - FI_LOG_LEVEL=warn
+        - D_LOG_STDERR_IN_LOG=1
       storage: auto
     1:
       pinned_numa_node: 1
@@ -41,6 +43,8 @@ server_config:
         - DD_MASK=group_metadata_only,io,epc,rebuild
         - D_LOG_FILE_APPEND_PID=1
         - D_LOG_FILE_APPEND_RANK=1
+        - FI_LOG_LEVEL=warn
+        - D_LOG_STDERR_IN_LOG=1
       storage: auto
   transport_config:
     allow_insecure: false

--- a/src/tests/ftest/daos_test/rebuild.yaml
+++ b/src/tests/ftest/daos_test/rebuild.yaml
@@ -32,7 +32,8 @@ server_config:
         - D_LOG_FILE_APPEND_PID=1
         - D_LOG_FILE_APPEND_RANK=1
         - FI_LOG_LEVEL=warn
-        - D_LOG_STDERR_IN_LOG=1
+        - HG_LOG_LEVEL=warn
+        - HG_LOG_SUBSYS=hg,na,libfabric
       storage: auto
     1:
       pinned_numa_node: 1
@@ -44,7 +45,8 @@ server_config:
         - D_LOG_FILE_APPEND_PID=1
         - D_LOG_FILE_APPEND_RANK=1
         - FI_LOG_LEVEL=warn
-        - D_LOG_STDERR_IN_LOG=1
+        - HG_LOG_LEVEL=warn
+        - HG_LOG_SUBSYS=hg,na,libfabric
       storage: auto
   transport_config:
     allow_insecure: false

--- a/src/tests/ftest/daos_test/rebuild.yaml
+++ b/src/tests/ftest/daos_test/rebuild.yaml
@@ -31,6 +31,7 @@ server_config:
         - DD_MASK=group_metadata_only,io,epc,rebuild
         - D_LOG_FILE_APPEND_PID=1
         - D_LOG_FILE_APPEND_RANK=1
+        - D_LOG_STDERR_IN_LOG=1
         - FI_LOG_LEVEL=warn
         - HG_LOG_LEVEL=warn
         - HG_LOG_SUBSYS=hg,na,libfabric
@@ -44,6 +45,7 @@ server_config:
         - DD_MASK=group_metadata_only,io,epc,rebuild
         - D_LOG_FILE_APPEND_PID=1
         - D_LOG_FILE_APPEND_RANK=1
+        - D_LOG_STDERR_IN_LOG=1
         - FI_LOG_LEVEL=warn
         - HG_LOG_LEVEL=warn
         - HG_LOG_SUBSYS=hg,na,libfabric


### PR DESCRIPTION
For the daos_test rebuild tests, set engine environment variables
needed to capture warnings in logfiles for connection disruptions
(e.g., when engines stopped, restarted, and reintegrated). The goal is
especially to log when there are *unusual* connectivity disruptions
(e.g., after an engine restart, specific engine endpoint pairs unable
to communicate, often involving a common engine's single CaRT context).

Test-tag: daos_core_test_rebuild
Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-test-rpms: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
