### PR TITLE
DAOS-19565 dlck: null-terminated string fix

### DIFF
--- a/src/utils/dlck/dlck_report.c
+++ b/src/utils/dlck/dlck_report.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -28,7 +28,7 @@ get_separator()
 	static bool initialized                       = false;
 
 	if (unlikely(!initialized)) {
-		memset(separator, '=', DLCK_PROGRESS_LINE_LEN);
+		memset(separator, '=', DLCK_PROGRESS_LINE_LEN - 1);
 		initialized = true;
 	}
 


### PR DESCRIPTION
Found with ASAN. It does not fix the issue on the ticket.

Skip-func-vm: true
Skip-fault-injection-test: true
Skip-test-el-9.6-rpms: true
Skip-test-leap-15-rpms: true
Skip-func-hw-test: true

### Steps for the author:

* [x] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [x] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [x] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [x] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [x] Gatekeeper requested (daos-gatekeeper added as a reviewer).
