### PR TITLE
DAOS-19616 placement: hide relocated shard from readers

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -85,8 +85,6 @@ struct pool_map {
 	uint32_t		po_in_ver;
 	/* Current least fseq version from all DOWN targets. */
 	uint32_t		po_fseq;
-	/** # targets in a transient state, i.e. DOWN, DRAIN or UP */
-	uint32_t                 po_transient_nr;
 };
 
 /* clang-format off */
@@ -2454,27 +2452,6 @@ update_failed_cnt_helper(struct pool_domain *dom,
 }
 
 /**
- * Count the targets which are in a transient state, i.e. DOWN, DRAIN or UP - a state which a
- * rebuild, a drain or a reintegration is currently moving the target out of. Placement needs
- * to know whether any such target exists to tell if the layout it generates depends on the
- * layout generation mode.
- */
-static void
-update_transient_cnt(struct pool_map *map, struct pool_domain *root)
-{
-	uint32_t nr = 0;
-	int      i;
-
-	for (i = 0; i < root->do_target_nr; i++) {
-		if (root->do_targets[i].ta_comp.co_status &
-		    (PO_COMP_ST_DOWN | PO_COMP_ST_DRAIN | PO_COMP_ST_UP))
-			nr++;
-	}
-
-	map->po_transient_nr = nr;
-}
-
-/**
  * Update the failed target count for the pool map.
  * This should be called anytime the pool map is updated.
  */
@@ -2492,7 +2469,6 @@ pool_map_update_failed_cnt(struct pool_map *map)
 		return -DER_INVAL;
 
 	update_failed_cnt_helper(root, fail_cnts, 0);
-	update_transient_cnt(map, root);
 	return 0;
 }
 
@@ -3185,16 +3161,6 @@ pool_map_bump_version(struct pool_map *map)
 	D_DEBUG(DB_TRACE, "Bump pool map to version %u\n", map->po_version);
 
 	return map->po_version;
-}
-
-/**
- * Check whether any target is in a transient state, see update_transient_cnt(). This is O(1),
- * the count is refreshed by pool_map_update_failed_cnt() on every pool map change.
- */
-bool
-pool_map_has_transient_tgt(struct pool_map *map)
-{
-	return map->po_transient_nr != 0;
 }
 
 int

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -85,6 +85,8 @@ struct pool_map {
 	uint32_t		po_in_ver;
 	/* Current least fseq version from all DOWN targets. */
 	uint32_t		po_fseq;
+	/** # targets in a transient state, i.e. DOWN, DRAIN or UP */
+	uint32_t                 po_transient_nr;
 };
 
 /* clang-format off */
@@ -2452,6 +2454,27 @@ update_failed_cnt_helper(struct pool_domain *dom,
 }
 
 /**
+ * Count the targets which are in a transient state, i.e. DOWN, DRAIN or UP - a state which a
+ * rebuild, a drain or a reintegration is currently moving the target out of. Placement needs
+ * to know whether any such target exists to tell if the layout it generates depends on the
+ * layout generation mode.
+ */
+static void
+update_transient_cnt(struct pool_map *map, struct pool_domain *root)
+{
+	uint32_t nr = 0;
+	int      i;
+
+	for (i = 0; i < root->do_target_nr; i++) {
+		if (root->do_targets[i].ta_comp.co_status &
+		    (PO_COMP_ST_DOWN | PO_COMP_ST_DRAIN | PO_COMP_ST_UP))
+			nr++;
+	}
+
+	map->po_transient_nr = nr;
+}
+
+/**
  * Update the failed target count for the pool map.
  * This should be called anytime the pool map is updated.
  */
@@ -2469,6 +2492,7 @@ pool_map_update_failed_cnt(struct pool_map *map)
 		return -DER_INVAL;
 
 	update_failed_cnt_helper(root, fail_cnts, 0);
+	update_transient_cnt(map, root);
 	return 0;
 }
 
@@ -3161,6 +3185,16 @@ pool_map_bump_version(struct pool_map *map)
 	D_DEBUG(DB_TRACE, "Bump pool map to version %u\n", map->po_version);
 
 	return map->po_version;
+}
+
+/**
+ * Check whether any target is in a transient state, see update_transient_cnt(). This is O(1),
+ * the count is refreshed by pool_map_update_failed_cnt() on every pool map change.
+ */
+bool
+pool_map_has_transient_tgt(struct pool_map *map)
+{
+	return map->po_transient_nr != 0;
 }
 
 int

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -277,6 +277,8 @@ uint32_t pool_map_get_version(struct pool_map *map);
 uint32_t pool_map_bump_version(struct pool_map *map);
 
 int pool_map_get_failed_cnt(struct pool_map *map, uint32_t domain);
+bool
+pool_map_has_transient_tgt(struct pool_map *map);
 
 #define PO_COMP_ID_ALL		(-1)
 

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -277,8 +277,6 @@ uint32_t pool_map_get_version(struct pool_map *map);
 uint32_t pool_map_bump_version(struct pool_map *map);
 
 int pool_map_get_failed_cnt(struct pool_map *map, uint32_t domain);
