### PR TITLE
DAOS-19548 rebuild: some rebuild fixes. (#18938)

### DIFF
--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -57,8 +57,7 @@ struct rebuild_tgt_pool_tracker {
 	/* number of obj records in rebuilt tree */
 	unsigned int		rt_rebuilt_obj_cnt;
 	d_rank_list_t		*rt_svc_list;
-	d_rank_t		rt_rank;
-	int			rt_errno;
+	d_rank_t                 rt_rank;
 	int			rt_refcount;
 	uint32_t		rt_tgts_num;
 	uint64_t		rt_leader_term;

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -200,8 +200,8 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	dst_iv->riv_stable_epoch = src_iv->riv_stable_epoch;
 	dst_iv->riv_global_dtx_resyc_version = src_iv->riv_global_dtx_resyc_version;
 
-	if (dst_iv->riv_global_done || dst_iv->riv_global_scan_done ||
-	    dst_iv->riv_stable_epoch || dst_iv->riv_dtx_resyc_version) {
+	if (dst_iv->riv_global_done || dst_iv->riv_global_scan_done || dst_iv->riv_stable_epoch ||
+	    dst_iv->riv_global_dtx_resyc_version) {
 		D_DEBUG(DB_REBUILD, DF_UUID"/%u/%u/"DF_U64" gsd/gd/stable/ver %d/%d/"DF_X64"/%u\n",
 			DP_UUID(src_iv->riv_pool_uuid), src_iv->riv_ver,
 			src_iv->riv_rebuild_gen, src_iv->riv_leader_term,

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -614,29 +614,52 @@ struct rebuild_obj_arg {
 };
 
 static void
+rebuild_obj_record_failure(struct rebuild_tgt_pool_tracker *rpt, int rc)
+{
+	struct rebuild_pool_tls *tls;
+
+	if (rc == 0 || rc == -DER_SHUTDOWN)
+		return;
+
+	/*
+	 * -DER_SHUTDOWN is the normal teardown status of the migrate TLS (mpt_fini), it does not
+	 * mean the rebuild failed. Report real errors through rebuild_pool_status, which
+	 * rebuild_tgt_query() aggregates into riv_status for the leader, so the rebuild is failed
+	 * and retried instead of being reported as complete. The caller may set rt_abort only
+	 * after this helper returns true; otherwise the target could report scan_done/pull_done
+	 * through the local abort path before the failure is visible in riv_status.
+	 */
+	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
+	D_ASSERT(tls != NULL);
+	if (tls->rebuild_pool_status == 0)
+		tls->rebuild_pool_status = rc;
+}
+
+static void
 rebuild_obj_ult(void *data)
 {
 	struct rebuild_obj_arg		*arg = data;
 	struct rebuild_tgt_pool_tracker	*rpt = arg->rpt;
+	int                              rc;
 
 	if (rpt->rt_stable_epoch == 0) {
-		int rc;
-
 		rc = rpt_wait_rebuild_epoch(rpt);
 		if (rc != 0) {
 			DL_ERROR(rc, DF_RB " rpt_wait_rebuild_epoch failed, abort the rebuild",
 				 DP_RB_RPT(rpt));
-			if (rpt->rt_errno == 0)
-				rpt->rt_errno = rc;
-			rpt->rt_abort = 1;
+			rebuild_obj_record_failure(rpt, rc);
+			goto out;
 		}
-		goto out;
 	}
 
-	ds_migrate_object(rpt->rt_pool_uuid, rpt->rt_poh_uuid, rpt->rt_coh_uuid, arg->co_uuid,
-			  rpt->rt_rebuild_ver, rpt->rt_rebuild_gen, rpt->rt_stable_epoch,
-			  rpt->rt_rebuild_op, &arg->oid, &arg->epoch, &arg->punched_epoch,
-			  &arg->shard, 1, arg->tgt_index, rpt->rt_new_layout_ver);
+	rc = ds_migrate_object(rpt->rt_pool_uuid, rpt->rt_poh_uuid, rpt->rt_coh_uuid, arg->co_uuid,
+			       rpt->rt_rebuild_ver, rpt->rt_rebuild_gen, rpt->rt_stable_epoch,
+			       rpt->rt_rebuild_op, &arg->oid, &arg->epoch, &arg->punched_epoch,
+			       &arg->shard, 1, arg->tgt_index, rpt->rt_new_layout_ver);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_RB " ds_migrate_object failed", DP_RB_RPT(rpt));
+		rebuild_obj_record_failure(rpt, rc);
+	}
 out:
 	rpt_put(rpt);
 	D_FREE(arg);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1337,9 +1337,9 @@ rebuild_task_get_min_version(struct pool_map *map, struct pool_target_id_list *t
  * Other return value indicates an error.
  */
 static int
-rebuild_try_merge_tgts(struct ds_pool *pool, uint32_t map_ver,
-		       daos_rebuild_opc_t rebuild_op,
-		       struct pool_target_id_list *tgts, uint64_t delay_sec)
+rebuild_try_merge_tgts(struct ds_pool *pool, uint32_t map_ver, daos_rebuild_opc_t rebuild_op,
+		       daos_epoch_t reclaim_eph, struct pool_target_id_list *tgts,
+		       uint64_t delay_sec)
 {
 	struct rebuild_task *task;
 	struct rebuild_task *merge_pre_task = NULL;
@@ -1416,6 +1416,7 @@ rebuild_try_merge_tgts(struct ds_pool *pool, uint32_t map_ver,
 
 	merge_task->dst_schedule_time = max(merge_task->dst_schedule_time,
 					    daos_gettime_coarse() + delay_sec);
+	merge_task->dst_reclaim_eph   = max(merge_task->dst_reclaim_eph, reclaim_eph);
 	merge_task->dst_reclaim_ver = rebuild_task_get_min_version(pool->sp_map, tgts);
 	D_PRINT("%s [%s] ("DF_UUID" ver=%u/%u) id %u\n",
 		RB_OP_STR(rebuild_op), merge_task->dst_schedule_time == -1 ?
@@ -2118,7 +2119,8 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 	if (tgts != NULL && tgts->pti_number > 0 &&
 	    rebuild_op != RB_OP_RECLAIM && rebuild_op != RB_OP_FAIL_RECLAIM) {
 		/* Check if the pool already in the queue list */
-		rc = rebuild_try_merge_tgts(pool, map_ver, rebuild_op, tgts, delay_sec);
+		rc =
+		    rebuild_try_merge_tgts(pool, map_ver, rebuild_op, reclaim_eph, tgts, delay_sec);
 		if (rc)
 			return rc == 1 ? 0 : rc;
 	}
@@ -2433,8 +2435,6 @@ rebuild_tgt_status_check_ult(void *arg)
 				DP_RC(rc == 0 ? status.status : rc));
 			if (status.status == 0)
 				status.status = rc;
-			if (rpt->rt_errno == 0)
-				rpt->rt_errno = status.status;
 		}
 
 		memset(&iv, 0, sizeof(iv));


### PR DESCRIPTION
The rebuild leader publishes the global DTX resync version through riv_global_dtx_resyc_version. The target refresh path copied that field but used riv_dtx_resyc_version to decide whether the refresh carried any DTX progress.

When a local rebuild task starts before the stable epoch is available, it waits for the epoch but then exits without migrating the object. This can silently skip local migration. Continue with ds_migrate_object() after the wait succeeds, and propagate migration failures to the rebuild tracker.

When a queued rebuild task is merged with another rebuild request, refresh the task reclaim epoch as well. Otherwise the merged task can keep an older reclaim epoch and later schedule cleanup with an insufficient boundary.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
