### PR TITLE
DAOS-19630 dfs: do not follow a symlink with an absolute value

### DIFF
--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -428,4 +428,7 @@ update_stbuf_times(struct dfs_entry entry, daos_epoch_t max_epoch, struct stat *
 int
 lookup_rel_path(dfs_t *dfs, dfs_obj_t *root, const char *path, int flags, dfs_obj_t **_obj,
 		mode_t *mode, struct stat *stbuf, size_t depth);
+int
+follow_symlink(dfs_t *dfs, dfs_obj_t *parent, const char *value, int flags, dfs_obj_t **_obj,
+	       mode_t *mode, struct stat *stbuf, size_t depth);
 #endif /* __DFS_INTERNAL_H__ */

--- a/src/client/dfs/lookup.c
+++ b/src/client/dfs/lookup.c
@@ -14,6 +14,22 @@
 
 #include "dfs_internal.h"
 
+/* A symlink value is resolved from the directory holding the link. dfs has no notion of the
+ * process root that POSIX resolves an absolute value from, so such a value is rejected wherever
+ * the link sits and left to a caller that can resolve it, as dfuse and pil4dfs do with the kernel.
+ */
+int
+follow_symlink(dfs_t *dfs, dfs_obj_t *parent, const char *value, int flags, dfs_obj_t **_obj,
+	       mode_t *mode, struct stat *stbuf, size_t depth)
+{
+	if (value[0] == '/') {
+		D_DEBUG(DB_TRACE, "Cannot follow absolute symlink value %s\n", value);
+		return EINVAL;
+	}
+
+	return lookup_rel_path(dfs, parent, value, flags, _obj, mode, stbuf, depth);
+}
+
 int
 lookup_rel_path(dfs_t *dfs, dfs_obj_t *root, const char *path, int flags, dfs_obj_t **_obj,
 		mode_t *mode, struct stat *stbuf, size_t depth)
@@ -196,8 +212,8 @@ lookup_rel_path_loop:
 					D_GOTO(err_obj, rc = ENOTSUP);
 				}
 
-				rc = lookup_rel_path(dfs, &parent, entry.value, flags, &sym, NULL,
-						     NULL, depth + 1);
+				rc = follow_symlink(dfs, &parent, entry.value, flags, &sym, NULL,
+						    NULL, depth + 1);
 				if (rc) {
 					D_DEBUG(DB_TRACE, "Failed to lookup symlink %s\n",
 						entry.value);
@@ -230,8 +246,8 @@ lookup_rel_path_loop:
 					D_GOTO(err_obj, rc = ENOTSUP);
 				}
 