-bool
-pool_map_has_transient_tgt(struct pool_map *map);
 
 #define PO_COMP_ID_ALL		(-1)
 

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -898,7 +898,13 @@ layout_mark_relocated(struct pl_jump_map *jmap, uint32_t layout_ver, struct jm_o
 	int                   i;
 	int                   rc;
 
-	if (!layout_may_relocate(layout))
+	/*
+	 * UPIN and DOWNOUT targets are handled identically in every layout generation mode, see
+	 * comp_need_remap(). So unless some target is DOWN, DRAIN or UP there is nothing to
+	 * compare: all the modes produce the very same layout. This is the steady state of a
+	 * pool, including one which has already been through a rebuild.
+	 */
+	if (!pool_map_has_transient_tgt(jmap->jmp_map.pl_poolmap))
 		return 0;
 
 	/*
@@ -907,6 +913,9 @@ layout_mark_relocated(struct pl_jump_map *jmap, uint32_t layout_ver, struct jm_o
 	 * layouts when the difference can only come from failure remapping.
 	 */
 	if (gen_mode == CURRENT && layout->ol_shard_peers > 0)
+		return 0;
+
+	if (!layout_may_relocate(layout))
 		return 0;
 
 	/* obj_layout_alloc_and_get() resets omd_grp_spec for the CURRENT mode */

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -838,6 +838,125 @@ out:
 }
 
 /**
+ * Check whether the layout may contain a shard which got relocated by the ongoing rebuild
+ * without being a shard of one of the targets it is rebuilding.
+ *
+ * The spare targets are allocated sequentially over the whole remap list, sharing the
+ * used-domain/used-target bookkeeping, and a shard whose spare candidate is unavailable is
+ * requeued with the fseq of that candidate (see determine_valid_spares()). Therefore a new
+ * failure can hand an already remapped shard a different spare, even when neither the shard
+ * nor its previous spare has anything to do with the newly failed target.
+ *
+ * Such a shard can only be one which is sitting on a spare of an earlier, already completed
+ * rebuild, i.e. po_fseq != 0 while it is not being rebuilt by the ongoing one.
+ */
+static bool
+layout_may_relocate(struct pl_obj_layout *layout)
+{
+	int i;
+
+	for (i = 0; i < layout->ol_nr; i++) {
+		if (layout->ol_shards[i].po_target == -1 || layout->ol_shards[i].po_rebuilding)
+			continue;
+		if (layout->ol_shards[i].po_fseq != 0)
+			return true;
+	}
+
+	return false;
+}
+
+/**
+ * Mark the shards which the ongoing rebuild has relocated as rebuilding, so that they are not
+ * used as a read source. Both the PRE_REBUILD and the CURRENT layout can carry such a shard,
+ * so each of them is compared against the other one:
+ *
+ * PRE_REBUILD is meant to describe where the data was before the ongoing rebuild, so that the
+ * migration can fetch from the original targets. That only holds for the shards which are on a
+ * target failed by the ongoing rebuild. A shard which got relocated as a side effect of that
+ * failure (see layout_may_relocate()) is different: its old target has been out of the write
+ * path since the new pool map version, so everything written since then is missing there.
+ * Reading from it returns stale or empty data, which shows up as -DER_DATA_LOSS in the
+ * migration (zero sized iod) or as lost records for a read-only client.
+ *
+ * CURRENT has the mirror image of the same problem. A relocated shard is only flagged there by
+ * accident, when one of the spare candidates it was offered happened to be a target failed by
+ * the ongoing rebuild - comp_need_remap() accumulates the flags of the rejected candidates into
+ * the remapped shard. When the shard is displaced purely because another shard took its spare
+ * first, no flag is accumulated and the new target, which has never been written to, is offered
+ * to readers. The data is on the target the PRE_REBUILD layout still points at, so a difference
+ * against a healthy PRE_REBUILD target means the CURRENT target has no data yet.
+ */
+static int
+layout_mark_relocated(struct pl_jump_map *jmap, uint32_t layout_ver, struct jm_obj_placement *jmop,
+		      struct daos_obj_md *md, enum layout_gen_mode gen_mode,
+		      struct pl_obj_layout *layout)
+{
+	struct pl_obj_layout *ref_layout = NULL;
+	enum layout_gen_mode  ref_mode   = gen_mode == PRE_REBUILD ? CURRENT : PRE_REBUILD;
+	uint32_t              grp_spec;
+	int                   nr;
+	int                   i;
+	int                   rc;
+
+	if (!layout_may_relocate(layout))
+		return 0;
+
+	/*
+	 * A drain, reintegration or extension in flight adds a peer target to the shard instead
+	 * of moving it, and the pre-rebuild layout does not describe that. Only compare the two
+	 * layouts when the difference can only come from failure remapping.
+	 */
+	if (gen_mode == CURRENT && layout->ol_shard_peers > 0)
+		return 0;
+
+	/* obj_layout_alloc_and_get() resets omd_grp_spec for the CURRENT mode */
+	grp_spec = md->omd_grp_spec;
+	rc       = obj_layout_alloc_and_get(jmap, layout_ver, jmop, md, md->omd_ver, ref_mode,
+					    &ref_layout);
+	md->omd_grp_spec = grp_spec;
+	if (rc != 0) {
+		D_ERROR(DF_OID ": failed to get the %s layout, " DF_RC "\n", DP_OID(md->omd_id),
+			ref_mode == CURRENT ? "current" : "pre-rebuild", DP_RC(rc));
+		return rc;
+	}
+
+	/* @layout may only cover the group the caller asked for */
+	D_ASSERT(ref_layout->ol_grp_size == layout->ol_grp_size);
+	nr = min(ref_layout->ol_nr, layout->ol_nr);
+	for (i = 0; i < nr; i++) {
+		uint32_t ref_tgt = ref_layout->ol_shards[i].po_target;
+
+		if (layout->ol_shards[i].po_target == -1 || layout->ol_shards[i].po_rebuilding)
+			continue;
+		if (ref_tgt == (uint32_t)-1 || layout->ol_shards[i].po_target == ref_tgt)
+			continue;
+		/*
+		 * The CURRENT layout only has to skip the shard when the data is known to be
+		 * elsewhere, i.e. the PRE_REBUILD target is still a healthy target which the
+		 * ongoing rebuild is not moving away from.
+		 */
+		if (gen_mode == CURRENT) {
+			struct pool_target *ref_pot;
+
+			rc = pool_map_find_target(jmap->jmp_map.pl_poolmap, ref_tgt, &ref_pot);
+			D_ASSERT(rc == 1);
+			if (ref_pot->ta_comp.co_status != PO_COMP_ST_UPIN)
+				continue;
+		}
+
+		D_DEBUG(DB_PL,
+			DF_OID " shard %d ver %u relocated from target %u to %u, skip it on read\n",
+			DP_OID(md->omd_id), i, md->omd_ver,
+			gen_mode == PRE_REBUILD ? layout->ol_shards[i].po_target : ref_tgt,
+			gen_mode == PRE_REBUILD ? ref_tgt : layout->ol_shards[i].po_target);
+		layout->ol_shards[i].po_rebuilding = 1;
+	}
+
+	pl_obj_layout_free(ref_layout);
+	return 0;
+}
+
+/**
  * Frees the placement map
  *
  * \param[in]   map     The placement map to be freed
@@ -1052,6 +1171,11 @@ jump_map_obj_place(struct pl_map *map, uint32_t layout_version, struct daos_obj_
 		D_ERROR("get_layout_alloc failed, rc "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
 	}
+
+	rc = layout_mark_relocated(jmap, layout_version, &jmop, md, gen_mode, layout);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
 	obj_layout_dump(oid, layout);
 
 	rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, PO_COMP_TP_ROOT, PO_COMP_ID_ALL, &root);

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -395,7 +395,8 @@ static int
 obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_md *md,
 		 struct pl_obj_layout *layout, struct jm_obj_placement *jmop, d_list_t *remap_list,
 		 uint32_t allow_version, enum layout_gen_mode gen_mode, uint8_t *tgts_used,
-		 uint8_t *dom_used, uint8_t *dom_full, uint32_t failed_in_layout, uint32_t fdom_lvl)
+		 uint8_t *dom_used, uint8_t *dom_full, uint32_t failed_in_layout, uint32_t fdom_lvl,
+		 bool *mode_dependent)
 {
 	struct failed_shard     *f_shard;
 	struct pool_target      *spare_tgt = NULL;
@@ -452,7 +453,7 @@ obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_
 			get_target(root, curr_pd, layout_ver, &spare_tgt, &spare_dom, rebuild_key,
 				   dom_used, dom_full, dgu->dgu_used, dgu->dgu_real, tgts_used,
 				   shard_id, allow_version, gen_mode, fdom_lvl, jmop->jmop_grp_size,
-				   &spares_left, &spare_avail);
+				   &spares_left, &spare_avail, mode_dependent);
 			if (layout_ver > 0) {
 				/*
 				 * After 2.4 (layout_ver > 0), it will always assign each shard
@@ -468,7 +469,7 @@ obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_
 		}
 
 		rc = determine_valid_spares(spare_tgt, md, spare_avail, remap_list, allow_version,
-					    gen_mode, f_shard, layout);
+					    gen_mode, f_shard, layout, mode_dependent);
 		if (rc == 1) {
 			d_list_del(&f_shard->fs_list);
 			D_FREE(f_shard);
@@ -572,7 +573,7 @@ remap_gpu_alloc_one(d_list_t *remap_list, uint8_t *dom_cur_grp_used,
 static int
 get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_layout *layout,
 		  struct jm_obj_placement *jmop, uint32_t allow_version,
-		  enum layout_gen_mode gen_mode, struct daos_obj_md *md)
+		  enum layout_gen_mode gen_mode, struct daos_obj_md *md, bool *mode_dependent)
 {
 	struct pool_target      *target;
 	struct pool_domain      *domain;
@@ -690,7 +691,7 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 				get_target(root, curr_pd, layout_ver, &target, &domain, key,
 					   dom_used, dom_full, dom_cur_grp_used, dom_cur_grp_real,
 					   tgts_used, k, allow_version, gen_mode, fdom_lvl,
-					   jmop->jmop_grp_size, NULL, NULL);
+					   jmop->jmop_grp_size, NULL, NULL, mode_dependent);
 			}
 
 			if (target == NULL) {
@@ -708,8 +709,8 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 			layout->ol_shards[k].po_index = target->ta_comp.co_index;
 
 			/** If target is failed queue it for remap*/
