### PR TITLE
DAOS-16485 test: Start daos_server with --auto-format

### DIFF
--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -665,16 +665,12 @@ class DaosServerManager(SubprocessManager):
         # Start the servers and wait for them to be ready for storage format
         self.detect_format_ready()
 
+        # Wait for all the engines to start
+        self.detect_engine_start()
+
         # Collect storage and network information from the servers.
         self.information.collect_storage_information()
         self.information.collect_network_information()
-
-        # Format storage and wait for server to change ownership
-        self.log.info("<SERVER> Formatting hosts: <%s>", self.dmg.hostlist)
-        self.storage_format()
-
-        # Wait for all the engines to start
-        self.detect_engine_start()
 
         return True
 

--- a/src/tests/ftest/util/systemctl_utils.py
+++ b/src/tests/ftest/util/systemctl_utils.py
@@ -1,6 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
-  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+  (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -203,7 +203,7 @@ def create_override_config(logger, hosts, service, user, service_command, servic
     override_contents = [
         "[Service]",
         "ExecStart=",
-        f"ExecStart={service_command} start -o {service_config}"
+        f"ExecStart={service_command} start -o {service_config} --auto-format"
     ]
     if path:
         override_contents.append(f'Environment="PATH={path}"')


### PR DESCRIPTION
Siimplify functionaal test server startup with --auto-format.

Quick-functional: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