-				rc = lookup_rel_path(dfs, &parent, entry.value, flags, &sym, mode,
-						     stbuf, depth + 1);
+				rc = follow_symlink(dfs, &parent, entry.value, flags, &sym, mode,
+						    stbuf, depth + 1);
 				if (rc) {
 					D_DEBUG(DB_TRACE, "Failed to lookup symlink %s\n",
 						entry.value);
@@ -508,7 +524,7 @@ lookup_rel_int(dfs_t *dfs, dfs_obj_t *parent, const char *name, int flags, dfs_o
 			if (entry.value == NULL)
 				D_GOTO(err_obj, rc = EIO);
 			/* dereference the symlink */
-			rc = lookup_rel_path(dfs, parent, entry.value, flags, &sym, mode, stbuf, 0);
+			rc = follow_symlink(dfs, parent, entry.value, flags, &sym, mode, stbuf, 0);
 			if (rc) {
 				D_DEBUG(DB_TRACE, "Failed to lookup symlink %s\n", entry.value);
 				D_FREE(entry.value);

--- a/src/client/dfs/obj.c
+++ b/src/client/dfs/obj.c
@@ -1148,7 +1148,7 @@ dfs_access(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask)
 
 	D_ASSERT(entry.value);
 
-	rc = lookup_rel_path(dfs, parent, entry.value, O_RDONLY, &sym, NULL, NULL, 0);
+	rc = follow_symlink(dfs, parent, entry.value, O_RDONLY, &sym, NULL, NULL, 0);
 	if (rc) {
 		D_DEBUG(DB_TRACE, "Failed to lookup symlink %s\n", entry.value);
 		D_GOTO(out, rc);
@@ -1223,7 +1223,7 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode)
 	if (S_ISLNK(entry.mode)) {
 		D_ASSERT(entry.value);
 
-		rc = lookup_rel_path(dfs, parent, entry.value, O_RDWR, &sym, NULL, NULL, 0);
+		rc = follow_symlink(dfs, parent, entry.value, O_RDWR, &sym, NULL, NULL, 0);
 		if (rc) {
 			D_ERROR("Failed to lookup symlink %s\n", entry.value);
 			D_FREE(entry.value);
@@ -1351,7 +1351,7 @@ dfs_chown(dfs_t *dfs, dfs_obj_t *parent, const char *name, uid_t uid, gid_t gid,
 	/** resolve symlink */
 	if (!(flags & O_NOFOLLOW) && S_ISLNK(entry.mode)) {
 		D_ASSERT(entry.value);
-		rc = lookup_rel_path(dfs, parent, entry.value, O_RDWR, &sym, NULL, NULL, 0);
+		rc = follow_symlink(dfs, parent, entry.value, O_RDWR, &sym, NULL, NULL, 0);
 		if (rc) {
 			D_DEBUG(DB_TRACE, "Failed to lookup symlink '%s': %d (%s)\n", entry.value,
 				rc, strerror(rc));

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -465,6 +465,11 @@ dfs_obj2id(dfs_obj_t *obj, daos_obj_id_t *oid);
  * Lookup a path in the DFS and return the associated open object and mode.
  * The object must be released with dfs_release().
  *
+ * Symlinks along the path, and the last one unless O_NOFOLLOW is passed, are
+ * followed within the container. DFS has no notion of the process root, so a
+ * symlink with an absolute value cannot be followed and the lookup fails with
+ * EINVAL; the caller has to resolve such a value itself.
+ *
  * \param[in]	dfs	Pointer to the mounted file system.
  * \param[in]	path	Path to lookup.
  * \param[in]	flags	Access flags to open with (O_RDONLY or O_RDWR).
@@ -480,9 +485,11 @@ dfs_lookup(dfs_t *dfs, const char *path, int flags, dfs_obj_t **obj,
 
 /**
  * Lookup an entry in the parent object and return the associated open object
- * and mode of that entry.  If the entry is a symlink, the symlink value is not
- * resolved and the user can decide what to do to further resolve the value of
- * the symlink. The object must be released with dfs_release().
+ * and mode of that entry.  If the entry is a symlink, it is followed unless
+ * O_NOFOLLOW is passed, in which case the symlink object itself is returned and
+ * the user can decide how to resolve its value. A symlink with an absolute
+ * value cannot be followed, see dfs_lookup().
+ * The object must be released with dfs_release().
  *
  * \param[in]	dfs	Pointer to the mounted file system.
  * \param[in]	parent	Opened parent directory object. If NULL, use root obj.

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -612,6 +612,106 @@ dfs_test_syml_follow(void **state)
 	assert_int_equal(rc, ELOOP);
 }
 
+/* dfs has no notion of the process root, so a symlink with an absolute value cannot be followed
+ * and is rejected with EINVAL wherever the link sits, in the container root or below. The link
+ * itself is still returned with O_NOFOLLOW, and a relative link that walks the same way works.
+ */
+static void
+dfs_test_syml_abs(void **state)
+{
+	test_arg_t *arg = *state;
+	dfs_obj_t  *dir;
+	dfs_obj_t  *obj;
+	mode_t      mode;
+	char        value[64];
+	daos_size_t value_len;
+	int         rc;
+
+	if (arg->myrank != 0)
+		return;
+
+	/** /abs_dir/target, /abs_root -> /abs_dir/target, /abs_dir/abs_deep -> /abs_dir/target */
+	rc = dfs_open(dfs_mt, NULL, "abs_dir", S_IFDIR | S_IWUSR | S_IRUSR | S_IXUSR,
+		      O_RDWR | O_CREAT | O_EXCL, 0, 0, NULL, &dir);
+	assert_int_equal(rc, 0);
+	rc = dfs_open(dfs_mt, dir, "target", S_IFREG | S_IWUSR | S_IRUSR, O_RDWR | O_CREAT | O_EXCL,
+		      0, 0, NULL, &obj);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+	rc = dfs_open(dfs_mt, NULL, "abs_root", S_IFLNK, O_RDWR | O_CREAT | O_EXCL, 0, 0,
+		      "/abs_dir/target", &obj);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+	rc = dfs_open(dfs_mt, dir, "abs_deep", S_IFLNK, O_RDWR | O_CREAT | O_EXCL, 0, 0,
+		      "/abs_dir/target", &obj);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+	/** /abs_dir/rel_deep -> ../abs_dir/target, the same target reached relatively */
+	rc = dfs_open(dfs_mt, dir, "rel_deep", S_IFLNK, O_RDWR | O_CREAT | O_EXCL, 0, 0,
+		      "../abs_dir/target", &obj);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+
+	/** following an absolute value fails the same way at both depths */
+	rc = dfs_lookup(dfs_mt, "/abs_root", O_RDONLY, &obj, &mode, NULL);
+	assert_int_equal(rc, EINVAL);
+	rc = dfs_lookup(dfs_mt, "/abs_dir/abs_deep", O_RDONLY, &obj, &mode, NULL);
+	assert_int_equal(rc, EINVAL);
+	rc = dfs_lookup_rel(dfs_mt, NULL, "abs_root", O_RDONLY, &obj, &mode, NULL);
+	assert_int_equal(rc, EINVAL);
+	rc = dfs_lookup_rel(dfs_mt, dir, "abs_deep", O_RDONLY, &obj, &mode, NULL);
+	assert_int_equal(rc, EINVAL);
+	rc = dfs_access(dfs_mt, NULL, "abs_root", R_OK);
+	assert_int_equal(rc, EINVAL);
+	rc = dfs_access(dfs_mt, dir, "abs_deep", R_OK);
+	assert_int_equal(rc, EINVAL);
+	/** and in the middle of a path */
+	rc = dfs_lookup(dfs_mt, "/abs_root/x", O_RDONLY, &obj, &mode, NULL);
+	assert_int_equal(rc, EINVAL);
+
+	/** the link itself is still accessible */
+	rc = dfs_lookup(dfs_mt, "/abs_root", O_RDONLY | O_NOFOLLOW, &obj, &mode, NULL);
+	assert_int_equal(rc, 0);
+	assert_true(S_ISLNK(mode));
+	value_len = sizeof(value);
+	rc        = dfs_get_symlink_value(obj, value, &value_len);
+	assert_int_equal(rc, 0);
+	assert_string_equal(value, "/abs_dir/target");
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+	rc = dfs_lookup_rel(dfs_mt, dir, "abs_deep", O_RDONLY | O_NOFOLLOW, &obj, &mode, NULL);
+	assert_int_equal(rc, 0);
+	assert_true(S_ISLNK(mode));
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+	rc = dfs_chown(dfs_mt, dir, "abs_deep", geteuid(), getegid(), O_NOFOLLOW);
+	assert_int_equal(rc, 0);
+
+	/** a relative value reaching the same target is followed */
+	rc = dfs_lookup_rel(dfs_mt, dir, "rel_deep", O_RDONLY, &obj, &mode, NULL);
+	assert_int_equal(rc, 0);
+	assert_true(S_ISREG(mode));
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_remove(dfs_mt, dir, "rel_deep", false, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_remove(dfs_mt, dir, "abs_deep", false, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_remove(dfs_mt, dir, "target", false, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(dir);
+	assert_int_equal(rc, 0);
+	rc = dfs_remove(dfs_mt, NULL, "abs_root", false, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_remove(dfs_mt, NULL, "abs_dir", false, NULL);
+	assert_int_equal(rc, 0);
+}
+
 static int
 dfs_test_file_gen(const char *name, daos_size_t chunk_size, daos_oclass_id_t cid,
 		  daos_size_t file_size)
@@ -3632,62 +3732,47 @@ dfs_test_pipeline_find(void **state)
 }
 
 static const struct CMUnitTest dfs_unit_tests[] = {
-	{ "DFS_UNIT_TEST1: DFS mount / umount",
-	  dfs_test_mount, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST2: DFS container modes",
-	  dfs_test_modes, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST3: DFS lookup / lookup_rel",
-	  dfs_test_lookup, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST4: Simple Symlinks",
-	  dfs_test_syml, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST5: Symlinks with / without O_NOFOLLOW",
-	  dfs_test_syml_follow, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST6: multi-threads read shared file",
-	  dfs_test_read_shared_file, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST7: DFS lookupx",
-	  dfs_test_lookupx, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST8: DFS IO sync error code",
-	  dfs_test_io_error_code, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST9: DFS IO async error code",
-	  dfs_test_io_error_code, async_enable, test_case_teardown},
-	{ "DFS_UNIT_TEST10: multi-threads mkdir same dir",
-	  dfs_test_mt_mkdir, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST11: Simple rename",
-	  dfs_test_rename, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST12: DFS API compat",
-	  dfs_test_compat, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST13: DFS l2g/g2l_all",
-	  dfs_test_handles, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST14: multi-threads connect to same container",
-	  dfs_test_mt_connect, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST15: DFS chown",
-	  dfs_test_chown, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST16: DFS stat mtime",
-	  dfs_test_mtime, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST17: multi-threads async IO",
-	  dfs_test_async_io_th, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST18: async IO",
-	  dfs_test_async_io, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST19: DFS readdir",
-	  dfs_test_readdir, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST20: dfs oclass hints",
-	  dfs_test_oclass_hints, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST21: dfs multiple pools",
-	  dfs_test_multiple_pools, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST22: dfs extended attributes",
-	  dfs_test_xattrs, test_case_teardown},
-	{ "DFS_UNIT_TEST23: dfs MWC container checker",
-	  dfs_test_checker, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST24: dfs MWC SB fix",
-	  dfs_test_fix_sb, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST25: dfs MWC root fix",
-	  dfs_test_relink_root, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST26: dfs MWC chunk size fix",
-	  dfs_test_fix_chunk_size, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST27: dfs pipeline find",
-	  dfs_test_pipeline_find, async_disable, test_case_teardown},
-	{ "DFS_UNIT_TEST28: dfs open/lookup flags",
-	  dfs_test_oflags, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST1: DFS mount / umount", dfs_test_mount, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST2: DFS container modes", dfs_test_modes, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST3: DFS lookup / lookup_rel", dfs_test_lookup, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST4: Simple Symlinks", dfs_test_syml, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST5: Symlinks with / without O_NOFOLLOW", dfs_test_syml_follow, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST6: multi-threads read shared file", dfs_test_read_shared_file, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST7: DFS lookupx", dfs_test_lookupx, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST8: DFS IO sync error code", dfs_test_io_error_code, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST9: DFS IO async error code", dfs_test_io_error_code, async_enable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST10: multi-threads mkdir same dir", dfs_test_mt_mkdir, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST11: Simple rename", dfs_test_rename, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST12: DFS API compat", dfs_test_compat, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST13: DFS l2g/g2l_all", dfs_test_handles, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST14: multi-threads connect to same container", dfs_test_mt_connect, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST15: DFS chown", dfs_test_chown, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST16: DFS stat mtime", dfs_test_mtime, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST17: multi-threads async IO", dfs_test_async_io_th, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST18: async IO", dfs_test_async_io, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST19: DFS readdir", dfs_test_readdir, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST20: dfs oclass hints", dfs_test_oclass_hints, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST21: dfs multiple pools", dfs_test_multiple_pools, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST22: dfs extended attributes", dfs_test_xattrs, test_case_teardown},
+    {"DFS_UNIT_TEST23: dfs MWC container checker", dfs_test_checker, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST24: dfs MWC SB fix", dfs_test_fix_sb, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST25: dfs MWC root fix", dfs_test_relink_root, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST26: dfs MWC chunk size fix", dfs_test_fix_chunk_size, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST27: dfs pipeline find", dfs_test_pipeline_find, async_disable,
+     test_case_teardown},
+    {"DFS_UNIT_TEST28: dfs open/lookup flags", dfs_test_oflags, async_disable, test_case_teardown},
+    {"DFS_UNIT_TEST29: Symlinks with an absolute value", dfs_test_syml_abs, async_disable,
+     test_case_teardown},
 };
 
 static int


### PR DESCRIPTION
lookup_rel_path() resolved a symlink value by recursing with the directory holding the link as the starting point. Its guard for the public API, which only accepts a leading "/" from the container root, was therefore applied to symlink values with the link's parent as the root: an absolute value was followed from the container root when the link sat in the root and rejected with EINVAL anywhere deeper.

dfs has no notion of the process root that POSIX resolves an absolute value from, so it cannot follow such a value correctly at any depth. dfuse never follows a symlink in dfs and hands the value to the kernel, so for everything created through it an absolute value is a host path, and the root case silently returned an in-container object whenever the same path also existed in the container. pil4dfs relies on the EINVAL to let the kernel resolve the path, which the root case defeated.

Route every symlink follow through follow_symlink(), which rejects an absolute value with EINVAL wherever the link sits. The link itself is still returned with O_NOFOLLOW. Document the rule in daos_fs.h and add a dfs_unit_test case for a link in the root and one level down.

Features: dfs pil4dfs

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