-			if (comp_need_remap(&target->ta_comp, allow_version, gen_mode,
-					    &remap_flags)) {
+			if (comp_need_remap(&target->ta_comp, allow_version, gen_mode, &remap_flags,
+					    mode_dependent)) {
 				struct failed_shard *shard;
 
 				fail_tgt_cnt++;
@@ -755,7 +756,7 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 	if (fail_tgt_cnt > 0)
 		rc = obj_remap_shards(jmap, layout_ver, md, layout, jmop, &remap_list,
 				      allow_version, gen_mode, tgts_used, dom_used, dom_full,
-				      fail_tgt_cnt, fdom_lvl);
+				      fail_tgt_cnt, fdom_lvl, mode_dependent);
 out:
 	if (rc)
 		D_ERROR("jump_map_obj_layout_fill failed, rc "DF_RC"\n", DP_RC(rc));
@@ -803,7 +804,7 @@ static int
 obj_layout_alloc_and_get(struct pl_jump_map *jmap, uint32_t layout_ver,
 			 struct jm_obj_placement *jmop, struct daos_obj_md *md,
 			 uint32_t allow_version, enum layout_gen_mode gen_mode,
-			 struct pl_obj_layout **layout_p)
+			 struct pl_obj_layout **layout_p, bool *mode_dependent)
 {
 	int rc;
 
@@ -822,7 +823,8 @@ obj_layout_alloc_and_get(struct pl_jump_map *jmap, uint32_t layout_ver,
 	if (gen_mode == CURRENT || !(md->omd_flags & PL_FL_GRP_SPEC))
 		md->omd_grp_spec = PL_GRP_MAX;
 
-	rc = get_object_layout(jmap, layout_ver, *layout_p, jmop, allow_version, gen_mode, md);
+	rc = get_object_layout(jmap, layout_ver, *layout_p, jmop, allow_version, gen_mode, md,
+			       mode_dependent);
 	if (rc) {
 		D_ERROR("get object layout failed, rc "DF_RC"\n",
 			DP_RC(rc));
@@ -899,15 +901,6 @@ layout_mark_relocated(struct pl_jump_map *jmap, uint32_t layout_ver, struct jm_o
 	int                   rc;
 
 	/*
-	 * UPIN and DOWNOUT targets are handled identically in every layout generation mode, see
-	 * comp_need_remap(). So unless some target is DOWN, DRAIN or UP there is nothing to
-	 * compare: all the modes produce the very same layout. This is the steady state of a
-	 * pool, including one which has already been through a rebuild.
-	 */
-	if (!pool_map_has_transient_tgt(jmap->jmp_map.pl_poolmap))
-		return 0;
-
-	/*
 	 * A drain, reintegration or extension in flight adds a peer target to the shard instead
 	 * of moving it, and the pre-rebuild layout does not describe that. Only compare the two
 	 * layouts when the difference can only come from failure remapping.
@@ -921,7 +914,7 @@ layout_mark_relocated(struct pl_jump_map *jmap, uint32_t layout_ver, struct jm_o
 	/* obj_layout_alloc_and_get() resets omd_grp_spec for the CURRENT mode */
 	grp_spec = md->omd_grp_spec;
 	rc       = obj_layout_alloc_and_get(jmap, layout_ver, jmop, md, md->omd_ver, ref_mode,
-					    &ref_layout);
+					    &ref_layout, NULL);
 	md->omd_grp_spec = grp_spec;
 	if (rc != 0) {
 		D_ERROR(DF_OID ": failed to get the %s layout, " DF_RC "\n", DP_OID(md->omd_id),
@@ -1094,7 +1087,7 @@ jump_map_obj_extend_layout(struct pl_jump_map *jmap, struct jm_obj_placement *jm
 
 	D_INIT_LIST_HEAD(&extend_list);
 	rc = obj_layout_alloc_and_get(jmap, layout_version, jmop, md, md->omd_ver, POST_REBUILD,
-				      &new_layout);
+				      &new_layout, NULL);
 	if (rc != 0) {
 		D_ERROR(DF_OID" get_layout_alloc failed, rc "DF_RC"\n",
 			DP_OID(md->omd_id), DP_RC(rc));
@@ -1151,6 +1144,7 @@ jump_map_obj_place(struct pl_map *map, uint32_t layout_version, struct daos_obj_
 	daos_obj_id_t		oid;
 	struct pool_domain	*root;
 	enum layout_gen_mode	gen_mode = CURRENT;
+	bool                     mode_dependent = false;
 	int			rc;
 
 	jmap = pl_map2jmap(map);
@@ -1175,15 +1169,25 @@ jump_map_obj_place(struct pl_map *map, uint32_t layout_version, struct daos_obj_
 		gen_mode = PRE_REBUILD;
 
 	rc = obj_layout_alloc_and_get(jmap, layout_version, &jmop, md, md->omd_ver, gen_mode,
-				      &layout);
+				      &layout, &mode_dependent);
 	if (rc != 0) {
 		D_ERROR("get_layout_alloc failed, rc "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
-	rc = layout_mark_relocated(jmap, layout_version, &jmop, md, gen_mode, layout);
-	if (rc != 0)
-		D_GOTO(out, rc);
+	/*
+	 * comp_need_remap() gives the same answer in every generation mode for UPIN and for
+	 * DOWNOUT targets, and get_target() only tells the modes apart through it. So unless
+	 * the placement above actually asked about a DOWN, DRAIN or UP target, PRE_REBUILD and
+	 * CURRENT are provably the same layout and there is nothing to compare. That is the
+	 * common case even while a rebuild is running, since only the few objects which touch
+	 * the handful of affected targets can differ.
+	 */
+	if (mode_dependent) {
+		rc = layout_mark_relocated(jmap, layout_version, &jmop, md, gen_mode, layout);
+		if (rc != 0)
+			D_GOTO(out, rc);
+	}
 
 	obj_layout_dump(oid, layout);
 
@@ -1268,13 +1272,14 @@ jump_map_obj_find_diff(struct pl_map *map, uint32_t layout_ver, struct daos_obj_
 	}
 
 	D_INIT_LIST_HEAD(&reint_list);
-	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jop, md, reint_ver, PRE_REBUILD, &layout);
+	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jop, md, reint_ver, PRE_REBUILD, &layout,
+				      NULL);
 	if (rc < 0)
 		D_GOTO(out, rc);
 
 	obj_layout_dump(md->omd_id, layout);
 	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jop, md, reint_ver, POST_REBUILD,
-				      &reint_layout);
+				      &reint_layout, NULL);
 	if (rc < 0)
 		D_GOTO(out, rc);
 

--- a/src/placement/jump_map.h
+++ b/src/placement/jump_map.h
@@ -1,6 +1,6 @@
 /**
  * (C) Copyright 2022-2023 Intel Corporation.
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -61,7 +61,8 @@ get_target(struct pool_domain *root, struct pool_domain *curr_pd, uint32_t layou
 	   struct pool_target **target, struct pool_domain **dom, uint64_t key, uint8_t *dom_used,
 	   uint8_t *dom_full, uint8_t *dom_cur_grp_used, uint8_t *dom_cur_grp_real,
 	   uint8_t *tgts_used, int shard_num, uint32_t allow_version, enum layout_gen_mode gen_mode,
-	   pool_comp_type_t fdom_lvl, uint32_t grp_size, uint32_t *spare_left, bool *spare_avail);
+	   pool_comp_type_t fdom_lvl, uint32_t grp_size, uint32_t *spare_left, bool *spare_avail,
+	   bool *mode_dependent);
 
 static inline uint64_t
 jm_crc(uint64_t val0, uint64_t val1, uint64_t val2)

--- a/src/placement/jump_map_versions.c
+++ b/src/placement/jump_map_versions.c
@@ -646,7 +646,8 @@ dom_reset_full(struct pool_domain *dom, uint8_t *dom_bits, uint8_t *tgts_used,
 }
 
 static bool
-dom_tgts_are_avaible(struct pool_domain *dom, uint32_t allow_version, enum layout_gen_mode gen_mode)
+dom_tgts_are_avaible(struct pool_domain *dom, uint32_t allow_version, enum layout_gen_mode gen_mode,
+		     bool *mode_dependent)
 {
 	int i;
 
@@ -654,7 +655,7 @@ dom_tgts_are_avaible(struct pool_domain *dom, uint32_t allow_version, enum layou
 		struct pool_target *tgt;
 
 		tgt = &dom->do_targets[i];
-		if (!comp_need_remap(&tgt->ta_comp, allow_version, gen_mode, NULL))
+		if (!comp_need_remap(&tgt->ta_comp, allow_version, gen_mode, NULL, mode_dependent))
 			return true;
 	}
 	return false;
@@ -665,7 +666,7 @@ static void
 reset_dom_cur_grp_v1(struct pool_domain *root, struct pool_domain *curr_pd,
 		     uint8_t *dom_cur_grp_used, uint8_t *dom_cur_grp_real, uint8_t *dom_full,
 		     uint8_t *tgts_used, uint32_t fdom_lvl, uint32_t allow_version,
-		     enum layout_gen_mode gen_mode)
+		     enum layout_gen_mode gen_mode, bool *mode_dependent)
 {
 	struct pool_domain	*tree;
 	uint32_t		dom_nr;
@@ -753,7 +754,7 @@ reset_dom_cur_grp_v1(struct pool_domain *root, struct pool_domain *curr_pd,
 			struct pool_domain *dom = &root[start_dom + i];
 
 			if (!isset(dom_cur_grp_real, start_dom + i) &&
-			    dom_tgts_are_avaible(dom, allow_version, gen_mode)) {
+			    dom_tgts_are_avaible(dom, allow_version, gen_mode, mode_dependent)) {
 				dom_reset_full(dom, dom_full, tgts_used, root,
 					       allow_version, gen_mode, fdom_lvl);
 				dom_reset_bit(dom, dom_cur_grp_used, root,
@@ -790,7 +791,8 @@ get_target_new(struct pool_domain *root, struct pool_domain *curr_pd, uint32_t l
 	       struct pool_target **target, struct pool_domain **dom, uint64_t key,
 	       uint8_t *dom_used, uint8_t *dom_full, uint8_t *dom_cur_grp_used,
 	       uint8_t *dom_cur_grp_real, uint8_t *tgts_used, int shard_num, uint32_t allow_version,
-	       enum layout_gen_mode gen_mode, pool_comp_type_t fdom_lvl, uint32_t grp_size)
+	       enum layout_gen_mode gen_mode, pool_comp_type_t fdom_lvl, uint32_t grp_size,
+	       bool *mode_dependent)
 {
 	struct pool_target	*found = NULL;
 	bool			 pd_ignored;
@@ -819,11 +821,11 @@ get_target_new(struct pool_domain *root, struct pool_domain *curr_pd, uint32_t l
 			if (pd_ignored)
 				reset_dom_cur_grp_v1(root, root, dom_cur_grp_used, dom_cur_grp_real,
 						     dom_full, tgts_used, fdom_lvl, allow_version,
-						     gen_mode);
+						     gen_mode, mode_dependent);
 			else
-				reset_dom_cur_grp_v1(root, curr_pd, dom_cur_grp_used,
-						     dom_cur_grp_real, dom_full, tgts_used,
-						     fdom_lvl, allow_version, gen_mode);
+				reset_dom_cur_grp_v1(
+				    root, curr_pd, dom_cur_grp_used, dom_cur_grp_real, dom_full,
+				    tgts_used, fdom_lvl, allow_version, gen_mode, mode_dependent);
 		}
 	}
 	*target = found;
@@ -1065,7 +1067,8 @@ get_target(struct pool_domain *root, struct pool_domain *curr_pd, uint32_t layou
 	   struct pool_target **target, struct pool_domain **dom, uint64_t key, uint8_t *dom_used,
 	   uint8_t *dom_full, uint8_t *dom_cur_grp_used, uint8_t *dom_cur_grp_real,
 	   uint8_t *tgts_used, int shard_num, uint32_t allow_version, enum layout_gen_mode gen_mode,
-	   pool_comp_type_t fdom_lvl, uint32_t grp_size, uint32_t *spare_left, bool *spare_avail)
+	   pool_comp_type_t fdom_lvl, uint32_t grp_size, uint32_t *spare_left, bool *spare_avail,
+	   bool *mode_dependent)
 {
 	switch(layout_ver) {
 	case 0:
@@ -1098,7 +1101,7 @@ get_target(struct pool_domain *root, struct pool_domain *curr_pd, uint32_t layou
 		 */
 		get_target_new(root, curr_pd, layout_ver, target, dom, key, dom_used, dom_full,
 			       dom_cur_grp_used, dom_cur_grp_real, tgts_used, shard_num,
-			       allow_version, gen_mode, fdom_lvl, grp_size);
+			       allow_version, gen_mode, fdom_lvl, grp_size, mode_dependent);
 		if (spare_avail)
 			*spare_avail = true;
 		break;

--- a/src/placement/pl_map.h
+++ b/src/placement/pl_map.h
@@ -140,7 +140,8 @@ remap_list_fill(struct pl_map *map, struct daos_obj_md *md, struct daos_obj_shar
 int
 determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md, bool spare_avail,
 		       d_list_t *remap_list, uint32_t allow_version, enum layout_gen_mode gen_mode,
-		       struct failed_shard *f_shard, struct pl_obj_layout *layout);
+		       struct failed_shard *f_shard, struct pl_obj_layout *layout,
+		       bool *mode_dependent);
 
 int
 spec_place_rank_get(unsigned int *pos, daos_obj_id_t oid,
@@ -151,7 +152,7 @@ pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list);
 
 bool
 comp_need_remap(struct pool_component *comp, uint32_t allow_status, enum layout_gen_mode gen_mode,
-		unsigned int *remap_flags);
+		unsigned int *remap_flags, bool *mode_dependent);
 
 enum {
 	/* rebuilding this shard */

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -257,10 +257,15 @@ remap_list_fill(struct pl_map *map, struct daos_obj_md *md, struct daos_obj_shar
  *   IS_REBUILDING    → po_rebuilding=1     skip shard on read
  *   IS_REINTEGRATING → po_reintegrating=1  shard is being reintegrated
  *   HAS_PEER         → ol_shard_peers++    triggers extend_layout (dual-write to old+new)
+ *
+ * @mode_dependent, when passed, is set as soon as the answer above depends on @gen_mode, i.e.
+ * for every status but UPIN and DOWNOUT. It lets a caller which would otherwise have to
+ * generate a second layout in another mode and diff it tell upfront that both modes must
+ * agree, see layout_mark_relocated().
  */
 bool
 comp_need_remap(struct pool_component *comp, uint32_t allow_version, enum layout_gen_mode gen_mode,
-		unsigned int *remap_flags)
+		unsigned int *remap_flags, bool *mode_dependent)
 {
 	unsigned int status = comp->co_status;
 	unsigned int flags  = 0;
@@ -271,6 +276,12 @@ comp_need_remap(struct pool_component *comp, uint32_t allow_version, enum layout
 
 	if (status == PO_COMP_ST_DOWNOUT)
 		return true; /* always remap */
+
+	/* Everything below is reached only by DOWN, DRAIN and UP, and every one of those
+	 * branches keys off @gen_mode.
+	 */
+	if (mode_dependent != NULL)
+		*mode_dependent = true;
 
 	/* NB: if @remap is false, @flags is applied to the current shard/target, otherwise
 	 * it's applied to the remapped shard/target.
@@ -338,7 +349,8 @@ comp_need_remap(struct pool_component *comp, uint32_t allow_version, enum layout
 int
 determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md, bool spare_avail,
 		       d_list_t *remap_list, uint32_t allow_version, enum layout_gen_mode gen_mode,
-		       struct failed_shard *f_shard, struct pl_obj_layout *layout)
+		       struct failed_shard *f_shard, struct pl_obj_layout *layout,
+		       bool *mode_dependent)
 {
 	struct pl_obj_shard *l_shard = &layout->ol_shards[f_shard->fs_shard_idx];
 
@@ -346,8 +358,8 @@ determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md, bo
 		goto next_fail;
 
 	/* The selected spare target is down as well */
-	if (comp_need_remap(&spare_tgt->ta_comp, allow_version, gen_mode,
-			    &f_shard->fs_remap_flags)) {
+	if (comp_need_remap(&spare_tgt->ta_comp, allow_version, gen_mode, &f_shard->fs_remap_flags,
+			    mode_dependent)) {
 		D_DEBUG(DB_PL, "Spare target is also unavailable " DF_TARGET
 			".\n", DP_TARGET(spare_tgt));
 

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -1020,7 +1020,7 @@ ring_obj_remap_shards(struct pl_ring_map *rimap, struct daos_obj_md *md,
 
 		spare_tgt = &tgts[plts[spare_idx].pt_pos];
 		determine_valid_spares(spare_tgt, md, spare_avail, remap_list, -1, -1, f_shard,
-				       layout);
+				       layout, NULL);
 	}
 
 	remap_dump(remap_list, md, "after remap:");

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -1,7 +1,7 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
  * (C) Copyright 2026 Google LLC
- * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2305,12 +2305,153 @@ fail_multiple_ranks(void **state)
 	jtc_fini(&ctx);
 }
 
+/**
+ * Generate the layout of @oid with a specific daos_obj_open() mode. DAOS_OO_RO selects the
+ * PRE_REBUILD layout, which is what the rebuild migration fetch and every read only client
+ * use (see jump_map_obj_place()).
+ */
+static int
+jtc_place_mode(struct jm_test_ctx *ctx, daos_obj_id_t oid, unsigned int mode,
+	       struct pl_obj_layout **layout)
+{
+	struct daos_obj_md md = {0};
+
+	md.omd_id  = oid;
+	md.omd_ver = pool_map_get_version(ctx->po_map);
+	*layout    = NULL;
+
+	return pl_obj_place(ctx->pl_map, PLT_LAYOUT_VERSION, &md, mode, NULL, layout);
+}
+
+/*
+ * A shard which was already remapped by an earlier, completed rebuild can be relocated to a
+ * different spare when a new and otherwise unrelated target fails: the spares are handed out
+ * sequentially over a shared used-target bitmap, and a shard whose spare candidate is
+ * unavailable is requeued with the fseq of that candidate, see determine_valid_spares().
+ *
+ * Neither of the two layouts a client can get was marking such a shard reliably:
+ *
+ * - The PRE_REBUILD layout still points at the old target with no flag at all. That target has
+ *   been out of the write path since the new pool map version, so anything written since then
+ *   is missing there - the migration fetch gets a zero sized iod and reports -DER_DATA_LOSS,
+ *   and a read only client silently misses records.
+ *
+ * - The CURRENT layout points at the new target, which has never been written to. It is only
+ *   flagged by accident, when one of the rejected spare candidates happened to be a target of
+ *   the ongoing rebuild, because comp_need_remap() accumulates the flags of the rejected
+ *   candidates. A shard displaced purely by another shard taking its spare first stays
+ *   unflagged and is offered to readers.
+ *
+ * Both must come back flagged as rebuilding so that they are skipped on read.
+ */
+static bool
+jtc_tgt_is_upin(struct jm_test_ctx *ctx, uint32_t tgt_id)
+{
+	struct pool_target *tgt;
+
+	assert_int_equal(1, pool_map_find_target(ctx->po_map, tgt_id, &tgt));
+
+	return tgt->ta_comp.co_status == PO_COMP_ST_UPIN;
+}
+
+static void
+_no_stale_read_source(uint32_t domain_nr, uint32_t target_nr, daos_oclass_id_t oc,
+		      uint32_t out_domains, uint32_t down_domains, uint32_t obj_nr)
+{
+	struct jm_test_ctx     ctx;
+	struct pl_obj_layout **before;
+	uint32_t               down_lo   = out_domains * target_nr;
+	uint32_t               down_hi   = down_lo + down_domains * target_nr;
+	uint32_t               relocated = 0;
+	uint32_t               i, o;
+
+	jtc_init(&ctx, domain_nr, 1, target_nr, oc, g_verbose);
+
+	/* the first failures, whose rebuild has completed */
+	for (i = 0; i < down_lo; i++)
+		jtc_set_status_on_target(&ctx, DOWN, i);
+	for (i = 0; i < down_lo; i++)
+		jtc_set_status_on_target(&ctx, DOWNOUT, i);
+
+	/* remember where the data is written before the next, unrelated failure */
+	D_ALLOC_ARRAY(before, obj_nr);
+	assert_non_null(before);
+	for (o = 0; o < obj_nr; o++) {
+		daos_obj_id_t oid;
+
+		gen_oid(&oid, o + 1, UINT64_MAX, oc);
+		assert_success(jtc_place_mode(&ctx, oid, 0, &before[o]));
+	}
+
+	/* the new failure, its rebuild is the one which is ongoing */
+	for (i = down_lo; i < down_hi; i++)
+		jtc_set_status_on_target(&ctx, DOWN, i);
+
+	for (o = 0; o < obj_nr; o++) {
+		struct pl_obj_layout *cur;
+		struct pl_obj_layout *ro;
+		daos_obj_id_t         oid;
+
+		gen_oid(&oid, o + 1, UINT64_MAX, oc);
+		assert_success(jtc_place_mode(&ctx, oid, 0, &cur));
+		assert_success(jtc_place_mode(&ctx, oid, DAOS_OO_RO, &ro));
+		assert_int_equal(cur->ol_nr, ro->ol_nr);
+		assert_int_equal(cur->ol_nr, before[o]->ol_nr);
+
+		for (i = 0; i < cur->ol_nr; i++) {
+			uint32_t cur_tgt = cur->ol_shards[i].po_target;
+			uint32_t ro_tgt  = ro->ol_shards[i].po_target;
+			uint32_t old_tgt = before[o]->ol_shards[i].po_target;
+
+			if (cur_tgt == (uint32_t)-1)
+				continue;
+
+			/* the pre-rebuild layout points at a target which the write path
+			 * does not use anymore, it must not be read from
+			 */
+			if (ro_tgt != (uint32_t)-1 && ro_tgt != cur_tgt)
+				assert_true(ro->ol_shards[i].po_rebuilding);
+
+			/* the shard was moved off a target which is still healthy, so the
+			 * data is there and not on the new target: the current layout must
+			 * not be read from either
+			 */
+			if (old_tgt != (uint32_t)-1 && old_tgt != cur_tgt &&
+			    jtc_tgt_is_upin(&ctx, old_tgt)) {
+				assert_true(cur->ol_shards[i].po_rebuilding);
+				relocated++;
+			}
+		}
+		pl_obj_layout_free(cur);
+		pl_obj_layout_free(ro);
+	}
+
+	/* the scenario has to actually relocate something, otherwise the checks above are
+	 * not testing anything
+	 */
+	print_message("%u shards relocated off a healthy target\n", relocated);
+	assert_true(relocated > 0);
+
+	for (o = 0; o < obj_nr; o++)
+		pl_obj_layout_free(before[o]);
+	D_FREE(before);
+	jtc_fini(&ctx);
+}
+
+static void
+no_stale_read_source(void **state)
+{
+	/* 4 ranks x 4 targets, replicated: the pool shape this was first seen on */
+	_no_stale_read_source(4, 4, OC_RP_4G2, 1, 1, 500);
+	/* EC over a pool with less spare room, where the current layout loses the flag too */
+	_no_stale_read_source(6, 4, OC_EC_4P2G2, 2, 1, 500);
+}
+
 /*
  * ------------------------------------------------
  * End Test Cases
  * ------------------------------------------------
  */
-
 static int
 placement_test_setup(void **state)
 {
@@ -2334,74 +2475,75 @@ placement_test_teardown(void **state)
 			  placement_test_setup, placement_test_teardown }
 
 static const struct CMUnitTest tests[] = {
-	/* Standard configurations */
-	T("Target for first shard continually goes to DOWN state and "
-	  "never finishes rebuild. Should still get new target until no more",
-	  down_continuously),
-	T("Object class is verified appropriately", object_class_is_verified),
-	T("With all healthy targets, can create layout, nothing is in "
-	  "rebuild, and no duplicates.", all_healthy),
-	/* DOWN */
-	T("Take a target down in a system with no servers available, but "
-	  "should still collocate", down_to_target),
-	T("Target for first shard continually goes to DOWN state and "
-	  "never finishes rebuild. Should still get new target until no more",
-	  down_continuously),
-	/* DOWNOUT */
-	T("Rebuild first shard's target repeatedly",
-	  chained_rebuild_completes_first_shard),
-	T("Rebuild all shards' targets", chained_rebuild_completes_all_at_once),
-	/* UP */
-	T("For each shard at a time, take the shard's target "
-	    "DOWN->DOWNOUT->UP. Then verify that the reintegration looks "
-	    "correct", one_is_being_reintegrated),
-	T("With all targets being reintegrated, make sure the correct "
-	    "targets are being rebuilt.", all_are_being_reintegrated),
-	T("Take a single shard's target down, downout, then again with the "
-	  "new target. Then reintegrate the first downed target, "
-	  "then the second.", down_up_sequences),
-	T("Take a single shard's target down, downout, then again with the "
-	  "new target. Then reintegrate the second downed target, "
-	  "then the first (Reverse of previous test).", down_up_sequences1),
-	T("multiple shard targets go down, then are reintegrated in the "
-	  "same order they were brought down",
-	  down_back_to_up_in_same_order),
-	T("multiple targets go down for the same shard, then are reintegrated "
-	  "in reverse order than how they were brought down",
-	  down_back_to_up_in_reverse_order),
-	/* DRAIN */
-	T("Drain all shards with extra domains", drain_all_with_extra_domains),
-	T("Drain all shards with extra targets",
-	  drain_all_with_enough_targets),
-	T("Drain the target of the first shard repeatedly until there is no "
-	    "where to drain to.",
-	    drain_target_same_shard_repeatedly_for_all_shards),
-	/* NEW */
-	T("A server is added and an object id is chosen that requires "
-	  "data movement to the new server",
-	  one_server_is_added),
-	/* Multiple */
-	T("Placement can handle multiple states (excluding addition)",
-	  placement_handles_multiple_states),
-	T("Placement can handle multiple states (including addition)",
-	  placement_handles_multiple_states_with_addition),
-	/* Non-standard system setups*/
-	T("Non-standard system configurations. All healthy",
-	  unbalanced_config),
-	T("shards in the same group not in the same domain",
-	  same_group_shards_not_in_same_domain),
-	T("shards in the same group not in the same domain with multiple objects",
-	  same_group_shards_not_in_same_domain_multiple_objs),
-	T("large shards over limited targets",
-	  large_shards_over_limited_targets),
-	T("multiple shards in the same target", multiple_shards_in_the_same_target),
-	T("shards over xpf", shards_over_xpf),
-	T("same group shards not in the same domain fail",
-	  same_group_shards_not_in_same_domain_with_fail),
-	T("fail shard during reintegration",
-	  fail_shard_during_reintegration),
-	T("fail reintegrate ranks", fail_reintegrate_multiple_ranks),
-	T("fail multiple ranks", fail_multiple_ranks),
+    /* Standard configurations */
+    T("Target for first shard continually goes to DOWN state and "
+      "never finishes rebuild. Should still get new target until no more",
+      down_continuously),
+    T("Object class is verified appropriately", object_class_is_verified),
+    T("With all healthy targets, can create layout, nothing is in "
+      "rebuild, and no duplicates.",
+      all_healthy),
+    /* DOWN */
+    T("Take a target down in a system with no servers available, but "
+      "should still collocate",
+      down_to_target),
+    T("Target for first shard continually goes to DOWN state and "
+      "never finishes rebuild. Should still get new target until no more",
+      down_continuously),
+    /* DOWNOUT */
+    T("Rebuild first shard's target repeatedly", chained_rebuild_completes_first_shard),
+    T("Rebuild all shards' targets", chained_rebuild_completes_all_at_once),
+    /* UP */
+    T("For each shard at a time, take the shard's target "
+      "DOWN->DOWNOUT->UP. Then verify that the reintegration looks "
+      "correct",
+      one_is_being_reintegrated),
+    T("With all targets being reintegrated, make sure the correct "
+      "targets are being rebuilt.",
+      all_are_being_reintegrated),
+    T("Take a single shard's target down, downout, then again with the "
+      "new target. Then reintegrate the first downed target, "
+      "then the second.",
+      down_up_sequences),
+    T("Take a single shard's target down, downout, then again with the "
+      "new target. Then reintegrate the second downed target, "
+      "then the first (Reverse of previous test).",
+      down_up_sequences1),
+    T("multiple shard targets go down, then are reintegrated in the "
+      "same order they were brought down",
+      down_back_to_up_in_same_order),
+    T("multiple targets go down for the same shard, then are reintegrated "
+      "in reverse order than how they were brought down",
+      down_back_to_up_in_reverse_order),
+    /* DRAIN */
+    T("Drain all shards with extra domains", drain_all_with_extra_domains),
+    T("Drain all shards with extra targets", drain_all_with_enough_targets),
+    T("Drain the target of the first shard repeatedly until there is no "
+      "where to drain to.",
+      drain_target_same_shard_repeatedly_for_all_shards),
+    /* NEW */
+    T("A server is added and an object id is chosen that requires "
+      "data movement to the new server",
+      one_server_is_added),
+    /* Multiple */
+    T("Placement can handle multiple states (excluding addition)",
+      placement_handles_multiple_states),
+    T("Placement can handle multiple states (including addition)",
+      placement_handles_multiple_states_with_addition),
+    /* Non-standard system setups*/
+    T("Non-standard system configurations. All healthy", unbalanced_config),
+    T("shards in the same group not in the same domain", same_group_shards_not_in_same_domain),
+    T("shards in the same group not in the same domain with multiple objects",
+      same_group_shards_not_in_same_domain_multiple_objs),
+    T("large shards over limited targets", large_shards_over_limited_targets),
+    T("multiple shards in the same target", multiple_shards_in_the_same_target),
+    T("shards over xpf", shards_over_xpf),
+    T("same group shards not in the same domain fail",
+      same_group_shards_not_in_same_domain_with_fail),
+    T("fail shard during reintegration", fail_shard_during_reintegration),
+    T("fail reintegrate ranks", fail_reintegrate_multiple_ranks),
+    T("fail multiple ranks", fail_multiple_ranks),
+    T("no stale read source", no_stale_read_source),
 };
 
 int


### PR DESCRIPTION
A shard which an earlier, completed rebuild had already remapped can be relocated again when a new and otherwise unrelated target fails. The spares are handed out sequentially over a shared used-target bitmap, and a shard whose spare candidate is itself unavailable is requeued with the fseq of that candidate, so changing the failed set reshuffles the spare stream and can displace a healthy shard.

The CURRENT layout flags such a shard as rebuilding, so clients write to the new target and skip the old one on read. The PRE_REBUILD layout, which the rebuild migration fetch and every DAOS_OO_RO client use, still pointed at the old target with no flag at all. That target has been out of the write path since the new pool map version, so anything written since then is missing there: the migration fetch gets a zero sized iod and reports -DER_DATA_LOSS, and a read only client can silently miss records.

Compare the PRE_REBUILD layout against the CURRENT one and mark every shard whose target differs as rebuilding, so it is never picked as a read source. The extra layout computation is skipped when no shard has been remapped by a previous failure.

Add a placement unit test reproducing the 4 rank pool where this was seen: rank 0 fails and its rebuild completes, then rank 1 fails, and the pre-rebuild layout must not expose any shard on a target the write path no longer uses.

To run the reproducer:

  ./utils/run_utest.py --suite_filter='^placement$'

or directly, after sourcing utils/sl/setup_local.sh:

  $PREFIX/bin/jump_pl_map -f pre_rebuild

Without the jump_map.c change the test aborts on the po_rebuilding assertion in pre_rebuild_no_stale_read_source().

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
